### PR TITLE
Add Hostname template variable

### DIFF
--- a/config/containers/logging/log_tags.md
+++ b/config/containers/logging/log_tags.md
@@ -24,9 +24,10 @@ Docker supports some special template markup you can use when specifying a tag's
 | `{{.FullID}}`      | The full container ID.                               |
 | `{{.Name}}`        | The container name.                                  |
 | `{{.ImageID}}`     | The first 12 characters of the container's image ID. |
-| `{{.ImageFullID}}` | The container's full image ID.               |
+| `{{.ImageFullID}}` | The container's full image ID.                       |
 | `{{.ImageName}}`   | The name of the image used by the container.         |
 | `{{.DaemonName}}`  | The name of the docker program (`docker`).           |
+| `{{.Hostname}}`    | Hostname from the underlying OS                      |
 
 {% endraw %}
 


### PR DESCRIPTION
It is a really important variable, which is not documented. It is really useful if docker is used in AMI and images are cloned. Hostname is unique in every instance and can be safely used as stream name

Here is an implementation:
https://github.com/moby/moby/blob/8e610b2b55bfd1bfa9436ab110d311f5e8a74dcb/daemon/logger/loginfo.go#L83

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    DO NOT edit files and directories listed in _data/not_edited_here.yaml.
    These are maintained in upstream repos and changes here will be lost.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

<!--Tell us what you did and why-->

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
