### PR TITLE
mirror.md: Add another gotcha

### DIFF
--- a/registry/recipes/mirror.md
+++ b/registry/recipes/mirror.md
@@ -22,10 +22,12 @@ simply pull them manually and push them to a simple, local, private registry.
 Furthermore, if your images are all built in-house, not using the Hub at all and
 relying entirely on your local registry is the simplest scenario.
 
-### Gotcha
+### Gotchas
 
-It's currently not possible to mirror another private registry. Only the central
-Hub can be mirrored.
+* It's currently not possible to mirror another private registry. Only the central
+  Hub can be mirrored.
+* If a registry is configured as a registry mirror, you can no longer push images
+  to the registry.
 
 ### Solution
 


### PR DESCRIPTION
### Proposed changes
Add another gotcha

### Details
I discovered this the hard way, after trying to get pushing to a pull-through registry working for a few hours... :smile: This is actually documented here: https://docs.docker.com/registry/configuration/#proxy

Perhaps it makes sense to mention it here as well.

----

As a slightly (un)related side note, are there any suggested workarounds to this? I tried for a while by setting up a separate read-only/read-write registry (using different host names, proxying the traffic via nginx) to be able to solve another problem related to the pull-through cache (authentication-related; because of https://github.com/moby/moby/issues/30880 I am trying to allow unauthenticated `pull` but require auth for `docker push` commands). 

[...]

I ended up getting this working. It's fine for our use case where the number of people pushing updates images is very limited, but there still seems like there would be some room for improvement here.
