### PR TITLE
Compatibility with newest CLI syntax

### DIFF
--- a/develop/develop-images/dockerfile_best-practices.md
+++ b/develop/develop-images/dockerfile_best-practices.md
@@ -59,12 +59,12 @@ stateless fashion.
 
 ### Understand build context
 
-When you issue a `docker build` command, the current working directory is called
-the _build context_. By default, the Dockerfile is assumed to be located here,
-but you can specify a different location with the file flag (`-f`). Regardless
-of where the `Dockerfile` actually lives, all recursive contents of files and
-directories in the current directory are sent to the Docker daemon as the build
-context.
+When you issue a `docker image build` command, the current working directory is
+called the _build context_. By default, the Dockerfile is assumed to be located
+here, but you can specify a different location with the file flag (`-f`).
+Regardless of where the `Dockerfile` actually lives, all recursive contents of
+files and directories in the current directory are sent to the Docker daemon as
+the build context.
 
 > Build context example
 >
@@ -240,7 +240,7 @@ EOF
 > When building an image using a remote Git repository as build context, Docker 
 > performs a `git clone` of the repository on the local machine, and sends
 > those files as build context to the daemon. This feature requires `git` to be
-> installed on the host where you run the `docker build` command.
+> installed on the host where you run the `docker image build` command.
 
 ### Exclude with .dockerignore
 
@@ -274,7 +274,7 @@ A Dockerfile for a Go application could look like:
 FROM golang:1.11-alpine AS build
 
 # Install tools required for project
-# Run `docker build --no-cache .` to update dependencies
+# Run `docker image build --no-cache .` to update dependencies
 RUN apk add --no-cache git
 RUN go get github.com/golang/dep/cmd/dep
 
@@ -363,7 +363,7 @@ examined, Docker looks for an existing image in its cache that it can reuse,
 rather than creating a new (duplicate) image.
 
 If you do not want to use the cache at all, you can use the `--no-cache=true`
-option on the `docker build` command. However, if you do let Docker use its
+option on the `docker image build` command. However, if you do let Docker use its
 cache, it is important to understand when it can, and cannot, find a matching
 image. The basic rules that Docker follows are outlined below:
 
@@ -604,11 +604,11 @@ for any service-based image.
 In most other cases, `CMD` should be given an interactive shell, such as bash,
 python and perl. For example, `CMD ["perl", "-de0"]`, `CMD ["python"]`, or `CMD
 ["php", "-a"]`. Using this form means that when you execute something like
-`docker run -it python`, you’ll get dropped into a usable shell, ready to go.
-`CMD` should rarely be used in the manner of `CMD ["param", "param"]` in
-conjunction with [`ENTRYPOINT`](../../engine/reference/builder.md#entrypoint), unless
-you and your expected users are already quite familiar with how `ENTRYPOINT`
-works.
+`docker container run -it python`, you’ll get dropped into a usable shell, ready
+to go. `CMD` should rarely be used in the manner of `CMD ["param", "param"]` in
+conjunction with [`ENTRYPOINT`](../../engine/reference/builder.md#entrypoint),
+unless you and your expected users are already quite familiar with how
+`ENTRYPOINT` works.
 
 ### EXPOSE
 
@@ -620,8 +620,8 @@ your application. For example, an image containing the Apache web server would
 use `EXPOSE 80`, while an image containing MongoDB would use `EXPOSE 27017` and
 so on.
 
-For external access, your users can execute `docker run` with a flag indicating
-how to map the specified port to the port of their choice.
+For external access, your users can execute `docker container run` with a flag
+indicating how to map the specified port to the port of their choice.
 For container linking, Docker provides environment variables for the path from
 the recipient container back to the source (ie, `MYSQL_PORT_3306_TCP`).
 
@@ -673,10 +673,10 @@ mark
 To prevent this, and really unset the environment variable, use a `RUN` command
 with shell commands, to set, use, and unset the variable all in a single layer.
 You can separate your commands with `;` or `&&`. If you use the second method,
-and one of the commands fails, the `docker build` also fails. This is usually a
-good idea. Using `\` as a line continuation character for Linux Dockerfiles
-improves readability. You could also put all of the commands into a shell script
-and have the `RUN` command just run that shell script.
+and one of the commands fails, the `docker image build` also fails. This is
+usually a good idea. Using `\` as a line continuation character for Linux
+Dockerfiles improves readability. You could also put all of the commands into a
+shell script and have the `RUN` command just run that shell script.
 
 ```dockerfile
 FROM alpine
@@ -921,4 +921,3 @@ These Official Images have exemplary `Dockerfile`s:
 * [More about Base Images](baseimages.md)
 * [More about Automated Builds](../../docker-hub/builds/index.md)
 * [Guidelines for Creating Official Images](../../docker-hub/official_images.md)
-


### PR DESCRIPTION
Maintain compatibility with documentation for [`docker image build`](https://docs.docker.com/engine/reference/commandline/image_build/) and [`docker container run`](https://docs.docker.com/engine/reference/commandline/container_run/).
Should I reference the oldest CLI version (something like _newest for_ `docker build` and _newest for_ `docker run`), respectively?

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    DO NOT edit files and directories listed in _data/not_edited_here.yaml.
    These are maintained in upstream repos and changes here will be lost.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

<!--Tell us what you did and why-->

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
