### PR TITLE
Added the aria-label to the search bar to improve accessibility

### DIFF
--- a/_includes/navigation.html
+++ b/_includes/navigation.html
@@ -5,7 +5,7 @@
 </div>
 <div class="search-form" id="search-div">
     <form class="search-form form-inline ng-pristine ng-valid" id="searchForm" action="/search/">
-        <input class="search-field form-control ds-input" id="st-search-input" value="" name="q" placeholder="Search the docs" type="search" autocomplete="off" spellcheck="false" dir="auto" style="position: relative; vertical-align: top;">
+        <input class="search-field form-control ds-input" id="st-search-input" value="" name="q" placeholder="Search the docs" type="search" autocomplete="off" spellcheck="false" dir="auto" style="position: relative; vertical-align: top;" aria-label="Search the docs">
         <div id="autocompleteContainer">
             <div id="autocompleteResults"></div>
         </div>


### PR DESCRIPTION
I found one more accessibility issue flagged by [Google Lighthouse](https://developers.google.com/web/tools/lighthouse) .

Lighthouse said 

> Form elements do not have associated labels
Labels ensure that form controls are announced properly by assistive technologies, like screen readers. Learn more.
Failing Elements
input#st-search-input.search-field.form-control.ds-input
 
This issue was flagged when I ran lighthouse  on : https://docs.docker.com/get-started/

One of the potential fixed to this issue it to add a [aria-label](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-label_attribute) and hence I have added it to the searchbar to enable people on screen readers to access docker docs more effectively.
