### PR TITLE
storage/index.md: bind mounts must use absolute paths

### DIFF
--- a/storage/index.md
+++ b/storage/index.md
@@ -78,8 +78,8 @@ mounts is to think about where the data lives on the Docker host.
 - **[Bind mounts](bind-mounts.md)**: Available since the early days of Docker.
   Bind mounts have limited functionality compared to volumes. When you use a
   bind mount, a file or directory on the _host machine_ is mounted into a
-  container. The file or directory is referenced by its full path on the host
-  machine. The file or directory does not need to exist on the Docker host
+  container. The file or directory must be referenced by its full path on the host
+  machine, or else it will silently fail. The file or directory does not need to exist on the Docker host
   already. It is created on demand if it does not yet exist. Bind mounts are
   very performant, but they rely on the host machine's filesystem having a
   specific directory structure available. If you are developing new Docker


### PR DESCRIPTION
### Proposed changes

<!--Tell us what you did and why-->
Clarified that bind mounts *must* use absolute paths, else they will silently "fail" (have unexpected behavior).  The language in the existing docs is not strong enough.

### Related issues (optional)

Related to:
https://github.com/moby/moby/issues/4830#issuecomment-404242401
https://github.com/docker/cli/issues/1203
