### PR TITLE
Update running_riak_service.md

### DIFF
--- a/engine/examples/running_riak_service.md
+++ b/engine/examples/running_riak_service.md
@@ -29,7 +29,8 @@ script and we download the setup script and run it.
 
     # Install Riak repository before we do apt-get update, so that update happens
     # in a single step
-    RUN apt-get install -q -y curl && \
+    RUN apt-get update && \
+        apt-get install -q -y curl && \
         curl -fsSL https://packagecloud.io/install/repositories/basho/riak/script.deb | sudo bash
 
 Then we install and setup a few dependencies:


### PR DESCRIPTION
fix error when apt-get is unable to locate package curl in cache

### Proposed changes

When building the riak image and installing curl with apt-get the command fails with the error "E: Unable to locate package curl", executing an 'apt-get update' on the same line fixes the issue
