### PR TITLE
Update Quickstart for Rails and PostgreSQL

### DIFF
--- a/compose/rails.md
+++ b/compose/rails.md
@@ -26,7 +26,6 @@ Dockerfile consists of:
     COPY entrypoint.sh /usr/bin/
     RUN chmod +x /usr/bin/entrypoint.sh
     ENTRYPOINT ["entrypoint.sh"]
-    EXPOSE 3000
 
     # Start the main process.
     CMD ["rails", "server", "-b", "0.0.0.0"]

--- a/compose/rails.md
+++ b/compose/rails.md
@@ -73,8 +73,6 @@ version: "{{ site.compose_file_v3 }}"
 services:
   db:
     image: postgres
-    volumes:
-      - ./tmp/db:/var/lib/postgresql/data
     environment:
       POSTGRES_PASSWORD: password
   web:

--- a/compose/rails.md
+++ b/compose/rails.md
@@ -14,7 +14,7 @@ Start by setting up the files needed to build the app. The app will run inside a
 Dockerfile consists of:
 
     FROM ruby:2.5
-    RUN apt-get update -qq && apt-get install -y nodejs postgresql-client
+    RUN apt-get update -qq && apt-get install -y nodejs
     RUN mkdir /myapp
     WORKDIR /myapp
     COPY Gemfile /myapp/Gemfile

--- a/compose/rails.md
+++ b/compose/rails.md
@@ -79,7 +79,6 @@ services:
       POSTGRES_PASSWORD: password
   web:
     build: .
-    command: bash -c "rm -f tmp/pids/server.pid && bundle exec rails s -p 3000 -b '0.0.0.0'"
     volumes:
       - .:/myapp
     ports:


### PR DESCRIPTION
### Proposed changes

- Fix command to suppress to run db container
- Remove command configuration
- Remove volume configuration
- Remove EXPOSE instruction
- Specify both the major and minor numbers
- Remove postgresql-client from apt-get install

#### Fix command to suppress to run db container

--no-deps is option for not rail but docker-compose.
This command doesn't suppress to run db container.

cf. [docker-compose run | Docker Documentation](https://docs.docker.com/compose/reference/run/)

#### Remove command configuration

Since its operations are already included in built image.
By the way, the path tmp/pids/server.pid is not correct.
The correct path is /myapp/tmp/pids/server.pid .

#### Remove volume configuration

Since this setting is not required for Quickstart.
If it requires database state,
it should not remove container but stop it.
When restart container, data is kept by the benefit of docker volume.
Or, almost programming language can define test data by code
and reproduce it by using fixture library like factory_bot.

#### Remove EXPOSE instruction

Since this is Quickstart.
Quickstart should let readers to focus on their first goal.

cf. [You aren't gonna need it - Wikipedia](https://en.wikipedia.org/wiki/You_aren%27t_gonna_need_it)

#### Specify both the major and minor numbers

Specify both the major and minor numbers Compose file version.
If no minor version is given, 0 is used by default
and not the latest minor version.
This behavior will confuse beginners
and it has possibility for a beginner
to mistake the wrong way for the right way.

cf. [v2 and v3 Declaration | Compose file versions and upgrading | Docker Documentation](https://docs.docker.com/compose/compose-file/compose-versioning/#v2-and-v3-declaration)

#### Remove postgresql-client from apt-get install

Since this is not required to run Rails in base image ruby:2.5 .