### PR TITLE
Update journald.md to add info about image name

### DIFF
--- a/config/containers/logging/journald.md
+++ b/config/containers/logging/journald.md
@@ -22,6 +22,7 @@ stores the following metadata in the journal with each message:
 | `CONTAINER_NAME`                     | The container name at the time it was started. If you use `docker rename` to rename a container, the new name is not reflected in the journal entries. |
 | `CONTAINER_TAG`, `SYSLOG_IDENTIFIER` | The container tag ([log tag option documentation](log_tags.md)).                                                                                       |
 | `CONTAINER_PARTIAL_MESSAGE`          | A field that flags log integrity. Improve logging of long log lines.                                                                                   |
+| `IMAGE_NAME`                         | The image name and tag for the container, displayed as `image:tag`. Note that tag will not be displayed if its value is `latest`.                      |
 
 ## Usage
 


### PR DESCRIPTION
Related to PR being opened in the `moby` project to add this functionality.

### Proposed changes

Add info about how IMAGE_NAME is logged in journald events.

### Related issues (optional)

Issue #21497 in the moby project, visible [here](https://github.com/moby/moby/issues/21497)\