### PR TITLE
Add instructions to install Compose V2 via repos

### DIFF
--- a/compose/cli-command.md
+++ b/compose/cli-command.md
@@ -72,6 +72,12 @@ $ docker-compose disable-v2
 
 ### Install on Linux
 
+#### Installation via per distro packages
+
+You can install Compose V2 using the [per distro repositories](https://docs.docker.com/engine/install/#server) via the `docker-compose-plugin` package.
+
+#### Installation via binary releases
+
 You can install Compose V2 by downloading the appropriate binary for your system
 from the [project release page](https://github.com/docker/compose/releases){:target="_blank" rel="noopener" class="_"} and copying it into `$HOME/.docker/cli-plugins` as `docker-compose`.
 


### PR DESCRIPTION
Packages are being published in the repos (at least for Debian), but there's no reference in the instructions about this and users are only directed down the binary release path with results in unmaintained installations.

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

Added instructions on how to install Compose V2 via repositories.

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
