### PR TITLE
Add 'pid' options to docker-compose docs

### DIFF
--- a/compose/compose-file/index.md
+++ b/compose/compose-file/index.md
@@ -1509,6 +1509,8 @@ container and the host operating system the PID address space.  Containers
 launched with this flag can access and manipulate other
 containers in the bare-metal machine's namespace and vice versa.
 
+> **Note**: It is possible to join PID namespace of another service or container by using `pid: "service:name` or `pid: "container:name-or-hash"`
+
 ### ports
 
 Expose ports.


### PR DESCRIPTION
### Proposed changes

* Document feature described in Docker Engine docs https://docs.docker.com/engine/reference/run/#pid-settings---pid
* Document usage of "service" keyword for `pid`.

### Related issues (optional)

https://github.com/docker/compose/pull/4930/