### PR TITLE
Update the trust sandbox documentation to use theupdateframework/notary images

### DIFF
--- a/engine/security/trust/trust_sandbox.md
+++ b/engine/security/trust/trust_sandbox.md
@@ -357,21 +357,23 @@ data. Then, you try and pull it.
         $ docker-compose exec registry sh
         root@65084fc6f047:/#
 
-3. List the layers for the `test/trusttest` image you pushed:
+3. Navigate to the docker registry folder.
 
-        root@65084fc6f047:/# ls -l /var/lib/registry/docker/registry/v2/repositories/test/trusttest/_layers/sha256
+        / # cd /var/lib/registry/docker/registry/v2/
+
+4. List the layers for the `test/trusttest` image you pushed:
+
+        /var/lib/registry/docker/registry/v2/ # ls -l repositories/test/trusttest/_layers/sha256
         total 12
-        drwxr-xr-x 2 root root 4096 Jun 10 17:26 a3ed95caeb02ffe68cdd9fd84406680ae93d633cb16422d00e8a7c22955b46d4
-        drwxr-xr-x 2 root root 4096 Jun 10 17:26 aac0c133338db2b18ff054943cee3267fe50c75cdee969aed88b1992539ed042
-        drwxr-xr-x 2 root root 4096 Jun 10 17:26 cc7629d1331a7362b5e5126beb5bf15ca0bf67eb41eab994c719a45de53255cd
-
-4. Change into the registry storage for one of those layers (this is in a different directory):
-
-        root@65084fc6f047:/# cd /var/lib/registry/docker/registry/v2/blobs/sha256/aa/aac0c133338db2b18ff054943cee3267fe50c75cdee969aed88b1992539ed042
+        drwxr-xr-x    2 root     root          4096 Dec 23 15:24 4f4fb700ef54461cfa02571ae0db9a0dc1e0cdb5577484a6d75e68dc38e8acc1
+        drwxr-xr-x    2 root     root          4096 Dec 23 15:24 cc7629d1331a7362b5e5126beb5bf15ca0bf67eb41eab994c719a45de53255cd
+        drwxr-xr-x    2 root     root          4096 Dec 23 15:24 fbe94c69c9b964ffe67daa6e1654ab4f1db1dc14decc30f7c03ae43284cfa72
 
 5. Add malicious data to one of the `trusttest` layers:
 
-        root@65084fc6f047:/# echo "Malicious data" > data
+        root@65084fc6f047:/# vi blobs/sha256/cc/cc7629d1331a7362b5e5126beb5bf15ca0bf67eb41eab994c719a45de53255cd/data
+
+    Change some date in for example the command and save the file.
 
 6. Go back to your `trustsandbox` terminal.
 
@@ -401,12 +403,11 @@ data. Then, you try and pull it.
 
         / # docker pull registry:5000/test/trusttest
         Using default tag: latest
-        Pull (1 of 1): registry:5000/test/trusttest:latest@sha256:35d5bc26fd358da8320c137784fe590d8fcf9417263ef261653e8e1c7f15672e
-        sha256:35d5bc26fd358da8320c137784fe590d8fcf9417263ef261653e8e1c7f15672e: Pulling from test/trusttest
-
-        aac0c133338d: Retrying in 5 seconds
-        a3ed95caeb02: Download complete
-        error pulling image configuration: unexpected EOF
+        Pull (1 of 1): registry:5000/test/trusttest:latest@sha256:7034d197b82fcb07299fda8b05c91d1601ce64f31bc102b1345d03a2953d210a
+        sha256:7034d197b82fcb07299fda8b05c91d1601ce64f31bc102b1345d03a2953d210a: Pulling from test/trusttest
+        fbe94c69c9b9: Downloading [>                                                  ]  36.41kB/2.296MB
+        4f4fb700ef54: Download complete
+        error pulling image configuration: image config verification failed for digest sha256:cc7629d1331a7362b5e5126beb5bf15ca0bf67eb41eab994c719a45de53255cd
 
       The pull did not complete because the trust system couldn't verify the
       image.

--- a/engine/security/trust/trust_sandbox.md
+++ b/engine/security/trust/trust_sandbox.md
@@ -330,41 +330,52 @@ Now, pull some images from within the `sandbox` container.
         Status: Downloaded newer image for registry:5000/test/trusttest@sha256:ebf59c538accdf160ef435f1a19938ab8c0d6bd96aef8d4ddd1b379edf15a926
         Tagging registry:5000/test/trusttest@sha256:ebf59c538accdf160ef435f1a19938ab8c0d6bd96aef8d4ddd1b379edf15a926 as registry:5000/test/trusttest:latest
 
+8. Inspect the Docker Trust data for the image
+
+        / # docker trust inspect --pretty registry:5000/test/trusttest
+        Signatures for registry:5000/test/trusttest
+
+        SIGNED TAG          DIGEST                                                             SIGNERS
+        latest              7034d197b82fcb07299fda8b05c91d1601ce64f31bc102b1345d03a2953d210a   (Repo Admin)
+
+        Administrative keys for registry:5000/test/trusttest
+
+        Repository Key: 0c0015a8db104e0138de5af72171100c38df1245c21c2ac1068abb2db6326287
+        Root Key:       6ac70a9c3e844f90a74eed5605a2d00ed9bdb3af75813d8fadb338d4c063e442
+
 ### Test with malicious images
 
 What happens when data is corrupted and you try to pull it when trust is
 enabled? In this section, you go into the `registry` and tamper with some
 data. Then, you try and pull it.
 
-1.  Leave the `sandbox` shell and container running.
+1. Leave the `sandbox` shell and container running.
 
-2.  Open a new interactive terminal from your host, and obtain a shell into the
+2. Open a new interactive terminal from your host, and obtain a shell into the
     `registry` container.
 
         $ docker-compose exec registry sh
         root@65084fc6f047:/#
 
-3.  List the layers for the `test/trusttest` image you pushed:
+3. List the layers for the `test/trusttest` image you pushed:
 
-    ```bash
-    root@65084fc6f047:/# ls -l /var/lib/registry/docker/registry/v2/repositories/test/trusttest/_layers/sha256
-    total 12
-    drwxr-xr-x 2 root root 4096 Jun 10 17:26 a3ed95caeb02ffe68cdd9fd84406680ae93d633cb16422d00e8a7c22955b46d4
-    drwxr-xr-x 2 root root 4096 Jun 10 17:26 aac0c133338db2b18ff054943cee3267fe50c75cdee969aed88b1992539ed042
-    drwxr-xr-x 2 root root 4096 Jun 10 17:26 cc7629d1331a7362b5e5126beb5bf15ca0bf67eb41eab994c719a45de53255cd
-    ```
+        root@65084fc6f047:/# ls -l /var/lib/registry/docker/registry/v2/repositories/test/trusttest/_layers/sha256
+        total 12
+        drwxr-xr-x 2 root root 4096 Jun 10 17:26 a3ed95caeb02ffe68cdd9fd84406680ae93d633cb16422d00e8a7c22955b46d4
+        drwxr-xr-x 2 root root 4096 Jun 10 17:26 aac0c133338db2b18ff054943cee3267fe50c75cdee969aed88b1992539ed042
+        drwxr-xr-x 2 root root 4096 Jun 10 17:26 cc7629d1331a7362b5e5126beb5bf15ca0bf67eb41eab994c719a45de53255cd
 
-4.  Change into the registry storage for one of those layers (this is in a different directory):
+4. Change into the registry storage for one of those layers (this is in a different directory):
 
         root@65084fc6f047:/# cd /var/lib/registry/docker/registry/v2/blobs/sha256/aa/aac0c133338db2b18ff054943cee3267fe50c75cdee969aed88b1992539ed042
 
-5.  Add malicious data to one of the `trusttest` layers:
+5. Add malicious data to one of the `trusttest` layers:
 
         root@65084fc6f047:/# echo "Malicious data" > data
 
-6.  Go back to your `trustsandbox` terminal.
+6. Go back to your `trustsandbox` terminal.
 
-7.  List the `trusttest` image.
+7. List the `trusttest` image.
 
         / # docker image ls | grep trusttest
         REPOSITORY                     TAG                 IMAGE ID            CREATED             SIZE
@@ -372,7 +383,7 @@ data. Then, you try and pull it.
         registry:5000/test/trusttest   latest              cc7629d1331a        11 months ago       5.025 MB
         registry:5000/test/trusttest   <none>              cc7629d1331a        11 months ago       5.025 MB
 
-8.  Remove the `trusttest:latest` image from our local cache.
+8. Remove the `trusttest:latest` image from our local cache.
 
         / # docker image rm -f cc7629d1331a
         Untagged: docker/trusttest:latest
@@ -386,7 +397,7 @@ data. Then, you try and pull it.
     Docker to attempt to download the tampered image from the registry and reject
     it because it is invalid.
 
-8.  Pull the image again. This downloads the image from the registry, because we don't have it cached.
+9. Pull the image again. This downloads the image from the registry, because we don't have it cached.
 
         / # docker pull registry:5000/test/trusttest
         Using default tag: latest


### PR DESCRIPTION
Update the trust sandbox docker-compose setup to be on par with latest notary images

### Proposed changes

I have updated the docker security trustsandbox documentation to use the actively developed notary server. The current example shows deprecation notices and isn't representative to what users would be using today.


