### PR TITLE
Add version information for mandatory variable syntax

### DIFF
--- a/_includes/content/compose-var-sub.md
+++ b/_includes/content/compose-var-sub.md
@@ -34,7 +34,8 @@ provide inline default values using typical shell syntax:
 - `${VARIABLE-default}` evaluates to `default` only if `VARIABLE` is unset
   in the environment.
 
-Similarly, the following syntax allows you to specify mandatory variables:
+Similarly, the following syntax allows you to specify mandatory variables when
+using **Compose 1.19.0+** or `docker stack deploy` **18.04.0+**:
 
 - `${VARIABLE:?err}` exits with an error message containing `err` if
   `VARIABLE` is unset or empty in the environment.


### PR DESCRIPTION
### Proposed changes
The mandatory variable syntax is only available in docker-compose 1.19+ (docker/compose#5531). However, no new compose file version was created to reflect this change, nor is this documented.

Adding this information for clarity.

### Related issues (optional)
Fixes docker/compose#5683.