### PR TITLE
Removed legacy --links from Compose overview

### DIFF
--- a/compose/index.md
+++ b/compose/index.md
@@ -30,7 +30,7 @@ so they can be run together in an isolated environment.
 
 A `docker-compose.yml` looks like this:
 
-    version: '3'
+    version: "3.7"
     services:
       web:
         build: .
@@ -38,13 +38,18 @@ A `docker-compose.yml` looks like this:
         - "5000:5000"
         volumes:
         - .:/code
-        - logvolume01:/var/log
-        links:
-        - redis
-      redis:
-        image: redis
+        - data-volume:/var/lib/db
+      db:
+        image: db
+        volumes:
+          - data-volume:/var/lib/db
+      backup:
+        image: backup-service
+        volumes:
+          - data-volume:/var/lib/backup/data
+
     volumes:
-      logvolume01: {}
+      data-volume:
 
 For more information about the Compose file, see the
 [Compose file reference](compose-file/index.md).


### PR DESCRIPTION
### Proposed changes

Fixes https://github.com/docker/docker.github.io/issues/9992

The sample `docker-compose.yml` in the [Overview of Docker Compose](https://docs.docker.com/compose/)---which seems to be a fictitious example (i.e., it is not runnable since it refers to a non-provided Dockerfile)---is replaced with a different fictitious example that does not use the legacy `links:` feature, yet still demonstrates basic features of Docker Compose such as having multiple services, explicit parameters (eg ports), and shared volumes.

(The new example is combined from the previous example and the sample volumes example [here](https://docs.docker.com/compose/compose-file/#volume-configuration-reference)).