### PR TITLE
Update download-rate-limit.md

### DIFF
--- a/docker-hub/download-rate-limit.md
+++ b/docker-hub/download-rate-limit.md
@@ -89,7 +89,13 @@ This means my limit is 100 per 21600 seconds (6 hours), I have 76 pulls remainin
 
 This header will show what it used to limit you. It can help diagnose any issue.
 If you are not authenticated, it will show your ip address.
-If you are authenticated, it will show your account name.
+If you are authenticated, it will show your `accountID`.
+
+You can compare this `accountID` with the one associated with your account by requesting the docker Hub API:
+```http
+https://hub.docker.com/v2/users/<namespace>/
+```
+(replace `<namespace>` with the account name)
 
 ### I don't see any RateLimit headers
 

--- a/docker-hub/download-rate-limit.md
+++ b/docker-hub/download-rate-limit.md
@@ -87,15 +87,13 @@ This means my limit is 100 pulls per 21600 seconds (6 hours), I have 76 pulls re
 
 ### docker-RateLimit-Source
 
-This header will show what it used to limit you. It can help diagnose any issue.
-If you are not authenticated, it will show your ip address.
+This header will show what source was used to limit you. It can help answer questions like "Am I authenticating correctly?" and "Is it rate limiting against my IP or my user account?"
+If you are not authenticated, it will show your IP address.
 If you are authenticated, it will show your `accountID`.
 
 You can compare this `accountID` with the one associated with your account by requesting the docker Hub API:
 ```http
 https://hub.docker.com/v2/users/<namespace>/
-```
-(replace `<namespace>` with the account name)
 
 ### I don't see any RateLimit headers
 

--- a/docker-hub/download-rate-limit.md
+++ b/docker-hub/download-rate-limit.md
@@ -50,7 +50,7 @@ Valid manifest API requests to Hub will usually include the following rate limit
 ```
 ratelimit-limit    
 ratelimit-remaining
-docker-RateLimit-Source
+docker-rateLimit-source
 ```
 
 These headers will be returned on both GET and HEAD requests. Note that using GET emulates a real pull and will count towards the limit; using HEAD will not, so we will use it in this example. To check your limits, you will need `curl`, `grep`, and `jq` installed.
@@ -78,7 +78,7 @@ Which should return headers including these:
 ```http
 ratelimit-limit: 100;w=21600
 ratelimit-remaining: 76;w=21600
-docker-RateLimit-Source: 0.0.0.0
+docker-rateLimit-source: 0.0.0.0
 ```
 
 This means my limit is 100 per 21600 seconds (6 hours), I have 76 pulls remaining and I am limited on the ip 0.0.0.0 (not a valid ip address, used as an example).

--- a/docker-hub/download-rate-limit.md
+++ b/docker-hub/download-rate-limit.md
@@ -81,7 +81,7 @@ ratelimit-remaining: 76;w=21600
 docker-rateLimit-source: 0.0.0.0
 ```
 
-This means my limit is 100 per 21600 seconds (6 hours), I have 76 pulls remaining and I am limited on the ip 0.0.0.0 (not a valid ip address, used as an example).
+This means my limit is 100 pulls per 21600 seconds (6 hours), I have 76 pulls remaining and I am limited on the ip 82.92.134.25.
 
 > Remember that these headers are best-effort and there will be small variations.
 

--- a/docker-hub/download-rate-limit.md
+++ b/docker-hub/download-rate-limit.md
@@ -91,7 +91,8 @@ This header will show what source was used to limit you. It can help answer ques
 If you are not authenticated, it will show your IP address.
 If you are authenticated, it will show your `accountID`.
 
-You can compare this `accountID` with the one associated with your account by requesting the docker Hub API:
+You can compare this `accountID` with the ID associated with your account by requesting the Docker Hub API:
+
 ```http
 https://hub.docker.com/v2/users/<namespace>/
 ```

--- a/docker-hub/download-rate-limit.md
+++ b/docker-hub/download-rate-limit.md
@@ -50,6 +50,7 @@ Valid manifest API requests to Hub will usually include the following rate limit
 ```
 ratelimit-limit    
 ratelimit-remaining
+docker-RateLimit-Source
 ```
 
 These headers will be returned on both GET and HEAD requests. Note that using GET emulates a real pull and will count towards the limit; using HEAD will not, so we will use it in this example. To check your limits, you will need `curl`, `grep`, and `jq` installed.
@@ -77,11 +78,18 @@ Which should return headers including these:
 ```http
 ratelimit-limit: 100;w=21600
 ratelimit-remaining: 76;w=21600
+docker-RateLimit-Source: 0.0.0.0
 ```
 
-This means my limit is 100 per 21600 seconds (6 hours), and I have 76 pulls remaining.
+This means my limit is 100 per 21600 seconds (6 hours), I have 76 pulls remaining and I am limited on the ip 0.0.0.0 (not a valid ip address, used as an example).
 
 > Remember that these headers are best-effort and there will be small variations.
+
+### docker-RateLimit-Source
+
+This header will show what it used to limit you. It can help diagnose any issue.
+If you are not authenticated, it will show your ip address.
+If you are authenticated, it will show your account name.
 
 ### I don't see any RateLimit headers
 

--- a/docker-hub/download-rate-limit.md
+++ b/docker-hub/download-rate-limit.md
@@ -78,7 +78,7 @@ Which should return headers including these:
 ```http
 ratelimit-limit: 100;w=21600
 ratelimit-remaining: 76;w=21600
-docker-rateLimit-source: 82.92.134.25
+docker-rateLimit-source: 192.0.2.1
 ```
 
 This means my limit is 100 pulls per 21600 seconds (6 hours), I have 76 pulls remaining and I am limited on the ip 82.92.134.25.

--- a/docker-hub/download-rate-limit.md
+++ b/docker-hub/download-rate-limit.md
@@ -78,7 +78,7 @@ Which should return headers including these:
 ```http
 ratelimit-limit: 100;w=21600
 ratelimit-remaining: 76;w=21600
-docker-rateLimit-source: 0.0.0.0
+docker-rateLimit-source: 82.92.134.25
 ```
 
 This means my limit is 100 pulls per 21600 seconds (6 hours), I have 76 pulls remaining and I am limited on the ip 82.92.134.25.

--- a/docker-hub/download-rate-limit.md
+++ b/docker-hub/download-rate-limit.md
@@ -81,7 +81,7 @@ ratelimit-remaining: 76;w=21600
 docker-rateLimit-source: 192.0.2.1
 ```
 
-This means my limit is 100 pulls per 21600 seconds (6 hours), I have 76 pulls remaining and I am limited on the ip 82.92.134.25.
+This means my limit is 100 pulls per 21600 seconds (6 hours), I have 76 pulls remaining, and I am being limited on the ip `192.0.2.1`.
 
 > Remember that these headers are best-effort and there will be small variations.
 

--- a/docker-hub/download-rate-limit.md
+++ b/docker-hub/download-rate-limit.md
@@ -94,6 +94,7 @@ If you are authenticated, it will show your `accountID`.
 You can compare this `accountID` with the one associated with your account by requesting the docker Hub API:
 ```http
 https://hub.docker.com/v2/users/<namespace>/
+```
 
 ### I don't see any RateLimit headers
 


### PR DESCRIPTION
Add information about `docker-rateLimit-source` Header

### Proposed changes

New header `docker-rateLimit-source` is available when checking the limit on docker hub.
Let me know if it is enough or need more information / better explanation
