### PR TITLE
Follow Docker Machine 0.16.2 release

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -26,7 +26,7 @@ docker_ce_version: "19.03"
 compose_version: "1.27.4"
 compose_file_v3: "3.8"
 compose_file_v2: "2.4"
-machine_version: "0.16.0"
+machine_version: "0.16.2"
 distribution_version: "2.7"
 
 collections:

--- a/_config_authoring.yml
+++ b/_config_authoring.yml
@@ -24,7 +24,7 @@ docker_ce_version: "19.03"
 compose_version: "1.27.4"
 compose_file_v3: "3.8"
 compose_file_v2: "2.4"
-machine_version: "0.16.0"
+machine_version: "0.16.2"
 distribution_version: "2.7"
 
 collections:


### PR DESCRIPTION
0.16.2 was released last month but the internal version was not bumped.
As a result the links in the install section still referenced 0.16.0.

### Proposed changes

Update the Docker Machine version to match the latest release.