### PR TITLE
Fix formula for quorum majority

### DIFF
--- a/engine/swarm/raft.md
+++ b/engine/swarm/raft.md
@@ -22,7 +22,7 @@ do require special care. They ensure that the cluster state stays consistent
 in the presence of failures by requiring a majority of nodes to agree on values.
 
 Raft tolerates up to `(N-1)/2` failures and requires a majority or quorum of
-`(N/2)+1` members to agree on values proposed to the cluster. This means that in
+`(N+1)/2` members to agree on values proposed to the cluster. This means that in
 a cluster of 5 Managers running Raft, if 3 nodes are unavailable, the system
 cannot process any more requests to schedule additional tasks. The existing
 tasks keep running but the scheduler cannot rebalance tasks to


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    DO NOT edit files and directories listed in _data/not_edited_here.yaml.
    These are maintained in upstream repos and changes here will be lost.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

Formula for majority needed for quorum seems to be wrong. Substracting (N-1)/2 (tolerated failures) from N gives (N+1)/2. Not (N/2)+1.

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

https://github.com/hashicorp/consul/pull/7286/files
