### PR TITLE
SDK: Address issues when installing with go modules

### DIFF
--- a/engine/api/sdk/index.md
+++ b/engine/api/sdk/index.md
@@ -24,6 +24,8 @@ installed and coexist together.
 
 ```bash
 go get github.com/docker/docker/client
+# OR, with go modules:
+go get github.com/docker/docker/client@v19.03.7
 ```
 
 The client requires a recent version of Go. Run `go version` and ensure that you 


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    DO NOT edit files and directories listed in _data/not_edited_here.yaml.
    These are maintained in upstream repos and changes here will be lost.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes
As discussed in moby/moby#39302 (specifically https://github.com/moby/moby/issues/39302#issuecomment-539764357),  the Go SDK is difficult to integrate in a Go Modules project. The recent releases of moby/moby, which docker/docker redirects to, are not compliant with semantic versioning due to incorrect formatting (e.g. v13.**0**3.7 instead of v13.3.7). This causes Go to only recognize outdated releases.

As a result, running `go get github.com/docker/docker/client` in a Go Modules environment installs the outdated 1.13.1 version, which cannot run any of the examples at https://docs.docker.com/engine/api/sdk/examples/.

The Moby maintainers say that setting up correct versioning for the repository will take time. In the meanwhile, they advise to update the documentation to address the issue (https://github.com/moby/moby/issues/39302#issuecomment-513977026).

The current solution is to install the SDK with a specific tag - `go get github.com/docker/docker/client@v19.03.7`. I added this line to the installation instructions. This is not optimal, since it specifies a version number which will also become outdated eventually. I'm new to this project, so there might be a better way to do this.

### Related issues
Closes #9536, #9126, #7609.
<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
