### PR TITLE
Compose > Compose-file > 'extra_hosts' > buildtime/runtime documentation

### DIFF
--- a/compose/compose-file/compose-file-v3.md
+++ b/compose/compose-file/compose-file-v3.md
@@ -1220,15 +1220,30 @@ external_links:
 
 ### extra_hosts
 
-Add hostname mappings. Use the same values as the docker client `--add-host` parameter.
+This property uses the same values as the docker client `--add-host` parameter.
+
+Add runtime hostname mappings (available at container lifetime).
 
 ```yaml
-extra_hosts:
-  - "somehost:162.242.195.82"
-  - "otherhost:50.31.209.229"
+services:
+  custom_service:
+    extra_hosts:
+      - somehost:162.242.195.82
+      - otherhost:50.31.209.229
 ```
 
-An entry with the ip address and hostname is created in `/etc/hosts` inside containers for this service, e.g:
+Add buildtime hostname mappings (available at docker image build).
+
+```yaml
+services:
+  custom_service:
+    build:
+      extra_hosts:
+        - somehost:162.242.195.82
+        - otherhost:50.31.209.229
+```
+
+An entry with the IP address and hostname is created in `/etc/hosts` inside containers for this service (buildtime or runtime), e.g:
 
 ```console
 162.242.195.82  somehost


### PR DESCRIPTION
Problem:
Incomplete documentation for 'extra_hosts'.

Description:
Added documentation for 'extra_hosts', which can be specified separately for buildtime as well as runtime.

Related:
  * https://github.com/docker/compose/issues/5282
  * https://github.com/docker/compose/issues/6355

Path:
```
/compose/compose-file/compose-file-v3/#extra_hosts
```
