### PR TITLE
Update flags in compose reference docs up to V1 1.29.2

### DIFF
--- a/compose/cli-command-compatibility.md
+++ b/compose/cli-command-compatibility.md
@@ -26,4 +26,4 @@ either because they are already deprecated in `docker-compose`, or because they 
 
 Global flags:
 
-* `compose --compatibility` Deprecated in docker-compose.
+* `compose --compatibility` Supported in Compose V2 (`docker compose`) but deprecated in Compose V1 (`docker-compose`).

--- a/compose/reference/index.md
+++ b/compose/reference/index.md
@@ -27,9 +27,11 @@ Options:
   -p, --project-name NAME     Specify an alternate project name
                               (default: directory name)
   --profile NAME              Specify a profile to enable
+  -c, --context NAME          Specify a context name
   --verbose                   Show more output
   --log-level LEVEL           Set log level (DEBUG, INFO, WARNING, ERROR, CRITICAL)
-  --no-ansi                   Do not print ANSI control characters
+  --ansi (never|always|auto)  Control when to print ANSI control characters
+  --no-ansi                   Do not print ANSI control characters (DEPRECATED)
   -v, --version               Print version and exit
   -H, --host HOST             Daemon socket to connect to
 
@@ -43,7 +45,8 @@ Options:
   --project-directory PATH    Specify an alternate working directory
                               (default: the path of the Compose file)
   --compatibility             If set, Compose will attempt to convert deploy
-                              keys in v3 files to their non-Swarm equivalent
+                              keys in v3 files to their non-Swarm equivalent (DEPRECATED)
+  --env-file PATH             Specify an alternate environment file
 
 Commands:
   build              Build or rebuild services


### PR DESCRIPTION
### Proposed changes

<!--Tell us what you did and why-->

1. The [compose/reference](https://docs.docker.com/compose/reference/) doc isn't up to date as the commands and options it contains are still from [version 1.20.0](https://github.com/docker/docker.github.io/blob/12757bf9532d677e83eb35d68fbd0b372baf0e8a/compose/reference/overview.md)
This adds docker-compose command options (flags) that are supported in the last compose V1 version (1.29.2) but not yet in the docs.

| Current Docs       | V1 1.29.2 command line     |
| :------------- | :----------: |
|  ![image](https://user-images.githubusercontent.com/58262528/138866190-805a028c-6086-47c7-825d-5e48edf4ee91.png) | ![docker_docs_website_issue_3_fix_1](https://user-images.githubusercontent.com/58262528/138866356-6fa5526d-3b79-4baf-a480-64f084ab2d48.png) |

2. The `--compatibility` flag is supported in Compose V2 (`docker compose`) but deprecated in Compose V1 (`docker-compose`) and this isn't properly explained in the [compose/cli-command-compatibility](https://docs.docker.com/compose/cli-command-compatibility/) docs.
This properly explains that section preventing issues like #13733 

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

Closes #13733 


@usha-mandya @thaJeztah  ptal