### PR TITLE
Update prometheus.md

### DIFF
--- a/config/daemon/prometheus.md
+++ b/config/daemon/prometheus.md
@@ -36,7 +36,7 @@ If the file is currently empty, paste the following:
 
 ```json
 {
-  "metrics-addr" : "127.0.0.1:9323",
+  "metrics-addr" : "0.0.0.0:9323",
   "experimental" : true
 }
 ```
@@ -111,7 +111,7 @@ scrape_configs:
          # scheme defaults to 'http'.
 
     static_configs:
-      - targets: ['localhost:9323']
+      - targets: ['<docker0 inet address>:9323']
 ```
 
 </div><!-- linux -->
@@ -240,7 +240,7 @@ PS C:\> docker service create --replicas 1 --name my-prometheus
 </div><!-- windows -->
 </div><!-- tabs -->
 
-Verify that the Docker target is listed at http://localhost:9090/targets/.
+Verify that the Docker target is listed at http://127.0.0.1:9090/targets/.
 
 ![Prometheus targets page](images/prometheus-targets.png)
 


### PR DESCRIPTION
Discussed in the [StackOverFlow](https://stackoverflow.com/questions/53202260/cant-collect-docker-metrics-using-prometheus), I couldn't get docker endpoint metrics on Ubuntu 20.04 (with `"metrics-addr" : "127.0.0.1:9323"` on `/etc/docker/daemon.json`, `- targets: ['localhost:9323']` on `prometheus.yml`, `http://localhost:9090/targets/` on url). By default, a docker container cannot access via localhost, can it? So if it is true, I think that we should use `127.0.0.1` insted of `localhost`.