### PR TITLE
UseDualstack feature for registry s3 storage driver

### DIFF
--- a/registry/storage-drivers/s3.md
+++ b/registry/storage-drivers/s3.md
@@ -165,6 +165,16 @@ Amazon S3 or S3 compatible services for object storage.
       endpoint on a bucket before using this option. A boolean value. The default is <code>false</code>.
     </td>
   </tr>
+  <tr>
+    <td>
+      <code>usedualstack
+    </td>
+    <td>
+      no
+    </td>
+    <td>
+      Use the dualstack endpoint to connect to S3 via IPv6 or IPv4. A boolean value. The default is <code>false</code>.
+    </td>
 </table>
 
 
@@ -198,6 +208,8 @@ Amazon S3 or S3 compatible services for object storage.
 `storageclass`: (optional) The storage class applied to each registry file. Defaults to STANDARD. Valid options are STANDARD and REDUCED_REDUNDANCY.
 
 `s3accelerate`: (optional) Whether you would like to use accelerate endpoint for communication with S3. You must enable acceleration on a bucket before using this option. See https://docs.aws.amazon.com/AmazonS3/latest/dev/transfer-acceleration.html on how to use enable option.
+
+`usedualstack`: (optional) Whether you would like to connect to Amazon S3 via the dualstack endpoint. This should only be provided if you are using Amazon S3 and would like to utilize the dualstack endpoint for IPv6 and IPv4 connections. Defaults to `false` if not specified. See [Making Requests to Amazon S3 over IPv6](https://docs.aws.amazon.com/AmazonS3/latest/dev/ipv6-access.html) for more information.
 
 ## S3 permission scopes
 


### PR DESCRIPTION
### Proposed changes

Add `usedualstack` as an option for the s3 storage driver.
This allows the registry to operate in IPv6 environments on AWS.

### Unreleased project version (optional)

docker/distribution v2.8.0 (or version after 2.7.1)

### Related issues (optional)

Documents docker/distribution#3067, with implementation docker/distribution#3068
