### PR TITLE
Add Step to Change mode of /var/lib/docker to 711

### DIFF
--- a/storage/storagedriver/btrfs-driver.md
+++ b/storage/storagedriver/btrfs-driver.md
@@ -99,7 +99,13 @@ This procedure is essentially identical on SLES and Ubuntu.
     $ sudo cp -au /var/lib/docker.bk/* /var/lib/docker/
     ```
 
-6.  Configure Docker to use the `btrfs` storage driver. This is required even
+6.  Change the mode of `/var/lib/docker` to `711`.
+
+    ```bash
+    $ sudo chmod 711 /var/lib/docker
+    ```
+
+7.  Configure Docker to use the `btrfs` storage driver. This is required even
     though `/var/lib/docker/` is now using a Btrfs filesystem.
     Edit or create the file `/etc/docker/daemon.json`. If it is a new file, add
     the following contents. If it is an existing file, add the key and value
@@ -117,7 +123,7 @@ This procedure is essentially identical on SLES and Ubuntu.
     - [Stable](/engine/reference/commandline/dockerd.md#storage-driver-options)
     - [Edge](/edge/engine/reference/commandline/dockerd.md#storage-driver-options)
 
-7.  Start Docker. After it is running, verify that `btrfs` is being used as the
+8.  Start Docker. After it is running, verify that `btrfs` is being used as the
     storage driver.
 
     ```bash
@@ -135,7 +141,7 @@ This procedure is essentially identical on SLES and Ubuntu.
     <output truncated>
     ```
 
-8.  When you are ready, remove the `/var/lib/docker.bk` directory.
+9.  When you are ready, remove the `/var/lib/docker.bk` directory.
 
 ## Manage a Btrfs volume
 


### PR DESCRIPTION
…re Docker to use the btrfs storage driver"

In Section "Configure Docker to use the btrfs storage driver", add below step to make the mode of /var/lib/docker same as that of /var/lib/docker.bk

6.  Change the mode of `/var/lib/docker` to `711`.

    ```bash
    $ sudo chmod 711 /var/lib/docker
    ```

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    DO NOT edit files and directories listed in _data/not_edited_here.yaml.
    These are maintained in upstream repos and changes here will be lost.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

<!--Tell us what you did and why-->

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
