### PR TITLE
Updated 'Use a pre-existing network' section

### DIFF
--- a/compose/networking.md
+++ b/compose/networking.md
@@ -168,8 +168,7 @@ Instead of (or as well as) specifying your own networks, you can also change the
 If you want your containers to join a pre-existing network, use the [`external` option](compose-file/compose-file-v2.md#network-configuration-reference):
 
     networks:
-      default:
-        external:
-          name: my-pre-existing-network
+      my-pre-existing-network:
+          external: true
 
 Instead of attempting to create a network called `[projectname]_default`, Compose looks for a network called `my-pre-existing-network` and connect your app's containers to it.


### PR DESCRIPTION
The already given criteria wasn't working. After experimentation, it was found that the way I proposed is the actual way we can use an already existing network in Docker Compose.

### Proposed changes
## In 'Use a pre-existing network' section
networks:
   my-pre-existing-network:
         external: true

<!--Tell us what you did and why-->
##Earlier, the mentioned steps were: 
networks:
  default:
    external:
      name: my-pre-existing-network

## Check here: https://docs.docker.com/compose/networking/#use-a-pre-existing-network
## This doesn't work. So, I tried and found out that actual way should be as such:
networks:
   my-pre-existing-network:
         external: true

