### PR TITLE
Update Go SDK examples

### DIFF
--- a/engine/api/sdk/examples.md
+++ b/engine/api/sdk/examples.md
@@ -52,7 +52,7 @@ import (
 
 func main() {
 	ctx := context.Background()
-	cli, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
+	cli, err := client.NewEnvClient()
 	if err != nil {
 		panic(err)
 	}
@@ -76,13 +76,9 @@ func main() {
 		panic(err)
 	}
 
-	statusCh, errCh := cli.ContainerWait(ctx, resp.ID, container.WaitConditionNotRunning)
-	select {
-	case err := <-errCh:
-		if err != nil {
-			panic(err)
-		}
-	case <-statusCh:
+	_, err := client.ContainerWait(ctx, resp.ID)
+	if err != nil {
+		panic(err)
 	}
 
 	out, err := cli.ContainerLogs(ctx, resp.ID, types.ContainerLogsOptions{ShowStdout: true})
@@ -157,7 +153,7 @@ import (
 
 func main() {
 	ctx := context.Background()
-	cli, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
+	cli, err := client.NewEnvClient()
 	if err != nil {
 		panic(err)
 	}
@@ -240,7 +236,7 @@ import (
 
 func main() {
 	ctx := context.Background()
-	cli, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
+	cli, err := client.NewEnvClient()
 	if err != nil {
 		panic(err)
 	}
@@ -316,7 +312,7 @@ import (
 
 func main() {
 	ctx := context.Background()
-	cli, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
+	cli, err := client.NewEnvClient()
 	if err != nil {
 		panic(err)
 	}
@@ -397,7 +393,7 @@ import (
 
 func main() {
 	ctx := context.Background()
-	cli, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
+	cli, err := client.NewEnvClient()
 	if err != nil {
 		panic(err)
 	}
@@ -466,7 +462,7 @@ import (
 
 func main() {
 	ctx := context.Background()
-	cli, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
+	cli, err := client.NewEnvClient()
 	if err != nil {
 		panic(err)
 	}
@@ -537,7 +533,7 @@ import (
 
 func main() {
 	ctx := context.Background()
-	cli, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
+	cli, err := client.NewEnvClient()
 	if err != nil {
 		panic(err)
 	}
@@ -613,7 +609,7 @@ import (
 
 func main() {
 	ctx := context.Background()
-	cli, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
+	cli, err := client.NewEnvClient()
 	if err != nil {
 		panic(err)
 	}
@@ -710,7 +706,7 @@ import (
 
 func main() {
 	ctx := context.Background()
-	cli, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
+	cli, err := client.NewEnvClient()
 	if err != nil {
 		panic(err)
 	}
@@ -727,13 +723,9 @@ func main() {
 		panic(err)
 	}
 
-	statusCh, errCh := cli.ContainerWait(ctx, createResp.ID, container.WaitConditionNotRunning)
-	select {
-	case err := <-errCh:
-		if err != nil {
-			panic(err)
-		}
-	case <-statusCh:
+	_, err := cli.ContainerWait(ctx, createResp.ID)
+	if err != nil {
+		panic(err)
 	}
 
 	commitResp, err := cli.ContainerCommit(ctx, createResp.ID, types.ContainerCommitOptions{Reference: "helloworld"})


### PR DESCRIPTION
### Proposed changes
This PR proposes several Go SDK example changes. The latest version of the Golang Docker client (v1.13.1) includes several changes that are not reflected in the Docker docs:
1. `client.NewClientWithOpts` is no longer available;
2. `client.ContainerWait` no longer returns `(<-chan container.ContainerWaitOKBody, <-chan error)`. Rather, it returns `(int64, error)`.

This motivate the following changes:
1. Update the **Run a container** section to use `client.NewEnvClient()` and the new `ContainerWait` return values;
2. Update **Run a container in the background** to use `client.NewEnvClient()`;
3. Update **List and manage containers** to use `client.NewEnvClient()`;
4. Update **Stop all running containers** to use `client.NewEnvClient()`;
5. Update **Print the logs of a specific container** to use `client.NewEnvClient()`;
6. Update **List all images** to use `client.NewEnvClient()`;
7. Update **Pull an image** to use `client.NewEnvClient()`;
8. Update **Pull an image with authentication** to use `client.NewEnvClient()`;
9. Update **Commit a container** to use `client.NewEnvClient()` and the new `ContainerWait` return values.

These changes are consistent with the latest versions of the client package, which can be found [here](https://pkg.go.dev/github.com/docker/docker/client?tab=doc).

Changes can be seen [on Netlify](https://deploy-preview-10631--docsdocker.netlify.com/engine/api/sdk/examples/#run-a-container).

### Unreleased project version (optional)

### Related issues (optional)

I have used the Docker docs "Edit this page" option - no issue to link.
