### PR TITLE
Enable the stable repository after adding it

### DIFF
--- a/install/linux/docker-ce/fedora.md
+++ b/install/linux/docker-ce/fedora.md
@@ -93,6 +93,12 @@ from the repository.
         {{ download-url-base }}/docker-ce.repo
     ```
 
+3.  Enable the **stable** repository using this command:
+
+    ```bash
+    $ sudo dnf config-manager --set-enabled docker-ce-stable
+    ```
+
 > **Optional**: Enable the **nightly** or **test** repositories.
 >
 > These repositories are included in the `docker.repo` file above but are disabled


### PR DESCRIPTION
I tried installing current docker from Fedora repositories.
It seems the manual is missing a step.
The stable repository is added but also has to be activated, otherwise the package cannot be installed.