### PR TITLE
Update overlayfs-driver.md

### DIFF
--- a/storage/storagedriver/overlayfs-driver.md
+++ b/storage/storagedriver/overlayfs-driver.md
@@ -195,9 +195,9 @@ bin  boot  dev  etc  home  lib  lib64  media  mnt  opt  proc  root  run  sbin  s
 
 The second-lowest layer, and each higher layer, contain a file called `lower`,
 which denotes its parent, and a directory called `diff` which contains its
-contents. It also contains a `merged` directory, which contains the unified
-contents of its parent layer and itself, and a `work` directory which is used
-internally by OverlayFS.
+contents. It also contains a `work` directory which is used internally by OverlayFS.
+In addition to this, the highest layer of a running container contains a
+`merged` directory, which contains the unified contents of all its lower layers.
 
 ```bash
 $ ls /var/lib/docker/overlay2/223c2864175491657d238e2664251df13b63adb8d050924fd1bfcdb278b866f7


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    DO NOT edit files and directories listed in _data/not_edited_here.yaml.
    These are maintained in upstream repos and changes here will be lost.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

<!--Tell us what you did and why-->

The Image Layers do not contain the merged mount directory.
Even the highest container layer of stopped container do not contain the merged mount directory.
Only Topmost layer of a running container contains the merged mount directory.
Verified on Alpine OS.

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
