### PR TITLE
Expand networks.*.driver_opts compose file example

### DIFF
--- a/compose/compose-file/index.md
+++ b/compose/compose-file/index.md
@@ -2411,9 +2411,12 @@ network. Those options are driver-dependent - consult the driver's
 documentation for more information. Optional.
 
 ```yaml
-driver_opts:
-  foo: "bar"
-  baz: 1
+networks:
+  mynet1:
+    driver_opts:
+      foo: "bar"
+      baz: 1
+      encrypted: ""
 ```
 
 ### attachable


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    DO NOT edit files and directories listed in _data/not_edited_here.yaml.
    These are maintained in upstream repos and changes here will be lost.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->
How do I set metadata?

### Proposed changes

I wanted to show where driver_opts would go in the file not just scoped to the network.

I also wanted to include an example of how to set --opt encrypted.

### Related issues (optional)

Helps with moby/moby#30865 a little.