### PR TITLE
Update bulletinboard image

### DIFF
--- a/get-started/kube-deploy.md
+++ b/get-started/kube-deploy.md
@@ -44,7 +44,7 @@ All containers in Kubernetes are scheduled as _pods_, which are groups of co-loc
         spec:
           containers:
           - name: bb-site
-            image: bulletinboard:1.0
+            image: bulletinboard/bulletinboard:1.0
     ---
     apiVersion: v1
     kind: Service


### PR DESCRIPTION
Update image to bulletinboard/bulletinboard:1.0

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

If you use the image in the yaml file you'll receive:
```
Failed to pull image "bulletinboard:1.0": rpc error: code = Unknown desc = Error response from daemon: pull access denied for bulletinboard, repository does not exist or may require 'docker login': denied: requested access to the resource is denied
```
The proper image appears to be located at https://hub.docker.com/r/bulletinboard/bulletinboard/tags?page=1&ordering=last_updated.

We would need to use `bulletinboard/bulletinboard:1.0` instead of `bulletinboard:1.0` since this implies `library/bulletinboard:1.0` which doesn't exist.

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
