### PR TITLE
Make the machine’s hardware name dynamic in docker-compose download URL

### DIFF
--- a/compose/cli-command.md
+++ b/compose/cli-command.md
@@ -80,7 +80,7 @@ from the [project release page](https://github.com/docker/compose/releases){:tar
     ```console
     $ DOCKER_CONFIG=${DOCKER_CONFIG:-$HOME/.docker}
     $ mkdir -p $DOCKER_CONFIG/cli-plugins
-    $ curl -SL https://github.com/docker/compose/releases/download/v{{site.compose_v2_version}}/docker-compose-linux-x86_64 -o $DOCKER_CONFIG/cli-plugins/docker-compose
+    $ curl -SL "https://github.com/docker/compose/releases/download/v{{site.compose_v2_version}}/docker-compose-linux-$(uname -m)" -o $DOCKER_CONFIG/cli-plugins/docker-compose
     ```
 
     This command installs Compose V2 for the active user under `$HOME` directory. To install Docker Compose for all users on your system, replace `~/.docker/cli-plugins` with `/usr/local/lib/docker/cli-plugins`.


### PR DESCRIPTION
### Proposed changes
I made the machine name dynamic in the GitHub release URL.

I faced an issue when trying to install compose on an ARM-based system because the command in the instruction was downloading the x86_64 build.