### PR TITLE
Fix fluentd-buffer-limit default value

### DIFF
--- a/config/containers/logging/fluentd.md
+++ b/config/containers/logging/fluentd.md
@@ -114,8 +114,7 @@ connection is established. Defaults to `false`.
 
 ### fluentd-buffer-limit
 
-The amount of data to buffer before flushing to disk. Defaults to the amount of RAM
-available to the container.
+The amount of data to buffer before flushing to disk. Defaults to 1MiB.
 
 ### fluentd-retry-wait
 


### PR DESCRIPTION
### Proposed changes
This changes the fluentd-logging-driver's documented default value for `fluentd-buffer-limit` to 1MiB, as the source code seems to use 1024byte * 1024byte:

https://github.com/moby/moby/blob/8d760280a232f98d92440539e1e8a8f66c213bdb/daemon/logger/fluentd/fluentd.go#L44

Knowing that the buffer is rather small can be important. In our case, we frequently lost log messages until we increased the size of this buffer.