### PR TITLE
Added a label to the search field for accessibility reasons - body-landing.html

### DIFF
--- a/_includes/body-landing.html
+++ b/_includes/body-landing.html
@@ -53,7 +53,7 @@
     <div class="row justify-content-center">
       <div class="col-xs-12 text-center">
         <h2>
-          What can we help you find?
+          <label for="st-search-input"> What can we help you find?</label>
         </h2>
       </div>
     </div>


### PR DESCRIPTION
I was auditing docs.docker.com using chrome's [Lighthouse](https://developers.google.com/web/tools/lighthouse) and it pointed out the following issue:

> Form elements do not have associated labels
Labels ensure that form controls are announced properly by assistive technologies, like screen readers. [Learn more](https://web.dev/label/).
Failing Elements
input#st-search-input.form-control


This ensures that people with accessibility needs ( Like folk using screen readers ) are not excluded from the docker docs.



