### PR TITLE
Attempt to add static iptables rules for DOCKER-USER on CentOS 7

### DIFF
--- a/network/iptables.md
+++ b/network/iptables.md
@@ -87,7 +87,16 @@ The following example provides a set of filters and uses those filters for conta
 
 COMMIT
 ```
-
+> **Note**: `--ctorigdstport` matches the destination port on the packet that initiated the connection, 
+	not the destination port on the packet being filtered. Therefore, responses to requests from Docker 
+	to other servers have `SPT=80`, and match `--ctorigdstport 80`.
+	
+	For tighter control, all rules allowing the connection should have `--ctdir` added to specifically 
+	express their meaning, as shown in the following example:
+	
+	```
+	-A DOCKER-USER -s 1.2.3.4/32 -i eth0 -p tcp -m conntrack --ctorigdstport 80 --ctdir ORIGINAL -j ACCEPT
+	```
 #### To filter host traffic:
 
 > **Note**: Set the filter for WAN based on your host WAN interface.

--- a/network/iptables.md
+++ b/network/iptables.md
@@ -17,7 +17,7 @@ before any rules Docker creates automatically.
 
 ### Add a DOCKER-USER filter chain to allow persistent rules 
 This can be useful if you need to pre-populate `iptables` rules that need to be in place before 
-Docker runs. The following example creates a new chain named `FILTERS` in which network traffic 
+Docker runs. The following example illustrates how rules can be added to the DOCKER-USER chain
 from `INPUT` AND `DOCKER-USER` is put.
 
 ### Restrict connections to the Docker daemon

--- a/network/iptables.md
+++ b/network/iptables.md
@@ -18,7 +18,6 @@ before any rules Docker creates automatically.
 ### Add a DOCKER-USER filter chain to allow persistent rules 
 This can be useful if you need to pre-populate `iptables` rules that need to be in place before 
 Docker runs. The following example illustrates how rules can be added to the DOCKER-USER chain
-from `INPUT` AND `DOCKER-USER` is put.
 
 ### Restrict connections to the Docker daemon
 

--- a/network/iptables.md
+++ b/network/iptables.md
@@ -159,7 +159,11 @@ COMMIT
 
 ## Commit
 COMMIT
-```
+Load this into the kernel with:
+	
+	```bash
+	$ iptables-restore -n /etc/iptables.conf
+	```
 
 ## Prevent Docker from manipulating iptables
 

--- a/network/iptables.md
+++ b/network/iptables.md
@@ -53,7 +53,7 @@ the source and destination. For instance, if the Docker daemon listens on both
 topic. See the [Netfilter.org HOWTO](https://www.netfilter.org/documentation/HOWTO/NAT-HOWTO.html)
 for a lot more information.
 
-### Filtering container and host traffic
+### Filtering container traffic
 The following example provides a set of filters and uses those filters for container and host traffic: 
 
 #### To filter container traffic:

--- a/network/iptables.md
+++ b/network/iptables.md
@@ -60,6 +60,14 @@ Use the previous FILTERS chain setup with the following configuration to allow `
 -A FILTERS -j DROP
 ```
 
+**Note**: `--ctorigdstport` matches the destination port on the packet that initiated the connection, not the destination port on the packet being filtered. Therefore, responses to requests from Docker to other servers have `SPT=80` and match `--ctorigdstport 80`.
+
+For tighter control, all rules allowing the connection should have `--ctdir` added to specifically express their meaning, as shown in the following example:
+
+```
+-A DOCKER-USER -s 1.2.3.4/32 -i eth0 -p tcp -m conntrack --ctorigdstport 80 --ctdir ORIGINAL -j ACCEPT
+```
+
 ### Restrict connections to the Docker daemon
 
 By default, all external source IPs are allowed to connect to the Docker daemon.

--- a/network/iptables.md
+++ b/network/iptables.md
@@ -119,7 +119,7 @@ The following example provides a set of filters and uses those filters for conta
 ```
 *filter
 
-# WAN = yourwan ; LAN = yourlan
+# WAN = ens0 ; LAN = eth0
 
 # Reset counters
 :DOCKER-USER - [0:0]
@@ -129,18 +129,18 @@ The following example provides a set of filters and uses those filters for conta
 
 # Filters :
 ## Activate established connexions
--A DOCKER-USER -i yourwan -m conntrack --ctstate RELATED,ESTABLISHED -j RETURN
+-A DOCKER-USER -i ens0 -m conntrack --ctstate RELATED,ESTABLISHED -j RETURN
 
 ## Allow all on https/http
--A DOCKER-USER -i yourwan -p tcp -m tcp -m conntrack --ctorigdstport 80 -j RETURN
--A DOCKER-USER -i yourwan -p tcp -m tcp -m conntrack --ctorigdstport 443 -j RETURN
+-A DOCKER-USER -i ens0 -p tcp -m tcp -m conntrack --ctorigdstport 80 -j RETURN
+-A DOCKER-USER -i ens0 -p tcp -m tcp -m conntrack --ctorigdstport 443 -j RETURN
 
 ## Allow 8080 from ip
--A DOCKER-USER -i yourwan -p tcp -m tcp -m conntrack --ctorigdstport 8080 -s 10.11.11.0/24 -j RETURN
--A DOCKER-USER -i yourwan -p tcp -m tcp -m conntrack --ctorigdstport 8080 -s 10.22.22.0/24 -j RETURN
+-A DOCKER-USER -i ens0 -p tcp -m tcp -m conntrack --ctorigdstport 8080 -s 10.11.11.0/24 -j RETURN
+-A DOCKER-USER -i ens0 -p tcp -m tcp -m conntrack --ctorigdstport 8080 -s 10.22.22.0/24 -j RETURN
 
 # Block all external
--A DOCKER-USER -i yourwan -j DROP
+-A DOCKER-USER -i ens0 -j DROP
 -A DOCKER-USER -j RETURN
 
 COMMIT
@@ -148,10 +148,12 @@ COMMIT
 
 #### To filter host traffic:
 
+> **Note**: Set the filter for WAN based on your host WAN interface.
+
 ```
 *filter
 
-# WAN = yourwan ; LAN = yourlan
+# WAN = ens0 ; LAN = eth0
 
 # Reset counters
 :INPUT ACCEPT [0:0]
@@ -167,8 +169,8 @@ COMMIT
 
 # Select
 -A INPUT -i lo -j ACCEPT
--A INPUT -i yourlan -j FILTERS-LAN
--A INPUT -i yourwan -j FILTERS
+-A INPUT -i eth0 -j FILTERS-LAN
+-A INPUT -i ens0 -j FILTERS
 
 # Filters
 ## Activate established connexions

--- a/network/iptables.md
+++ b/network/iptables.md
@@ -17,7 +17,7 @@ before any rules Docker creates automatically.
 
 ### Add a DOCKER-USER filter chain to allow persistent rules 
 This can be useful if you need to pre-populate `iptables` rules that need to be in place before Docker runs. The following example creates a new chain named `FILTERS` in which network traffic from `INPUT` AND `DOCKER-USER` is put.
-
+```
 *filter
 :INPUT ACCEPT [0:0]
 :FORWARD DROP [0:0]
@@ -44,6 +44,8 @@ This can be useful if you need to pre-populate `iptables` rules that need to be 
 -A FILTERS -j REJECT --reject-with icmp-host-prohibited
 
 COMMIT
+```
+
 Load this into the kernel with:
 ```
 iptables-restore -n /etc/iptables.conf

--- a/network/iptables.md
+++ b/network/iptables.md
@@ -119,7 +119,7 @@ The following example provides a set of filters and uses those filters for conta
 ```
 *filter
 
-# WAN = ens0 ; LAN = eth0
+# WAN = eth0 ; LAN = eth1
 
 # Reset counters
 :DOCKER-USER - [0:0]
@@ -129,18 +129,18 @@ The following example provides a set of filters and uses those filters for conta
 
 # Filters :
 ## Activate established connexions
--A DOCKER-USER -i ens0 -m conntrack --ctstate RELATED,ESTABLISHED -j RETURN
+-A DOCKER-USER -i eth0 -m conntrack --ctstate RELATED,ESTABLISHED -j RETURN
 
 ## Allow all on https/http
--A DOCKER-USER -i ens0 -p tcp -m tcp -m conntrack --ctorigdstport 80 -j RETURN
--A DOCKER-USER -i ens0 -p tcp -m tcp -m conntrack --ctorigdstport 443 -j RETURN
+-A DOCKER-USER -i eth0 -p tcp -m tcp -m conntrack --ctorigdstport 80 -j RETURN
+-A DOCKER-USER -i eth0 -p tcp -m tcp -m conntrack --ctorigdstport 443 -j RETURN
 
 ## Allow 8080 from ip
--A DOCKER-USER -i ens0 -p tcp -m tcp -m conntrack --ctorigdstport 8080 -s 10.11.11.0/24 -j RETURN
--A DOCKER-USER -i ens0 -p tcp -m tcp -m conntrack --ctorigdstport 8080 -s 10.22.22.0/24 -j RETURN
+-A DOCKER-USER -i eth0 -p tcp -m tcp -m conntrack --ctorigdstport 8080 -s 10.11.11.0/24 -j RETURN
+-A DOCKER-USER -i eth0 -p tcp -m tcp -m conntrack --ctorigdstport 8080 -s 10.22.22.0/24 -j RETURN
 
 # Block all external
--A DOCKER-USER -i ens0 -j DROP
+-A DOCKER-USER -i eth0 -j DROP
 -A DOCKER-USER -j RETURN
 
 COMMIT
@@ -153,7 +153,7 @@ COMMIT
 ```
 *filter
 
-# WAN = ens0 ; LAN = eth0
+# WAN = eth0 ; LAN = eth1
 
 # Reset counters
 :INPUT ACCEPT [0:0]
@@ -169,8 +169,8 @@ COMMIT
 
 # Select
 -A INPUT -i lo -j ACCEPT
--A INPUT -i eth0 -j FILTERS-LAN
--A INPUT -i ens0 -j FILTERS
+-A INPUT -i eth1 -j FILTERS-LAN
+-A INPUT -i eth0 -j FILTERS
 
 # Filters
 ## Activate established connexions

--- a/network/iptables.md
+++ b/network/iptables.md
@@ -111,37 +111,15 @@ the source and destination. For instance, if the Docker daemon listens on both
 topic. See the [Netfilter.org HOWTO](https://www.netfilter.org/documentation/HOWTO/NAT-HOWTO.html)
 for a lot more information.
 
-### Name of example???
-The following example provides a set of filters, and uses those filters for container and host traffic: 
-
-```
-# Filters
-## Activate established connexions
--A FILTERS -m state --state ESTABLISHED,RELATED -j ACCEPT
-
-## Monitoring
--A FILTERS -s 10.1.1.1/32 -p udp -m udp --dport 161 -j ACCEPT
--A FILTERS -s 10.1.1.1/32 -p tcp -m tcp --dport 5666 -j ACCEPT
--A FILTERS -s 10.1.1.1/32 -p icmp --icmp-type any -j ACCEPT
-
-## Admin ssh
--A FILTERS -s 10.0.0.1/32 -p tcp -m tcp --dport 22 -j ACCEPT
--A FILTERS -s 10.0.1.1/32 -p tcp -m tcp --dport 22 -j ACCEPT
-
-## Admin ping
--A FILTERS -s 10.0.0.1/32 -p icmp --icmp-type any -j ACCEPT
--A FILTERS -s 10.0.1.1/32 -p icmp --icmp-type any -j ACCEPT
-
-## Drop public in
--A FILTERS -j DROP
-```
+### Filtering container and host traffic
+The following example provides a set of filters and uses those filters for container and host traffic: 
 
 #### To filter container traffic:
 
 ```
 *filter
 
-# WAN = ens192 ; LAN = ens160
+# WAN = yourwan ; LAN = yourlan
 
 # Reset counters
 :DOCKER-USER - [0:0]
@@ -151,18 +129,18 @@ The following example provides a set of filters, and uses those filters for cont
 
 # Filters :
 ## Activate established connexions
--A DOCKER-USER -i ens192 -m conntrack --ctstate RELATED,ESTABLISHED -j RETURN
+-A DOCKER-USER -i yourwan -m conntrack --ctstate RELATED,ESTABLISHED -j RETURN
 
 ## Allow all on https/http
--A DOCKER-USER -i ens192 -p tcp -m tcp -m conntrack --ctorigdstport 80 -j RETURN
--A DOCKER-USER -i ens192 -p tcp -m tcp -m conntrack --ctorigdstport 443 -j RETURN
+-A DOCKER-USER -i yourwan -p tcp -m tcp -m conntrack --ctorigdstport 80 -j RETURN
+-A DOCKER-USER -i yourwan -p tcp -m tcp -m conntrack --ctorigdstport 443 -j RETURN
 
 ## Allow 8080 from ip
--A DOCKER-USER -i ens192 -p tcp -m tcp -m conntrack --ctorigdstport 8080 -s 10.11.11.0/24 -j RETURN
--A DOCKER-USER -i ens192 -p tcp -m tcp -m conntrack --ctorigdstport 8080 -s 10.22.22.0/24 -j RETURN
+-A DOCKER-USER -i yourwan -p tcp -m tcp -m conntrack --ctorigdstport 8080 -s 10.11.11.0/24 -j RETURN
+-A DOCKER-USER -i yourwan -p tcp -m tcp -m conntrack --ctorigdstport 8080 -s 10.22.22.0/24 -j RETURN
 
 # Block all external
--A DOCKER-USER -i ens192 -j DROP
+-A DOCKER-USER -i yourwan -j DROP
 -A DOCKER-USER -j RETURN
 
 COMMIT
@@ -173,7 +151,7 @@ COMMIT
 ```
 *filter
 
-# WAN = ens192 ; LAN = ens160
+# WAN = yourwan ; LAN = yourlan
 
 # Reset counters
 :INPUT ACCEPT [0:0]
@@ -189,8 +167,8 @@ COMMIT
 
 # Select
 -A INPUT -i lo -j ACCEPT
--A INPUT -i ens160 -j FILTERS-LAN
--A INPUT -i ens192 -j FILTERS
+-A INPUT -i yourlan -j FILTERS-LAN
+-A INPUT -i yourwan -j FILTERS
 
 # Filters
 ## Activate established connexions


### PR DESCRIPTION
#8087 

Extra information (is any of this is useful):

$ docker run -d -p 7777:6379 --name data1 redis
$ docker run -d -p 8888:6379 --name data2 redis
$ sudo iptables -N DOCKER-USER-redis1
$ sudo iptables -A DOCKER-USER-redis1 -s 192.168.56.0/24 -p tcp -m tcp -j RETURN
$ sudo iptables -A DOCKER-USER-redis1 -j REJECT --reject-with icmp-port-unreachable
$ sudo iptables -N DOCKER-USER-redis2
$ sudo iptables -A DOCKER-USER-redis2 -s 10.0.24.0/24 -p tcp -m tcp -j RETURN
$ sudo iptables -A DOCKER-USER-redis2 -j REJECT --reject-with icmp-port-unreachable
$ sudo iptables -A DOCKER-USER -i eth0 -p tcp -m conntrack --ctorigdstport 7777 -j DOCKER-USER-redis1
$ sudo iptables -A DOCKER-USER -i eth0 -p tcp -m conntrack --ctorigdstport 8888 -j DOCKER-USER-redis2

"I think an example like this belongs in the docs as it probably covers what 99% of users are looking for: the ability to expose ports using `-p` but still be able to control traffic to them using common filters like `-s`."


Note that --ctorigdstport matches the original destination port of the first packet of the connection, not the packet being filtered. So the dropping rule will also drop responses to the outgoing connections from Docker to the world on 5000-9999! Add --ctdir ORIGINAL to the DROP rule to match only incoming packets. See github.com/moby/moby/issues/22054#issuecomment-466663033

You can also specify which chains docker should use. For example, in the filter table, specify another chain instead of `FORWARD`. This allows you to use traditional tools to manage the firewall and decide when to pass control to docker.

Information pulled from:
https://github.com/moby/moby/issues/33567
https://unrouted.io/2017/08/15/docker-firewall/
https://github.com/docker/libnetwork/pull/1675

