### PR TITLE
Clarify COMPOSE_PROJECT_NAME actually defaults to empty string

### DIFF
--- a/compose/reference/envvars.md
+++ b/compose/reference/envvars.md
@@ -19,8 +19,9 @@ the container on start up. For example, if your project name is `myapp` and it
 includes two services `db` and `web`, then Compose starts containers named
 `myapp_db_1` and `myapp_web_1` respectively.
 
-Setting this is optional. If you do not set this, the `COMPOSE_PROJECT_NAME`
-defaults to the `basename` of the project directory. See also the `-p`
+Setting this is optional. If you do not set this, then Compose will 
+default to using the `basename` of the project directory, and `COMPOSE_PROJECT_NAME`
+defaults to an empty string. See also the `-p`
 [command-line option](overview.md).
 
 ## COMPOSE\_FILE


### PR DESCRIPTION
If you do not explicitly set COMPOSE_PROJECT_NAME, it defaults to empty string. Anyone writing a docker-compose.yml file cannot expect the environment variable to default to what Compose will default to (the current wording on the doc page incorrectly says the environment variable will default to what Compose defaults to).

For example, if you refer to COMPOSE_PROJECT_NAME with out actually setting it, Compose prints this message:
```docker-compose build
WARNING: The COMPOSE_PROJECT_NAME variable is not set. Defaulting to a blank string.
```

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    DO NOT edit files and directories listed in _data/not_edited_here.yaml.
    These are maintained in upstream repos and changes here will be lost.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

Clarify that the environment variable COMPOSE_PROJECT_NAME will not default to anything other than an empty string. 

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
