### PR TITLE
Improve Delegation Docs with Export/Import Key Info

### DIFF
--- a/engine/security/trust/trust_delegation.md
+++ b/engine/security/trust/trust_delegation.md
@@ -134,7 +134,7 @@ copy the exported private key to the signing machine and execute the command:
 
 ```bash
 $ docker trust key load --name jeff jeff-private-key.pem
-Loading key from "jeff-key.pem"...
+Loading key from "jeff-private-key.pem"...
 Successfully imported key from jeff-private-key.pem
 ```
 

--- a/engine/security/trust/trust_delegation.md
+++ b/engine/security/trust/trust_delegation.md
@@ -125,6 +125,19 @@ Repeat passphrase for new jeff key with ID 9deed25:
 Successfully generated and loaded private key. Corresponding public key available: /home/ubuntu/Documents/mytrustdir/jeff.pub
 ```
 
+To use the key for signing on another machine, it must be exported and imported to the signing machine.
+
+```bash
+$ notary key export --key 9deed25 -o jeff-private-key.pem
+```
+copy the exported private key to the signing machine and execute the command:
+
+```bash
+$ docker trust key load --name jeff jeff-private-key.pem
+Loading key from "jeff-key.pem"...
+Successfully imported key from jeff-private-key.pem
+```
+
 ### Manually Generating Keys
 
 If you need to manually generate a private key (either RSA or ECDSA) and a x509 

--- a/notary/advanced_usage.md
+++ b/notary/advanced_usage.md
@@ -94,6 +94,22 @@ it is possible for the notary server to manage the snapshot key, if the snapshot
 key is rotated from the notary client to server, as described in the following
 subsection.
 
+### Export Keys to Other Machines
+
+To use a key for signing from a different machine, it must be exported and imported
+to the signing machine.
+
+```bash
+$ notary key export --key 729c7094a8210fd1e780e7b17b7bb55c9a28a48b871b07f65d97baf93898523a -o delegation-private-key.pem
+```
+copy the exported private key to the destination machine and execute the command:
+
+```bash
+$ docker trust key load --name my-delegate delegation-private-key.pem
+Loading key from "delegation-private-key.pem"...
+Successfully imported key from delegation-private-key.pem
+```
+
 ### Rotate keys
 
 In case of potential compromise, notary provides a CLI command for rotating keys.


### PR DESCRIPTION
### Proposed changes

I was trying to figure out how to use Docker Content Trust in a Jenkins pipeline, and I ran into problems. There were two issues. First, the docs don't show the require step to export the key using the notary command so that it can be imported using the dockery key trust.

The second was the CLI gives a success message even when import failed.

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

https://github.com/docker/cli/issues/2031

