### PR TITLE
add docker-ce and containerd.io in uninstall

### DIFF
--- a/install/linux/docker-ce/debian.md
+++ b/install/linux/docker-ce/debian.md
@@ -38,7 +38,7 @@ Older versions of Docker were called `docker`, `docker.io `, or `docker-engine`.
 If these are installed, uninstall them:
 
 ```bash
-$ sudo apt-get remove docker docker-engine docker.io containerd runc
+$ sudo apt-get remove docker docker-engine docker.io containerd.io docker-ce runc
 ```
 
 It's OK if `apt-get` reports that none of these packages are installed.


### PR DESCRIPTION
### Proposed changes
we need to uninstall more packages if we want to re-install docker on debian
