### PR TITLE
Update go example in examples.md

### DIFF
--- a/develop/sdk/examples.md
+++ b/develop/sdk/examples.md
@@ -244,7 +244,7 @@ func main() {
 		panic(err)
 	}
 
-	containers, err := cli.ContainerList(context.Background(), types.ContainerListOptions{})
+	containers, err := cli.ContainerList(ctx, types.ContainerListOptions{})
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
### Proposed changes
Fixed a go api example - ctx was declared but not used as in other examples so it threw an error.  I changed the code to match the other examples