### PR TITLE
Add information about supported Storage Account Types

### DIFF
--- a/registry/storage-drivers/azure.md
+++ b/registry/storage-drivers/azure.md
@@ -6,7 +6,14 @@ title: Microsoft Azure storage driver
 
 {% include registry.md %}
 
-An implementation of the `storagedriver.StorageDriver` interface which uses [Microsoft Azure Blob Storage](https://azure.microsoft.com/en-us/services/storage/) for object storage.
+An implementation of the `storagedriver.StorageDriver` interface which uses
+[Microsoft Azure Blob Storage](https://azure.microsoft.com/en-us/services/storage/) for object
+storage.
+The objects are uploaded as Block Blobs, which are available when using a
+Storage Account of type `StorageV2` and the `Standard` performance tier
+(see
+[Azure Storage Account Overview](https://docs.microsoft.com/en-us/azure/storage/common/storage-account-overview)
+for reference).
 
 ## Parameters
 

--- a/registry/storage-drivers/azure.md
+++ b/registry/storage-drivers/azure.md
@@ -7,12 +7,11 @@ title: Microsoft Azure storage driver
 {% include registry.md %}
 
 An implementation of the `storagedriver.StorageDriver` interface which uses
-[Microsoft Azure Blob Storage](https://azure.microsoft.com/en-us/services/storage/) for object
-storage.
+[Microsoft Azure Blob Storage](https://azure.microsoft.com/en-us/products/storage/blobs/)
+for object storage.
 The objects are uploaded as Block Blobs, which are available when using a
 Storage Account of type `StorageV2` and the `Standard` performance tier
-(see
-[Azure Storage Account Overview](https://docs.microsoft.com/en-us/azure/storage/common/storage-account-overview)
+(see [Azure Storage Account Overview](https://learn.microsoft.com/en-us/azure/storage/common/storage-account-overview)
 for reference).
 
 ## Parameters
@@ -21,13 +20,12 @@ for reference).
 |:--------------|:---------|:--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `accountname` | yes      | Name of the Azure Storage Account.                                                                                                                                                                                                                                  |
 | `accountkey`  | yes      | Primary or Secondary Key for the Storage Account.                                                                                                                                                                                                                   |
-| `container`   | yes      | Name of the Azure root storage container in which all registry data is stored. Must comply the storage container name [requirements](https://docs.microsoft.com/rest/api/storageservices/fileservices/naming-and-referencing-containers--blobs--and-metadata). For example, if your url is `https://myaccount.blob.core.windows.net/myblob` use the container value of `myblob`.|
+| `container`   | yes      | Name of the Azure root storage container in which all registry data is stored. Must comply the storage container name [requirements](https://learn.microsoft.com/en-us/rest/api/storageservices/naming-and-referencing-containers--blobs--and-metadata). For example, if your url is `https://myaccount.blob.core.windows.net/myblob` use the container value of `myblob`.|
 | `realm`       | no       | Domain name suffix for the Storage Service API endpoint. For example realm for "Azure in China" would be `core.chinacloudapi.cn` and realm for "Azure Government" would be `core.usgovcloudapi.net`. By default, this is `core.windows.net`.                        |
 
 
 ## Related information
 
-* To get information about
-[azure-blob-storage](https://azure.microsoft.com/en-us/services/storage/), visit
-the Microsoft website.
-* You can use Microsoft's [Blob Service REST API](https://docs.microsoft.com/en-us/rest/api/storageservices/Blob-Service-REST-API) to [create a storage container](https://docs.microsoft.com/en-us/rest/api/storageservices/Create-Container).
+* To get information about [azure-blob-storage](https://azure.microsoft.com/en-us/products/storage/blobs/),
+visit the Microsoft website.
+* You can use Microsoft's [Blob Service REST API](https://learn.microsoft.com/en-us/rest/api/storageservices/Blob-Service-REST-API) to [create a storage container](https://learn.microsoft.com/en-us/rest/api/storageservices/Create-Container).


### PR DESCRIPTION
Only specific storage account types are currently supported by docker/distribution.

### Proposed changes

The documentation for the Azure storage driver currently doesn't specify that only specific storage account types that support block blobs are supported. This PR fixes that.