### PR TITLE
Try to clear blocking/non-blocking text on `--log-driver`

### DIFF
--- a/config/containers/logging/configure.md
+++ b/config/containers/logging/configure.md
@@ -106,14 +106,14 @@ driver:
 * non-blocking delivery that stores log messages in an intermediate per-container
   ring buffer for consumption by driver
 
-The `non-blocking` message delivery mode prevents applications from blocking due
+The `non-blocking` message delivery mode _prevents blocking_ of applications due
 to logging back pressure. Applications are likely to fail in unexpected ways when
-STDERR or STDOUT streams block.
+STDERR or STDOUT streams are blocked.
 
 > **WARNING**
-> When the buffer is full and a new message is enqueued, the oldest message in
-> memory is dropped.  Dropping messages is often preferred to blocking the
-> log-writing process of an application.
+> In `non-blocking` mode, when the buffer is full and a new message is enqueued, 
+> the oldest message in memory is dropped. Dropping messages is often preferred 
+> to blocking the log-writing process of an application.
 {: .warning}
 
 The `mode` log option controls whether to use the `blocking` (default) or


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    DO NOT edit files and directories listed in _data/not_edited_here.yaml.
    These are maintained in upstream repos and changes here will be lost.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

The section about logging options `blocking`/`non-blocking` _mode_ was a bit confusing
by having those values entangled to the meaning of _blocking_ an application.

I did not change the terms used, but I tried to rearrange them -- and explicitly add the
_mode_ it is being talked about in the _warning_ box.

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
