### PR TITLE
Fix restart_policy documentation

### DIFF
--- a/compose/compose-file/index.md
+++ b/compose/compose-file/index.md
@@ -851,10 +851,9 @@ Configures if and how to restart containers when they exit. Replaces
 - `delay`: How long to wait between restart attempts, specified as a
   [duration](#specifying-durations) (default: 0).
 - `max_attempts`: How many times to attempt to restart a container before giving
-  up (default: never give up). If the restart does not succeed within the configured
+  up (default: never give up). If the restart does not succeed outside the configured
   `window`, this attempt doesn't count toward the configured `max_attempts` value.
-  For example, if `max_attempts` is set to '2', and the restart fails on the first
-  attempt, more than two restarts may be attempted.
+  For example, if `max_attempts` is set to '2', and the `window` is set to '120s', and the restart fails 5min after the first attempt, more than two restarts may be attempted.
 - `window`: How long to wait before deciding if a restart has succeeded,
   specified as a [duration](#specifying-durations) (default:
   decide immediately).


### PR DESCRIPTION
The Restart policy documentation was incorrect. If a service is failing and restarting quickly within the window, the service will not be started again after max_attempts is reached. Conversely if a service is failing after long intervals, outside the "window" the service will continue to be restarted.

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    DO NOT edit files and directories listed in _data/not_edited_here.yaml.
    These are maintained in upstream repos and changes here will be lost.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

<!--Tell us what you did and why-->

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
