### PR TITLE
Docs: document DNS server IP address 127.0.0.11

### DIFF
--- a/config/containers/container-networking.md
+++ b/config/containers/container-networking.md
@@ -67,6 +67,8 @@ settings on a per-container basis.
 | `--dns-opt`    | A key-value pair representing a DNS option and its value. See your operating system's documentation for `resolv.conf` for valid options.                                                                                                                            |
 | `--hostname`   | The hostname a container uses for itself. Defaults to the container's ID if not specified.                                                                                                                                                                          |
 
+> **Note**: The DNS server is always at `127.0.0.11`.
+
 ## Proxy server
 
 If your container needs to use a proxy server, see


### PR DESCRIPTION
### Proposed changes

The DNS server IP address `127.0.0.11` is missing in the current docs while still working as expected. It was present in the 17.09 docs (https://docs.docker.com/v17.09/engine/userguide/networking/configure-dns/), so probably just missed out during docs restructuring?

### Related issues

2017 issue and fix about the same:

* https://github.com/docker/docker.github.io/issues/1969
* https://github.com/docker/docker.github.io/pull/2822
