### PR TITLE
Change aspnet:3.1 to aspnet:5.0 in first code example

### DIFF
--- a/samples/dotnetcore.md
+++ b/samples/dotnetcore.md
@@ -59,7 +59,7 @@ COPY ../engine/examples ./
 RUN dotnet publish -c Release -o out
 
 # Build runtime image
-FROM mcr.microsoft.com/dotnet/aspnet:3.1
+FROM mcr.microsoft.com/dotnet/aspnet:5.0
 WORKDIR /app
 COPY --from=build-env /app/out .
 ENTRYPOINT ["dotnet", "aspnetapp.dll"]


### PR DESCRIPTION
The first code example was still referencing aspnet:3.1. This PR changes it to aspnet:5.0 to match the sdk version used as well as the runtime version used in later code examples.

### Proposed changes

Change the runtime image layer in the first code example from 3.1 to 5.0 in order to match with the rest of the page.

