### PR TITLE
Explicitly mention ignoring variables not conforming to the desired format

### DIFF
--- a/compose/env-file.md
+++ b/compose/env-file.md
@@ -13,6 +13,7 @@ named `.env` placed in the folder where the `docker-compose` command is executed
 These syntax rules apply to the `.env` file:
 
 * Compose expects each line in an `env` file to be in `VAR=VAL` format.
+* Lines not conforming to the above syntax **will be ignored**.
 * Lines beginning with `#` are processed as comments and ignored.
 * Blank lines are ignored.
 * There is no special handling of quotation marks. This means that


### PR DESCRIPTION
### Proposed changes

Adjust spec for the `.env` file to adopt the de facto behaviour up until https://github.com/docker/compose/commit/0612d973c7b624c1a7902579f52b787ab014977a was merged. 

Some users depended on lines starting with `export` being ignored by docker-compose so they could use the `.env` file via `source` command or some other tools that also read the `.env` file.

The spec didn't say what would happen with lines not conforming to the syntax. Breakage ensured when the aforementioned merge request was pulled into docker-compose (https://github.com/docker/compose/issues/6511 https://github.com/docker/compose/issues/6838).

There is a feature request for a switch that would prevent docker-compose from reading `.env` but it only solves the problem of `I don't want docker-compose to use my .env file at all` (https://github.com/docker/compose/issues/6741). It's implemented in https://github.com/docker/compose/pull/6850

### Related issues (optional)

https://github.com/docker/compose/issues/6511
https://github.com/docker/compose/issues/6838

https://github.com/docker/compose/issues/6741
https://github.com/docker/compose/pull/6850
