### PR TITLE
Update 06_bind_mounts.md

### DIFF
--- a/get-started/06_bind_mounts.md
+++ b/get-started/06_bind_mounts.md
@@ -46,7 +46,7 @@ So, let's do it!
     docker run -dp 3000:3000 \
         -w /app -v "$(pwd):/app" \
         node:12-alpine \
-        sh -c "yarn install && yarn run dev"
+        sh -c "apk add --no-cache python g++ make && yarn install && yarn run dev"
     ```
 
     If you are using PowerShell then use this command:
@@ -55,7 +55,7 @@ So, let's do it!
     docker run -dp 3000:3000 `
         -w /app -v "$(pwd):/app" `
         node:12-alpine `
-        sh -c "yarn install && yarn run dev"
+        sh -c "apk add --no-cache python g++ make && yarn install && yarn run dev"
     ```
 
     - `-dp 3000:3000` - same as before. Run in detached (background) mode and create a port mapping


### PR DESCRIPTION
### Proposed changes

This script crashing on 4th step, with error:
`error /app/node_modules/sqlite3: Command failed.
Exit code: 1
Command: node-pre-gyp install --fallback-to-build
Arguments: 
Directory: /app/node_modules/sqlite3`

```
You need to install the latest version of Python.
gyp ERR! find Python Node-gyp should be able to find and use Python.

```

Because docker image alpine hasn`t installed python and g++
On previous step in this Guides (https://docs.docker.com/get-started/02_our_app/) you used the command to preinstall python and g++ before calling "yarn install && yarn run ..."


### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

