### PR TITLE
Update the version and change the RDBMS as described in the example for Rails.

### DIFF
--- a/compose/rails.md
+++ b/compose/rails.md
@@ -5,7 +5,7 @@ title: "Quickstart: Compose and Rails"
 ---
 
 This Quickstart guide shows you how to use Docker Compose to set up and run
-a Rails/PostgreSQL app. Before starting, [install Compose](install.md).
+a Rails/MySQL app. Before starting, [install Compose](install.md).
 
 ### Define the project
 
@@ -13,8 +13,11 @@ a Rails/PostgreSQL app. Before starting, [install Compose](install.md).
 Start by setting up the files needed to build the app. The app will run inside a Docker container containing its dependencies. Defining dependencies is done using a file called `Dockerfile`. To begin with, the 
 Dockerfile consists of:
 
-    FROM ruby:2.5
-    RUN apt-get update -qq && apt-get install -y nodejs postgresql-client
+    FROM ruby:2.7
+    RUN apt-get update -qq && apt-get install -y curl apt-transport-https wget nodejs default-mysql-client
+    RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
+      echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list && \
+      apt-get update -qq && apt-get install -y yarn
     RUN mkdir /myapp
     WORKDIR /myapp
     COPY Gemfile /myapp/Gemfile
@@ -40,7 +43,7 @@ Next, create a bootstrap `Gemfile` which just loads Rails. It'll be overwritten
 in a moment by `rails new`.
 
     source 'https://rubygems.org'
-    gem 'rails', '~>5'
+    gem 'rails', '~>6.0.0'
 
 Create an empty `Gemfile.lock` to build our `Dockerfile`.
 
@@ -62,22 +65,41 @@ rm -f /myapp/tmp/pids/server.pid
 exec "$@"
 ```
 
+Create a `.env` file.
+Describe what you want to set as environment variables, and set them to the `docker-compose.yml`.
+Used by containers by referring to them in an `emvironment` or by specifying them in an `env_file` if you will be able to.
+Please refer to [this page](https://docs.docker.com/compose/environment-variables/) for details on how to set the environment variables.
+
+    DB_ROOT_PASSWORD=mysql_root_password
+    DB_USER=myapp
+    DB_PASSWORD=myapp_password
+    DB_PORT=3306
+
+
 Finally, `docker-compose.yml` is where the magic happens. This file describes
 the services that comprise your app (a database and a web app), how to get each
-one's Docker image (the database just runs on a pre-made PostgreSQL image, and
+one's Docker image (the database just runs on a pre-made MySQL8.0 image, and
 the web app is built from the current directory), and the configuration needed
 to link them together and expose the web app's port.
 
     version: '3'
     services:
       db:
-        image: postgres
+        image: mysql:8.0
         volumes:
-          - ./tmp/db:/var/lib/postgresql/data
+          - db-data:/var/lib/mysql
         environment:
-          POSTGRES_PASSWORD: password
+          - MYSQL_ROOT_PASSWORD=${DB_ROOT_PASSWORD}
+          - MYSQL_USER=${DB_USER}
+          - MYSQL_PASSWORD=${DB_PASSWORD}
+        volumes:
+          - db-data:/var/lib/mysql
+        command: --default-authentication-plugin=mysql_native_password
+        ports:
+          - ${DB_PORT}:3306
       web:
         build: .
+        env_file: .env
         command: bash -c "rm -f tmp/pids/server.pid && bundle exec rails s -p 3000 -b '0.0.0.0'"
         volumes:
           - .:/myapp
@@ -85,6 +107,8 @@ to link them together and expose the web app's port.
           - "3000:3000"
         depends_on:
           - db
+    volumes:
+      db-data:
 
 >**Tip**: You can use either a `.yml` or `.yaml` extension for this file.
 
@@ -93,7 +117,7 @@ to link them together and expose the web app's port.
 With those files in place, you can now generate the Rails skeleton app
 using [docker-compose run](reference/run.md):
 
-    docker-compose run web rails new . --force --no-deps --database=postgresql
+    docker-compose run web rails new . --force --no-deps --database=mysql --webpacker --skip-test
 
 First, Compose builds the image for the `web` service using the
 `Dockerfile`. Then it runs `rails new` inside a new container, using that
@@ -102,27 +126,38 @@ image. Once it's done, you should have generated a fresh app.
 List the files.
 
 ```bash
-$ ls -l
-total 64
--rw-r--r--   1 vmb  staff   222 Jun  7 12:05 Dockerfile
--rw-r--r--   1 vmb  staff  1738 Jun  7 12:09 Gemfile
--rw-r--r--   1 vmb  staff  4297 Jun  7 12:09 Gemfile.lock
--rw-r--r--   1 vmb  staff   374 Jun  7 12:09 README.md
--rw-r--r--   1 vmb  staff   227 Jun  7 12:09 Rakefile
-drwxr-xr-x  10 vmb  staff   340 Jun  7 12:09 app
-drwxr-xr-x   8 vmb  staff   272 Jun  7 12:09 bin
-drwxr-xr-x  14 vmb  staff   476 Jun  7 12:09 config
--rw-r--r--   1 vmb  staff   130 Jun  7 12:09 config.ru
-drwxr-xr-x   3 vmb  staff   102 Jun  7 12:09 db
--rw-r--r--   1 vmb  staff   211 Jun  7 12:06 docker-compose.yml
--rw-r--r--   1 vmb  staff   184 Jun  7 12:08 entrypoint.sh
-drwxr-xr-x   4 vmb  staff   136 Jun  7 12:09 lib
-drwxr-xr-x   3 vmb  staff   102 Jun  7 12:09 log
--rw-r--r--   1 vmb  staff    63 Jun  7 12:09 package.json
-drwxr-xr-x   9 vmb  staff   306 Jun  7 12:09 public
-drwxr-xr-x   9 vmb  staff   306 Jun  7 12:09 test
-drwxr-xr-x   4 vmb  staff   136 Jun  7 12:09 tmp
-drwxr-xr-x   3 vmb  staff   102 Jun  7 12:09 vendor
+$ ls -la
+total 776
+drwxr-xr-x   30 vmb  staff     960  6 14 17:21 ./
+drwxr-xr-x   15 vmb  staff     480  6 14 17:07 ../
+-rw-r--r--    1 vmb  staff       9  6 14 17:19 .browserslistrc
+-rw-r--r--    1 vmb  staff      91  6 14 17:07 .env
+drwxr-xr-x   13 vmb  staff     416  6 14 17:14 .git/
+-rw-r--r--    1 vmb  staff     771  6 14 17:19 .gitignore
+-rw-r--r--    1 vmb  staff      11  6 14 17:14 .ruby-version
+-rw-r--r--    1 vmb  staff     823  6 14 17:07 Dockerfile
+-rw-r--r--    1 vmb  staff    1726  6 14 17:14 Gemfile
+-rw-r--r--    1 vmb  staff    4858  6 14 17:19 Gemfile.lock
+-rw-r--r--    1 vmb  staff     374  6 14 17:14 README.md
+-rw-r--r--    1 vmb  staff     227  6 14 17:14 Rakefile
+drwxr-xr-x   11 vmb  staff     352  6 14 17:14 app/
+-rw-r--r--    1 vmb  staff    1722  6 14 17:19 babel.config.js
+drwxr-xr-x   10 vmb  staff     320  6 14 17:19 bin/
+drwxr-xr-x   18 vmb  staff     576  6 14 17:19 config/
+-rw-r--r--    1 vmb  staff     130  6 14 17:14 config.ru
+drwxr-xr-x    3 vmb  staff      96  6 14 17:14 db/
+-rw-r--r--    1 vmb  staff     581  6 14 17:07 docker-compose.yml
+-rw-r--r--    1 vmb  staff     202  6 14 17:07 entrypoint.sh
+drwxr-xr-x    4 vmb  staff     128  6 14 17:14 lib/
+drwxr-xr-x    4 vmb  staff     128  6 14 17:19 log/
+drwxr-xr-x  775 vmb  staff   24800  6 14 18:17 node_modules/
+-rw-r--r--    1 vmb  staff     314  6 14 18:17 package.json
+-rw-r--r--    1 vmb  staff     224  6 14 17:19 postcss.config.js
+drwxr-xr-x    9 vmb  staff     288  6 14 17:14 public/
+drwxr-xr-x    3 vmb  staff      96  6 14 17:14 storage/
+drwxr-xr-x    7 vmb  staff     224  6 14 17:19 tmp/
+drwxr-xr-x    3 vmb  staff      96  6 14 17:14 vendor/
+-rw-r--r--    1 vmb  staff  329959  6 14 18:17 yarn.lock
 ```
 
 If you are running Docker on Linux, the files `rails new` created are owned by
@@ -154,51 +189,59 @@ Replace the contents of `config/database.yml` with the following:
 
 ```none
 default: &default
-  adapter: postgresql
-  encoding: unicode
+  adapter: mysql2
+  encoding: utf8mb4
+  pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
+  username: <%= ENV['DB_USER'] %>
+  password: <%= ENV['DB_PASSWORD'] %>
   host: db
-  username: postgres
-  password: password
-  pool: 5
 
 development:
   <<: *default
   database: myapp_development
 
-
 test:
   <<: *default
   database: myapp_test
+
+production:
+  <<: *default
+  database: myapp_production
+  username: myapp
+  password: <%= ENV['MYAPP_DATABASE_PASSWORD'] %>
 ```
 
 You can now boot the app with [docker-compose up](reference/up.md):
 
     docker-compose up
 
-If all's well, you should see some PostgreSQL output.
+If all's well, you should see some MySQL output.
 
 ```bash
-rails_db_1 is up-to-date
-Creating rails_web_1 ... done
-Attaching to rails_db_1, rails_web_1
-db_1   | PostgreSQL init process complete; ready for start up.
-db_1   |
-db_1   | 2018-03-21 20:18:37.437 UTC [1] LOG:  listening on IPv4 address "0.0.0.0", port 5432
-db_1   | 2018-03-21 20:18:37.437 UTC [1] LOG:  listening on IPv6 address "::", port 5432
-db_1   | 2018-03-21 20:18:37.443 UTC [1] LOG:  listening on Unix socket "/var/run/postgresql/.s.PGSQL.5432"
-db_1   | 2018-03-21 20:18:37.726 UTC [55] LOG:  database system was shut down at 2018-03-21 20:18:37 UTC
-db_1   | 2018-03-21 20:18:37.772 UTC [1] LOG:  database system is ready to accept connections
+...
+db_1   | 2020-06-14T08:13:37.437475Z 0 [System] [MY-010116] [Server] /usr/sbin/mysqld (mysqld 8.0.20) starting as process 1
+db_1   | 2020-06-14T08:13:37.468468Z 1 [System] [MY-013576] [InnoDB] InnoDB initialization has started.
+db_1   | 2020-06-14T08:13:37.926219Z 1 [System] [MY-013577] [InnoDB] InnoDB initialization has ended.
+db_1   | 2020-06-14T08:13:38.144866Z 0 [System] [MY-011323] [Server] X Plugin ready for connections. Socket: '/var/run/mysqld/mysqlx.sock' bind-address: '::' port: 33060
+db_1   | 2020-06-14T08:13:38.272678Z 0 [Warning] [MY-010068] [Server] CA certificate ca.pem is self signed.
+db_1   | 2020-06-14T08:13:38.277202Z 0 [Warning] [MY-011810] [Server] Insecure configuration for --pid-file: Location '/var/run/mysqld' in the path is accessible to all OS users. Consider choosing a different directory.
+db_1   | 2020-06-14T08:13:38.314726Z 0 [System] [MY-010931] [Server] /usr/sbin/mysqld: ready for connections. Version: '8.0.20'  socket: '/var/run/mysqld/mysqld.sock'  port: 3306  MySQL Community Server - GPL.
 ```
+
+Grant privileges to the MySQL user created by `.env`.
+
+    docker-compose exec db mysql -uroot -p -e"GRANT ALL PRIVILEGES ON *.* TO 'myapp'@'%';FLUSH PRIVILEGES;"
+    Enter password:
 
 Finally, you need to create the database. In another terminal, run:
 
-    docker-compose run web rake db:create
+    docker-compose run web rails db:create
 
 Here is an example of the output from that command:
 
 ```none
 vmb at snapair in ~/sandbox/rails
-$ docker-compose run web rake db:create
+$ docker-compose run web rails db:create
 Starting rails_db_1 ... done
 Created database 'myapp_development'
 Created database 'myapp_test'
@@ -273,3 +316,4 @@ host.
 - [Get started with WordPress](wordpress.md)
 - [Command line reference](reference/index.md)
 - [Compose file reference](compose-file/index.md)
+- [Environment variables in Compose](environment-variables.md)


### PR DESCRIPTION
### Proposed changes
Update versions of Ruby on Rails and change the Database from PostgreSQL to Change to MySQL 8.0.

Because
* Ruby2.5+Rails5 is old.
* There are more users of MySQL than PostgreSQL.
* There wasn't much information on building Rails+MySQL 8.0 with Docker.