### PR TITLE
Clarify healthcheck CMD-SHELL command

### DIFF
--- a/compose/compose-file/index.md
+++ b/compose/compose-file/index.md
@@ -1174,7 +1174,7 @@ healthcheck:
 file format.
 
 `test` must be either a string or a list. If it's a list, the first item must be
-either `NONE`, `CMD` or `CMD-SHELL`. If it's a string, it's equivalent to
+either `NONE` or `CMD`. If it's a string, it's equivalent to
 specifying `CMD-SHELL` followed by that string.
 
 ```yaml


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    DO NOT edit files and directories listed in _data/not_edited_here.yaml.
    These are maintained in upstream repos and changes here will be lost.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes
With the current description, it is not clear that for example setting this array as test
test: ["CMD-SHELL", "curl -s -X GET http://127.0.0.1:5000/actuator/health", "|", "grep 'UP'"]

would result in executing the first (curl) command only to evaluate the status. (more details https://stackoverflow.com/questions/59269073/docker-swarm-stack-file-healthcheck-command-does-not-work-as-expected/59390396#59390396)
It is not clear because it is said that `test must be either a string or a list. If it’s a list, the first item must be either NONE, CMD or CMD-SHELL` - so it does not make sense to use CMD-SHELL with a list.
<!--Tell us what you did and why-->

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
