### PR TITLE
split code block when output-logs are included

### DIFF
--- a/engine/security/https.md
+++ b/engine/security/https.md
@@ -31,6 +31,7 @@ it only connects to servers with a certificate signed by that CA.
 
 First, on the **Docker daemon's host machine**, generate CA private and public keys:
 
+```bash
     $ openssl genrsa -aes256 -out ca-key.pem 4096
     Generating RSA private key, 4096 bit long modulus
     ............................................................................................................................................................................................++
@@ -38,7 +39,8 @@ First, on the **Docker daemon's host machine**, generate CA private and public k
     e is 65537 (0x10001)
     Enter pass phrase for ca-key.pem:
     Verifying - Enter pass phrase for ca-key.pem:
-
+```
+```bash
     $ openssl req -new -x509 -days 365 -key ca-key.pem -sha256 -out ca.pem
     Enter pass phrase for ca-key.pem:
     You are about to be asked to enter information that will be incorporated
@@ -55,6 +57,7 @@ First, on the **Docker daemon's host machine**, generate CA private and public k
     Organizational Unit Name (eg, section) []:Sales
     Common Name (e.g. server FQDN or YOUR name) []:$HOST
     Email Address []:Sven@home.org.au
+```
 
 Now that you have a CA, you can create a server key and certificate
 signing request (CSR). Make sure that "Common Name" matches the hostname you use
@@ -63,13 +66,16 @@ to connect to Docker:
 > **Note**: Replace all instances of `$HOST` in the following example with the
 > DNS name of your Docker daemon's host.
 
+```bash
     $ openssl genrsa -out server-key.pem 4096
     Generating RSA private key, 4096 bit long modulus
     .....................................................................++
     .................................................................................................++
     e is 65537 (0x10001)
-
+```
+```bash
     $ openssl req -subj "/CN=$HOST" -sha256 -new -key server-key.pem -out server.csr
+```
 
 Next, we're going to sign the public key with our CA:
 
@@ -77,21 +83,27 @@ Since TLS connections can be made through IP address as well as DNS name, the IP
 need to be specified when creating the certificate. For example, to allow connections
 using `10.10.10.20` and `127.0.0.1`:
 
+```bash
     $ echo subjectAltName = DNS:$HOST,IP:10.10.10.20,IP:127.0.0.1 >> extfile.cnf
+```
 
 Set the Docker daemon key's extended usage attributes to be used only for
 server authentication:
 
+```bash
     $ echo extendedKeyUsage = serverAuth >> extfile.cnf
+```
 
 Now, generate the signed certificate:
 
+```bash
     $ openssl x509 -req -days 365 -sha256 -in server.csr -CA ca.pem -CAkey ca-key.pem \
       -CAcreateserial -out server-cert.pem -extfile extfile.cnf
     Signature ok
     subject=/CN=your.host.com
     Getting CA Private Key
     Enter pass phrase for ca-key.pem:
+```
 
 [Authorization plugins](../extend/plugins_authorization) offer more
 fine-grained control to supplement authentication from mutual TLS. In addition
@@ -105,32 +117,41 @@ request:
 > **Note**: For simplicity of the next couple of steps, you may perform this
 > step on the Docker daemon's host machine as well.
 
+```bash
     $ openssl genrsa -out key.pem 4096
     Generating RSA private key, 4096 bit long modulus
     .........................................................++
     ................++
     e is 65537 (0x10001)
-
+```
+```bash
     $ openssl req -subj '/CN=client' -new -key key.pem -out client.csr
+```
 
 To make the key suitable for client authentication, create a new extensions
 config file:
 
+```bash
     $ echo extendedKeyUsage = clientAuth > extfile-client.cnf
+```
 
 Now, generate the signed certificate:
 
+```bash
     $ openssl x509 -req -days 365 -sha256 -in client.csr -CA ca.pem -CAkey ca-key.pem \
       -CAcreateserial -out cert.pem -extfile extfile-client.cnf
     Signature ok
     subject=/CN=client
     Getting CA Private Key
     Enter pass phrase for ca-key.pem:
+```
 
 After generating `cert.pem` and `server-cert.pem` you can safely remove the
 two certificate signing requests and extensions config files:
 
+```bash
     $ rm -v client.csr server.csr extfile.cnf extfile-client.cnf
+```
 
 With a default `umask` of 022, your secret keys are *world-readable* and
 writable for you and your group.
@@ -138,18 +159,24 @@ writable for you and your group.
 To protect your keys from accidental damage, remove their
 write permissions. To make them only readable by you, change file modes as follows:
 
+```bash
     $ chmod -v 0400 ca-key.pem key.pem server-key.pem
+```
 
 Certificates can be world-readable, but you might want to remove write access to
 prevent accidental damage:
 
+```bash
     $ chmod -v 0444 ca.pem server-cert.pem cert.pem
+```
 
 Now you can make the Docker daemon only accept connections from clients
 providing a certificate trusted by your CA:
 
+```bash
     $ dockerd --tlsverify --tlscacert=ca.pem --tlscert=server-cert.pem --tlskey=server-key.pem \
       -H=0.0.0.0:2376
+```
 
 To connect to Docker and validate its certificate, provide your client keys,
 certificates and trusted CA:
@@ -163,8 +190,10 @@ certificates and trusted CA:
 > **Note**: Replace all instances of `$HOST` in the following example with the
 > DNS name of your Docker daemon's host.
 
+```bash
     $ docker --tlsverify --tlscacert=ca.pem --tlscert=cert.pem --tlskey=key.pem \
       -H=$HOST:2376 version
+```
 
 > **Note**:
 > Docker over TLS should run on TCP port 2376.
@@ -184,14 +213,18 @@ the files to the `.docker` directory in your home directory --- and set the
 `DOCKER_HOST` and `DOCKER_TLS_VERIFY` variables as well (instead of passing
 `-H=tcp://$HOST:2376` and `--tlsverify` on every call).
 
+```bash
     $ mkdir -pv ~/.docker
     $ cp -v {ca,cert,key}.pem ~/.docker
 
     $ export DOCKER_HOST=tcp://$HOST:2376 DOCKER_TLS_VERIFY=1
+```
 
 Docker now connects securely by default:
 
+```bash
     $ docker ps
+```
 
 ## Other modes
 
@@ -217,18 +250,22 @@ to drop your keys into `~/.docker/{ca,cert,key}.pem`. Alternatively,
 if you want to store your keys in another location, you can specify that
 location using the environment variable `DOCKER_CERT_PATH`.
 
+```bash
     $ export DOCKER_CERT_PATH=~/.docker/zone1/
     $ docker --tlsverify ps
+```
 
 ### Connecting to the secure Docker port using `curl`
 
 To use `curl` to make test API requests, you need to use three extra command line
 flags:
 
+```bash
     $ curl https://$HOST:2376/images/json \
       --cert ~/.docker/cert.pem \
       --key ~/.docker/key.pem \
       --cacert ~/.docker/ca.pem
+```
 
 ## Related information
 


### PR DESCRIPTION
I knw the use od ` [```bash ... ```] ` can be redundant compared with simple indentation. However (like for the first set of instructions) when the code block includes long output logs one can miss the sequence of commands .. so IMHO in those cases (relatively long output-logs) the instructions are more readable by splitting the code block for each instruction .

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    DO NOT edit files and directories listed in _data/not_edited_here.yaml.
    These are maintained in upstream repos and changes here will be lost.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

<!--Tell us what you did and why-->

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
