### PR TITLE
Add unlinked Wordpress example to Samples homepage

### DIFF
--- a/samples/index.md
+++ b/samples/index.md
@@ -37,6 +37,7 @@ Run popular software using Docker.
 | [PostgreSQL](/engine/examples/postgresql_service/) | Run a Dockerized PostgreSQL instance. |
 | [Rails + PostgreSQL](/compose/rails/) | Run a Dockerized Rails + PostgreSQL environment. |
 | [Riak](/engine/examples/running_riak_service/) | Run a Dockerized Riak instance. |
+| [Wordpress](compose/wordpress/) | Run a Dockerized Wordpress environment. |
 | [SSHd](/engine/examples/running_ssh_service/) | Run a Dockerized SSHd instance. |
 
 ## Library references


### PR DESCRIPTION
### Proposed changes

The [Wordpress example](https://docs.docker.com/compose/wordpress/) is linked from [samples-for-compose](https://docs.docker.com/compose/samples-for-compose/), along with the [Django](https://docs.docker.com/compose/django/) and [Rails](https://docs.docker.com/compose/rails/) examples, but it is not listed in this proposed-edited [Samples](https://docs.docker.com/samples/) home page, unlike those other two examples which are listed.   This is inconsistent, and can make that example harder to find.

Also the Wordpress example lacks the left sidebar navigation, which this change hopefully fixes as well.

### Related issues (optional)

Not very related, but looks like this Wordpress example could use a review for content---or simply closing of a dangling open issue about its content: https://github.com/docker/docker.github.io/issues/7630
