### PR TITLE
Document compatibility option environment variable

### DIFF
--- a/compose/reference/envvars.md
+++ b/compose/reference/envvars.md
@@ -115,6 +115,11 @@ and `exec` operations. This option is not available on Windows where the CLI
 is required for the aforementioned operations.
 Supported: `true` or `1` to enable, `false` or `0` to disable.
 
+## COMPOSE\_COMPATIBILITY
+
+If set, Compose will attempt to convert keys in v3 files to their non-Swarm equivalent.
+Supported: `true` or `1` to enable, `false` or `0` to disable.
+
 ## Related information
 
 - [User guide](/compose/index.md)


### PR DESCRIPTION

### Proposed changes
Document the new `COMPOSE_COMPATIBILITY` environment variable.

### Related issues (optional)
https://github.com/docker/compose/issues/7026
https://github.com/docker/compose/pull/7027
