### PR TITLE
Update ASP.NET Core samples to use version 3.1

### DIFF
--- a/compose/aspnet-mssql-compose.md
+++ b/compose/aspnet-mssql-compose.md
@@ -44,13 +44,13 @@ configure this app to use our SQL Server database, and then create a
 
     ```dockerfile
     FROM mcr.microsoft.com/dotnet/core/sdk:3.1
-    RUN ["dotnet", "tool", "install", "--global", "dotnet-ef"]
+    RUN dotnet tool install --global dotnet-ef
     ENV PATH "~/.dotnet/tools/:$PATH"
     COPY . /app
     WORKDIR /app
-    RUN ["dotnet", "restore"]
-    RUN ["dotnet", "build"]
-    RUN ["dotnet", "ef", "migrations", "add", "InitialCreate"]
+    RUN dotnet restore
+    RUN dotnet build
+    RUN dotnet ef migrations add InitialCreate
     EXPOSE 80/tcp
     RUN chmod +x ./entrypoint.sh
     CMD /bin/bash ./entrypoint.sh

--- a/engine/examples/dotnetcore.md
+++ b/engine/examples/dotnetcore.md
@@ -41,7 +41,7 @@ Windows](/docker-for-windows/). Read more on [switching containers](/docker-for-
    the `Dockerfile` to use the DLL file of your project.
 
 ```dockerfile
-FROM mcr.microsoft.com/dotnet/core/sdk:2.2 AS build-env
+FROM mcr.microsoft.com/dotnet/core/sdk:3.1 AS build-env
 WORKDIR /app
 
 # Copy csproj and restore as distinct layers
@@ -53,7 +53,7 @@ COPY . ./
 RUN dotnet publish -c Release -o out
 
 # Build runtime image
-FROM mcr.microsoft.com/dotnet/core/aspnet:2.2
+FROM mcr.microsoft.com/dotnet/core/aspnet:3.1
 WORKDIR /app
 COPY --from=build-env /app/out .
 ENTRYPOINT ["dotnet", "aspnetapp.dll"]


### PR DESCRIPTION
Updates the documentation for ASP.NET Core samples so that they are based on .NET Core 3.1.  At its most basic, this involves just referencing the 3.1 image tags.  But since there were breaking changes from 2.x to 3.x, the instructions needed to be updated to account for those changes.