### PR TITLE
Update awslogs.md

### DIFF
--- a/config/containers/logging/awslogs.md
+++ b/config/containers/logging/awslogs.md
@@ -204,7 +204,6 @@ The following `strftime` codes are supported:
 | `%p` | AM or PM.                                                        | AM       |
 | `%M` | Minute as a zero-padded decimal number.                          | 57       |
 | `%S` | Second as a zero-padded decimal number.                          | 04       |
-| `%L` | Milliseconds as a zero-padded decimal number.                    | .123     |
 | `%f` | Microseconds as a zero-padded decimal number.                    | 000345   |
 | `%z` | UTC offset in the form +HHMM or -HHMM.                           | +1300    |
 | `%Z` | Time zone name.                                                  | PST      |


### PR DESCRIPTION
### Proposed changes
Need to remove confusing docs line.
According to https://strftime.org/ and https://docs.python.org/3/library/datetime.html#strftime-and-strptime-format-codes `%L`  (Milliseconds as a zero-padded decimal number) is not supported in awslogs-datetime-format now. Tested in AWS - using `%L` breaks the parsing.
