### PR TITLE
Include ipv6 flag in dual-stack macvlan IPv4/IPv6 network

### DIFF
--- a/network/macvlan.md
+++ b/network/macvlan.md
@@ -98,7 +98,7 @@ If you have [configured the Docker daemon to allow IPv6](../config/daemon/ipv6.m
 you can use dual-stack IPv4/IPv6 `macvlan` networks.
 
 ```bash
-$ docker network create -d macvlan \
+$ docker network create --ipv6 -d macvlan \
     --subnet=192.168.216.0/24 --subnet=192.168.218.0/24 \
     --gateway=192.168.216.1 --gateway=192.168.218.1 \
     --subnet=2001:db8:abc8::/64 --gateway=2001:db8:abc8::10 \


### PR DESCRIPTION
Hello,
I just spent several hours trying to debug why my macvlan network wasn't working with ipv6 connectivity.
Turns out, I needed the `--ipv6` flag in the `docker network create` command.
It would be nice if the documentation indicated that this flag was needed.

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

Add `--ipv6` flag to the example command to create a dual-stack IPv4/IPv6 `macvlan` network.
