### PR TITLE
Documenting compose-inside-docker gotcha

### DIFF
--- a/compose/install.md
+++ b/compose/install.md
@@ -200,6 +200,10 @@ $ sudo curl -L --fail https://github.com/docker/compose/releases/download/{{site
 $ sudo chmod +x /usr/local/bin/docker-compose
 ```
 
+Warning: as docker-compose runs inside a container, variable expansion in your 
+`docker-compose.yml` will not work as expected. A tilde expands to `/root`, not
+to your own home directory, for instance.
+
 </div>
 </div>
 

--- a/compose/install.md
+++ b/compose/install.md
@@ -200,7 +200,7 @@ $ sudo curl -L --fail https://github.com/docker/compose/releases/download/{{site
 $ sudo chmod +x /usr/local/bin/docker-compose
 ```
 
-Warning: as docker-compose runs inside a container, variable expansion in your 
+Warning: when docker-compose runs inside a container, variable expansion in your 
 `docker-compose.yml` will not work as expected. A tilde expands to `/root`, not
 to your own home directory, for instance.
 


### PR DESCRIPTION
### Proposed changes

This is a documentation fix for https://github.com/docker/compose/issues/6506

When you use the dockerized docker-compose, a `~` in your `docker-compose.yml` doesn't expand to what you expect (`/home/myuser`), but to `/root` as that is the home dir inside the docker it is running in :-)

### Related issues

https://github.com/docker/compose/issues/6506
