### PR TITLE
Dockerfile: try using official jekyll/jekyll:4 image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -13,7 +13,6 @@ CONTRIBUTING.md
 Dockerfile
 Dockerfile.archive
 docker-compose.yml
-Gemfile
 Gemfile.lock
 _website*.json
 

--- a/Gemfile
+++ b/Gemfile
@@ -39,5 +39,7 @@ source "https://rubygems.org"
 # live site deploy, which uses the Dockerfiles found in the publish-tools
 # branch.
 
-gem "github-pages", "198"
+gem "github-pages", "218"
 gem 'wdm' if Gem.win_platform?
+gem "jekyll-relative-links"
+gem "rouge", "3.26.0"


### PR DESCRIPTION
The starefossen image hasn't been maintained for some time, so perhaps it's time to switch to the upstream jekyll image.

This image does not have some of the plugins installed that we use (no github pages, and relative links), so we need to install these through the Gemfile.

I'm experimenting here to see if we can preserve Jekyll's cache in between builds (which is not exactly trivial), and some work is still needed.
