### PR TITLE
Make changes to device-mapper.md

### DIFF
--- a/storage/storagedriver/device-mapper-driver.md
+++ b/storage/storagedriver/device-mapper-driver.md
@@ -80,6 +80,34 @@ For production systems, see
 
     Docker does not start if the `daemon.json` file contains badly-formed JSON.
 
+    Perform the steps following the below error 
+    otherwise Docker fails to start with below error.
+    
+    ```bash
+    unable to configure the Docker daemon with file /etc/docker/daemon.json: 
+    the following directives are specified both as a flag and in the configuration
+    file: storage-driver: (from flag: overlay2, from file: devicemapper)
+    ```
+    
+    In CentOS or Fedora, comment below line in `/usr/lib/systemd/system/docker.service`.
+    
+    ```bash
+    EnvironmentFile=-/etc/sysconfig/docker-storage
+    ```
+    
+    In Ubuntu or Debian, remove below flag in line starting with `ExecStart=`
+    in file `/etc/systemd/system/docker.service.d/10-machine.conf`.
+    
+    ```bash
+    --storage-driver overlay2
+    ```
+    
+    In CentOS or Fedora or Ubuntu or Debian, run the following command
+    
+    ```bash
+    $ sudo systemctl daemon-reload
+    ```
+    
 3.  Start Docker.
 
     ```bash
@@ -187,6 +215,34 @@ See all storage options for each storage driver:
 
 - [Stable](/engine/reference/commandline/dockerd.md#storage-driver-options)
 - [Edge](/edge/engine/reference/commandline/dockerd.md#storage-driver-options)
+
+Perform the steps following the below error 
+otherwise Docker fails to start with below error.
+
+```bash
+unable to configure the Docker daemon with file /etc/docker/daemon.json: 
+the following directives are specified both as a flag and in the configuration
+file: storage-driver: (from flag: overlay2, from file: devicemapper)
+```
+
+In CentOS or Fedora, comment below line in `/usr/lib/systemd/system/docker.service`.
+
+```bash
+EnvironmentFile=-/etc/sysconfig/docker-storage
+```
+
+In Ubuntu or Debian, remove below flag in line starting with `ExecStart=`
+in file `/etc/systemd/system/docker.service.d/10-machine.conf`.
+
+```bash
+--storage-driver overlay2
+```
+
+In CentOS or Fedora or Ubuntu or Debian, run the following command
+
+```bash
+$ sudo systemctl daemon-reload
+```
 
 Restart Docker for the changes to take effect. Docker invokes the commands to
 configure the block device for you.
@@ -360,6 +416,34 @@ assumes that the Docker daemon is in the `stopped` state.
         "dm.use_deferred_deletion=true"
         ]
     }
+    ```
+    
+    Perform the steps following the below error 
+    otherwise Docker fails to start with below error.
+    
+    ```bash
+    unable to configure the Docker daemon with file /etc/docker/daemon.json: 
+    the following directives are specified both as a flag and in the configuration
+    file: storage-driver: (from flag: overlay2, from file: devicemapper)
+    ```
+    
+    In CentOS or Fedora, comment below line in `/usr/lib/systemd/system/docker.service`.
+    
+    ```bash
+    EnvironmentFile=-/etc/sysconfig/docker-storage
+    ```
+    
+    In Ubuntu or Debian, remove below flag in line starting with `ExecStart=`
+    in file `/etc/systemd/system/docker.service.d/10-machine.conf`.
+    
+    ```bash
+    --storage-driver overlay2
+    ```
+    
+    In CentOS or Fedora or Ubuntu or Debian, run the following command
+    
+    ```bash
+    $ sudo systemctl daemon-reload
     ```
 
 14. Start Docker.
@@ -687,10 +771,9 @@ the Devicemapper configuration itself and about each image and container layer
 that exist. The `devicemapper` storage driver uses snapshots, and this metadata
 include information about those snapshots. These files are in JSON format.
 
-The `/var/lib/docker/devicemapper/mnt/` directory contains a mount point for each image
-and container layer that exists. Image layer mount points are empty, but a
-container's mount point shows the container's filesystem as it appears from
-within the container.
+The `/var/lib/docker/devicemapper/mnt/` directory contains a mount point for each
+container layer that exists. A container's mount point shows the container's 
+filesystem as it appears from within the container.
 
 
 ### Image layering and sharing
@@ -739,8 +822,7 @@ devices, either loopback devices (testing only) or physical disks.
   from their parent layers.
 
 - Each container's writable layer is mounted on a mountpoint in
-  `/var/lib/docker/devicemapper/mnt/`. An empty directory exists for each
-  read-only image layer and each stopped container.
+  `/var/lib/docker/devicemapper/mnt/`.
 
 Each image layer is a snapshot of the layer below it. The lowest layer of each
 image is a snapshot of the base device that exists in the pool. When you run a

--- a/storage/storagedriver/device-mapper-driver.md
+++ b/storage/storagedriver/device-mapper-driver.md
@@ -461,7 +461,7 @@ instead.
 A community-contributed script called `device_tool.go` is available in the
 [moby/moby](https://github.com/moby/moby/tree/master/contrib/docker-device-tool)
 Github repository. You can use this tool to resize a `loop-lvm` thin pool,
-avoiding the long process above. This tool is not guaranteed to work, but you
+avoiding the long process using operating system utilities. This tool is not guaranteed to work, but you
 should only be using `loop-lvm` on non-production systems.
 
 If you do not want to use `device_tool`, you can [resize the thin pool manually](#use-operating-system-utilities) instead.
@@ -587,7 +587,7 @@ block device and other parameters to suit your situation.
     use by your thin pool, and the volume group's name.
 
     ```bash
-    $ sudo pvdisplay |grep 'VG Name'
+    $ sudo pvdisplay |grep -e 'PV Name' -e 'VG Name'
 
     PV Name               /dev/xvdf
     VG Name               docker
@@ -678,7 +678,7 @@ $ mount |grep devicemapper
 
 When you use `devicemapper`, Docker stores image and layer contents in the
 thinpool, and exposes them to containers by mounting them under
-subdirectories of `/var/lib/docker/devicemapper/`.
+subdirectories of `/var/lib/docker/devicemapper/mnt`.
 
 ### Image and container layers on-disk
 
@@ -687,7 +687,7 @@ the Devicemapper configuration itself and about each image and container layer
 that exist. The `devicemapper` storage driver uses snapshots, and this metadata
 include information about those snapshots. These files are in JSON format.
 
-The `/var/lib/devicemapper/mnt/` directory contains a mount point for each image
+The `/var/lib/docker/devicemapper/mnt/` directory contains a mount point for each image
 and container layer that exists. Image layer mount points are empty, but a
 container's mount point shows the container's filesystem as it appears from
 within the container.


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    DO NOT edit files and directories listed in _data/not_edited_here.yaml.
    These are maintained in upstream repos and changes here will be lost.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

<!--Tell us what you did and why-->

#### Added steps to fix issue where docker daemon does not start with below error

unable to configure the Docker daemon with file /etc/docker/daemon.json: the following directives are specified both as a flag and in the configuration file: storage-driver: (from flag: overlay2, from file: devicemapper)

#### Made the required changes for below

Only the running container snapshot is mounted on /var/lib/docker/devicemapper/mnt
No empty directories exist for Images and Stopped Containers
Also, Snapshot Devices exist only for Running Containers Writable Layer
No devices exist for Images and Stopped Containers and they are just in the thin pool.
Verified in CentOS and Ubuntu.

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
