### PR TITLE
Remove $ from Ubuntu install code examples

### DIFF
--- a/install/linux/docker-ce/ubuntu.md
+++ b/install/linux/docker-ce/ubuntu.md
@@ -46,7 +46,7 @@ Older versions of Docker were called `docker`, `docker.io`, or `docker-engine`.
 If these are installed, uninstall them:
 
 ```bash
-$ sudo apt-get remove docker docker-engine docker.io containerd runc
+sudo apt-get remove docker docker-engine docker.io containerd runc
 ```
 
 It's OK if `apt-get` reports that none of these packages are installed.
@@ -95,13 +95,13 @@ from the repository.
 1.  Update the `apt` package index:
 
     ```bash
-    $ sudo apt-get update
+    sudo apt-get update
     ```
 
 2.  Install packages to allow `apt` to use a repository over HTTPS:
 
     ```bash
-    $ sudo apt-get install \
+    sudo apt-get install \
         apt-transport-https \
         ca-certificates \
         curl \
@@ -112,7 +112,7 @@ from the repository.
 3.  Add Docker's official GPG key:
 
     ```bash
-    $ curl -fsSL {{ download-url-base }}/gpg | sudo apt-key add -
+    curl -fsSL {{ download-url-base }}/gpg | sudo apt-key add -
     ```
 
     Verify that you now have the key with the fingerprint
@@ -120,7 +120,7 @@ from the repository.
     last 8 characters of the fingerprint.
 
     ```bash
-    $ sudo apt-key fingerprint 0EBFCD88
+    sudo apt-key fingerprint 0EBFCD88
     
     pub   rsa4096 2017-02-22 [SCEA]
           9DC8 5822 9FC7 DD38 854A  E2D8 8D81 803C 0EBF CD88
@@ -151,7 +151,7 @@ from the repository.
     <div id="x86_64_repo" class="tab-pane fade in active" markdown="1">
 
     ```bash
-    $ sudo add-apt-repository \
+    sudo add-apt-repository \
        "deb [arch=amd64] {{ download-url-base }} \
        $(lsb_release -cs) \
        stable"
@@ -161,7 +161,7 @@ from the repository.
     <div id="armhf_repo" class="tab-pane fade" markdown="1">
 
     ```bash
-    $ sudo add-apt-repository \
+    sudo add-apt-repository \
        "deb [arch=armhf] {{ download-url-base }} \
        $(lsb_release -cs) \
        stable"
@@ -171,7 +171,7 @@ from the repository.
     <div id="arm64_repo" class="tab-pane fade" markdown="1">
 
     ```bash
-    $ sudo add-apt-repository \
+    sudo add-apt-repository \
        "deb [arch=arm64] {{ download-url-base }} \
        $(lsb_release -cs) \
        stable"
@@ -181,7 +181,7 @@ from the repository.
     <div id="ppc64le_repo" class="tab-pane fade" markdown="1">
 
     ```bash
-    $ sudo add-apt-repository \
+    sudo add-apt-repository \
        "deb [arch=ppc64el] {{ download-url-base }} \
        $(lsb_release -cs) \
        stable"
@@ -191,7 +191,7 @@ from the repository.
     <div id="s390x_repo" class="tab-pane fade" markdown="1">
 
     ```bash
-    $ sudo add-apt-repository \
+    sudo add-apt-repository \
        "deb [arch=s390x] {{ download-url-base }} \
        $(lsb_release -cs) \
        stable"
@@ -205,13 +205,13 @@ from the repository.
 1.  Update the `apt` package index.
 
     ```bash
-    $ sudo apt-get update
+    sudo apt-get update
     ```
 
 2.  Install the _latest version_ of Docker Engine - Community and containerd, or go to the next step to install a specific version:
 
     ```bash
-    $ sudo apt-get install docker-ce docker-ce-cli containerd.io
+    sudo apt-get install docker-ce docker-ce-cli containerd.io
     ```
 
     > Got multiple Docker repositories?
@@ -226,7 +226,7 @@ from the repository.
     a. List the versions available in your repo:
 
     ```bash
-    $ apt-cache madison docker-ce
+    apt-cache madison docker-ce
 
       docker-ce | 5:18.09.1~3-0~ubuntu-xenial | {{ download-url-base }}  xenial/stable amd64 Packages
       docker-ce | 5:18.09.0~3-0~ubuntu-xenial | {{ download-url-base }}  xenial/stable amd64 Packages
@@ -239,14 +239,14 @@ from the repository.
        for example, `5:18.09.1~3-0~ubuntu-xenial`.
 
     ```bash
-    $ sudo apt-get install docker-ce=<VERSION_STRING> docker-ce-cli=<VERSION_STRING> containerd.io
+    sudo apt-get install docker-ce=<VERSION_STRING> docker-ce-cli=<VERSION_STRING> containerd.io
     ```
 
 4.  Verify that Docker Engine - Community is installed correctly by running the `hello-world`
     image.
 
     ```bash
-    $ sudo docker run hello-world
+    sudo docker run hello-world
     ```
 
     This command downloads a test image and runs it in a container. When the
@@ -283,7 +283,7 @@ a new file each time you want to upgrade Docker.
     the Docker package.
 
     ```bash
-    $ sudo dpkg -i /path/to/package.deb
+    sudo dpkg -i /path/to/package.deb
     ```
 
     The Docker daemon starts automatically.
@@ -292,7 +292,7 @@ a new file each time you want to upgrade Docker.
     image.
 
     ```bash
-    $ sudo docker run hello-world
+    sudo docker run hello-world
     ```
 
     This command downloads a test image and runs it in a container. When the
@@ -316,7 +316,7 @@ To upgrade Docker Engine - Community, download the newer package file and repeat
 1.  Uninstall the Docker Engine - Community package:
 
     ```bash
-    $ sudo apt-get purge docker-ce
+    sudo apt-get purge docker-ce
     ```
 
 2.  Images, containers, volumes, or customized configuration files on your host
@@ -324,7 +324,7 @@ To upgrade Docker Engine - Community, download the newer package file and repeat
     volumes:
 
     ```bash
-    $ sudo rm -rf /var/lib/docker
+    sudo rm -rf /var/lib/docker
     ```
 
 You must delete any edited configuration files manually.


### PR DESCRIPTION
Currently, you can't just copy an entire code snippet and paste because the $ prevents the command from executing successfully. This requires precise cursor control to only select the text after `$`.

Removing the `$` from code snippets fixes this.

Starting with changes to a single file to get feedback, but I would love to see this should be done for all docs.