### PR TITLE
Docker swam join host should be <myvm1 ip>

### DIFF
--- a/get-started/part4.md
+++ b/get-started/part4.md
@@ -209,7 +209,7 @@ join your new swarm as a worker:
 ```shell
 $ docker-machine ssh myvm2 "docker swarm join \
 --token <token> \
-<ip>:2377"
+<myvm1 ip>:2377"
 
 This node joined a swarm as a worker.
 ```


### PR DESCRIPTION
### Proposed changes

There will have a chance of confusion about which IP want to use when looking like `<ip>:2377`. Here we can specify the exact VM's IP address like `<myvm1 ip>:2377`. (In order to avoid confusion for very beginners).