### PR TITLE
Mention about use of `|` or `&&` in one's commands

### DIFF
--- a/compose/compose-file/compose-file-v3.md
+++ b/compose/compose-file/compose-file-v3.md
@@ -450,6 +450,14 @@ The command can also be a list, in a manner similar to
 command: ["bundle", "exec", "thin", "-p", "3000"]
 ```
 
+> Note when using pipes (`|`) or `&&` in your command
+>
+> If you want to bind multiple commands, instead of placing them in an external `.sh` file, use the below syntax. Otherwise, your command gets quietly chopped at the `|` or `&&`. `-o pipefail` makes sure that a failing command fails the whole pipe (and thereafter, the composed Docker stack).
+>
+>```yaml
+>command: bash -o pipefail -c 'echo a | grep -v a'
+>``` 
+
 ### configs
 
 Grant access to configs on a per-service basis using the per-service `configs`


### PR DESCRIPTION
I think the root documentation should have a little bit more about what's allowed and what not in the `command`. I find it handy to place even complicated commands, within the YAML file (instead of spreading them into external `.sh` files), just like we sometimes do in `npm` `package.json`.

Anyhow, the fact that `|` or `&&` quietly chops my command was surprising.

The content of the PR is just a suggestion.

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

<!--Tell us what you did and why-->

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
