### PR TITLE
Fix outdated syntax rule about handling of quotes in Compose `.env` files

### DIFF
--- a/compose/env-file.md
+++ b/compose/env-file.md
@@ -25,8 +25,6 @@ The following syntax rules apply to the `.env` file:
 - Compose expects each line in an `env` file to be in `VAR=VAL` format.
 - Lines beginning with `#` are processed as comments and ignored.
 - Blank lines are ignored.
-- There is no special handling of quotation marks. This means that
-  **they are part of the VAL**.
 
 ## Compose file and CLI variables
 


### PR DESCRIPTION
### Proposed changes

Since [Compose 1.26.0](https://docs.docker.com/compose/release-notes/#1260), the following information doesn't seem to be true anymore:

> - There is no special handling of quotation marks. This means that **they are part of the VAL**.

Surrounding quotes (single or double) are effectively **removed** from the value, like in a shell.

Proof:

```ini
# .env
MY_VAL='some_value'
```

```yaml
# docker-compose.yml
version: '3.7'

services:

  env-test:
    image: alpine
    environment:
      MY_VAL: ${MY_VAL:-}
    entrypoint:
      - sleep
      - '3600'
    init: true
```

With either Compose 1.29.2 or Compose 2.2.3:

```console
$ docker-compose config
services:
  env-test:
    entrypoint:
    - sleep
    - '3600'
    environment:
      MY_VAL: some_value
    image: alpine
    init: true
version: '3.7'
```

After executing `docker-compose up` with either Compose 1.29.2 or Compose 2.2.3:

```console
$ docker-compose exec env-test printenv MY_VAL
some_value
```

Related:
- https://github.com/docker/compose/issues/2854
- https://github.com/docker/compose/pull/7150

cc. @ulyssessouza, maybe you can validate my assumption that the docs are wrong since you worked on the aforementioned issue a while ago?

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
