### PR TITLE
[WIP] test engine cli reference changes

### DIFF
--- a/_data/engine-cli/docker_attach.yaml
+++ b/_data/engine-cli/docker_attach.yaml
@@ -1,5 +1,6 @@
 command: docker attach
-short: Attach local standard input, output, and error streams to a running container
+short: |
+  Attach local standard input, output, and error streams to a running container
 long: |-
   Use `docker attach` to attach your terminal's standard input, output, and error
   (or any combination of the three) to a running container using the container's
@@ -68,6 +69,7 @@ options:
   value_type: string
   description: Override the key sequence for detaching a container
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -77,6 +79,7 @@ options:
   default_value: "false"
   description: Do not attach STDIN
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -86,6 +89,7 @@ options:
   default_value: "true"
   description: Proxy all received signals to the process
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false

--- a/_data/engine-cli/docker_build.yaml
+++ b/_data/engine-cli/docker_build.yaml
@@ -41,22 +41,16 @@ long: |-
   The following table represents all the valid suffixes with their build
   contexts:
 
-  Build Syntax Suffix             | Commit Used           | Build Context Used
-  --------------------------------|-----------------------|-------------------
-  `myrepo.git`                    | `refs/heads/master`   | `/`
-  `myrepo.git#mytag`              | `refs/tags/mytag`     | `/`
-  `myrepo.git#mybranch`           | `refs/heads/mybranch` | `/`
-  `myrepo.git#pull/42/head`       | `refs/pull/42/head`   | `/`
-  `myrepo.git#:myfolder`          | `refs/heads/master`   | `/myfolder`
-  `myrepo.git#master:myfolder`    | `refs/heads/master`   | `/myfolder`
-  `myrepo.git#mytag:myfolder`     | `refs/tags/mytag`     | `/myfolder`
-  `myrepo.git#mybranch:myfolder`  | `refs/heads/mybranch` | `/myfolder`
-
-  > **Note**
-  >
-  > You cannot specify the build-context directory (`myfolder` in the examples above)
-  > when using BuildKit as builder (`DOCKER_BUILDKIT=1`). Support for this feature
-  > is tracked in [buildkit#1684](https://github.com/moby/buildkit/issues/1684).
+  | Build Syntax Suffix            | Commit Used           | Build Context Used |
+  |--------------------------------|-----------------------|--------------------|
+  | `myrepo.git`                   | `refs/heads/master`   | `/`                |
+  | `myrepo.git#mytag`             | `refs/tags/mytag`     | `/`                |
+  | `myrepo.git#mybranch`          | `refs/heads/mybranch` | `/`                |
+  | `myrepo.git#pull/42/head`      | `refs/pull/42/head`   | `/`                |
+  | `myrepo.git#:myfolder`         | `refs/heads/master`   | `/myfolder`        |
+  | `myrepo.git#master:myfolder`   | `refs/heads/master`   | `/myfolder`        |
+  | `myrepo.git#mytag:myfolder`    | `refs/tags/mytag`     | `/myfolder`        |
+  | `myrepo.git#mybranch:myfolder` | `refs/heads/mybranch` | `/myfolder`        |
 
   ### Tarball contexts
 
@@ -116,7 +110,9 @@ options:
 - option: add-host
   value_type: list
   description: Add a custom host-to-IP mapping (host:ip)
+  details_url: '#add-host'
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -124,7 +120,9 @@ options:
 - option: build-arg
   value_type: list
   description: Set build-time variables
+  details_url: '#build-arg'
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -133,7 +131,9 @@ options:
   value_type: stringSlice
   default_value: '[]'
   description: Images to consider as cache sources
+  details_url: '#cache-from'
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -141,7 +141,9 @@ options:
 - option: cgroup-parent
   value_type: string
   description: Optional parent cgroup for the container
+  details_url: '#cgroup-parent'
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -151,6 +153,7 @@ options:
   default_value: "false"
   description: Compress the build context using gzip
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -160,6 +163,7 @@ options:
   default_value: "0"
   description: Limit the CPU CFS (Completely Fair Scheduler) period
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -169,6 +173,7 @@ options:
   default_value: "0"
   description: Limit the CPU CFS (Completely Fair Scheduler) quota
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -179,6 +184,7 @@ options:
   default_value: "0"
   description: CPU shares (relative weight)
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -187,6 +193,7 @@ options:
   value_type: string
   description: CPUs in which to allow execution (0-3, 0,1)
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -195,6 +202,7 @@ options:
   value_type: string
   description: MEMs in which to allow execution (0-3, 0,1)
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -204,6 +212,7 @@ options:
   default_value: "true"
   description: Skip image verification
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -212,7 +221,9 @@ options:
   shorthand: f
   value_type: string
   description: Name of the Dockerfile (Default is 'PATH/Dockerfile')
+  details_url: '#file'
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -222,6 +233,7 @@ options:
   default_value: "false"
   description: Always remove intermediate containers
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -230,6 +242,7 @@ options:
   value_type: string
   description: Write the image ID to the file
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -237,7 +250,9 @@ options:
 - option: isolation
   value_type: string
   description: Container isolation technology
+  details_url: '#isolation'
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -246,6 +261,7 @@ options:
   value_type: list
   description: Set metadata for an image
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -256,6 +272,7 @@ options:
   default_value: "0"
   description: Memory limit
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -266,6 +283,7 @@ options:
   description: |
     Swap limit equal to memory plus swap: '-1' to enable unlimited swap
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -273,9 +291,9 @@ options:
 - option: network
   value_type: string
   default_value: default
-  description: |
-    Set the networking mode for the RUN instructions during build
+  description: Set the networking mode for the RUN instructions during build
   deprecated: false
+  hidden: false
   min_api_version: "1.25"
   experimental: false
   experimentalcli: false
@@ -286,17 +304,7 @@ options:
   default_value: "false"
   description: Do not use cache when building the image
   deprecated: false
-  experimental: false
-  experimentalcli: false
-  kubernetes: false
-  swarm: false
-- option: output
-  shorthand: o
-  value_type: stringArray
-  default_value: '[]'
-  description: 'Output destination (format: type=local,dest=path)'
-  deprecated: false
-  min_api_version: "1.40"
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -305,17 +313,8 @@ options:
   value_type: string
   description: Set platform if server is multi-platform capable
   deprecated: false
+  hidden: false
   min_api_version: "1.38"
-  experimental: false
-  experimentalcli: false
-  kubernetes: false
-  swarm: false
-- option: progress
-  value_type: string
-  default_value: auto
-  description: |
-    Set type of progress output (auto, plain, tty). Use plain to show container output
-  deprecated: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -325,6 +324,7 @@ options:
   default_value: "false"
   description: Always attempt to pull a newer version of the image
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -335,6 +335,7 @@ options:
   default_value: "false"
   description: Suppress the build output and print image ID on success
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -344,17 +345,7 @@ options:
   default_value: "true"
   description: Remove intermediate containers after a successful build
   deprecated: false
-  experimental: false
-  experimentalcli: false
-  kubernetes: false
-  swarm: false
-- option: secret
-  value_type: stringArray
-  default_value: '[]'
-  description: |
-    Secret file to expose to the build (only if BuildKit enabled): id=mysecret,src=/local/secret
-  deprecated: false
-  min_api_version: "1.39"
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -363,7 +354,9 @@ options:
   value_type: stringSlice
   default_value: '[]'
   description: Security options
+  details_url: '#security-opt'
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -373,6 +366,7 @@ options:
   default_value: "0"
   description: Size of /dev/shm
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -381,20 +375,11 @@ options:
   value_type: bool
   default_value: "false"
   description: Squash newly built layers into a single new layer
+  details_url: '#squash'
   deprecated: false
+  hidden: false
   min_api_version: "1.25"
   experimental: true
-  experimentalcli: false
-  kubernetes: false
-  swarm: false
-- option: ssh
-  value_type: stringArray
-  default_value: '[]'
-  description: |
-    SSH agent socket or keys to expose to the build (only if BuildKit enabled) (format: default|<id>[=<socket>|<key>[,<key>]])
-  deprecated: false
-  min_api_version: "1.39"
-  experimental: false
   experimentalcli: false
   kubernetes: false
   swarm: false
@@ -403,6 +388,7 @@ options:
   default_value: "false"
   description: Stream attaches to server to negotiate build context
   deprecated: false
+  hidden: true
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -411,7 +397,9 @@ options:
   shorthand: t
   value_type: list
   description: Name and optionally a tag in the 'name:tag' format
+  details_url: '#tag'
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -419,7 +407,9 @@ options:
 - option: target
   value_type: string
   description: Set the target build stage to build.
+  details_url: '#target'
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -428,7 +418,9 @@ options:
   value_type: ulimit
   default_value: '[]'
   description: Ulimit options
+  details_url: '#ulimit'
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -570,7 +562,7 @@ examples: |-
   files.
 
 
-  ### Tag an image (-t)
+  ### Tag an image (-t, --tag) {#tag}
 
   ```console
   $ docker build -t vieux/apache:2.0 .
@@ -590,7 +582,7 @@ examples: |-
   $ docker build -t whenry/fedora-jboss:latest -t whenry/fedora-jboss:v2.1 .
   ```
 
-  ### Specify a Dockerfile (-f)
+  ### Specify a Dockerfile (-f, --file) {#file}
 
   ```console
   $ docker build -f Dockerfile.debug .
@@ -637,17 +629,17 @@ examples: |-
   > repeatable builds on remote Docker hosts. This is also the reason why
   > `ADD ../file` does not work.
 
-  ### Use a custom parent cgroup (--cgroup-parent)
+  ### Use a custom parent cgroup (--cgroup-parent) {#cgroup-parent}
 
   When `docker build` is run with the `--cgroup-parent` option the containers
   used in the build will be run with the [corresponding `docker run` flag](../run.md#specify-custom-cgroups).
 
-  ### Set ulimits in container (--ulimit)
+  ### Set ulimits in container (--ulimit) {#ulimit}
 
   Using the `--ulimit` option with `docker build` will cause each build step's
   container to be started using those [`--ulimit` flag values](run.md#set-ulimits-in-container---ulimit).
 
-  ### Set build-time variables (--build-arg)
+  ### Set build-time variables (--build-arg) {#build-arg}
 
   You can use `ENV` instructions in a Dockerfile to define variable
   values. These values persist in the built image. However, often
@@ -682,16 +674,16 @@ examples: |-
   $ docker build --build-arg HTTP_PROXY .
   ```
 
-  This is similar to how `docker run -e` works. Refer to the [`docker run` documentation](https://docs.docker.com/engine/reference/commandline/run/#set-environment-variables--e---env---env-file)
+  This is similar to how `docker run -e` works. Refer to the [`docker run` documentation](/engine/reference/commandline/run/#set-environment-variables--e---env---env-file)
   for more information.
 
-  ### Optional security options (--security-opt)
+  ### Optional security options (--security-opt) {#security-opt}
 
   This flag is only supported on a daemon running on Windows, and only supports
   the `credentialspec` option. The `credentialspec` must be in the format
   `file://spec.txt` or `registry://keyname`.
 
-  ### Specify isolation technology for container (--isolation)
+  ### Specify isolation technology for container (--isolation) {#isolation}
 
   This option is useful in situations where you are running Docker containers on
   Windows. The `--isolation=<value>` option sets a container's isolation
@@ -699,15 +691,15 @@ examples: |-
   Linux namespaces. On Microsoft Windows, you can specify these values:
 
 
-  | Value     | Description                                                                                                                                                   |
-  |-----------|---------------------------------------------------------------------------------------------------------------------------------------------------------------|
-  | `default` | Use the value specified by the Docker daemon's `--exec-opt` . If the `daemon` does not specify an isolation technology, Microsoft Windows uses `process` as its default value.  |
-  | `process` | Namespace isolation only.                                                                                                                                     |
-  | `hyperv`  | Hyper-V hypervisor partition-based isolation.                                                                                                                 |
+  | Value     | Description                                                                                                                                                                    |
+  |-----------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+  | `default` | Use the value specified by the Docker daemon's `--exec-opt` . If the `daemon` does not specify an isolation technology, Microsoft Windows uses `process` as its default value. |
+  | `process` | Namespace isolation only.                                                                                                                                                      |
+  | `hyperv`  | Hyper-V hypervisor partition-based isolation.                                                                                                                                  |
 
   Specifying the `--isolation` flag without a value is the same as setting `--isolation="default"`.
 
-  ### Add entries to container hosts file (--add-host)
+  ### Add entries to container hosts file (--add-host) {#add-host}
 
   You can add other hosts into a container's `/etc/hosts` file by using one or
   more `--add-host` flags. This example adds a static address for a host named
@@ -715,7 +707,7 @@ examples: |-
 
       $ docker build --add-host=docker:10.180.0.1 .
 
-  ### Specifying target build stage (--target)
+  ### Specifying target build stage (--target) {#target}
 
   When building a Dockerfile with multiple build stages, `--target` can be used to
   specify an intermediate build stage by name as a final stage for the resulting
@@ -723,17 +715,17 @@ examples: |-
 
   ```dockerfile
   FROM debian AS build-env
-  ...
+  # ...
 
   FROM alpine AS production-env
-  ...
+  # ...
   ```
 
   ```console
   $ docker build -t mybuildimage --target build-env .
   ```
 
-  ### Custom build outputs
+  ### Custom build outputs (--output) {#output}
 
   By default, a local container image is created from the build result. The
   `--output` (or `-o`) flag allows you to override this behavior, and a specify a
@@ -826,7 +818,7 @@ examples: |-
   > [enable BuildKit](../builder.md#buildkit) or use the [buildx](https://github.com/docker/buildx)
   > plugin which provides more output type options.
 
-  ### Specifying external cache sources
+  ### Specifying external cache sources (--cache-from) {#cache-from}
 
   In addition to local build cache, the builder can reuse the cache generated from
   previous builds with the `--cache-from` flag pointing to an image in the registry.
@@ -869,7 +861,7 @@ examples: |-
   > plugin. The previous builder has limited support for reusing cache from
   > pre-pulled images.
 
-  ### Squash an image's layers (--squash) (experimental)
+  ### Squash an image's layers (--squash) (experimental) {#squash}
 
   #### Overview
 
@@ -892,7 +884,7 @@ examples: |-
 
   For most use cases, multi-stage builds are a better alternative, as they give more
   fine-grained control over your build, and can take advantage of future
-  optimizations in the builder. Refer to the [use multi-stage builds](https://docs.docker.com/develop/develop-images/multistage-build/)
+  optimizations in the builder. Refer to the [use multi-stage builds](/develop/develop-images/multistage-build/)
   section in the userguide for more information.
 
 

--- a/_data/engine-cli/docker_builder_build.yaml
+++ b/_data/engine-cli/docker_builder_build.yaml
@@ -9,6 +9,7 @@ options:
   value_type: list
   description: Add a custom host-to-IP mapping (host:ip)
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -17,6 +18,7 @@ options:
   value_type: list
   description: Set build-time variables
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -26,6 +28,7 @@ options:
   default_value: '[]'
   description: Images to consider as cache sources
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -34,6 +37,7 @@ options:
   value_type: string
   description: Optional parent cgroup for the container
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -43,6 +47,7 @@ options:
   default_value: "false"
   description: Compress the build context using gzip
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -52,6 +57,7 @@ options:
   default_value: "0"
   description: Limit the CPU CFS (Completely Fair Scheduler) period
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -61,6 +67,7 @@ options:
   default_value: "0"
   description: Limit the CPU CFS (Completely Fair Scheduler) quota
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -71,6 +78,7 @@ options:
   default_value: "0"
   description: CPU shares (relative weight)
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -79,6 +87,7 @@ options:
   value_type: string
   description: CPUs in which to allow execution (0-3, 0,1)
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -87,6 +96,7 @@ options:
   value_type: string
   description: MEMs in which to allow execution (0-3, 0,1)
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -96,6 +106,7 @@ options:
   default_value: "true"
   description: Skip image verification
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -105,6 +116,7 @@ options:
   value_type: string
   description: Name of the Dockerfile (Default is 'PATH/Dockerfile')
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -114,6 +126,7 @@ options:
   default_value: "false"
   description: Always remove intermediate containers
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -122,6 +135,7 @@ options:
   value_type: string
   description: Write the image ID to the file
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -130,6 +144,7 @@ options:
   value_type: string
   description: Container isolation technology
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -138,6 +153,7 @@ options:
   value_type: list
   description: Set metadata for an image
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -148,6 +164,7 @@ options:
   default_value: "0"
   description: Memory limit
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -158,6 +175,7 @@ options:
   description: |
     Swap limit equal to memory plus swap: '-1' to enable unlimited swap
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -165,9 +183,9 @@ options:
 - option: network
   value_type: string
   default_value: default
-  description: |
-    Set the networking mode for the RUN instructions during build
+  description: Set the networking mode for the RUN instructions during build
   deprecated: false
+  hidden: false
   min_api_version: "1.25"
   experimental: false
   experimentalcli: false
@@ -178,17 +196,7 @@ options:
   default_value: "false"
   description: Do not use cache when building the image
   deprecated: false
-  experimental: false
-  experimentalcli: false
-  kubernetes: false
-  swarm: false
-- option: output
-  shorthand: o
-  value_type: stringArray
-  default_value: '[]'
-  description: 'Output destination (format: type=local,dest=path)'
-  deprecated: false
-  min_api_version: "1.40"
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -197,17 +205,8 @@ options:
   value_type: string
   description: Set platform if server is multi-platform capable
   deprecated: false
+  hidden: false
   min_api_version: "1.38"
-  experimental: false
-  experimentalcli: false
-  kubernetes: false
-  swarm: false
-- option: progress
-  value_type: string
-  default_value: auto
-  description: |
-    Set type of progress output (auto, plain, tty). Use plain to show container output
-  deprecated: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -217,6 +216,7 @@ options:
   default_value: "false"
   description: Always attempt to pull a newer version of the image
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -227,6 +227,7 @@ options:
   default_value: "false"
   description: Suppress the build output and print image ID on success
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -236,17 +237,7 @@ options:
   default_value: "true"
   description: Remove intermediate containers after a successful build
   deprecated: false
-  experimental: false
-  experimentalcli: false
-  kubernetes: false
-  swarm: false
-- option: secret
-  value_type: stringArray
-  default_value: '[]'
-  description: |
-    Secret file to expose to the build (only if BuildKit enabled): id=mysecret,src=/local/secret
-  deprecated: false
-  min_api_version: "1.39"
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -256,6 +247,7 @@ options:
   default_value: '[]'
   description: Security options
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -265,6 +257,7 @@ options:
   default_value: "0"
   description: Size of /dev/shm
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -274,19 +267,9 @@ options:
   default_value: "false"
   description: Squash newly built layers into a single new layer
   deprecated: false
+  hidden: false
   min_api_version: "1.25"
   experimental: true
-  experimentalcli: false
-  kubernetes: false
-  swarm: false
-- option: ssh
-  value_type: stringArray
-  default_value: '[]'
-  description: |
-    SSH agent socket or keys to expose to the build (only if BuildKit enabled) (format: default|<id>[=<socket>|<key>[,<key>]])
-  deprecated: false
-  min_api_version: "1.39"
-  experimental: false
   experimentalcli: false
   kubernetes: false
   swarm: false
@@ -295,6 +278,7 @@ options:
   default_value: "false"
   description: Stream attaches to server to negotiate build context
   deprecated: false
+  hidden: true
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -304,6 +288,7 @@ options:
   value_type: list
   description: Name and optionally a tag in the 'name:tag' format
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -312,6 +297,7 @@ options:
   value_type: string
   description: Set the target build stage to build.
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -321,6 +307,7 @@ options:
   default_value: '[]'
   description: Ulimit options
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false

--- a/_data/engine-cli/docker_builder_prune.yaml
+++ b/_data/engine-cli/docker_builder_prune.yaml
@@ -11,6 +11,7 @@ options:
   default_value: "false"
   description: Remove all unused build cache, not just dangling ones
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -19,6 +20,7 @@ options:
   value_type: filter
   description: Provide filter values (e.g. 'until=24h')
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -29,6 +31,7 @@ options:
   default_value: "false"
   description: Do not prompt for confirmation
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -38,6 +41,7 @@ options:
   default_value: "0"
   description: Amount of disk space to keep for cache
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false

--- a/_data/engine-cli/docker_checkpoint.yaml
+++ b/_data/engine-cli/docker_checkpoint.yaml
@@ -5,7 +5,7 @@ long: |-
   container by checkpointing it, which turns its state into a collection of files
   on disk. Later, the container can be restored from the point it was frozen.
 
-  This is accomplished using a tool called [CRIU](http://criu.org), which is an
+  This is accomplished using a tool called [CRIU](https://criu.org), which is an
   external dependency of this feature. A good overview of the history of
   checkpoint and restore in Docker is available in this
   [Kubernetes blog post](https://kubernetes.io/blog/2015/07/how-did-quake-demo-from-dockercon-work/).

--- a/_data/engine-cli/docker_checkpoint_create.yaml
+++ b/_data/engine-cli/docker_checkpoint_create.yaml
@@ -9,6 +9,7 @@ options:
   value_type: string
   description: Use a custom checkpoint storage directory
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -18,6 +19,7 @@ options:
   default_value: "false"
   description: Leave the container running after checkpoint
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false

--- a/_data/engine-cli/docker_checkpoint_ls.yaml
+++ b/_data/engine-cli/docker_checkpoint_ls.yaml
@@ -10,6 +10,7 @@ options:
   value_type: string
   description: Use a custom checkpoint storage directory
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false

--- a/_data/engine-cli/docker_checkpoint_rm.yaml
+++ b/_data/engine-cli/docker_checkpoint_rm.yaml
@@ -10,6 +10,7 @@ options:
   value_type: string
   description: Use a custom checkpoint storage directory
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false

--- a/_data/engine-cli/docker_commit.yaml
+++ b/_data/engine-cli/docker_commit.yaml
@@ -27,6 +27,7 @@ options:
   value_type: string
   description: Author (e.g., "John Hannibal Smith <hannibal@a-team.com>")
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -35,7 +36,9 @@ options:
   shorthand: c
   value_type: list
   description: Apply Dockerfile instruction to the created image
+  details_url: '#change'
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -45,6 +48,7 @@ options:
   value_type: string
   description: Commit message
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -55,6 +59,7 @@ options:
   default_value: "true"
   description: Pause container during commit
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -79,7 +84,7 @@ examples: |-
   svendowideit/testimage            version3            f5283438590d        16 seconds ago      335.7 MB
   ```
 
-  ### Commit a container with new configurations
+  ### Commit a container with new configurations (--change) {#change}
 
   ```console
   $ docker ps

--- a/_data/engine-cli/docker_config_create.yaml
+++ b/_data/engine-cli/docker_config_create.yaml
@@ -3,13 +3,13 @@ short: Create a config from a file or STDIN
 long: |-
   Creates a config using standard input or from a file for the config content.
 
-  For detailed information about using configs, refer to [store configuration data using Docker Configs](https://docs.docker.com/engine/swarm/configs/).
+  For detailed information about using configs, refer to [store configuration data using Docker Configs](/engine/swarm/configs/).
 
   > **Note**
   >
   > This is a cluster management command, and must be executed on a swarm
   > manager node. To learn about managers and workers, refer to the
-  > [Swarm mode section](https://docs.docker.com/engine/swarm/) in the
+  > [Swarm mode section](/engine/swarm/) in the
   > documentation.
 usage: docker config create [OPTIONS] CONFIG file|-
 pname: docker config
@@ -19,7 +19,9 @@ options:
   shorthand: l
   value_type: list
   description: Config labels
+  details_url: '#label'
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -28,6 +30,7 @@ options:
   value_type: string
   description: Template driver
   deprecated: false
+  hidden: false
   min_api_version: "1.37"
   experimental: false
   experimentalcli: false
@@ -60,7 +63,7 @@ examples: |-
   dg426haahpi5ezmkkj5kyl3sn   my_config           7 seconds ago       7 seconds ago
   ```
 
-  ### Create a config with labels
+  ### Create a config with labels (-l, --label) {#label}
 
   ```console
   $ docker config create \

--- a/_data/engine-cli/docker_config_inspect.yaml
+++ b/_data/engine-cli/docker_config_inspect.yaml
@@ -9,13 +9,13 @@ long: |-
   Go's [text/template](https://golang.org/pkg/text/template/) package
   describes all the details of the format.
 
-  For detailed information about using configs, refer to [store configuration data using Docker Configs](https://docs.docker.com/engine/swarm/configs/).
+  For detailed information about using configs, refer to [store configuration data using Docker Configs](/engine/swarm/configs/).
 
   > **Note**
   >
   > This is a cluster management command, and must be executed on a swarm
   > manager node. To learn about managers and workers, refer to the
-  > [Swarm mode section](https://docs.docker.com/engine/swarm/) in the
+  > [Swarm mode section](/engine/swarm/) in the
   > documentation.
 usage: docker config inspect [OPTIONS] CONFIG [CONFIG...]
 pname: docker config
@@ -24,8 +24,14 @@ options:
 - option: format
   shorthand: f
   value_type: string
-  description: Format the output using the given Go template
+  description: |-
+    Format output using a custom template:
+    'json':             Print in JSON format
+    'TEMPLATE':         Print output using the given Go template.
+    Refer to https://docs.docker.com/go/formatting/ for more information about formatting output with templates
+  details_url: '#format'
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -35,6 +41,7 @@ options:
   default_value: "false"
   description: Print the information in a human friendly format
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -80,7 +87,7 @@ examples: |-
   ]
   ```
 
-  ### Formatting
+  ### Format the output (--format) {#format}
 
   You can use the --format option to obtain specific information about a
   config. The following example command outputs the creation time of the

--- a/_data/engine-cli/docker_config_ls.yaml
+++ b/_data/engine-cli/docker_config_ls.yaml
@@ -4,13 +4,13 @@ short: List configs
 long: |-
   Run this command on a manager node to list the configs in the swarm.
 
-  For detailed information about using configs, refer to [store configuration data using Docker Configs](https://docs.docker.com/engine/swarm/configs/).
+  For detailed information about using configs, refer to [store configuration data using Docker Configs](/engine/swarm/configs/).
 
   > **Note**
   >
   > This is a cluster management command, and must be executed on a swarm
   > manager node. To learn about managers and workers, refer to the
-  > [Swarm mode section](https://docs.docker.com/engine/swarm/) in the
+  > [Swarm mode section](/engine/swarm/) in the
   > documentation.
 usage: docker config ls [OPTIONS]
 pname: docker config
@@ -20,15 +20,25 @@ options:
   shorthand: f
   value_type: filter
   description: Filter output based on conditions provided
+  details_url: '#filter'
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
   swarm: false
 - option: format
   value_type: string
-  description: Pretty-print configs using a Go template
+  description: |-
+    Format output using a custom template:
+    'table':            Print output in table format with column headers (default)
+    'table TEMPLATE':   Print output in table format using the given Go template
+    'json':             Print in JSON format
+    'TEMPLATE':         Print output using the given Go template.
+    Refer to https://docs.docker.com/go/formatting/ for more information about formatting output with templates
+  details_url: '#format'
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -39,6 +49,7 @@ options:
   default_value: "false"
   description: Only display IDs
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -53,7 +64,7 @@ examples: |-
   mem02h8n73mybpgqjf0kfi1n0   test_config                 3 seconds ago       3 seconds ago
   ```
 
-  ### Filtering
+  ### Filtering (-f, --filter) {#filter}
 
   The filtering flag (`-f` or `--filter`) format is a `key=value` pair. If there is more
   than one filter, then pass multiple flags (e.g., `--filter "foo=bar" --filter "bif=baz"`)
@@ -113,7 +124,7 @@ examples: |-
   mem02h8n73mybpgqjf0kfi1n0   test_config                 About an hour ago   About an hour ago
   ```
 
-  ### Format the output
+  ### Format the output (--format) {#format}
 
   The formatting option (`--format`) pretty prints configs output
   using a Go template.
@@ -121,7 +132,7 @@ examples: |-
   Valid placeholders for the Go template are listed below:
 
   | Placeholder  | Description                                                                          |
-  | ------------ | ------------------------------------------------------------------------------------ |
+  |--------------|--------------------------------------------------------------------------------------|
   | `.ID`        | Config ID                                                                            |
   | `.Name`      | Config name                                                                          |
   | `.CreatedAt` | Time when the config was created                                                     |

--- a/_data/engine-cli/docker_config_rm.yaml
+++ b/_data/engine-cli/docker_config_rm.yaml
@@ -4,13 +4,13 @@ short: Remove one or more configs
 long: |-
   Removes the specified configs from the swarm.
 
-  For detailed information about using configs, refer to [store configuration data using Docker Configs](https://docs.docker.com/engine/swarm/configs/).
+  For detailed information about using configs, refer to [store configuration data using Docker Configs](/engine/swarm/configs/).
 
   > **Note**
   >
   > This is a cluster management command, and must be executed on a swarm
   > manager node. To learn about managers and workers, refer to the
-  > [Swarm mode section](https://docs.docker.com/engine/swarm/) in the
+  > [Swarm mode section](/engine/swarm/) in the
   > documentation.
 usage: docker config rm CONFIG [CONFIG...]
 pname: docker config

--- a/_data/engine-cli/docker_container_attach.yaml
+++ b/_data/engine-cli/docker_container_attach.yaml
@@ -1,6 +1,8 @@
 command: docker container attach
-short: Attach local standard input, output, and error streams to a running container
-long: Attach local standard input, output, and error streams to a running container
+short: |
+  Attach local standard input, output, and error streams to a running container
+long: |
+  Attach local standard input, output, and error streams to a running container
 usage: docker container attach [OPTIONS] CONTAINER
 pname: docker container
 plink: docker_container.yaml
@@ -9,6 +11,7 @@ options:
   value_type: string
   description: Override the key sequence for detaching a container
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -18,6 +21,7 @@ options:
   default_value: "false"
   description: Do not attach STDIN
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -27,6 +31,7 @@ options:
   default_value: "true"
   description: Proxy all received signals to the process
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false

--- a/_data/engine-cli/docker_container_commit.yaml
+++ b/_data/engine-cli/docker_container_commit.yaml
@@ -10,6 +10,7 @@ options:
   value_type: string
   description: Author (e.g., "John Hannibal Smith <hannibal@a-team.com>")
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -19,6 +20,7 @@ options:
   value_type: list
   description: Apply Dockerfile instruction to the created image
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -28,6 +30,7 @@ options:
   value_type: string
   description: Commit message
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -38,6 +41,7 @@ options:
   default_value: "true"
   description: Pause container during commit
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false

--- a/_data/engine-cli/docker_container_cp.yaml
+++ b/_data/engine-cli/docker_container_cp.yaml
@@ -18,6 +18,7 @@ options:
   default_value: "false"
   description: Archive mode (copy all uid/gid information)
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -28,6 +29,19 @@ options:
   default_value: "false"
   description: Always follow symbol link in SRC_PATH
   deprecated: false
+  hidden: false
+  experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
+- option: quiet
+  shorthand: q
+  value_type: bool
+  default_value: "false"
+  description: |
+    Suppress progress output during copy. Progress output is automatically suppressed if no terminal is attached
+  deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false

--- a/_data/engine-cli/docker_container_create.yaml
+++ b/_data/engine-cli/docker_container_create.yaml
@@ -9,6 +9,7 @@ options:
   value_type: list
   description: Add a custom host-to-IP mapping (host:ip)
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -18,6 +19,7 @@ options:
   value_type: list
   description: Attach to STDIN, STDOUT or STDERR
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -28,6 +30,7 @@ options:
   description: |
     Block IO (relative weight), between 10 and 1000, or 0 to disable (default 0)
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -37,6 +40,7 @@ options:
   default_value: '[]'
   description: Block IO weight (relative device weight)
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -45,6 +49,7 @@ options:
   value_type: list
   description: Add Linux capabilities
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -53,6 +58,7 @@ options:
   value_type: list
   description: Drop Linux capabilities
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -61,6 +67,7 @@ options:
   value_type: string
   description: Optional parent cgroup for the container
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -74,6 +81,7 @@ options:
     '':        Use the cgroup namespace as configured by the
                default-cgroupns-mode option on the daemon (default)
   deprecated: false
+  hidden: false
   min_api_version: "1.41"
   experimental: false
   experimentalcli: false
@@ -83,6 +91,7 @@ options:
   value_type: string
   description: Write the container ID to the file
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -92,6 +101,7 @@ options:
   default_value: "0"
   description: CPU count (Windows only)
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -102,6 +112,7 @@ options:
   default_value: "0"
   description: CPU percent (Windows only)
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -112,6 +123,7 @@ options:
   default_value: "0"
   description: Limit CPU CFS (Completely Fair Scheduler) period
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -121,6 +133,7 @@ options:
   default_value: "0"
   description: Limit CPU CFS (Completely Fair Scheduler) quota
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -130,6 +143,7 @@ options:
   default_value: "0"
   description: Limit CPU real-time period in microseconds
   deprecated: false
+  hidden: false
   min_api_version: "1.25"
   experimental: false
   experimentalcli: false
@@ -140,6 +154,7 @@ options:
   default_value: "0"
   description: Limit CPU real-time runtime in microseconds
   deprecated: false
+  hidden: false
   min_api_version: "1.25"
   experimental: false
   experimentalcli: false
@@ -151,6 +166,7 @@ options:
   default_value: "0"
   description: CPU shares (relative weight)
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -159,6 +175,7 @@ options:
   value_type: decimal
   description: Number of CPUs
   deprecated: false
+  hidden: false
   min_api_version: "1.25"
   experimental: false
   experimentalcli: false
@@ -168,6 +185,7 @@ options:
   value_type: string
   description: CPUs in which to allow execution (0-3, 0,1)
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -176,6 +194,7 @@ options:
   value_type: string
   description: MEMs in which to allow execution (0-3, 0,1)
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -184,6 +203,7 @@ options:
   value_type: list
   description: Add a host device to the container
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -192,6 +212,7 @@ options:
   value_type: list
   description: Add a rule to the cgroup allowed devices list
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -201,6 +222,7 @@ options:
   default_value: '[]'
   description: Limit read rate (bytes per second) from a device
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -210,6 +232,7 @@ options:
   default_value: '[]'
   description: Limit read rate (IO per second) from a device
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -219,6 +242,7 @@ options:
   default_value: '[]'
   description: Limit write rate (bytes per second) to a device
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -228,6 +252,7 @@ options:
   default_value: '[]'
   description: Limit write rate (IO per second) to a device
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -237,6 +262,7 @@ options:
   default_value: "true"
   description: Skip image verification
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -245,6 +271,7 @@ options:
   value_type: list
   description: Set custom DNS servers
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -253,6 +280,7 @@ options:
   value_type: list
   description: Set DNS options
   deprecated: false
+  hidden: true
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -261,6 +289,7 @@ options:
   value_type: list
   description: Set DNS options
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -269,6 +298,7 @@ options:
   value_type: list
   description: Set custom DNS search domains
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -277,6 +307,7 @@ options:
   value_type: string
   description: Container NIS domain name
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -285,6 +316,7 @@ options:
   value_type: string
   description: Overwrite the default ENTRYPOINT of the image
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -294,6 +326,7 @@ options:
   value_type: list
   description: Set environment variables
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -302,6 +335,7 @@ options:
   value_type: list
   description: Read in a file of environment variables
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -310,6 +344,7 @@ options:
   value_type: list
   description: Expose a port or a range of ports
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -318,6 +353,7 @@ options:
   value_type: gpu-request
   description: GPU devices to add to the container ('all' to pass all GPUs)
   deprecated: false
+  hidden: false
   min_api_version: "1.40"
   experimental: false
   experimentalcli: false
@@ -327,6 +363,7 @@ options:
   value_type: list
   description: Add additional groups to join
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -335,6 +372,7 @@ options:
   value_type: string
   description: Command to run to check health
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -344,6 +382,7 @@ options:
   default_value: 0s
   description: Time between running the check (ms|s|m|h) (default 0s)
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -353,6 +392,7 @@ options:
   default_value: "0"
   description: Consecutive failures needed to report unhealthy
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -363,6 +403,7 @@ options:
   description: |
     Start period for the container to initialize before starting health-retries countdown (ms|s|m|h) (default 0s)
   deprecated: false
+  hidden: false
   min_api_version: "1.29"
   experimental: false
   experimentalcli: false
@@ -371,9 +412,9 @@ options:
 - option: health-timeout
   value_type: duration
   default_value: 0s
-  description: |
-    Maximum time to allow one check to run (ms|s|m|h) (default 0s)
+  description: Maximum time to allow one check to run (ms|s|m|h) (default 0s)
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -383,6 +424,7 @@ options:
   default_value: "false"
   description: Print usage
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -392,6 +434,7 @@ options:
   value_type: string
   description: Container host name
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -402,6 +445,7 @@ options:
   description: |
     Run an init inside the container that forwards signals and reaps processes
   deprecated: false
+  hidden: false
   min_api_version: "1.25"
   experimental: false
   experimentalcli: false
@@ -413,6 +457,7 @@ options:
   default_value: "false"
   description: Keep STDIN open even if not attached
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -420,9 +465,9 @@ options:
 - option: io-maxbandwidth
   value_type: bytes
   default_value: "0"
-  description: |
-    Maximum IO bandwidth limit for the system drive (Windows only)
+  description: Maximum IO bandwidth limit for the system drive (Windows only)
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -433,6 +478,7 @@ options:
   default_value: "0"
   description: Maximum IOps limit for the system drive (Windows only)
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -442,6 +488,7 @@ options:
   value_type: string
   description: IPv4 address (e.g., 172.30.100.104)
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -450,6 +497,7 @@ options:
   value_type: string
   description: IPv6 address (e.g., 2001:db8::33)
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -458,6 +506,7 @@ options:
   value_type: string
   description: IPC mode to use
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -466,6 +515,7 @@ options:
   value_type: string
   description: Container isolation technology
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -475,6 +525,7 @@ options:
   default_value: "0"
   description: Kernel memory limit
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -484,6 +535,7 @@ options:
   value_type: list
   description: Set meta data on a container
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -492,6 +544,7 @@ options:
   value_type: list
   description: Read in a line delimited file of labels
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -500,6 +553,7 @@ options:
   value_type: list
   description: Add link to another container
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -508,6 +562,7 @@ options:
   value_type: list
   description: Container IPv4/IPv6 link-local addresses
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -516,6 +571,7 @@ options:
   value_type: string
   description: Logging driver for the container
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -524,6 +580,7 @@ options:
   value_type: list
   description: Log driver options
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -532,6 +589,7 @@ options:
   value_type: string
   description: Container MAC address (e.g., 92:d0:c6:0a:29:33)
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -542,6 +600,7 @@ options:
   default_value: "0"
   description: Memory limit
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -551,6 +610,7 @@ options:
   default_value: "0"
   description: Memory soft limit
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -561,6 +621,7 @@ options:
   description: |
     Swap limit equal to memory plus swap: '-1' to enable unlimited swap
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -570,6 +631,7 @@ options:
   default_value: "-1"
   description: Tune container memory swappiness (0 to 100)
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -578,6 +640,7 @@ options:
   value_type: mount
   description: Attach a filesystem mount to the container
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -586,6 +649,7 @@ options:
   value_type: string
   description: Assign a name to the container
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -594,6 +658,7 @@ options:
   value_type: network
   description: Connect a container to a network
   deprecated: false
+  hidden: true
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -602,6 +667,7 @@ options:
   value_type: list
   description: Add network-scoped alias for the container
   deprecated: false
+  hidden: true
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -610,6 +676,7 @@ options:
   value_type: network
   description: Connect a container to a network
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -618,6 +685,7 @@ options:
   value_type: list
   description: Add network-scoped alias for the container
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -627,6 +695,7 @@ options:
   default_value: "false"
   description: Disable any container-specified HEALTHCHECK
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -636,6 +705,7 @@ options:
   default_value: "false"
   description: Disable OOM Killer
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -645,6 +715,7 @@ options:
   default_value: "0"
   description: Tune host's OOM preferences (-1000 to 1000)
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -653,6 +724,7 @@ options:
   value_type: string
   description: PID namespace to use
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -662,6 +734,7 @@ options:
   default_value: "0"
   description: Tune container pids limit (set -1 for unlimited)
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -670,6 +743,7 @@ options:
   value_type: string
   description: Set platform if server is multi-platform capable
   deprecated: false
+  hidden: false
   min_api_version: "1.32"
   experimental: false
   experimentalcli: false
@@ -680,6 +754,7 @@ options:
   default_value: "false"
   description: Give extended privileges to this container
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -689,6 +764,7 @@ options:
   value_type: list
   description: Publish a container's port(s) to the host
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -699,6 +775,7 @@ options:
   default_value: "false"
   description: Publish all exposed ports to random ports
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -708,6 +785,18 @@ options:
   default_value: missing
   description: Pull image before creating ("always"|"missing"|"never")
   deprecated: false
+  hidden: false
+  experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
+- option: quiet
+  shorthand: q
+  value_type: bool
+  default_value: "false"
+  description: Suppress the pull output
+  deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -717,6 +806,7 @@ options:
   default_value: "false"
   description: Mount the container's root filesystem as read only
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -726,6 +816,7 @@ options:
   default_value: "no"
   description: Restart policy to apply when a container exits
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -735,6 +826,7 @@ options:
   default_value: "false"
   description: Automatically remove the container when it exits
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -743,6 +835,7 @@ options:
   value_type: string
   description: Runtime to use for this container
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -751,6 +844,7 @@ options:
   value_type: list
   description: Security Options
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -760,15 +854,16 @@ options:
   default_value: "0"
   description: Size of /dev/shm
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
   swarm: false
 - option: stop-signal
   value_type: string
-  default_value: SIGTERM
-  description: Signal to stop a container
+  description: Signal to stop the container
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -778,6 +873,7 @@ options:
   default_value: "0"
   description: Timeout (in seconds) to stop a container
   deprecated: false
+  hidden: false
   min_api_version: "1.25"
   experimental: false
   experimentalcli: false
@@ -787,6 +883,7 @@ options:
   value_type: list
   description: Storage driver options for the container
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -796,6 +893,7 @@ options:
   default_value: map[]
   description: Sysctl options
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -804,6 +902,7 @@ options:
   value_type: list
   description: Mount a tmpfs directory
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -814,6 +913,7 @@ options:
   default_value: "false"
   description: Allocate a pseudo-TTY
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -823,6 +923,7 @@ options:
   default_value: '[]'
   description: Ulimit options
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -832,6 +933,7 @@ options:
   value_type: string
   description: 'Username or UID (format: <name|uid>[:<group|gid>])'
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -840,6 +942,7 @@ options:
   value_type: string
   description: User namespace to use
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -848,6 +951,7 @@ options:
   value_type: string
   description: UTS namespace to use
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -857,6 +961,7 @@ options:
   value_type: list
   description: Bind mount a volume
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -865,6 +970,7 @@ options:
   value_type: string
   description: Optional volume driver for the container
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -873,6 +979,7 @@ options:
   value_type: list
   description: Mount volumes from the specified container(s)
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -882,6 +989,7 @@ options:
   value_type: string
   description: Working directory inside the container
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false

--- a/_data/engine-cli/docker_container_exec.yaml
+++ b/_data/engine-cli/docker_container_exec.yaml
@@ -11,6 +11,7 @@ options:
   default_value: "false"
   description: 'Detached mode: run command in the background'
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -19,6 +20,7 @@ options:
   value_type: string
   description: Override the key sequence for detaching a container
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -28,6 +30,7 @@ options:
   value_type: list
   description: Set environment variables
   deprecated: false
+  hidden: false
   min_api_version: "1.25"
   experimental: false
   experimentalcli: false
@@ -37,6 +40,7 @@ options:
   value_type: list
   description: Read in a file of environment variables
   deprecated: false
+  hidden: false
   min_api_version: "1.25"
   experimental: false
   experimentalcli: false
@@ -48,6 +52,7 @@ options:
   default_value: "false"
   description: Keep STDIN open even if not attached
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -57,6 +62,7 @@ options:
   default_value: "false"
   description: Give extended privileges to the command
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -67,6 +73,7 @@ options:
   default_value: "false"
   description: Allocate a pseudo-TTY
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -76,6 +83,7 @@ options:
   value_type: string
   description: 'Username or UID (format: <name|uid>[:<group|gid>])'
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -85,6 +93,7 @@ options:
   value_type: string
   description: Working directory inside the container
   deprecated: false
+  hidden: false
   min_api_version: "1.35"
   experimental: false
   experimentalcli: false

--- a/_data/engine-cli/docker_container_export.yaml
+++ b/_data/engine-cli/docker_container_export.yaml
@@ -10,6 +10,7 @@ options:
   value_type: string
   description: Write to a file, instead of STDOUT
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false

--- a/_data/engine-cli/docker_container_inspect.yaml
+++ b/_data/engine-cli/docker_container_inspect.yaml
@@ -8,8 +8,13 @@ options:
 - option: format
   shorthand: f
   value_type: string
-  description: Format the output using the given Go template
+  description: |-
+    Format output using a custom template:
+    'json':             Print in JSON format
+    'TEMPLATE':         Print output using the given Go template.
+    Refer to https://docs.docker.com/go/formatting/ for more information about formatting output with templates
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -20,6 +25,7 @@ options:
   default_value: "false"
   description: Display total file sizes
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false

--- a/_data/engine-cli/docker_container_kill.yaml
+++ b/_data/engine-cli/docker_container_kill.yaml
@@ -11,6 +11,7 @@ options:
   default_value: KILL
   description: Signal to send to the container
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false

--- a/_data/engine-cli/docker_container_logs.yaml
+++ b/_data/engine-cli/docker_container_logs.yaml
@@ -10,6 +10,7 @@ options:
   default_value: "false"
   description: Show extra details provided to logs
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -20,6 +21,7 @@ options:
   default_value: "false"
   description: Follow log output
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -29,6 +31,7 @@ options:
   description: |
     Show logs since timestamp (e.g. 2013-01-02T13:23:37Z) or relative (e.g. 42m for 42 minutes)
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -39,6 +42,7 @@ options:
   default_value: all
   description: Number of lines to show from the end of the logs
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -49,6 +53,7 @@ options:
   default_value: "false"
   description: Show timestamps
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -58,6 +63,7 @@ options:
   description: |
     Show logs before a timestamp (e.g. 2013-01-02T13:23:37Z) or relative (e.g. 42m for 42 minutes)
   deprecated: false
+  hidden: false
   min_api_version: "1.35"
   experimental: false
   experimentalcli: false

--- a/_data/engine-cli/docker_container_ls.yaml
+++ b/_data/engine-cli/docker_container_ls.yaml
@@ -12,6 +12,7 @@ options:
   default_value: "false"
   description: Show all containers (default shows just running)
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -21,14 +22,22 @@ options:
   value_type: filter
   description: Filter output based on conditions provided
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
   swarm: false
 - option: format
   value_type: string
-  description: Pretty-print containers using a Go template
+  description: |-
+    Format output using a custom template:
+    'table':            Print output in table format with column headers (default)
+    'table TEMPLATE':   Print output in table format using the given Go template
+    'json':             Print in JSON format
+    'TEMPLATE':         Print output using the given Go template.
+    Refer to https://docs.docker.com/go/formatting/ for more information about formatting output with templates
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -39,6 +48,7 @@ options:
   default_value: "-1"
   description: Show n last created containers (includes all states)
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -49,6 +59,7 @@ options:
   default_value: "false"
   description: Show the latest created container (includes all states)
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -58,6 +69,7 @@ options:
   default_value: "false"
   description: Don't truncate output
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -68,6 +80,7 @@ options:
   default_value: "false"
   description: Only display container IDs
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -78,6 +91,7 @@ options:
   default_value: "false"
   description: Display total file sizes
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false

--- a/_data/engine-cli/docker_container_prune.yaml
+++ b/_data/engine-cli/docker_container_prune.yaml
@@ -8,7 +8,9 @@ options:
 - option: filter
   value_type: filter
   description: Provide filter values (e.g. 'until=<timestamp>')
+  details_url: '#filter'
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -19,6 +21,7 @@ options:
   default_value: "false"
   description: Do not prompt for confirmation
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -37,7 +40,7 @@ examples: |-
   Total reclaimed space: 212 B
   ```
 
-  ### Filtering
+  ### Filtering (--filter) {#filter}
 
   The filtering flag (`--filter`) format is of "key=value". If there is more
   than one filter, then pass multiple flags (e.g., `--filter "foo=bar" --filter "bif=baz"`)

--- a/_data/engine-cli/docker_container_restart.yaml
+++ b/_data/engine-cli/docker_container_restart.yaml
@@ -11,6 +11,7 @@ options:
   default_value: "10"
   description: Seconds to wait for stop before killing the container
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false

--- a/_data/engine-cli/docker_container_rm.yaml
+++ b/_data/engine-cli/docker_container_rm.yaml
@@ -11,6 +11,7 @@ options:
   default_value: "false"
   description: Force the removal of a running container (uses SIGKILL)
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -21,6 +22,7 @@ options:
   default_value: "false"
   description: Remove the specified link
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -31,6 +33,7 @@ options:
   default_value: "false"
   description: Remove anonymous volumes associated with the container
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false

--- a/_data/engine-cli/docker_container_run.yaml
+++ b/_data/engine-cli/docker_container_run.yaml
@@ -9,6 +9,7 @@ options:
   value_type: list
   description: Add a custom host-to-IP mapping (host:ip)
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -18,6 +19,7 @@ options:
   value_type: list
   description: Attach to STDIN, STDOUT or STDERR
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -28,6 +30,7 @@ options:
   description: |
     Block IO (relative weight), between 10 and 1000, or 0 to disable (default 0)
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -37,6 +40,7 @@ options:
   default_value: '[]'
   description: Block IO weight (relative device weight)
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -45,6 +49,7 @@ options:
   value_type: list
   description: Add Linux capabilities
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -53,6 +58,7 @@ options:
   value_type: list
   description: Drop Linux capabilities
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -61,6 +67,7 @@ options:
   value_type: string
   description: Optional parent cgroup for the container
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -74,6 +81,7 @@ options:
     '':        Use the cgroup namespace as configured by the
                default-cgroupns-mode option on the daemon (default)
   deprecated: false
+  hidden: false
   min_api_version: "1.41"
   experimental: false
   experimentalcli: false
@@ -83,6 +91,7 @@ options:
   value_type: string
   description: Write the container ID to the file
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -92,6 +101,7 @@ options:
   default_value: "0"
   description: CPU count (Windows only)
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -102,6 +112,7 @@ options:
   default_value: "0"
   description: CPU percent (Windows only)
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -112,6 +123,7 @@ options:
   default_value: "0"
   description: Limit CPU CFS (Completely Fair Scheduler) period
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -121,6 +133,7 @@ options:
   default_value: "0"
   description: Limit CPU CFS (Completely Fair Scheduler) quota
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -130,6 +143,7 @@ options:
   default_value: "0"
   description: Limit CPU real-time period in microseconds
   deprecated: false
+  hidden: false
   min_api_version: "1.25"
   experimental: false
   experimentalcli: false
@@ -140,6 +154,7 @@ options:
   default_value: "0"
   description: Limit CPU real-time runtime in microseconds
   deprecated: false
+  hidden: false
   min_api_version: "1.25"
   experimental: false
   experimentalcli: false
@@ -151,6 +166,7 @@ options:
   default_value: "0"
   description: CPU shares (relative weight)
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -159,6 +175,7 @@ options:
   value_type: decimal
   description: Number of CPUs
   deprecated: false
+  hidden: false
   min_api_version: "1.25"
   experimental: false
   experimentalcli: false
@@ -168,6 +185,7 @@ options:
   value_type: string
   description: CPUs in which to allow execution (0-3, 0,1)
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -176,6 +194,7 @@ options:
   value_type: string
   description: MEMs in which to allow execution (0-3, 0,1)
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -186,6 +205,7 @@ options:
   default_value: "false"
   description: Run container in background and print container ID
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -194,6 +214,7 @@ options:
   value_type: string
   description: Override the key sequence for detaching a container
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -202,6 +223,7 @@ options:
   value_type: list
   description: Add a host device to the container
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -210,6 +232,7 @@ options:
   value_type: list
   description: Add a rule to the cgroup allowed devices list
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -219,6 +242,7 @@ options:
   default_value: '[]'
   description: Limit read rate (bytes per second) from a device
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -228,6 +252,7 @@ options:
   default_value: '[]'
   description: Limit read rate (IO per second) from a device
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -237,6 +262,7 @@ options:
   default_value: '[]'
   description: Limit write rate (bytes per second) to a device
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -246,6 +272,7 @@ options:
   default_value: '[]'
   description: Limit write rate (IO per second) to a device
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -255,6 +282,7 @@ options:
   default_value: "true"
   description: Skip image verification
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -263,6 +291,7 @@ options:
   value_type: list
   description: Set custom DNS servers
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -271,6 +300,7 @@ options:
   value_type: list
   description: Set DNS options
   deprecated: false
+  hidden: true
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -279,6 +309,7 @@ options:
   value_type: list
   description: Set DNS options
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -287,6 +318,7 @@ options:
   value_type: list
   description: Set custom DNS search domains
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -295,6 +327,7 @@ options:
   value_type: string
   description: Container NIS domain name
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -303,6 +336,7 @@ options:
   value_type: string
   description: Overwrite the default ENTRYPOINT of the image
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -312,6 +346,7 @@ options:
   value_type: list
   description: Set environment variables
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -320,6 +355,7 @@ options:
   value_type: list
   description: Read in a file of environment variables
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -328,6 +364,7 @@ options:
   value_type: list
   description: Expose a port or a range of ports
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -336,6 +373,7 @@ options:
   value_type: gpu-request
   description: GPU devices to add to the container ('all' to pass all GPUs)
   deprecated: false
+  hidden: false
   min_api_version: "1.40"
   experimental: false
   experimentalcli: false
@@ -345,6 +383,7 @@ options:
   value_type: list
   description: Add additional groups to join
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -353,6 +392,7 @@ options:
   value_type: string
   description: Command to run to check health
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -362,6 +402,7 @@ options:
   default_value: 0s
   description: Time between running the check (ms|s|m|h) (default 0s)
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -371,6 +412,7 @@ options:
   default_value: "0"
   description: Consecutive failures needed to report unhealthy
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -381,6 +423,7 @@ options:
   description: |
     Start period for the container to initialize before starting health-retries countdown (ms|s|m|h) (default 0s)
   deprecated: false
+  hidden: false
   min_api_version: "1.29"
   experimental: false
   experimentalcli: false
@@ -389,9 +432,9 @@ options:
 - option: health-timeout
   value_type: duration
   default_value: 0s
-  description: |
-    Maximum time to allow one check to run (ms|s|m|h) (default 0s)
+  description: Maximum time to allow one check to run (ms|s|m|h) (default 0s)
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -401,6 +444,7 @@ options:
   default_value: "false"
   description: Print usage
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -410,6 +454,7 @@ options:
   value_type: string
   description: Container host name
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -420,6 +465,7 @@ options:
   description: |
     Run an init inside the container that forwards signals and reaps processes
   deprecated: false
+  hidden: false
   min_api_version: "1.25"
   experimental: false
   experimentalcli: false
@@ -431,6 +477,7 @@ options:
   default_value: "false"
   description: Keep STDIN open even if not attached
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -438,9 +485,9 @@ options:
 - option: io-maxbandwidth
   value_type: bytes
   default_value: "0"
-  description: |
-    Maximum IO bandwidth limit for the system drive (Windows only)
+  description: Maximum IO bandwidth limit for the system drive (Windows only)
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -451,6 +498,7 @@ options:
   default_value: "0"
   description: Maximum IOps limit for the system drive (Windows only)
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -460,6 +508,7 @@ options:
   value_type: string
   description: IPv4 address (e.g., 172.30.100.104)
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -468,6 +517,7 @@ options:
   value_type: string
   description: IPv6 address (e.g., 2001:db8::33)
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -476,6 +526,7 @@ options:
   value_type: string
   description: IPC mode to use
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -484,6 +535,7 @@ options:
   value_type: string
   description: Container isolation technology
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -493,6 +545,7 @@ options:
   default_value: "0"
   description: Kernel memory limit
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -502,6 +555,7 @@ options:
   value_type: list
   description: Set meta data on a container
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -510,6 +564,7 @@ options:
   value_type: list
   description: Read in a line delimited file of labels
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -518,6 +573,7 @@ options:
   value_type: list
   description: Add link to another container
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -526,6 +582,7 @@ options:
   value_type: list
   description: Container IPv4/IPv6 link-local addresses
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -534,6 +591,7 @@ options:
   value_type: string
   description: Logging driver for the container
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -542,6 +600,7 @@ options:
   value_type: list
   description: Log driver options
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -550,6 +609,7 @@ options:
   value_type: string
   description: Container MAC address (e.g., 92:d0:c6:0a:29:33)
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -560,6 +620,7 @@ options:
   default_value: "0"
   description: Memory limit
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -569,6 +630,7 @@ options:
   default_value: "0"
   description: Memory soft limit
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -579,6 +641,7 @@ options:
   description: |
     Swap limit equal to memory plus swap: '-1' to enable unlimited swap
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -588,6 +651,7 @@ options:
   default_value: "-1"
   description: Tune container memory swappiness (0 to 100)
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -596,6 +660,7 @@ options:
   value_type: mount
   description: Attach a filesystem mount to the container
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -604,6 +669,7 @@ options:
   value_type: string
   description: Assign a name to the container
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -612,6 +678,7 @@ options:
   value_type: network
   description: Connect a container to a network
   deprecated: false
+  hidden: true
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -620,6 +687,7 @@ options:
   value_type: list
   description: Add network-scoped alias for the container
   deprecated: false
+  hidden: true
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -628,6 +696,7 @@ options:
   value_type: network
   description: Connect a container to a network
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -636,6 +705,7 @@ options:
   value_type: list
   description: Add network-scoped alias for the container
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -645,6 +715,7 @@ options:
   default_value: "false"
   description: Disable any container-specified HEALTHCHECK
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -654,6 +725,7 @@ options:
   default_value: "false"
   description: Disable OOM Killer
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -663,6 +735,7 @@ options:
   default_value: "0"
   description: Tune host's OOM preferences (-1000 to 1000)
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -671,6 +744,7 @@ options:
   value_type: string
   description: PID namespace to use
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -680,6 +754,7 @@ options:
   default_value: "0"
   description: Tune container pids limit (set -1 for unlimited)
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -688,6 +763,7 @@ options:
   value_type: string
   description: Set platform if server is multi-platform capable
   deprecated: false
+  hidden: false
   min_api_version: "1.32"
   experimental: false
   experimentalcli: false
@@ -698,6 +774,7 @@ options:
   default_value: "false"
   description: Give extended privileges to this container
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -707,6 +784,7 @@ options:
   value_type: list
   description: Publish a container's port(s) to the host
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -717,6 +795,7 @@ options:
   default_value: "false"
   description: Publish all exposed ports to random ports
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -726,6 +805,18 @@ options:
   default_value: missing
   description: Pull image before running ("always"|"missing"|"never")
   deprecated: false
+  hidden: false
+  experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
+- option: quiet
+  shorthand: q
+  value_type: bool
+  default_value: "false"
+  description: Suppress the pull output
+  deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -735,6 +826,7 @@ options:
   default_value: "false"
   description: Mount the container's root filesystem as read only
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -744,6 +836,7 @@ options:
   default_value: "no"
   description: Restart policy to apply when a container exits
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -753,6 +846,7 @@ options:
   default_value: "false"
   description: Automatically remove the container when it exits
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -761,6 +855,7 @@ options:
   value_type: string
   description: Runtime to use for this container
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -769,6 +864,7 @@ options:
   value_type: list
   description: Security Options
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -778,6 +874,7 @@ options:
   default_value: "0"
   description: Size of /dev/shm
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -787,15 +884,16 @@ options:
   default_value: "true"
   description: Proxy received signals to the process
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
   swarm: false
 - option: stop-signal
   value_type: string
-  default_value: SIGTERM
-  description: Signal to stop a container
+  description: Signal to stop the container
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -805,6 +903,7 @@ options:
   default_value: "0"
   description: Timeout (in seconds) to stop a container
   deprecated: false
+  hidden: false
   min_api_version: "1.25"
   experimental: false
   experimentalcli: false
@@ -814,6 +913,7 @@ options:
   value_type: list
   description: Storage driver options for the container
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -823,6 +923,7 @@ options:
   default_value: map[]
   description: Sysctl options
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -831,6 +932,7 @@ options:
   value_type: list
   description: Mount a tmpfs directory
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -841,6 +943,7 @@ options:
   default_value: "false"
   description: Allocate a pseudo-TTY
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -850,6 +953,7 @@ options:
   default_value: '[]'
   description: Ulimit options
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -859,6 +963,7 @@ options:
   value_type: string
   description: 'Username or UID (format: <name|uid>[:<group|gid>])'
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -867,6 +972,7 @@ options:
   value_type: string
   description: User namespace to use
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -875,6 +981,7 @@ options:
   value_type: string
   description: UTS namespace to use
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -884,6 +991,7 @@ options:
   value_type: list
   description: Bind mount a volume
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -892,6 +1000,7 @@ options:
   value_type: string
   description: Optional volume driver for the container
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -900,6 +1009,7 @@ options:
   value_type: list
   description: Mount volumes from the specified container(s)
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -909,6 +1019,7 @@ options:
   value_type: string
   description: Working directory inside the container
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false

--- a/_data/engine-cli/docker_container_start.yaml
+++ b/_data/engine-cli/docker_container_start.yaml
@@ -11,6 +11,7 @@ options:
   default_value: "false"
   description: Attach STDOUT/STDERR and forward signals
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -19,6 +20,7 @@ options:
   value_type: string
   description: Restore from this checkpoint
   deprecated: false
+  hidden: false
   experimental: true
   experimentalcli: false
   kubernetes: false
@@ -28,6 +30,7 @@ options:
   value_type: string
   description: Use a custom checkpoint storage directory
   deprecated: false
+  hidden: false
   experimental: true
   experimentalcli: false
   kubernetes: false
@@ -37,6 +40,7 @@ options:
   value_type: string
   description: Override the key sequence for detaching a container
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -47,6 +51,7 @@ options:
   default_value: "false"
   description: Attach container's STDIN
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false

--- a/_data/engine-cli/docker_container_stats.yaml
+++ b/_data/engine-cli/docker_container_stats.yaml
@@ -11,14 +11,22 @@ options:
   default_value: "false"
   description: Show all containers (default shows just running)
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
   swarm: false
 - option: format
   value_type: string
-  description: Pretty-print images using a Go template
+  description: |-
+    Format output using a custom template:
+    'table':            Print output in table format with column headers (default)
+    'table TEMPLATE':   Print output in table format using the given Go template
+    'json':             Print in JSON format
+    'TEMPLATE':         Print output using the given Go template.
+    Refer to https://docs.docker.com/go/formatting/ for more information about formatting output with templates
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -28,6 +36,7 @@ options:
   default_value: "false"
   description: Disable streaming stats and only pull the first result
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -37,6 +46,7 @@ options:
   default_value: "false"
   description: Do not truncate output
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false

--- a/_data/engine-cli/docker_container_stop.yaml
+++ b/_data/engine-cli/docker_container_stop.yaml
@@ -11,6 +11,7 @@ options:
   default_value: "10"
   description: Seconds to wait for stop before killing it
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false

--- a/_data/engine-cli/docker_container_update.yaml
+++ b/_data/engine-cli/docker_container_update.yaml
@@ -11,6 +11,7 @@ options:
   description: |
     Block IO (relative weight), between 10 and 1000, or 0 to disable (default 0)
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -20,6 +21,7 @@ options:
   default_value: "0"
   description: Limit CPU CFS (Completely Fair Scheduler) period
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -29,6 +31,7 @@ options:
   default_value: "0"
   description: Limit CPU CFS (Completely Fair Scheduler) quota
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -38,6 +41,7 @@ options:
   default_value: "0"
   description: Limit the CPU real-time period in microseconds
   deprecated: false
+  hidden: false
   min_api_version: "1.25"
   experimental: false
   experimentalcli: false
@@ -48,6 +52,7 @@ options:
   default_value: "0"
   description: Limit the CPU real-time runtime in microseconds
   deprecated: false
+  hidden: false
   min_api_version: "1.25"
   experimental: false
   experimentalcli: false
@@ -59,6 +64,7 @@ options:
   default_value: "0"
   description: CPU shares (relative weight)
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -67,6 +73,7 @@ options:
   value_type: decimal
   description: Number of CPUs
   deprecated: false
+  hidden: false
   min_api_version: "1.29"
   experimental: false
   experimentalcli: false
@@ -76,6 +83,7 @@ options:
   value_type: string
   description: CPUs in which to allow execution (0-3, 0,1)
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -84,6 +92,7 @@ options:
   value_type: string
   description: MEMs in which to allow execution (0-3, 0,1)
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -93,6 +102,7 @@ options:
   default_value: "0"
   description: Kernel memory limit
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -103,6 +113,7 @@ options:
   default_value: "0"
   description: Memory limit
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -112,6 +123,7 @@ options:
   default_value: "0"
   description: Memory soft limit
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -122,6 +134,7 @@ options:
   description: |
     Swap limit equal to memory plus swap: '-1' to enable unlimited swap
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -131,6 +144,7 @@ options:
   default_value: "0"
   description: Tune container pids limit (set -1 for unlimited)
   deprecated: false
+  hidden: false
   min_api_version: "1.40"
   experimental: false
   experimentalcli: false
@@ -140,6 +154,7 @@ options:
   value_type: string
   description: Restart policy to apply when a container exits
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false

--- a/_data/engine-cli/docker_context.yaml
+++ b/_data/engine-cli/docker_context.yaml
@@ -1,6 +1,6 @@
 command: docker context
 short: Manage contexts
-long: Manage contexts
+long: Manage contexts.
 usage: docker context
 pname: docker
 plink: docker.yaml

--- a/_data/engine-cli/docker_context_create.yaml
+++ b/_data/engine-cli/docker_context_create.yaml
@@ -12,6 +12,7 @@ options:
   description: |
     Default orchestrator for stack operations to use with this context (swarm|kubernetes|all)
   deprecated: true
+  hidden: true
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -20,6 +21,7 @@ options:
   value_type: string
   description: Description of the context
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -28,7 +30,9 @@ options:
   value_type: stringToString
   default_value: '[]'
   description: set the docker endpoint
+  details_url: '#docker'
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -36,7 +40,9 @@ options:
 - option: from
   value_type: string
   description: create context from a named context
+  details_url: '#from'
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -46,26 +52,25 @@ options:
   default_value: '[]'
   description: set the kubernetes endpoint
   deprecated: true
+  hidden: true
   experimental: false
   experimentalcli: false
   kubernetes: true
   swarm: false
 examples: |-
-  ### Create a context with a docker and kubernetes endpoint
+  ### Create a context with a docker endpoint (--docker) {#docker}
 
   To create a context from scratch provide the docker and, if required,
   kubernetes options. The example below creates the context `my-context`
-  with a docker endpoint of `/var/run/docker.sock` and a kubernetes configuration
-  sourced from the file `/home/me/my-kube-config`:
+  with a docker endpoint of `/var/run/docker.sock`:
 
   ```console
   $ docker context create \
       --docker host=unix:///var/run/docker.sock \
-      --kubernetes config-file=/home/me/my-kube-config \
       my-context
   ```
 
-  ### Create a context based on an existing context
+  ### Create a context based on an existing context (--from) {#from}
 
   Use the `--from=<context-name>` option to create a new context from
   an existing context. The example below creates a new context named `my-context`
@@ -88,33 +93,19 @@ examples: |-
   $ docker context create my-context
   ```
 
-  To source only the `docker` endpoint configuration from an existing context
+  To source the `docker` endpoint configuration from an existing context
   use the `--docker from=<context-name>` option. The example below creates a
   new context named `my-context` using the docker endpoint configuration from
-  the existing context `existing-context` and a kubernetes configuration sourced
-  from the file `/home/me/my-kube-config`:
+  the existing context `existing-context`:
 
   ```console
   $ docker context create \
       --docker from=existing-context \
-      --kubernetes config-file=/home/me/my-kube-config \
       my-context
   ```
 
-  To source only the `kubernetes` configuration from an existing context use the
-  `--kubernetes from=<context-name>` option. The example below creates a new
-  context named `my-context` using the kuberentes configuration from the existing
-  context `existing-context` and a docker endpoint of `/var/run/docker.sock`:
-
-  ```console
-  $ docker context create \
-      --docker host=unix:///var/run/docker.sock \
-      --kubernetes from=existing-context \
-      my-context
-  ```
-
-  Docker and Kubernetes endpoints configurations, as well as default stack
-  orchestrator and description can be modified with `docker context update`.
+  Docker endpoints configurations, as well as the description can be modified with
+  `docker context update`.
 
   Refer to the [`docker context update` reference](context_update.md) for details.
 deprecated: false

--- a/_data/engine-cli/docker_context_export.yaml
+++ b/_data/engine-cli/docker_context_export.yaml
@@ -1,10 +1,14 @@
 command: docker context export
-short: Export a context to a tar or kubeconfig file
+short: Export a context to a tar archive FILE or a tar stream on STDOUT.
 long: |-
-  Exports a context in a file that can then be used with `docker context import`
-  (or with `kubectl` if `--kubeconfig` is set). Default output filename is
-  `<CONTEXT>.dockercontext`, or `<CONTEXT>.kubeconfig` if `--kubeconfig` is set.
-  To export to `STDOUT`, you can run `docker context export my-context -`.
+  Exports a context to a file that can then be used with `docker context import`.
+
+  The default output filename is `<CONTEXT>.dockercontext`. To export to `STDOUT`,
+  use `-` as filename, for example:
+
+  ```console
+  $ docker context export my-context -
+  ```
 usage: docker context export [OPTIONS] CONTEXT [FILE|-]
 pname: docker context
 plink: docker_context.yaml
@@ -14,6 +18,7 @@ options:
   default_value: "false"
   description: Export as a kubeconfig file
   deprecated: true
+  hidden: true
   experimental: false
   experimentalcli: false
   kubernetes: true

--- a/_data/engine-cli/docker_context_inspect.yaml
+++ b/_data/engine-cli/docker_context_inspect.yaml
@@ -8,8 +8,13 @@ options:
 - option: format
   shorthand: f
   value_type: string
-  description: Format the output using the given Go template
+  description: |-
+    Format output using a custom template:
+    'json':             Print in JSON format
+    'TEMPLATE':         Print output using the given Go template.
+    Refer to https://docs.docker.com/go/formatting/ for more information about formatting output with templates
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -24,27 +29,16 @@ examples: |-
     {
       "Name": "local+aks",
       "Metadata": {
-        "Description": "Local Docker Engine + Azure AKS endpoint",
-        "StackOrchestrator": "kubernetes"
+        "Description": "Local Docker Engine",
+        "StackOrchestrator": "swarm"
       },
       "Endpoints": {
         "docker": {
           "Host": "npipe:////./pipe/docker_engine",
           "SkipTLSVerify": false
-        },
-        "kubernetes": {
-          "Host": "https://simon-aks-***.hcp.uksouth.azmk8s.io:443",
-          "SkipTLSVerify": false,
-          "DefaultNamespace": "default"
         }
       },
-      "TLSMaterial": {
-        "kubernetes": [
-          "ca.pem",
-          "cert.pem",
-          "key.pem"
-        ]
-      },
+      "TLSMaterial": {},
       "Storage": {
         "MetadataPath": "C:\\Users\\simon\\.docker\\contexts\\meta\\cb6d08c0a1bfa5fe6f012e61a442788c00bed93f509141daff05f620fc54ddee",
         "TLSPath": "C:\\Users\\simon\\.docker\\contexts\\tls\\cb6d08c0a1bfa5fe6f012e61a442788c00bed93f509141daff05f620fc54ddee"

--- a/_data/engine-cli/docker_context_ls.yaml
+++ b/_data/engine-cli/docker_context_ls.yaml
@@ -8,8 +8,15 @@ plink: docker_context.yaml
 options:
 - option: format
   value_type: string
-  description: Pretty-print contexts using a Go template
+  description: |-
+    Format output using a custom template:
+    'table':            Print output in table format with column headers (default)
+    'table TEMPLATE':   Print output in table format using the given Go template
+    'json':             Print in JSON format
+    'TEMPLATE':         Print output using the given Go template.
+    Refer to https://docs.docker.com/go/formatting/ for more information about formatting output with templates
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -20,6 +27,7 @@ options:
   default_value: "false"
   description: Only show context names
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -31,8 +39,8 @@ examples: |-
   ```console
   $ docker context ls
 
-  NAME                DESCRIPTION                               DOCKER ENDPOINT                      KUBERNETES ENDPOINT   ORCHESTRATOR
-  default *           Current DOCKER_HOST based configuration   unix:///var/run/docker.sock                                swarm
+  NAME                DESCRIPTION                               DOCKER ENDPOINT                      ORCHESTRATOR
+  default *           Current DOCKER_HOST based configuration   unix:///var/run/docker.sock          swarm
   production                                                    tcp:///prod.corp.example.com:2376
   staging                                                       tcp:///stage.corp.example.com:2376
   ```

--- a/_data/engine-cli/docker_context_rm.yaml
+++ b/_data/engine-cli/docker_context_rm.yaml
@@ -12,6 +12,7 @@ options:
   default_value: "false"
   description: Force the removal of a context in use
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false

--- a/_data/engine-cli/docker_context_update.yaml
+++ b/_data/engine-cli/docker_context_update.yaml
@@ -12,6 +12,7 @@ options:
   description: |
     Default orchestrator for stack operations to use with this context (swarm|kubernetes|all)
   deprecated: true
+  hidden: true
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -20,6 +21,7 @@ options:
   value_type: string
   description: Description of the context
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -29,6 +31,7 @@ options:
   default_value: '[]'
   description: set the docker endpoint
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -38,6 +41,7 @@ options:
   default_value: '[]'
   description: set the kubernetes endpoint
   deprecated: true
+  hidden: true
   experimental: false
   experimentalcli: false
   kubernetes: true

--- a/_data/engine-cli/docker_cp.yaml
+++ b/_data/engine-cli/docker_cp.yaml
@@ -64,6 +64,65 @@ long: |-
   you must be explicit with a relative or absolute path, for example:
 
       `/path/to/file:name.txt` or `./file:name.txt`
+usage: "docker cp [OPTIONS] CONTAINER:SRC_PATH DEST_PATH|-\n\tdocker cp [OPTIONS]
+  SRC_PATH|- CONTAINER:DEST_PATH"
+pname: docker
+plink: docker.yaml
+options:
+- option: archive
+  shorthand: a
+  value_type: bool
+  default_value: "false"
+  description: Archive mode (copy all uid/gid information)
+  deprecated: false
+  hidden: false
+  experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
+- option: follow-link
+  shorthand: L
+  value_type: bool
+  default_value: "false"
+  description: Always follow symbol link in SRC_PATH
+  deprecated: false
+  hidden: false
+  experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
+- option: quiet
+  shorthand: q
+  value_type: bool
+  default_value: "false"
+  description: |
+    Suppress progress output during copy. Progress output is automatically suppressed if no terminal is attached
+  deprecated: false
+  hidden: false
+  experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
+examples: |-
+  Copy a local file into container
+
+  ```console
+  $ docker cp ./some_file CONTAINER:/work
+  ```
+
+  Copy files from container to local path
+
+  ```console
+  $ docker cp CONTAINER:/var/logs/ /tmp/app_logs
+  ```
+
+  Copy a file from container to stdout. Please note `cp` command produces a tar stream
+
+  ```console
+  $ docker cp CONTAINER:/var/logs/app.log - | tar x -O | grep "ERROR"
+  ```
+
+  ### Corner cases
 
   It is not possible to copy certain system files such as resources under
   `/proc`, `/sys`, `/dev`, [tmpfs](run.md#mount-tmpfs---tmpfs), and mounts created by
@@ -83,31 +142,6 @@ long: |-
   The command extracts the content of the tar to the `DEST_PATH` in container's
   filesystem. In this case, `DEST_PATH` must specify a directory. Using `-` as
   the `DEST_PATH` streams the contents of the resource as a tar archive to `STDOUT`.
-usage: "docker cp [OPTIONS] CONTAINER:SRC_PATH DEST_PATH|-\n\tdocker cp [OPTIONS]
-  SRC_PATH|- CONTAINER:DEST_PATH"
-pname: docker
-plink: docker.yaml
-options:
-- option: archive
-  shorthand: a
-  value_type: bool
-  default_value: "false"
-  description: Archive mode (copy all uid/gid information)
-  deprecated: false
-  experimental: false
-  experimentalcli: false
-  kubernetes: false
-  swarm: false
-- option: follow-link
-  shorthand: L
-  value_type: bool
-  default_value: "false"
-  description: Always follow symbol link in SRC_PATH
-  deprecated: false
-  experimental: false
-  experimentalcli: false
-  kubernetes: false
-  swarm: false
 deprecated: false
 experimental: false
 experimentalcli: false

--- a/_data/engine-cli/docker_create.yaml
+++ b/_data/engine-cli/docker_create.yaml
@@ -1,17 +1,23 @@
 command: docker create
 short: Create a new container
 long: |-
-  The `docker create` command creates a writeable container layer over the
-  specified image and prepares it for running the specified command.  The
+  The `docker container create` (or shorthand: `docker create`) command creates a
+  new container from the specified image, without starting it.
+
+  When creating a container, the docker daemon creates a writeable container layer
+  over the specified image and prepares it for running the specified command.  The
   container ID is then printed to `STDOUT`.  This is similar to `docker run -d`
-  except the container is never started.  You can then use the
-  `docker start <container_id>` command to start the container at any point.
+  except the container is never started. You can then use the `docker container start`
+  (or shorthand: `docker start`) command to start the container at any point.
 
   This is useful when you want to set up a container configuration ahead of time
   so that it is ready to start when you need it. The initial status of the
   new container is `created`.
 
-  Please see the [run command](run.md) section and the [Docker run reference](../run.md) for more details.
+  The `docker create` command shares most of its options with the `docker run`
+  command (which performs a `docker create` before starting it). Refer to the
+  [`docker run` command](run.md) section and the [Docker run reference](../run.md)
+  for details on the available flags and options.
 usage: docker create [OPTIONS] IMAGE [COMMAND] [ARG...]
 pname: docker
 plink: docker.yaml
@@ -20,6 +26,7 @@ options:
   value_type: list
   description: Add a custom host-to-IP mapping (host:ip)
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -29,6 +36,7 @@ options:
   value_type: list
   description: Attach to STDIN, STDOUT or STDERR
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -39,6 +47,7 @@ options:
   description: |
     Block IO (relative weight), between 10 and 1000, or 0 to disable (default 0)
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -48,6 +57,7 @@ options:
   default_value: '[]'
   description: Block IO weight (relative device weight)
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -56,6 +66,7 @@ options:
   value_type: list
   description: Add Linux capabilities
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -64,6 +75,7 @@ options:
   value_type: list
   description: Drop Linux capabilities
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -72,6 +84,7 @@ options:
   value_type: string
   description: Optional parent cgroup for the container
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -85,6 +98,7 @@ options:
     '':        Use the cgroup namespace as configured by the
                default-cgroupns-mode option on the daemon (default)
   deprecated: false
+  hidden: false
   min_api_version: "1.41"
   experimental: false
   experimentalcli: false
@@ -94,6 +108,7 @@ options:
   value_type: string
   description: Write the container ID to the file
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -103,6 +118,7 @@ options:
   default_value: "0"
   description: CPU count (Windows only)
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -113,6 +129,7 @@ options:
   default_value: "0"
   description: CPU percent (Windows only)
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -123,6 +140,7 @@ options:
   default_value: "0"
   description: Limit CPU CFS (Completely Fair Scheduler) period
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -132,6 +150,7 @@ options:
   default_value: "0"
   description: Limit CPU CFS (Completely Fair Scheduler) quota
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -141,6 +160,7 @@ options:
   default_value: "0"
   description: Limit CPU real-time period in microseconds
   deprecated: false
+  hidden: false
   min_api_version: "1.25"
   experimental: false
   experimentalcli: false
@@ -151,6 +171,7 @@ options:
   default_value: "0"
   description: Limit CPU real-time runtime in microseconds
   deprecated: false
+  hidden: false
   min_api_version: "1.25"
   experimental: false
   experimentalcli: false
@@ -162,6 +183,7 @@ options:
   default_value: "0"
   description: CPU shares (relative weight)
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -170,6 +192,7 @@ options:
   value_type: decimal
   description: Number of CPUs
   deprecated: false
+  hidden: false
   min_api_version: "1.25"
   experimental: false
   experimentalcli: false
@@ -179,6 +202,7 @@ options:
   value_type: string
   description: CPUs in which to allow execution (0-3, 0,1)
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -187,6 +211,7 @@ options:
   value_type: string
   description: MEMs in which to allow execution (0-3, 0,1)
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -195,6 +220,7 @@ options:
   value_type: list
   description: Add a host device to the container
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -203,6 +229,7 @@ options:
   value_type: list
   description: Add a rule to the cgroup allowed devices list
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -212,6 +239,7 @@ options:
   default_value: '[]'
   description: Limit read rate (bytes per second) from a device
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -221,6 +249,7 @@ options:
   default_value: '[]'
   description: Limit read rate (IO per second) from a device
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -230,6 +259,7 @@ options:
   default_value: '[]'
   description: Limit write rate (bytes per second) to a device
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -239,6 +269,7 @@ options:
   default_value: '[]'
   description: Limit write rate (IO per second) to a device
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -248,6 +279,7 @@ options:
   default_value: "true"
   description: Skip image verification
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -256,6 +288,7 @@ options:
   value_type: list
   description: Set custom DNS servers
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -264,6 +297,7 @@ options:
   value_type: list
   description: Set DNS options
   deprecated: false
+  hidden: true
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -272,6 +306,7 @@ options:
   value_type: list
   description: Set DNS options
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -280,6 +315,7 @@ options:
   value_type: list
   description: Set custom DNS search domains
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -288,6 +324,7 @@ options:
   value_type: string
   description: Container NIS domain name
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -296,6 +333,7 @@ options:
   value_type: string
   description: Overwrite the default ENTRYPOINT of the image
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -305,6 +343,7 @@ options:
   value_type: list
   description: Set environment variables
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -313,6 +352,7 @@ options:
   value_type: list
   description: Read in a file of environment variables
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -321,6 +361,7 @@ options:
   value_type: list
   description: Expose a port or a range of ports
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -329,6 +370,7 @@ options:
   value_type: gpu-request
   description: GPU devices to add to the container ('all' to pass all GPUs)
   deprecated: false
+  hidden: false
   min_api_version: "1.40"
   experimental: false
   experimentalcli: false
@@ -338,6 +380,7 @@ options:
   value_type: list
   description: Add additional groups to join
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -346,6 +389,7 @@ options:
   value_type: string
   description: Command to run to check health
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -355,6 +399,7 @@ options:
   default_value: 0s
   description: Time between running the check (ms|s|m|h) (default 0s)
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -364,6 +409,7 @@ options:
   default_value: "0"
   description: Consecutive failures needed to report unhealthy
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -374,6 +420,7 @@ options:
   description: |
     Start period for the container to initialize before starting health-retries countdown (ms|s|m|h) (default 0s)
   deprecated: false
+  hidden: false
   min_api_version: "1.29"
   experimental: false
   experimentalcli: false
@@ -382,9 +429,9 @@ options:
 - option: health-timeout
   value_type: duration
   default_value: 0s
-  description: |
-    Maximum time to allow one check to run (ms|s|m|h) (default 0s)
+  description: Maximum time to allow one check to run (ms|s|m|h) (default 0s)
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -394,6 +441,7 @@ options:
   default_value: "false"
   description: Print usage
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -403,6 +451,7 @@ options:
   value_type: string
   description: Container host name
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -413,6 +462,7 @@ options:
   description: |
     Run an init inside the container that forwards signals and reaps processes
   deprecated: false
+  hidden: false
   min_api_version: "1.25"
   experimental: false
   experimentalcli: false
@@ -424,6 +474,7 @@ options:
   default_value: "false"
   description: Keep STDIN open even if not attached
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -431,9 +482,9 @@ options:
 - option: io-maxbandwidth
   value_type: bytes
   default_value: "0"
-  description: |
-    Maximum IO bandwidth limit for the system drive (Windows only)
+  description: Maximum IO bandwidth limit for the system drive (Windows only)
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -444,6 +495,7 @@ options:
   default_value: "0"
   description: Maximum IOps limit for the system drive (Windows only)
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -453,6 +505,7 @@ options:
   value_type: string
   description: IPv4 address (e.g., 172.30.100.104)
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -461,6 +514,7 @@ options:
   value_type: string
   description: IPv6 address (e.g., 2001:db8::33)
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -469,6 +523,7 @@ options:
   value_type: string
   description: IPC mode to use
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -477,6 +532,7 @@ options:
   value_type: string
   description: Container isolation technology
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -486,6 +542,7 @@ options:
   default_value: "0"
   description: Kernel memory limit
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -495,6 +552,7 @@ options:
   value_type: list
   description: Set meta data on a container
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -503,6 +561,7 @@ options:
   value_type: list
   description: Read in a line delimited file of labels
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -511,6 +570,7 @@ options:
   value_type: list
   description: Add link to another container
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -519,6 +579,7 @@ options:
   value_type: list
   description: Container IPv4/IPv6 link-local addresses
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -527,6 +588,7 @@ options:
   value_type: string
   description: Logging driver for the container
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -535,6 +597,7 @@ options:
   value_type: list
   description: Log driver options
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -543,6 +606,7 @@ options:
   value_type: string
   description: Container MAC address (e.g., 92:d0:c6:0a:29:33)
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -553,6 +617,7 @@ options:
   default_value: "0"
   description: Memory limit
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -562,6 +627,7 @@ options:
   default_value: "0"
   description: Memory soft limit
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -572,6 +638,7 @@ options:
   description: |
     Swap limit equal to memory plus swap: '-1' to enable unlimited swap
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -581,6 +648,7 @@ options:
   default_value: "-1"
   description: Tune container memory swappiness (0 to 100)
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -589,6 +657,7 @@ options:
   value_type: mount
   description: Attach a filesystem mount to the container
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -597,6 +666,7 @@ options:
   value_type: string
   description: Assign a name to the container
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -605,6 +675,7 @@ options:
   value_type: network
   description: Connect a container to a network
   deprecated: false
+  hidden: true
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -613,6 +684,7 @@ options:
   value_type: list
   description: Add network-scoped alias for the container
   deprecated: false
+  hidden: true
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -621,6 +693,7 @@ options:
   value_type: network
   description: Connect a container to a network
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -629,6 +702,7 @@ options:
   value_type: list
   description: Add network-scoped alias for the container
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -638,6 +712,7 @@ options:
   default_value: "false"
   description: Disable any container-specified HEALTHCHECK
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -647,6 +722,7 @@ options:
   default_value: "false"
   description: Disable OOM Killer
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -656,6 +732,7 @@ options:
   default_value: "0"
   description: Tune host's OOM preferences (-1000 to 1000)
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -664,6 +741,7 @@ options:
   value_type: string
   description: PID namespace to use
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -673,6 +751,7 @@ options:
   default_value: "0"
   description: Tune container pids limit (set -1 for unlimited)
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -681,6 +760,7 @@ options:
   value_type: string
   description: Set platform if server is multi-platform capable
   deprecated: false
+  hidden: false
   min_api_version: "1.32"
   experimental: false
   experimentalcli: false
@@ -691,6 +771,7 @@ options:
   default_value: "false"
   description: Give extended privileges to this container
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -700,6 +781,7 @@ options:
   value_type: list
   description: Publish a container's port(s) to the host
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -710,6 +792,7 @@ options:
   default_value: "false"
   description: Publish all exposed ports to random ports
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -719,6 +802,18 @@ options:
   default_value: missing
   description: Pull image before creating ("always"|"missing"|"never")
   deprecated: false
+  hidden: false
+  experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
+- option: quiet
+  shorthand: q
+  value_type: bool
+  default_value: "false"
+  description: Suppress the pull output
+  deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -728,6 +823,7 @@ options:
   default_value: "false"
   description: Mount the container's root filesystem as read only
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -737,6 +833,7 @@ options:
   default_value: "no"
   description: Restart policy to apply when a container exits
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -746,6 +843,7 @@ options:
   default_value: "false"
   description: Automatically remove the container when it exits
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -754,6 +852,7 @@ options:
   value_type: string
   description: Runtime to use for this container
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -762,6 +861,7 @@ options:
   value_type: list
   description: Security Options
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -771,15 +871,16 @@ options:
   default_value: "0"
   description: Size of /dev/shm
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
   swarm: false
 - option: stop-signal
   value_type: string
-  default_value: SIGTERM
-  description: Signal to stop a container
+  description: Signal to stop the container
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -789,6 +890,7 @@ options:
   default_value: "0"
   description: Timeout (in seconds) to stop a container
   deprecated: false
+  hidden: false
   min_api_version: "1.25"
   experimental: false
   experimentalcli: false
@@ -798,6 +900,7 @@ options:
   value_type: list
   description: Storage driver options for the container
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -807,6 +910,7 @@ options:
   default_value: map[]
   description: Sysctl options
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -815,6 +919,7 @@ options:
   value_type: list
   description: Mount a tmpfs directory
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -825,6 +930,7 @@ options:
   default_value: "false"
   description: Allocate a pseudo-TTY
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -834,6 +940,7 @@ options:
   default_value: '[]'
   description: Ulimit options
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -843,6 +950,7 @@ options:
   value_type: string
   description: 'Username or UID (format: <name|uid>[:<group|gid>])'
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -851,6 +959,7 @@ options:
   value_type: string
   description: User namespace to use
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -859,6 +968,7 @@ options:
   value_type: string
   description: UTS namespace to use
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -868,6 +978,7 @@ options:
   value_type: list
   description: Bind mount a volume
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -876,6 +987,7 @@ options:
   value_type: string
   description: Optional volume driver for the container
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -884,6 +996,7 @@ options:
   value_type: list
   description: Mount volumes from the specified container(s)
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -893,6 +1006,7 @@ options:
   value_type: string
   description: Working directory inside the container
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -900,19 +1014,29 @@ options:
 examples: |-
   ### Create and start a container
 
-  ```console
-  $ docker create -t -i fedora bash
+  The following example creates an interactive container with a pseudo-TTY attached,
+  then starts the container and attaches to it:
 
+  ```console
+  $ docker container create -i -t --name mycontainer alpine
   6d8af538ec541dd581ebc2a24153a28329acb5268abe5ef868c1f1a261221752
 
-  $ docker start -a -i 6d8af538ec5
+  $ docker container start --attach -i mycontainer
+  / # echo hello world
+  hello world
+  ```
 
-  bash-4.2#
+  The above is the equivalent of a `docker run`:
+
+  ```console
+  $ docker run -it --name mycontainer2 alpine
+  / # echo hello world
+  hello world
   ```
 
   ### Initialize volumes
 
-  As of v1.4.0 container volumes are initialized during the `docker create` phase
+  Container volumes are initialized during the `docker create` phase
   (i.e., `docker run` too). For example, this allows you to `create` the `data`
   volume container, and then use it from another container:
 
@@ -949,62 +1073,6 @@ examples: |-
   drwx--S---  2 1000 staff  460 Dec  5 00:51 .ssh
   drwxr-xr-x 32 1000 staff 1140 Dec  5 04:01 docker
   ```
-
-
-  Set storage driver options per container.
-
-  ```console
-  $ docker create -it --storage-opt size=120G fedora /bin/bash
-  ```
-
-  This (size) will allow to set the container rootfs size to 120G at creation time.
-  This option is only available for the `devicemapper`, `btrfs`, `overlay2`,
-  `windowsfilter` and `zfs` graph drivers.
-  For the `devicemapper`, `btrfs`, `windowsfilter` and `zfs` graph drivers,
-  user cannot pass a size less than the Default BaseFS Size.
-  For the `overlay2` storage driver, the size option is only available if the
-  backing fs is `xfs` and mounted with the `pquota` mount option.
-  Under these conditions, user can pass any size less than the backing fs size.
-
-  ### Specify isolation technology for container (--isolation)
-
-  This option is useful in situations where you are running Docker containers on
-  Windows. The `--isolation=<value>` option sets a container's isolation
-  technology. On Linux, the only supported is the `default` option which uses
-  Linux namespaces. On Microsoft Windows, you can specify these values:
-
-
-  | Value     | Description                                                                                                                                                   |
-  |-----------|---------------------------------------------------------------------------------------------------------------------------------------------------------------|
-  | `default` | Use the value specified by the Docker daemon's `--exec-opt` . If the `daemon` does not specify an isolation technology, Microsoft Windows uses `process` as its default value if the
-  daemon is running on Windows server, or `hyperv` if running on Windows client.  |
-  | `process` | Namespace isolation only.                                                                                                                                     |
-  | `hyperv`   | Hyper-V hypervisor partition-based isolation.                                                                                                                  |
-
-  Specifying the `--isolation` flag without a value is the same as setting `--isolation="default"`.
-
-  ### Dealing with dynamically created devices (--device-cgroup-rule)
-
-  Devices available to a container are assigned at creation time. The
-  assigned devices will both be added to the cgroup.allow file and
-  created into the container once it is run. This poses a problem when
-  a new device needs to be added to running container.
-
-  One of the solutions is to add a more permissive rule to a container
-  allowing it access to a wider range of devices. For example, supposing
-  our container needs access to a character device with major `42` and
-  any number of minor number (added as new devices appear), the
-  following rule would be added:
-
-  ```console
-  $ docker create --device-cgroup-rule='c 42:* rmw' -name my-container my-image
-  ```
-
-  Then, a user could ask `udev` to execute a script that would `docker exec my-container mknod newDevX c 42 <minor>`
-  the required device when it is added.
-
-  NOTE: initially present devices still need to be explicitly added to
-  the create/run command
 deprecated: false
 experimental: false
 experimentalcli: false

--- a/_data/engine-cli/docker_events.yaml
+++ b/_data/engine-cli/docker_events.yaml
@@ -121,7 +121,7 @@ long: |-
 
   ### Limiting, filtering, and formatting the output
 
-  #### Limit events by time
+  #### Limit events by time (--since, --until) {#since}
 
   The `--since` and `--until` parameters can be Unix timestamps, date formatted
   timestamps, or Go duration strings (e.g. `10m`, `1h30m`) computed
@@ -139,7 +139,7 @@ long: |-
   Only the last 1000 log events are returned. You can use filters to further limit
   the number of events returned.
 
-  #### Filtering
+  #### Filtering (--filter) {#filter}
 
   The filtering flag (`-f` or `--filter`) format is of "key=value". If you would
   like to use multiple filters, pass multiple flags (e.g.,
@@ -170,7 +170,7 @@ long: |-
   * type (`type=<container or image or volume or network or daemon or plugin or service or node or secret or config>`)
   * volume (`volume=<name>`)
 
-  #### Format
+  #### Format the output (--format) {#format}
 
   If a format (`--format`) is specified, the given template will be executed
   instead of the default
@@ -188,6 +188,7 @@ options:
   value_type: filter
   description: Filter output based on conditions provided
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -196,6 +197,7 @@ options:
   value_type: string
   description: Format the output using the given Go template
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -204,6 +206,7 @@ options:
   value_type: string
   description: Show all events created since timestamp
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -212,6 +215,7 @@ options:
   value_type: string
   description: Stream events until this timestamp
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false

--- a/_data/engine-cli/docker_exec.yaml
+++ b/_data/engine-cli/docker_exec.yaml
@@ -24,6 +24,7 @@ options:
   default_value: "false"
   description: 'Detached mode: run command in the background'
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -32,6 +33,7 @@ options:
   value_type: string
   description: Override the key sequence for detaching a container
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -41,6 +43,7 @@ options:
   value_type: list
   description: Set environment variables
   deprecated: false
+  hidden: false
   min_api_version: "1.25"
   experimental: false
   experimentalcli: false
@@ -50,6 +53,7 @@ options:
   value_type: list
   description: Read in a file of environment variables
   deprecated: false
+  hidden: false
   min_api_version: "1.25"
   experimental: false
   experimentalcli: false
@@ -61,6 +65,7 @@ options:
   default_value: "false"
   description: Keep STDIN open even if not attached
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -70,6 +75,7 @@ options:
   default_value: "false"
   description: Give extended privileges to the command
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -80,6 +86,7 @@ options:
   default_value: "false"
   description: Allocate a pseudo-TTY
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -89,6 +96,7 @@ options:
   value_type: string
   description: 'Username or UID (format: <name|uid>[:<group|gid>])'
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -98,6 +106,7 @@ options:
   value_type: string
   description: Working directory inside the container
   deprecated: false
+  hidden: false
   min_api_version: "1.35"
   experimental: false
   experimentalcli: false
@@ -131,15 +140,15 @@ examples: |-
 
   This will create a new Bash session in the container `ubuntu_bash`.
 
-  Next, set an environment variable in the current bash session.
+  Next, set environment variables in the current bash session.
 
   ```console
-  $ docker exec -it -e VAR=1 ubuntu_bash bash
+  $ docker exec -it -e VAR_A=1 -e VAR_B=2 ubuntu_bash bash
   ```
 
   This will create a new Bash session in the container `ubuntu_bash` with environment
-  variable `$VAR` set to "1". Note that this environment variable will only be valid
-  on the current Bash session.
+  variables `$VAR_A` and `$VAR_B` set to "1" and "2" respectively. Note that these
+  environment variables will only be valid on the current Bash session.
 
   By default `docker exec` command runs in the same working directory set when container was created.
 

--- a/_data/engine-cli/docker_export.yaml
+++ b/_data/engine-cli/docker_export.yaml
@@ -6,7 +6,7 @@ long: |-
   the container, `docker export` will export the contents of the *underlying*
   directory, not the contents of the volume.
 
-  Refer to [Backup, restore, or migrate data volumes](https://docs.docker.com/storage/volumes/#backup-restore-or-migrate-data-volumes)
+  Refer to [Backup, restore, or migrate data volumes](/storage/volumes/#backup-restore-or-migrate-data-volumes)
   in the user guide for examples on exporting data in a volume.
 usage: docker export [OPTIONS] CONTAINER
 pname: docker
@@ -17,6 +17,7 @@ options:
   value_type: string
   description: Write to a file, instead of STDOUT
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false

--- a/_data/engine-cli/docker_history.yaml
+++ b/_data/engine-cli/docker_history.yaml
@@ -7,8 +7,16 @@ plink: docker.yaml
 options:
 - option: format
   value_type: string
-  description: Pretty-print images using a Go template
+  description: |-
+    Format output using a custom template:
+    'table':            Print output in table format with column headers (default)
+    'table TEMPLATE':   Print output in table format using the given Go template
+    'json':             Print in JSON format
+    'TEMPLATE':         Print output using the given Go template.
+    Refer to https://docs.docker.com/go/formatting/ for more information about formatting output with templates
+  details_url: '#format'
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -19,6 +27,7 @@ options:
   default_value: "true"
   description: Print sizes and dates in human readable format
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -28,6 +37,7 @@ options:
   default_value: "false"
   description: Don't truncate output
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -38,6 +48,7 @@ options:
   default_value: "false"
   description: Only show image IDs
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -68,21 +79,21 @@ examples: |-
   511136ea3c5a        19 months ago                                                       0 B                 Imported from -
   ```
 
-  ### Format the output
+  ### Format the output (--format) {#format}
 
   The formatting option (`--format`) will pretty-prints history output
   using a Go template.
 
   Valid placeholders for the Go template are listed below:
 
-  | Placeholder     | Description |
-  | --------------- | ----------- |
-  | `.ID`           | Image ID    |
+  | Placeholder     | Description                                                                                               |
+  |-----------------|-----------------------------------------------------------------------------------------------------------|
+  | `.ID`           | Image ID                                                                                                  |
   | `.CreatedSince` | Elapsed time since the image was created if `--human=true`, otherwise timestamp of when image was created |
-  | `.CreatedAt`    | Timestamp of when image was created |
-  | `.CreatedBy`    | Command that was used to create the image |
-  | `.Size`         | Image disk size |
-  | `.Comment`      | Comment for image |
+  | `.CreatedAt`    | Timestamp of when image was created                                                                       |
+  | `.CreatedBy`    | Command that was used to create the image                                                                 |
+  | `.Size`         | Image disk size                                                                                           |
+  | `.Comment`      | Comment for image                                                                                         |
 
   When using the `--format` option, the `history` command will either
   output the data exactly as the template declares or, when using the

--- a/_data/engine-cli/docker_image_build.yaml
+++ b/_data/engine-cli/docker_image_build.yaml
@@ -9,6 +9,7 @@ options:
   value_type: list
   description: Add a custom host-to-IP mapping (host:ip)
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -17,6 +18,7 @@ options:
   value_type: list
   description: Set build-time variables
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -26,6 +28,7 @@ options:
   default_value: '[]'
   description: Images to consider as cache sources
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -34,6 +37,7 @@ options:
   value_type: string
   description: Optional parent cgroup for the container
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -43,6 +47,7 @@ options:
   default_value: "false"
   description: Compress the build context using gzip
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -52,6 +57,7 @@ options:
   default_value: "0"
   description: Limit the CPU CFS (Completely Fair Scheduler) period
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -61,6 +67,7 @@ options:
   default_value: "0"
   description: Limit the CPU CFS (Completely Fair Scheduler) quota
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -71,6 +78,7 @@ options:
   default_value: "0"
   description: CPU shares (relative weight)
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -79,6 +87,7 @@ options:
   value_type: string
   description: CPUs in which to allow execution (0-3, 0,1)
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -87,6 +96,7 @@ options:
   value_type: string
   description: MEMs in which to allow execution (0-3, 0,1)
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -96,6 +106,7 @@ options:
   default_value: "true"
   description: Skip image verification
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -105,6 +116,7 @@ options:
   value_type: string
   description: Name of the Dockerfile (Default is 'PATH/Dockerfile')
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -114,6 +126,7 @@ options:
   default_value: "false"
   description: Always remove intermediate containers
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -122,6 +135,7 @@ options:
   value_type: string
   description: Write the image ID to the file
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -130,6 +144,7 @@ options:
   value_type: string
   description: Container isolation technology
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -138,6 +153,7 @@ options:
   value_type: list
   description: Set metadata for an image
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -148,6 +164,7 @@ options:
   default_value: "0"
   description: Memory limit
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -158,6 +175,7 @@ options:
   description: |
     Swap limit equal to memory plus swap: '-1' to enable unlimited swap
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -165,9 +183,9 @@ options:
 - option: network
   value_type: string
   default_value: default
-  description: |
-    Set the networking mode for the RUN instructions during build
+  description: Set the networking mode for the RUN instructions during build
   deprecated: false
+  hidden: false
   min_api_version: "1.25"
   experimental: false
   experimentalcli: false
@@ -178,17 +196,7 @@ options:
   default_value: "false"
   description: Do not use cache when building the image
   deprecated: false
-  experimental: false
-  experimentalcli: false
-  kubernetes: false
-  swarm: false
-- option: output
-  shorthand: o
-  value_type: stringArray
-  default_value: '[]'
-  description: 'Output destination (format: type=local,dest=path)'
-  deprecated: false
-  min_api_version: "1.40"
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -197,17 +205,8 @@ options:
   value_type: string
   description: Set platform if server is multi-platform capable
   deprecated: false
+  hidden: false
   min_api_version: "1.38"
-  experimental: false
-  experimentalcli: false
-  kubernetes: false
-  swarm: false
-- option: progress
-  value_type: string
-  default_value: auto
-  description: |
-    Set type of progress output (auto, plain, tty). Use plain to show container output
-  deprecated: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -217,6 +216,7 @@ options:
   default_value: "false"
   description: Always attempt to pull a newer version of the image
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -227,6 +227,7 @@ options:
   default_value: "false"
   description: Suppress the build output and print image ID on success
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -236,17 +237,7 @@ options:
   default_value: "true"
   description: Remove intermediate containers after a successful build
   deprecated: false
-  experimental: false
-  experimentalcli: false
-  kubernetes: false
-  swarm: false
-- option: secret
-  value_type: stringArray
-  default_value: '[]'
-  description: |
-    Secret file to expose to the build (only if BuildKit enabled): id=mysecret,src=/local/secret
-  deprecated: false
-  min_api_version: "1.39"
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -256,6 +247,7 @@ options:
   default_value: '[]'
   description: Security options
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -265,6 +257,7 @@ options:
   default_value: "0"
   description: Size of /dev/shm
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -274,19 +267,9 @@ options:
   default_value: "false"
   description: Squash newly built layers into a single new layer
   deprecated: false
+  hidden: false
   min_api_version: "1.25"
   experimental: true
-  experimentalcli: false
-  kubernetes: false
-  swarm: false
-- option: ssh
-  value_type: stringArray
-  default_value: '[]'
-  description: |
-    SSH agent socket or keys to expose to the build (only if BuildKit enabled) (format: default|<id>[=<socket>|<key>[,<key>]])
-  deprecated: false
-  min_api_version: "1.39"
-  experimental: false
   experimentalcli: false
   kubernetes: false
   swarm: false
@@ -295,6 +278,7 @@ options:
   default_value: "false"
   description: Stream attaches to server to negotiate build context
   deprecated: false
+  hidden: true
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -304,6 +288,7 @@ options:
   value_type: list
   description: Name and optionally a tag in the 'name:tag' format
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -312,6 +297,7 @@ options:
   value_type: string
   description: Set the target build stage to build.
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -321,6 +307,7 @@ options:
   default_value: '[]'
   description: Ulimit options
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false

--- a/_data/engine-cli/docker_image_history.yaml
+++ b/_data/engine-cli/docker_image_history.yaml
@@ -7,8 +7,15 @@ plink: docker_image.yaml
 options:
 - option: format
   value_type: string
-  description: Pretty-print images using a Go template
+  description: |-
+    Format output using a custom template:
+    'table':            Print output in table format with column headers (default)
+    'table TEMPLATE':   Print output in table format using the given Go template
+    'json':             Print in JSON format
+    'TEMPLATE':         Print output using the given Go template.
+    Refer to https://docs.docker.com/go/formatting/ for more information about formatting output with templates
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -19,6 +26,7 @@ options:
   default_value: "true"
   description: Print sizes and dates in human readable format
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -28,6 +36,7 @@ options:
   default_value: "false"
   description: Don't truncate output
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -38,6 +47,7 @@ options:
   default_value: "false"
   description: Only show image IDs
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false

--- a/_data/engine-cli/docker_image_import.yaml
+++ b/_data/engine-cli/docker_image_import.yaml
@@ -10,6 +10,7 @@ options:
   value_type: list
   description: Apply Dockerfile instruction to the created image
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -19,6 +20,7 @@ options:
   value_type: string
   description: Set commit message for imported image
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -27,6 +29,7 @@ options:
   value_type: string
   description: Set platform if server is multi-platform capable
   deprecated: false
+  hidden: false
   min_api_version: "1.32"
   experimental: false
   experimentalcli: false

--- a/_data/engine-cli/docker_image_inspect.yaml
+++ b/_data/engine-cli/docker_image_inspect.yaml
@@ -8,8 +8,13 @@ options:
 - option: format
   shorthand: f
   value_type: string
-  description: Format the output using the given Go template
+  description: |-
+    Format output using a custom template:
+    'json':             Print in JSON format
+    'TEMPLATE':         Print output using the given Go template.
+    Refer to https://docs.docker.com/go/formatting/ for more information about formatting output with templates
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false

--- a/_data/engine-cli/docker_image_load.yaml
+++ b/_data/engine-cli/docker_image_load.yaml
@@ -10,6 +10,7 @@ options:
   value_type: string
   description: Read from tar archive file, instead of STDIN
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -20,6 +21,7 @@ options:
   default_value: "false"
   description: Suppress the load output
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false

--- a/_data/engine-cli/docker_image_ls.yaml
+++ b/_data/engine-cli/docker_image_ls.yaml
@@ -12,6 +12,7 @@ options:
   default_value: "false"
   description: Show all images (default hides intermediate images)
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -21,6 +22,7 @@ options:
   default_value: "false"
   description: Show digests
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -30,14 +32,22 @@ options:
   value_type: filter
   description: Filter output based on conditions provided
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
   swarm: false
 - option: format
   value_type: string
-  description: Pretty-print images using a Go template
+  description: |-
+    Format output using a custom template:
+    'table':            Print output in table format with column headers (default)
+    'table TEMPLATE':   Print output in table format using the given Go template
+    'json':             Print in JSON format
+    'TEMPLATE':         Print output using the given Go template.
+    Refer to https://docs.docker.com/go/formatting/ for more information about formatting output with templates
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -47,6 +57,7 @@ options:
   default_value: "false"
   description: Don't truncate output
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -57,6 +68,7 @@ options:
   default_value: "false"
   description: Only show image IDs
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false

--- a/_data/engine-cli/docker_image_prune.yaml
+++ b/_data/engine-cli/docker_image_prune.yaml
@@ -1,7 +1,7 @@
 command: docker image prune
 short: Remove unused images
-long: Remove all dangling images. If `-a` is specified, will also remove all images
-  not referenced by any container.
+long: |
+  Remove all dangling images. If `-a` is specified, will also remove all images not referenced by any container.
 usage: docker image prune [OPTIONS]
 pname: docker image
 plink: docker_image.yaml
@@ -12,6 +12,7 @@ options:
   default_value: "false"
   description: Remove all unused images, not just dangling ones
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -19,7 +20,9 @@ options:
 - option: filter
   value_type: filter
   description: Provide filter values (e.g. 'until=<timestamp>')
+  details_url: '#filter'
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -30,6 +33,7 @@ options:
   default_value: "false"
   description: Do not prompt for confirmation
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -70,7 +74,7 @@ examples: |-
   Total reclaimed space: 16.43 MB
   ```
 
-  ### Filtering
+  ### Filtering (--filter) {#filter}
 
   The filtering flag (`--filter`) format is of "key=value". If there is more
   than one filter, then pass multiple flags (e.g., `--filter "foo=bar" --filter "bif=baz"`)

--- a/_data/engine-cli/docker_image_pull.yaml
+++ b/_data/engine-cli/docker_image_pull.yaml
@@ -11,6 +11,7 @@ options:
   default_value: "false"
   description: Download all tagged images in the repository
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -20,6 +21,7 @@ options:
   default_value: "true"
   description: Skip image verification
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -28,6 +30,7 @@ options:
   value_type: string
   description: Set platform if server is multi-platform capable
   deprecated: false
+  hidden: false
   min_api_version: "1.32"
   experimental: false
   experimentalcli: false
@@ -39,6 +42,7 @@ options:
   default_value: "false"
   description: Suppress verbose output
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false

--- a/_data/engine-cli/docker_image_push.yaml
+++ b/_data/engine-cli/docker_image_push.yaml
@@ -9,8 +9,9 @@ options:
   shorthand: a
   value_type: bool
   default_value: "false"
-  description: Push all tagged images in the repository
+  description: Push all tags of an image to the repository
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -20,6 +21,7 @@ options:
   default_value: "true"
   description: Skip image signing
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -30,6 +32,7 @@ options:
   default_value: "false"
   description: Suppress verbose output
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false

--- a/_data/engine-cli/docker_image_rm.yaml
+++ b/_data/engine-cli/docker_image_rm.yaml
@@ -12,6 +12,7 @@ options:
   default_value: "false"
   description: Force removal of the image
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -21,6 +22,7 @@ options:
   default_value: "false"
   description: Do not delete untagged parents
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false

--- a/_data/engine-cli/docker_image_save.yaml
+++ b/_data/engine-cli/docker_image_save.yaml
@@ -10,6 +10,7 @@ options:
   value_type: string
   description: Write to a file, instead of STDOUT
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false

--- a/_data/engine-cli/docker_images.yaml
+++ b/_data/engine-cli/docker_images.yaml
@@ -26,6 +26,7 @@ options:
   default_value: "false"
   description: Show all images (default hides intermediate images)
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -34,7 +35,9 @@ options:
   value_type: bool
   default_value: "false"
   description: Show digests
+  details_url: '#digests'
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -43,15 +46,24 @@ options:
   shorthand: f
   value_type: filter
   description: Filter output based on conditions provided
+  details_url: '#filter'
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
   swarm: false
 - option: format
   value_type: string
-  description: Pretty-print images using a Go template
+  description: |-
+    Format output using a custom template:
+    'table':            Print output in table format with column headers (default)
+    'table TEMPLATE':   Print output in table format using the given Go template
+    'json':             Print in JSON format
+    'TEMPLATE':         Print output using the given Go template.
+    Refer to https://docs.docker.com/go/formatting/ for more information about formatting output with templates
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -60,7 +72,9 @@ options:
   value_type: bool
   default_value: "false"
   description: Don't truncate output
+  details_url: '#no-trunc'
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -71,6 +85,7 @@ options:
   default_value: "false"
   description: Only show image IDs
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -133,7 +148,7 @@ examples: |-
   REPOSITORY          TAG                 IMAGE ID            CREATED             SIZE
   ```
 
-  ### List the full length image IDs
+  ### List the full length image IDs (--no-trunc) {#no-trunc}
 
   ```console
   $ docker images --no-trunc
@@ -150,7 +165,7 @@ examples: |-
   <none>                        <none>              sha256:5ed6274db6ceb2397844896966ea239290555e74ef307030ebb01ff91b1914df   24 hours ago        1.089 GB
   ```
 
-  ### List image digests
+  ### List image digests (--digests) {#digests}
 
   Images that use the v2 or later format have a content-addressable identifier
   called a `digest`. As long as the input used to generate the image is
@@ -168,7 +183,7 @@ examples: |-
   also reference by digest in `create`, `run`, and `rmi` commands, as well as the
   `FROM` image reference in a Dockerfile.
 
-  ### Filtering
+  ### Filtering (--filter) {#filter}
 
   The filtering flag (`-f` or `--filter`) format is of "key=value". If there is more
   than one filter, then pass multiple flags (e.g., `--filter "foo=bar" --filter "bif=baz"`)
@@ -323,15 +338,15 @@ examples: |-
 
   Valid placeholders for the Go template are listed below:
 
-  | Placeholder | Description|
-  | ---- | ---- |
-  | `.ID` | Image ID |
-  | `.Repository` | Image repository |
-  | `.Tag` | Image tag |
-  | `.Digest` | Image digest |
+  | Placeholder     | Description                              |
+  |-----------------|------------------------------------------|
+  | `.ID`           | Image ID                                 |
+  | `.Repository`   | Image repository                         |
+  | `.Tag`          | Image tag                                |
+  | `.Digest`       | Image digest                             |
   | `.CreatedSince` | Elapsed time since the image was created |
-  | `.CreatedAt` | Time when the image was created |
-  | `.Size` | Image disk size |
+  | `.CreatedAt`    | Time when the image was created          |
+  | `.Size`         | Image disk size                          |
 
   When using the `--format` option, the `image` command will either
   output the data exactly as the template declares or, when using the
@@ -370,6 +385,14 @@ examples: |-
   746b819f315e        postgres                  9.3
   746b819f315e        postgres                  9.3.5
   746b819f315e        postgres                  latest
+  ```
+
+  To list all images in JSON format, use the `json` directive:
+
+  ```console
+  $ docker images --format json
+  {"Containers":"N/A","CreatedAt":"2021-03-04 03:24:42 +0100 CET","CreatedSince":"5 days ago","Digest":"\u003cnone\u003e","ID":"4dd97cefde62","Repository":"ubuntu","SharedSize":"N/A","Size":"72.9MB","Tag":"latest","UniqueSize":"N/A","VirtualSize":"72.9MB"}
+  {"Containers":"N/A","CreatedAt":"2021-02-17 22:19:54 +0100 CET","CreatedSince":"2 weeks ago","Digest":"\u003cnone\u003e","ID":"28f6e2705743","Repository":"alpine","SharedSize":"N/A","Size":"5.61MB","Tag":"latest","UniqueSize":"N/A","VirtualSize":"5.613MB"}
   ```
 deprecated: false
 experimental: false

--- a/_data/engine-cli/docker_import.yaml
+++ b/_data/engine-cli/docker_import.yaml
@@ -9,9 +9,8 @@ long: |-
   the host. To import from a remote location, specify a `URI` that begins with the
   `http://` or `https://` protocol.
 
-  The `--change` option will apply `Dockerfile` instructions to the image
-  that is created.
-  Supported `Dockerfile` instructions:
+  The `--change` option applies `Dockerfile` instructions to the image that is
+  created. Supported `Dockerfile` instructions:
   `CMD`|`ENTRYPOINT`|`ENV`|`EXPOSE`|`ONBUILD`|`USER`|`VOLUME`|`WORKDIR`
 usage: docker import [OPTIONS] file|URL|- [REPOSITORY[:TAG]]
 pname: docker
@@ -22,6 +21,7 @@ options:
   value_type: list
   description: Apply Dockerfile instruction to the created image
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -31,6 +31,7 @@ options:
   value_type: string
   description: Set commit message for imported image
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -39,6 +40,7 @@ options:
   value_type: string
   description: Set platform if server is multi-platform capable
   deprecated: false
+  hidden: false
   min_api_version: "1.32"
   experimental: false
   experimentalcli: false
@@ -47,7 +49,7 @@ options:
 examples: |-
   ### Import from a remote location
 
-  This will create a new untagged image.
+  This creates a new untagged image.
 
   ```console
   $ docker import https://example.com/exampleimage.tgz

--- a/_data/engine-cli/docker_info.yaml
+++ b/_data/engine-cli/docker_info.yaml
@@ -26,7 +26,9 @@ options:
   shorthand: f
   value_type: string
   description: Format the output using the given Go template
+  details_url: '#format'
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -94,7 +96,7 @@ examples: |-
     127.0.0.0/8
   ```
 
-  ### Show debugging output
+  ### Show debugging output (--debug) {#debug}
 
   Here is a sample output for a daemon running on Ubuntu, using the overlay2
   storage driver and a node that is part of a 2-node swarm:
@@ -186,7 +188,7 @@ examples: |-
 
   The global `-D` option causes all `docker` commands to output debug information.
 
-  ### Format the output
+  ### Format the output (--format) {#format}
 
   You can also specify the output format:
 

--- a/_data/engine-cli/docker_inspect.yaml
+++ b/_data/engine-cli/docker_inspect.yaml
@@ -4,6 +4,30 @@ long: |-
   Docker inspect provides detailed information on constructs controlled by Docker.
 
   By default, `docker inspect` will render results in a JSON array.
+
+  ### Format the output (--format) {#format}
+
+  If a format is specified, the given template will be executed for each result.
+
+  Go's [text/template](https://golang.org/pkg/text/template/) package
+  describes all the details of the format.
+
+  ### Specify target type (--type) {#type}
+
+  `--type container|image|node|network|secret|service|volume|task|plugin`
+
+  The `docker inspect` command matches any type of object by either ID or name.
+  In some cases multiple type of objects (for example, a container and a volume)
+  exist with the same name, making the result ambiguous.
+
+  To restrict `docker inspect` to a specific type of object, use the `--type`
+  option.
+
+  The following example inspects a _volume_ named "myvolume"
+
+  ```console
+  $ docker inspect --type=volume myvolume
+  ```
 usage: docker inspect [OPTIONS] NAME|ID [NAME|ID...]
 pname: docker
 plink: docker.yaml
@@ -11,8 +35,13 @@ options:
 - option: format
   shorthand: f
   value_type: string
-  description: Format the output using the given Go template
+  description: |-
+    Format output using a custom template:
+    'json':             Print in JSON format
+    'TEMPLATE':         Print output using the given Go template.
+    Refer to https://docs.docker.com/go/formatting/ for more information about formatting output with templates
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -23,6 +52,7 @@ options:
   default_value: "false"
   description: Display total file sizes if the type is container
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -31,6 +61,7 @@ options:
   value_type: string
   description: Return JSON for specified type
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false

--- a/_data/engine-cli/docker_kill.yaml
+++ b/_data/engine-cli/docker_kill.yaml
@@ -6,10 +6,10 @@ long: |-
   specified with the `--signal` option. You can reference a container by its
   ID, ID-prefix, or name.
 
-  The `--signal` (or `-s` shorthand) flag sets the system call signal that is sent
-  to the container. This signal can be a signal name in the format `SIG<NAME>`, for
-  instance `SIGINT`, or an unsigned number that matches a position in the kernel's
-  syscall table, for instance `2`.
+  The `--signal` flag sets the system call signal that is sent to the container.
+  This signal can be a signal name in the format `SIG<NAME>`, for instance `SIGINT`,
+  or an unsigned number that matches a position in the kernel's syscall table,
+  for instance `2`.
 
   While the default (`SIGKILL`) signal will terminate the container, the signal
   set through `--signal` may be non-terminal, depending on the container's main
@@ -30,7 +30,9 @@ options:
   value_type: string
   default_value: KILL
   description: Signal to send to the container
+  details_url: '#signal'
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -45,7 +47,7 @@ examples: |-
   $ docker kill my_container
   ```
 
-  ### Send a custom signal to a container
+  ### Send a custom signal to a container (--signal) {#signal}
 
   The following example sends a `SIGHUP` signal to the container named
   `my_container`:

--- a/_data/engine-cli/docker_load.yaml
+++ b/_data/engine-cli/docker_load.yaml
@@ -11,7 +11,9 @@ options:
   shorthand: i
   value_type: string
   description: Read from tar archive file, instead of STDIN
+  details_url: '#input'
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -22,6 +24,7 @@ options:
   default_value: "false"
   description: Suppress the load output
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -31,18 +34,25 @@ examples: |-
   $ docker image ls
 
   REPOSITORY          TAG                 IMAGE ID            CREATED             SIZE
+  ```
 
+  ### Load images from STDIN
+
+  ```console
   $ docker load < busybox.tar.gz
 
   Loaded image: busybox:latest
   $ docker images
   REPOSITORY          TAG                 IMAGE ID            CREATED             SIZE
   busybox             latest              769b9341d937        7 weeks ago         2.489 MB
+  ```
 
+  ### Load images from a file (--input) {#input}
+
+  ```console
   $ docker load --input fedora.tar
 
   Loaded image: fedora:rawhide
-
   Loaded image: fedora:20
 
   $ docker images

--- a/_data/engine-cli/docker_login.yaml
+++ b/_data/engine-cli/docker_login.yaml
@@ -10,6 +10,7 @@ options:
   value_type: string
   description: Password
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -18,7 +19,9 @@ options:
   value_type: bool
   default_value: "false"
   description: Take the password from stdin
+  details_url: '#password-stdin'
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -28,6 +31,7 @@ options:
   value_type: string
   description: Username
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -42,7 +46,7 @@ examples: |-
   $ docker login localhost:8080
   ```
 
-  ### Provide a password using STDIN
+  ### Provide a password using STDIN (--password-stdin) {#password-stdin}
 
   To run the `docker login` command non-interactively, you can set the
   `--password-stdin` flag to provide a password through `STDIN`. Using
@@ -61,7 +65,7 @@ examples: |-
   `docker login` requires user to use `sudo` or be `root`, except when:
 
   1.  connecting to a remote daemon, such as a `docker-machine` provisioned `docker engine`.
-  2.  user is added to the `docker` group.  This will impact the security of your system; the `docker` group is `root` equivalent.  See [Docker Daemon Attack Surface](https://docs.docker.com/engine/security/#docker-daemon-attack-surface) for details.
+  2.  user is added to the `docker` group.  This will impact the security of your system; the `docker` group is `root` equivalent.  See [Docker Daemon Attack Surface](/engine/security/#docker-daemon-attack-surface) for details.
 
   You can log into any public or private repository for which you have
   credentials.  When you log in, the command stores credentials in

--- a/_data/engine-cli/docker_logout.yaml
+++ b/_data/engine-cli/docker_logout.yaml
@@ -1,6 +1,8 @@
 command: docker logout
 short: Log out from a Docker registry
-long: Log out from a Docker registry
+long: |-
+  Log out from a Docker registry.
+  If no server is specified, the default is defined by the daemon.
 usage: docker logout [SERVER]
 pname: docker
 plink: docker.yaml

--- a/_data/engine-cli/docker_logs.yaml
+++ b/_data/engine-cli/docker_logs.yaml
@@ -9,7 +9,7 @@ long: |-
   > `json-file` or `journald` logging driver.
 
   For more information about selecting and configuring logging drivers, refer to
-  [Configure logging drivers](https://docs.docker.com/config/containers/logging/configure/).
+  [Configure logging drivers](/config/containers/logging/configure/).
 
   The `docker logs --follow` command will continue streaming the new output from
   the container's `STDOUT` and `STDERR`.
@@ -47,6 +47,7 @@ options:
   default_value: "false"
   description: Show extra details provided to logs
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -57,6 +58,7 @@ options:
   default_value: "false"
   description: Follow log output
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -66,6 +68,7 @@ options:
   description: |
     Show logs since timestamp (e.g. 2013-01-02T13:23:37Z) or relative (e.g. 42m for 42 minutes)
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -76,6 +79,7 @@ options:
   default_value: all
   description: Number of lines to show from the end of the logs
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -86,6 +90,7 @@ options:
   default_value: "false"
   description: Show timestamps
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -94,14 +99,16 @@ options:
   value_type: string
   description: |
     Show logs before a timestamp (e.g. 2013-01-02T13:23:37Z) or relative (e.g. 42m for 42 minutes)
+  details_url: '#until'
   deprecated: false
+  hidden: false
   min_api_version: "1.35"
   experimental: false
   experimentalcli: false
   kubernetes: false
   swarm: false
 examples: |-
-  ### Retrieve logs until a specific point in time
+  ### Retrieve logs until a specific point in time (--until) {#until}
 
   In order to retrieve logs before a specific point in time, run:
 

--- a/_data/engine-cli/docker_manifest_annotate.yaml
+++ b/_data/engine-cli/docker_manifest_annotate.yaml
@@ -9,6 +9,7 @@ options:
   value_type: string
   description: Set architecture
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -17,6 +18,7 @@ options:
   value_type: string
   description: Set operating system
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -26,6 +28,7 @@ options:
   default_value: '[]'
   description: Set operating system feature
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -34,6 +37,7 @@ options:
   value_type: string
   description: Set operating system version
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -42,6 +46,7 @@ options:
   value_type: string
   description: Set architecture variant
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false

--- a/_data/engine-cli/docker_manifest_create.yaml
+++ b/_data/engine-cli/docker_manifest_create.yaml
@@ -11,6 +11,7 @@ options:
   default_value: "false"
   description: Amend an existing manifest list
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -20,6 +21,7 @@ options:
   default_value: "false"
   description: Allow communication with an insecure registry
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false

--- a/_data/engine-cli/docker_manifest_inspect.yaml
+++ b/_data/engine-cli/docker_manifest_inspect.yaml
@@ -10,6 +10,7 @@ options:
   default_value: "false"
   description: Allow communication with an insecure registry
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -20,6 +21,7 @@ options:
   default_value: "false"
   description: Output additional info including layers and platform
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false

--- a/_data/engine-cli/docker_manifest_push.yaml
+++ b/_data/engine-cli/docker_manifest_push.yaml
@@ -10,6 +10,7 @@ options:
   default_value: "false"
   description: Allow push to an insecure registry
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -20,6 +21,7 @@ options:
   default_value: "false"
   description: Remove the local manifest list after push
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false

--- a/_data/engine-cli/docker_network_connect.yaml
+++ b/_data/engine-cli/docker_network_connect.yaml
@@ -12,7 +12,9 @@ options:
   value_type: stringSlice
   default_value: '[]'
   description: Add network-scoped alias for the container
+  details_url: '#alias'
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -22,6 +24,7 @@ options:
   default_value: '[]'
   description: driver options for the network
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -29,7 +32,9 @@ options:
 - option: ip
   value_type: string
   description: IPv4 address (e.g., 172.30.100.104)
+  details_url: '#ip'
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -38,6 +43,7 @@ options:
   value_type: string
   description: IPv6 address (e.g., 2001:db8::33)
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -45,7 +51,9 @@ options:
 - option: link
   value_type: list
   description: Add link to another container
+  details_url: '#link'
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -55,6 +63,7 @@ options:
   default_value: '[]'
   description: Add a link-local address for the container
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -68,13 +77,14 @@ examples: |-
 
   ### Connect a container to a network when it starts
 
-  You can also use the `docker run --network=<network-name>` option to start a container and immediately connect it to a network.
+  You can also use the `docker run --network=<network-name>` option to start a
+  container and immediately connect it to a network.
 
   ```console
   $ docker run -itd --network=multi-host-network busybox
   ```
 
-  ### Specify the IP address a container will use on a given network
+  ### Specify the IP address a container will use on a given network (--ip) {#ip}
 
   You can specify the IP address you want to be assigned to the container's interface.
 
@@ -82,7 +92,7 @@ examples: |-
   $ docker network connect --ip 10.10.36.122 multi-host-network container2
   ```
 
-  ### Use the legacy `--link` option
+  ### Use the legacy `--link` option (--link) {#link}
 
   You can use `--link` option to link another container with a preferred alias
 
@@ -90,7 +100,7 @@ examples: |-
   $ docker network connect --link container1:c1 multi-host-network container2
   ```
 
-  ### Create a network alias for a container
+  ### Create a network alias for a container (--alias) {#alias}
 
   `--alias` option can be used to resolve the container by another name in the network
   being connected to.
@@ -119,14 +129,17 @@ examples: |-
   $ docker network connect --ip 172.20.128.2 multi-host-network container2
   ```
 
-  To verify the container is connected, use the `docker network inspect` command. Use `docker network disconnect` to remove a container from the network.
+  To verify the container is connected, use the `docker network inspect` command.
+  Use `docker network disconnect` to remove a container from the network.
 
   Once connected in network, containers can communicate using only another
   container's IP address or name. For `overlay` networks or custom plugins that
   support multi-host connectivity, containers connected to the same multi-host
   network but launched from different Engines can also communicate in this way.
 
-  You can connect a container to one or more networks. The networks need not be the same type. For example, you can connect a single container bridge and overlay networks.
+  You can connect a container to one or more networks. The networks need not be
+  the same type. For example, you can connect a single container bridge and overlay
+  networks.
 deprecated: false
 min_api_version: "1.21"
 experimental: false

--- a/_data/engine-cli/docker_network_create.yaml
+++ b/_data/engine-cli/docker_network_create.yaml
@@ -32,7 +32,7 @@ long: |-
   * `--cluster-advertise`
 
   To read more about these options and how to configure them, see ["*Get started
-  with multi-host network*"](https://docs.docker.com/engine/userguide/networking/get-started-overlay).
+  with multi-host network*"](/engine/userguide/networking/get-started-overlay).
 
   While not required, it is a good idea to install Docker Swarm to
   manage the cluster that makes up your network. Swarm provides sophisticated
@@ -58,7 +58,7 @@ long: |-
   need more than 256 IP addresses, do not increase the IP block size. You can
   either use `dnsrr` endpoint mode with an external load balancer, or use multiple
   smaller overlay networks. See
-  [Configure service discovery](https://docs.docker.com/engine/swarm/networking/#configure-service-discovery)
+  [Configure service discovery](/engine/swarm/networking/#configure-service-discovery)
   for more information about different endpoint modes.
 usage: docker network create [OPTIONS] NETWORK
 pname: docker network
@@ -69,6 +69,7 @@ options:
   default_value: "false"
   description: Enable manual container attachment
   deprecated: false
+  hidden: false
   min_api_version: "1.25"
   experimental: false
   experimentalcli: false
@@ -79,6 +80,7 @@ options:
   default_value: map[]
   description: Auxiliary IPv4 or IPv6 addresses used by Network driver
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -87,6 +89,7 @@ options:
   value_type: string
   description: The network from which to copy the configuration
   deprecated: false
+  hidden: false
   min_api_version: "1.30"
   experimental: false
   experimentalcli: false
@@ -97,6 +100,7 @@ options:
   default_value: "false"
   description: Create a configuration only network
   deprecated: false
+  hidden: false
   min_api_version: "1.30"
   experimental: false
   experimentalcli: false
@@ -108,6 +112,7 @@ options:
   default_value: bridge
   description: Driver to manage the Network
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -117,6 +122,7 @@ options:
   default_value: '[]'
   description: IPv4 or IPv6 Gateway for the master subnet
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -125,7 +131,9 @@ options:
   value_type: bool
   default_value: "false"
   description: Create swarm routing-mesh network
+  details_url: '#ingress'
   deprecated: false
+  hidden: false
   min_api_version: "1.29"
   experimental: false
   experimentalcli: false
@@ -135,7 +143,9 @@ options:
   value_type: bool
   default_value: "false"
   description: Restrict external access to the network
+  details_url: '#internal'
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -145,6 +155,7 @@ options:
   default_value: '[]'
   description: Allocate container ip from a sub-range
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -154,6 +165,7 @@ options:
   default_value: default
   description: IP Address Management Driver
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -163,6 +175,7 @@ options:
   default_value: map[]
   description: Set IPAM driver specific options
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -172,6 +185,7 @@ options:
   default_value: "false"
   description: Enable IPv6 networking
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -180,6 +194,7 @@ options:
   value_type: list
   description: Set metadata on a network
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -190,6 +205,7 @@ options:
   default_value: map[]
   description: Set driver specific options
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -198,6 +214,7 @@ options:
   value_type: string
   description: Control the network's scope
   deprecated: false
+  hidden: false
   min_api_version: "1.30"
   experimental: false
   experimentalcli: false
@@ -208,6 +225,7 @@ options:
   default_value: '[]'
   description: Subnet in CIDR format that represents a network segment
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -300,7 +318,7 @@ examples: |-
   |--------------|----------------|--------------------------------------------|
   | `--gateway`  | -              | IPv4 or IPv6 Gateway for the master subnet |
   | `--ip-range` | `--fixed-cidr` | Allocate IPs from a range                  |
-  | `--internal` | -              | Restrict external access to the network   |
+  | `--internal` | -              | Restrict external access to the network    |
   | `--ipv6`     | `--ipv6`       | Enable IPv6 networking                     |
   | `--subnet`   | `--bip`        | Subnet for network                         |
 
@@ -313,14 +331,14 @@ examples: |-
       simple-network
   ```
 
-  ### Network internal mode
+  ### Network internal mode (--internal) {#internal}
 
   By default, when you connect a container to an `overlay` network, Docker also
   connects a bridge network to it to provide external connectivity. If you want
   to create an externally isolated `overlay` network, you can specify the
   `--internal` option.
 
-  ### Network ingress mode
+  ### Network ingress mode (--ingress) {#ingress}
 
   You can create the network which will be used to provide the routing-mesh in the
   swarm cluster. You do so by specifying `--ingress` when creating the network. Only

--- a/_data/engine-cli/docker_network_disconnect.yaml
+++ b/_data/engine-cli/docker_network_disconnect.yaml
@@ -13,6 +13,7 @@ options:
   default_value: "false"
   description: Force the container to disconnect from a network
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false

--- a/_data/engine-cli/docker_network_inspect.yaml
+++ b/_data/engine-cli/docker_network_inspect.yaml
@@ -10,8 +10,13 @@ options:
 - option: format
   shorthand: f
   value_type: string
-  description: Format the output using the given Go template
+  description: |-
+    Format output using a custom template:
+    'json':             Print in JSON format
+    'TEMPLATE':         Print output using the given Go template.
+    Refer to https://docs.docker.com/go/formatting/ for more information about formatting output with templates
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -22,6 +27,7 @@ options:
   default_value: "false"
   description: Verbose output for diagnostics
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false

--- a/_data/engine-cli/docker_network_ls.yaml
+++ b/_data/engine-cli/docker_network_ls.yaml
@@ -12,15 +12,25 @@ options:
   shorthand: f
   value_type: filter
   description: Provide filter values (e.g. 'driver=bridge')
+  details_url: '#filter'
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
   swarm: false
 - option: format
   value_type: string
-  description: Pretty-print networks using a Go template
+  description: |-
+    Format output using a custom template:
+    'table':            Print output in table format with column headers (default)
+    'table TEMPLATE':   Print output in table format using the given Go template
+    'json':             Print in JSON format
+    'TEMPLATE':         Print output using the given Go template.
+    Refer to https://docs.docker.com/go/formatting/ for more information about formatting output with templates
+  details_url: '#format'
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -30,6 +40,7 @@ options:
   default_value: "false"
   description: Do not truncate the output
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -40,6 +51,7 @@ options:
   default_value: "false"
   description: Only display network IDs
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -68,7 +80,7 @@ examples: |-
   63d1ff1f77b07ca51070a8c227e962238358bd310bde1529cf62e6c307ade161   dev                 bridge           local
   ```
 
-  ### Filtering
+  ### Filtering (--filter) {#filter}
 
   The filtering flag (`-f` or `--filter`) format is a `key=value` pair. If there
   is more than one filter, then pass multiple flags (e.g. `--filter "foo=bar" --filter "bif=baz"`).
@@ -213,24 +225,24 @@ examples: |-
   A warning will be issued when trying to remove a network that has containers
   attached.
 
-  ### Formatting
+  ### Format the output (--format) {#format}
 
   The formatting options (`--format`) pretty-prints networks output
   using a Go template.
 
   Valid placeholders for the Go template are listed below:
 
-  Placeholder  | Description
-  -------------|------------------------------------------------------------------------------------------
-  `.ID`        | Network ID
-  `.Name`      | Network name
-  `.Driver`    | Network driver
-  `.Scope`     | Network scope (local, global)
-  `.IPv6`      | Whether IPv6 is enabled on the network or not.
-  `.Internal`  | Whether the network is internal or not.
-  `.Labels`    | All labels assigned to the network.
-  `.Label`     | Value of a specific label for this network. For example `{{.Label "project.version"}}`
-  `.CreatedAt` | Time when the network was created
+  | Placeholder  | Description                                                                            |
+  |--------------|----------------------------------------------------------------------------------------|
+  | `.ID`        | Network ID                                                                             |
+  | `.Name`      | Network name                                                                           |
+  | `.Driver`    | Network driver                                                                         |
+  | `.Scope`     | Network scope (local, global)                                                          |
+  | `.IPv6`      | Whether IPv6 is enabled on the network or not.                                         |
+  | `.Internal`  | Whether the network is internal or not.                                                |
+  | `.Labels`    | All labels assigned to the network.                                                    |
+  | `.Label`     | Value of a specific label for this network. For example `{{.Label "project.version"}}` |
+  | `.CreatedAt` | Time when the network was created                                                      |
 
   When using the `--format` option, the `network ls` command will either
   output the data exactly as the template declares or, when using the
@@ -244,6 +256,15 @@ examples: |-
   afaaab448eb2: bridge
   d1584f8dc718: host
   391df270dc66: null
+  ```
+
+  To list all networks in JSON format, use the `json` directive:
+
+  ```console
+  $ docker network ls --format json
+  {"CreatedAt":"2021-03-09 21:41:29.798999529 +0000 UTC","Driver":"bridge","ID":"f33ba176dd8e","IPv6":"false","Internal":"false","Labels":"","Name":"bridge","Scope":"local"}
+  {"CreatedAt":"2021-03-09 21:41:29.772806592 +0000 UTC","Driver":"host","ID":"caf47bb3ac70","IPv6":"false","Internal":"false","Labels":"","Name":"host","Scope":"local"}
+  {"CreatedAt":"2021-03-09 21:41:29.752212603 +0000 UTC","Driver":"null","ID":"9d096c122066","IPv6":"false","Internal":"false","Labels":"","Name":"none","Scope":"local"}
   ```
 deprecated: false
 min_api_version: "1.21"

--- a/_data/engine-cli/docker_network_prune.yaml
+++ b/_data/engine-cli/docker_network_prune.yaml
@@ -10,7 +10,9 @@ options:
 - option: filter
   value_type: filter
   description: Provide filter values (e.g. 'until=<timestamp>')
+  details_url: '#filter'
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -21,6 +23,7 @@ options:
   default_value: "false"
   description: Do not prompt for confirmation
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -36,7 +39,7 @@ examples: |-
   n2
   ```
 
-  ### Filtering
+  ### Filtering (--filter) {#filter}
 
   The filtering flag (`--filter`) format is of "key=value". If there is more
   than one filter, then pass multiple flags (e.g., `--filter "foo=bar" --filter "bif=baz"`)

--- a/_data/engine-cli/docker_node_demote.yaml
+++ b/_data/engine-cli/docker_node_demote.yaml
@@ -7,7 +7,7 @@ long: |-
   >
   > This is a cluster management command, and must be executed on a swarm
   > manager node. To learn about managers and workers, refer to the [Swarm mode
-  > section](https://docs.docker.com/engine/swarm/) in the documentation.
+  > section](/engine/swarm/) in the documentation.
 usage: docker node demote NODE [NODE...]
 pname: docker node
 plink: docker_node.yaml

--- a/_data/engine-cli/docker_node_inspect.yaml
+++ b/_data/engine-cli/docker_node_inspect.yaml
@@ -11,7 +11,7 @@ long: |-
   >
   > This is a cluster management command, and must be executed on a swarm
   > manager node. To learn about managers and workers, refer to the
-  > [Swarm mode section](https://docs.docker.com/engine/swarm/) in the
+  > [Swarm mode section](/engine/swarm/) in the
   > documentation.
 usage: docker node inspect [OPTIONS] self|NODE [NODE...]
 pname: docker node
@@ -20,8 +20,14 @@ options:
 - option: format
   shorthand: f
   value_type: string
-  description: Format the output using the given Go template
+  description: |-
+    Format output using a custom template:
+    'json':             Print in JSON format
+    'TEMPLATE':         Print output using the given Go template.
+    Refer to https://docs.docker.com/go/formatting/ for more information about formatting output with templates
+  details_url: '#format'
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -31,6 +37,7 @@ options:
   default_value: "false"
   description: Print the information in a human friendly format
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -113,7 +120,7 @@ examples: |-
   ]
   ```
 
-  ### Specify an output format
+  ### Format the output (--format) {#format}
 
   ```console
   $ docker node inspect --format '{{ .ManagerStatus.Leader }}' self

--- a/_data/engine-cli/docker_node_ls.yaml
+++ b/_data/engine-cli/docker_node_ls.yaml
@@ -10,7 +10,7 @@ long: |-
   >
   > This is a cluster management command, and must be executed on a swarm
   > manager node. To learn about managers and workers, refer to the
-  > [Swarm mode section](https://docs.docker.com/engine/swarm/) in the
+  > [Swarm mode section](/engine/swarm/) in the
   > documentation.
 usage: docker node ls [OPTIONS]
 pname: docker node
@@ -20,15 +20,25 @@ options:
   shorthand: f
   value_type: filter
   description: Filter output based on conditions provided
+  details_url: '#filter'
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
   swarm: false
 - option: format
   value_type: string
-  description: Pretty-print nodes using a Go template
+  description: |-
+    Format output using a custom template:
+    'table':            Print output in table format with column headers (default)
+    'table TEMPLATE':   Print output in table format using the given Go template
+    'json':             Print in JSON format
+    'TEMPLATE':         Print output using the given Go template.
+    Refer to https://docs.docker.com/go/formatting/ for more information about formatting output with templates
+  details_url: '#format'
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -39,6 +49,7 @@ options:
   default_value: "false"
   description: Only display IDs
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -60,7 +71,7 @@ examples: |-
   > `e216jshn25ckzbvmwlnh5jr3g *`) means this node is the current docker daemon.
 
 
-  ### Filtering
+  ### Filtering (--filter) {#filter}
 
   The filtering flag (`-f` or `--filter`) format is of "key=value". If there is more
   than one filter, then pass multiple flags (e.g., `--filter "foo=bar" --filter "bif=baz"`)
@@ -178,23 +189,23 @@ examples: |-
   e216jshn25ckzbvmwlnh5jr3g *  swarm-manager1  Ready   Active        Leader
   ```
 
-  ### Formatting
+  ### Format the output (--format) {#format}
 
   The formatting options (`--format`) pretty-prints nodes output
   using a Go template.
 
   Valid placeholders for the Go template are listed below:
 
-  Placeholder      | Description
-  -----------------|------------------------------------------------------------------------------------------
-  `.ID`            | Node ID
-  `.Self`          | Node of the daemon (`true/false`, `true`indicates that the node is the same as current docker daemon)
-  `.Hostname`      | Node hostname
-  `.Status`        | Node status
-  `.Availability`  | Node availability ("active", "pause", or "drain")
-  `.ManagerStatus` | Manager status of the node
-  `.TLSStatus`     | TLS status of the node ("Ready", or "Needs Rotation" has TLS certificate signed by an old CA)
-  `.EngineVersion` | Engine version
+  | Placeholder      | Description                                                                                           |
+  |------------------|-------------------------------------------------------------------------------------------------------|
+  | `.ID`            | Node ID                                                                                               |
+  | `.Self`          | Node of the daemon (`true/false`, `true`indicates that the node is the same as current docker daemon) |
+  | `.Hostname`      | Node hostname                                                                                         |
+  | `.Status`        | Node status                                                                                           |
+  | `.Availability`  | Node availability ("active", "pause", or "drain")                                                     |
+  | `.ManagerStatus` | Manager status of the node                                                                            |
+  | `.TLSStatus`     | TLS status of the node ("Ready", or "Needs Rotation" has TLS certificate signed by an old CA)         |
+  | `.EngineVersion` | Engine version                                                                                        |
 
   When using the `--format` option, the `node ls` command will either
   output the data exactly as the template declares or, when using the
@@ -209,6 +220,12 @@ examples: |-
 
   e216jshn25ckzbvmwlnh5jr3g: swarm-manager1 Ready
   35o6tiywb700jesrt3dmllaza: swarm-worker1 Needs Rotation
+  ```
+
+  To list all nodes in JSON format, use the `json` directive:
+  ```console
+  $ docker node ls --format json
+  {"Availability":"Active","EngineVersion":"20.10.5","Hostname":"docker-desktop","ID":"k8f4w7qtzpj5sqzclcqafw35g","ManagerStatus":"Leader","Self":true,"Status":"Ready","TLSStatus":"Ready"}
   ```
 deprecated: false
 min_api_version: "1.24"

--- a/_data/engine-cli/docker_node_promote.yaml
+++ b/_data/engine-cli/docker_node_promote.yaml
@@ -7,7 +7,7 @@ long: |-
   >
   > This is a cluster management command, and must be executed on a swarm
   > manager node. To learn about managers and workers, refer to the
-  > [Swarm mode section](https://docs.docker.com/engine/swarm/) in the
+  > [Swarm mode section](/engine/swarm/) in the
   > documentation.
 usage: docker node promote NODE [NODE...]
 pname: docker node

--- a/_data/engine-cli/docker_node_ps.yaml
+++ b/_data/engine-cli/docker_node_ps.yaml
@@ -9,7 +9,7 @@ long: |-
   >
   > This is a cluster management command, and must be executed on a swarm
   > manager node. To learn about managers and workers, refer to the
-  > [Swarm mode section](https://docs.docker.com/engine/swarm/) in the
+  > [Swarm mode section](/engine/swarm/) in the
   > documentation.
 usage: docker node ps [OPTIONS] [NODE...]
 pname: docker node
@@ -19,7 +19,9 @@ options:
   shorthand: f
   value_type: filter
   description: Filter output based on conditions provided
+  details_url: '#filter'
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -27,7 +29,9 @@ options:
 - option: format
   value_type: string
   description: Pretty-print tasks using a Go template
+  details_url: '#format'
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -37,6 +41,7 @@ options:
   default_value: "false"
   description: Do not map IDs to Names
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -46,6 +51,7 @@ options:
   default_value: "false"
   description: Do not truncate output
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -56,6 +62,7 @@ options:
   default_value: "false"
   description: Only display task IDs
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -72,7 +79,7 @@ examples: |-
   redis.10.0tgctg8h8cech4w0k0gwrmr23  redis:3.0.6  swarm-manager1  Running        Running 5 seconds
   ```
 
-  ### Filtering
+  ### Filtering (--filter) {#filter}
 
   The filtering flag (`-f` or `--filter`) format is of "key=value". If there is more
   than one filter, then pass multiple flags (e.g., `--filter "foo=bar" --filter "bif=baz"`)
@@ -133,23 +140,23 @@ examples: |-
   The `desired-state` filter can take the values `running`, `shutdown`, or `accepted`.
 
 
-  ### Formatting
+  ### Format the output (--format) {#format}
 
   The formatting options (`--format`) pretty-prints tasks output
   using a Go template.
 
   Valid placeholders for the Go template are listed below:
 
-  Placeholder     | Description
-  ----------------|------------------------------------------------------------------------------------------
-  `.ID`           | Task ID
-  `.Name`         | Task name
-  `.Image`        | Task image
-  `.Node`         | Node ID
-  `.DesiredState` | Desired state of the task (`running`, `shutdown`, or `accepted`)
-  `.CurrentState` | Current state of the task
-  `.Error`        | Error
-  `.Ports`        | Task published ports
+  | Placeholder     | Description                                                      |
+  |-----------------|------------------------------------------------------------------|
+  | `.ID`           | Task ID                                                          |
+  | `.Name`         | Task name                                                        |
+  | `.Image`        | Task image                                                       |
+  | `.Node`         | Node ID                                                          |
+  | `.DesiredState` | Desired state of the task (`running`, `shutdown`, or `accepted`) |
+  | `.CurrentState` | Current state of the task                                        |
+  | `.Error`        | Error                                                            |
+  | `.Ports`        | Task published ports                                             |
 
   When using the `--format` option, the `node ps` command will either
   output the data exactly as the template declares or, when using the

--- a/_data/engine-cli/docker_node_rm.yaml
+++ b/_data/engine-cli/docker_node_rm.yaml
@@ -8,7 +8,7 @@ long: |-
   >
   > This is a cluster management command, and must be executed on a swarm
   > manager node. To learn about managers and workers, refer to the
-  > [Swarm mode section](https://docs.docker.com/engine/swarm/) in the
+  > [Swarm mode section](/engine/swarm/) in the
   > documentation.
 usage: docker node rm [OPTIONS] NODE [NODE...]
 pname: docker node
@@ -19,7 +19,9 @@ options:
   value_type: bool
   default_value: "false"
   description: Force remove a node from the swarm
+  details_url: '#force'
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -45,7 +47,7 @@ examples: |-
   down and can't be removed
   ```
 
-  ### Forcibly remove an inaccessible node from a swarm
+  ### Forcibly remove an inaccessible node from a swarm (--force) {#force}
 
   If you lose access to a worker node or need to shut it down because it has been
   compromised or is not behaving as expected, you can use the `--force` option.

--- a/_data/engine-cli/docker_node_update.yaml
+++ b/_data/engine-cli/docker_node_update.yaml
@@ -7,7 +7,7 @@ long: |-
   >
   > This is a cluster management command, and must be executed on a swarm
   > manager node. To learn about managers and workers, refer to the
-  > [Swarm mode section](https://docs.docker.com/engine/swarm/) in the
+  > [Swarm mode section](/engine/swarm/) in the
   > documentation.
 usage: docker node update [OPTIONS] NODE
 pname: docker node
@@ -17,6 +17,7 @@ options:
   value_type: string
   description: Availability of the node ("active"|"pause"|"drain")
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -24,7 +25,9 @@ options:
 - option: label-add
   value_type: list
   description: Add or update a node label (key=value)
+  details_url: '#label-add'
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -33,6 +36,7 @@ options:
   value_type: list
   description: Remove a node label if exists
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -41,12 +45,13 @@ options:
   value_type: string
   description: Role of the node ("worker"|"manager")
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
   swarm: false
 examples: |-
-  ### Add label metadata to a node
+  ### Add label metadata to a node (--label-add) {#label-add}
 
   Add metadata to a swarm node using node labels. You can specify a node label as
   a key with an empty value:
@@ -77,7 +82,7 @@ examples: |-
   [dockerd](dockerd.md).
 
   For more information about labels, refer to [apply custom
-  metadata](https://docs.docker.com/engine/userguide/labels-custom-metadata/).
+  metadata](/engine/userguide/labels-custom-metadata/).
 deprecated: false
 min_api_version: "1.24"
 experimental: false

--- a/_data/engine-cli/docker_plugin_create.yaml
+++ b/_data/engine-cli/docker_plugin_create.yaml
@@ -1,6 +1,6 @@
 command: docker plugin create
-short: Create a plugin from a rootfs and configuration. Plugin data directory must
-  contain config.json and rootfs directory.
+short: |
+  Create a plugin from a rootfs and configuration. Plugin data directory must contain config.json and rootfs directory.
 long: |-
   Creates a plugin. Before creating the plugin, prepare the plugin's root filesystem as well as
   [the config.json](../../extend/config.md)
@@ -13,6 +13,7 @@ options:
   default_value: "false"
   description: Compress the context using gzip
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false

--- a/_data/engine-cli/docker_plugin_disable.yaml
+++ b/_data/engine-cli/docker_plugin_disable.yaml
@@ -14,6 +14,7 @@ options:
   default_value: "false"
   description: Force the disable of an active plugin
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false

--- a/_data/engine-cli/docker_plugin_enable.yaml
+++ b/_data/engine-cli/docker_plugin_enable.yaml
@@ -12,6 +12,7 @@ options:
   default_value: "30"
   description: HTTP client timeout (in seconds)
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false

--- a/_data/engine-cli/docker_plugin_inspect.yaml
+++ b/_data/engine-cli/docker_plugin_inspect.yaml
@@ -10,8 +10,14 @@ options:
 - option: format
   shorthand: f
   value_type: string
-  description: Format the output using the given Go template
+  description: |-
+    Format output using a custom template:
+    'json':             Print in JSON format
+    'TEMPLATE':         Print output using the given Go template.
+    Refer to https://docs.docker.com/go/formatting/ for more information about formatting output with templates
+  details_url: '#format'
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -66,7 +72,7 @@ examples: |-
     "Manifest": {
       "ManifestVersion": "v0",
       "Description": "A test plugin for Docker",
-      "Documentation": "https://docs.docker.com/engine/extend/plugins/",
+      "Documentation": "/engine/extend/plugins/",
       "Interface": {
         "Types": [
           "docker.volumedriver/1.0"
@@ -136,7 +142,7 @@ examples: |-
   ```
 
 
-  ### Formatting the output
+  ### Format the output (--format) {#format}
 
   ```console
   $ docker plugin inspect -f '{{.Id}}' tiborvass/sample-volume-plugin:latest

--- a/_data/engine-cli/docker_plugin_install.yaml
+++ b/_data/engine-cli/docker_plugin_install.yaml
@@ -13,6 +13,7 @@ options:
   value_type: string
   description: Local name for plugin
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -22,6 +23,7 @@ options:
   default_value: "false"
   description: Do not enable the plugin on install
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -31,6 +33,7 @@ options:
   default_value: "true"
   description: Skip image verification
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -40,6 +43,7 @@ options:
   default_value: "false"
   description: Grant all permissions necessary to run the plugin
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false

--- a/_data/engine-cli/docker_plugin_ls.yaml
+++ b/_data/engine-cli/docker_plugin_ls.yaml
@@ -15,14 +15,23 @@ options:
   value_type: filter
   description: Provide filter values (e.g. 'enabled=true')
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
   swarm: false
 - option: format
   value_type: string
-  description: Pretty-print plugins using a Go template
+  description: |-
+    Format output using a custom template:
+    'table':            Print output in table format with column headers (default)
+    'table TEMPLATE':   Print output in table format using the given Go template
+    'json':             Print in JSON format
+    'TEMPLATE':         Print output using the given Go template.
+    Refer to https://docs.docker.com/go/formatting/ for more information about formatting output with templates
+  details_url: '#format'
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -32,6 +41,7 @@ options:
   default_value: "false"
   description: Don't truncate output
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -42,6 +52,7 @@ options:
   default_value: "false"
   description: Only display plugin IDs
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -54,7 +65,7 @@ examples: |-
   69553ca1d123  tiborvass/sample-volume-plugin:latest   A test plugin for Docker   true
   ```
 
-  ### Filtering
+  ### Filtering (--filter) {#format}
 
   The filtering flag (`-f` or `--filter`) format is of "key=value". If there is more
   than one filter, then pass multiple flags (e.g., `--filter "foo=bar" --filter "bif=baz"`)
@@ -84,20 +95,20 @@ examples: |-
   ID                  NAME                DESCRIPTION         ENABLED
   ```
 
-  ### Formatting
+  ### Format the output (--format) {#format}
 
   The formatting options (`--format`) pretty-prints plugins output
   using a Go template.
 
   Valid placeholders for the Go template are listed below:
 
-  Placeholder        | Description
-  -------------------|------------------------------------------------------------
-  `.ID`              | Plugin ID
-  `.Name`            | Plugin name and tag
-  `.Description`     | Plugin description
-  `.Enabled`         | Whether plugin is enabled or not
-  `.PluginReference` | The reference used to push/pull from a registry
+  | Placeholder        | Description                                     |
+  |--------------------|-------------------------------------------------|
+  | `.ID`              | Plugin ID                                       |
+  | `.Name`            | Plugin name and tag                             |
+  | `.Description`     | Plugin description                              |
+  | `.Enabled`         | Whether plugin is enabled or not                |
+  | `.PluginReference` | The reference used to push/pull from a registry |
 
   When using the `--format` option, the `plugin ls` command will either
   output the data exactly as the template declares or, when using the
@@ -110,6 +121,12 @@ examples: |-
   $ docker plugin ls --format "{{.ID}}: {{.Name}}"
 
   4be01827a72e: vieux/sshfs:latest
+  ```
+
+  To list all plugins in JSON format, use the `json` directive:
+  ```console
+  $ docker plugin ls --format json
+  {"Description":"sshFS plugin for Docker","Enabled":false,"ID":"856d89febb1c","Name":"vieux/sshfs:latest","PluginReference":"docker.io/vieux/sshfs:latest"}
   ```
 deprecated: false
 min_api_version: "1.25"

--- a/_data/engine-cli/docker_plugin_push.yaml
+++ b/_data/engine-cli/docker_plugin_push.yaml
@@ -15,6 +15,7 @@ options:
   default_value: "true"
   description: Skip image signing
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false

--- a/_data/engine-cli/docker_plugin_rm.yaml
+++ b/_data/engine-cli/docker_plugin_rm.yaml
@@ -16,6 +16,7 @@ options:
   default_value: "false"
   description: Force the removal of an active plugin
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false

--- a/_data/engine-cli/docker_plugin_upgrade.yaml
+++ b/_data/engine-cli/docker_plugin_upgrade.yaml
@@ -14,6 +14,7 @@ options:
   default_value: "true"
   description: Skip image verification
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -23,6 +24,7 @@ options:
   default_value: "false"
   description: Grant all permissions necessary to run the plugin
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -33,6 +35,7 @@ options:
   description: |
     Do not check if specified remote plugin matches existing plugin image
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false

--- a/_data/engine-cli/docker_ps.yaml
+++ b/_data/engine-cli/docker_ps.yaml
@@ -10,7 +10,9 @@ options:
   value_type: bool
   default_value: "false"
   description: Show all containers (default shows just running)
+  details_url: '#all'
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -19,15 +21,25 @@ options:
   shorthand: f
   value_type: filter
   description: Filter output based on conditions provided
+  details_url: '#filter'
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
   swarm: false
 - option: format
   value_type: string
-  description: Pretty-print containers using a Go template
+  description: |-
+    Format output using a custom template:
+    'table':            Print output in table format with column headers (default)
+    'table TEMPLATE':   Print output in table format using the given Go template
+    'json':             Print in JSON format
+    'TEMPLATE':         Print output using the given Go template.
+    Refer to https://docs.docker.com/go/formatting/ for more information about formatting output with templates
+  details_url: '#format'
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -38,6 +50,7 @@ options:
   default_value: "-1"
   description: Show n last created containers (includes all states)
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -48,6 +61,7 @@ options:
   default_value: "false"
   description: Show the latest created container (includes all states)
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -56,7 +70,9 @@ options:
   value_type: bool
   default_value: "false"
   description: Don't truncate output
+  details_url: '#no-trunc'
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -67,6 +83,7 @@ options:
   default_value: "false"
   description: Only display container IDs
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -76,13 +93,15 @@ options:
   value_type: bool
   default_value: "false"
   description: Display total file sizes
+  details_url: '#size'
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
   swarm: false
 examples: |-
-  ### Prevent truncating output
+  ### Do not truncate output (--no-trunc) {#no-trunc}
 
   Running `docker ps --no-trunc` showing 2 linked containers.
 
@@ -94,10 +113,10 @@ examples: |-
   d7886598dbe2        crosbymichael/redis:latest   /redis-server --dir    33 minutes ago       Up 33 minutes       6379/tcp            redis,webapp/db
   ```
 
-  ### Show both running and stopped containers
+  ### Show both running and stopped containers (-a, --all) {#all}
 
   The `docker ps` command only shows running containers by default. To see all
-  containers, use the `-a` (or `--all`) flag:
+  containers, use the `--all` (or `-a`) flag:
 
   ```console
   $ docker ps -a
@@ -107,12 +126,12 @@ examples: |-
   container that exposes TCP ports `100, 101, 102` displays `100-102/tcp` in
   the `PORTS` column.
 
-  ### Show disk usage by container
+  ### Show disk usage by container (--size) {#size}
 
-  The `docker ps -s` command displays two different on-disk-sizes for each container:
+  The `docker ps --size` (or `-s`) command displays two different on-disk-sizes for each container:
 
   ```console
-  $ docker ps -s
+  $ docker ps --size
 
   CONTAINER ID   IMAGE          COMMAND                  CREATED        STATUS       PORTS   NAMES        SIZE                                                                                      SIZE
   e90b8831a4b8   nginx          "/bin/bash -c 'mkdir "   11 weeks ago   Up 4 hours           my_nginx     35.58 kB (virtual 109.2 MB)
@@ -121,12 +140,12 @@ examples: |-
     * The "size" information shows the amount of data (on disk) that is used for the _writable_ layer of each container
     * The "virtual size" is the total amount of disk-space used for the read-only _image_ data used by the container and the writable layer.
 
-  For more information, refer to the [container size on disk](https://docs.docker.com/storage/storagedriver/#container-size-on-disk) section.
+  For more information, refer to the [container size on disk](/storage/storagedriver/#container-size-on-disk) section.
 
 
-  ### Filtering
+  ### Filtering (--filter) {#filter}
 
-  The filtering flag (`-f` or `--filter`) format is a `key=value` pair. If there is more
+  The `--filter` (or `-f`) flag format is a `key=value` pair. If there is more
   than one filter, then pass multiple flags (e.g. `--filter "foo=bar" --filter "bif=baz"`)
 
   The currently supported filters are:
@@ -435,7 +454,7 @@ examples: |-
   CONTAINER ID        IMAGE               COMMAND             CREATED             STATUS              PORTS               NAMES
   ```
 
-  ### Formatting
+  ### Format the output (--format) {#format}
 
   The formatting option (`--format`) pretty-prints container output using a Go
   template.
@@ -485,6 +504,13 @@ examples: |-
   01946d9d34d8
   c1d3b0166030        com.docker.swarm.node=debian,com.docker.swarm.cpu=6
   41d50ecd2f57        com.docker.swarm.node=fedora,com.docker.swarm.cpu=3,com.docker.swarm.storage=ssd
+  ```
+
+  To list all running containers in JSON format, use the `json` directive:
+
+  ```console
+  $ docker ps --format json
+  {"Command":"\"/docker-entrypoint.…\"","CreatedAt":"2021-03-10 00:15:05 +0100 CET","ID":"a762a2b37a1d","Image":"nginx","Labels":"maintainer=NGINX Docker Maintainers \u003cdocker-maint@nginx.com\u003e","LocalVolumes":"0","Mounts":"","Names":"boring_keldysh","Networks":"bridge","Ports":"80/tcp","RunningFor":"4 seconds ago","Size":"0B","State":"running","Status":"Up 3 seconds"}
   ```
 deprecated: false
 experimental: false

--- a/_data/engine-cli/docker_pull.yaml
+++ b/_data/engine-cli/docker_pull.yaml
@@ -16,7 +16,7 @@ long: |-
   before open a connect to registry, you may need to configure the Docker
   daemon's proxy settings, using the `HTTP_PROXY`, `HTTPS_PROXY`, and `NO_PROXY`
   environment variables. To set these environment variables on a host using
-  `systemd`, refer to the [control and configure Docker with systemd](https://docs.docker.com/config/daemon/systemd/#httphttps-proxy)
+  `systemd`, refer to the [control and configure Docker with systemd](/config/daemon/systemd/#httphttps-proxy)
   for variables configuration.
 
   ### Concurrent downloads
@@ -34,7 +34,9 @@ options:
   value_type: bool
   default_value: "false"
   description: Download all tagged images in the repository
+  details_url: '#all-tags'
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -44,6 +46,7 @@ options:
   default_value: "true"
   description: Skip image verification
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -52,6 +55,7 @@ options:
   value_type: string
   description: Set platform if server is multi-platform capable
   deprecated: false
+  hidden: false
   min_api_version: "1.32"
   experimental: false
   experimentalcli: false
@@ -63,6 +67,7 @@ options:
   default_value: "false"
   description: Suppress verbose output
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -122,7 +127,7 @@ examples: |-
   space.
 
   For more information about images, layers, and the content-addressable store,
-  refer to [understand images, containers, and storage drivers](https://docs.docker.com/storage/storagedriver/).
+  refer to [understand images, containers, and storage drivers](/storage/storagedriver/).
 
 
   ### Pull an image by digest (immutable identifier)
@@ -130,8 +135,8 @@ examples: |-
   So far, you've pulled images by their name (and "tag"). Using names and tags is
   a convenient way to work with images. When using tags, you can `docker pull` an
   image again to make sure you have the most up-to-date version of that image.
-  For example, `docker pull ubuntu:14.04` pulls the latest version of the Ubuntu
-  14.04 image.
+  For example, `docker pull ubuntu:20.04` pulls the latest version of the Ubuntu
+  20.04 image.
 
   In some cases you don't want images to be updated to newer versions, but prefer
   to use a fixed version of an image. Docker enables you to pull an image by its
@@ -140,7 +145,7 @@ examples: |-
   and guarantee that the image you're using is always the same.
 
   To know the digest of an image, pull the image first. Let's pull the latest
-  `ubuntu:14.04` image from Docker Hub:
+  `ubuntu:20.04` image from Docker Hub:
 
   ```console
   $ docker pull ubuntu:20.04
@@ -210,7 +215,7 @@ examples: |-
   [insecure registries](dockerd.md#insecure-registries) section for more information.
 
 
-  ### Pull a repository with multiple images
+  ### Pull a repository with multiple images (-a, --all-tags) {#all-tags}
 
   By default, `docker pull` pulls a *single* image from the registry. A repository
   can contain multiple images. To pull all images from a repository, provide the

--- a/_data/engine-cli/docker_push.yaml
+++ b/_data/engine-cli/docker_push.yaml
@@ -30,8 +30,10 @@ options:
   shorthand: a
   value_type: bool
   default_value: "false"
-  description: Push all tagged images in the repository
+  description: Push all tags of an image to the repository
+  details_url: '#all-tags'
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -41,6 +43,7 @@ options:
   default_value: "true"
   description: Skip image signing
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -51,6 +54,7 @@ options:
   default_value: "false"
   description: Suppress verbose output
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -86,7 +90,7 @@ examples: |-
   You should see both `rhel-httpd` and `registry-host:5000/myadmin/rhel-httpd`
   listed.
 
-  ### Push all tags of an image
+  ### Push all tags of an image (-a, --all-tags) {#all-tags}
 
   Use the `-a` (or `--all-tags`) option to push all tags of a local image.
 

--- a/_data/engine-cli/docker_restart.yaml
+++ b/_data/engine-cli/docker_restart.yaml
@@ -11,6 +11,7 @@ options:
   default_value: "10"
   description: Seconds to wait for stop before killing the container
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false

--- a/_data/engine-cli/docker_rm.yaml
+++ b/_data/engine-cli/docker_rm.yaml
@@ -10,7 +10,9 @@ options:
   value_type: bool
   default_value: "false"
   description: Force the removal of a running container (uses SIGKILL)
+  details_url: '#force'
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -20,7 +22,9 @@ options:
   value_type: bool
   default_value: "false"
   description: Remove the specified link
+  details_url: '#link'
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -30,7 +34,9 @@ options:
   value_type: bool
   default_value: "false"
   description: Remove anonymous volumes associated with the container
+  details_url: '#volumes'
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -46,7 +52,7 @@ examples: |-
   /redis
   ```
 
-  ### Remove a link specified with `--link` on the default bridge network
+  ### Remove a link specified with `--link` on the default bridge network (--link) {#link}
 
   This removes the underlying link between `/webapp` and the `/redis`
   containers on the default bridge network, removing all network communication
@@ -59,7 +65,7 @@ examples: |-
   /webapp/redis
   ```
 
-  ### Force-remove a running container
+  ### Force-remove a running container (--force) {#force}
 
   This command force-removes a running container.
 
@@ -102,10 +108,10 @@ examples: |-
   $ docker ps --filter status=exited -q | xargs docker rm
   ```
 
-  ### Remove a container and its volumes
+  ### Remove a container and its volumes (-v, --volumes) {#volumes}
 
   ```console
-  $ docker rm -v redis
+  $ docker rm --volumes redis
   redis
   ```
 

--- a/_data/engine-cli/docker_rmi.yaml
+++ b/_data/engine-cli/docker_rmi.yaml
@@ -19,6 +19,7 @@ options:
   default_value: "false"
   description: Force removal of the image
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -28,6 +29,7 @@ options:
   default_value: "false"
   description: Do not delete untagged parents
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false

--- a/_data/engine-cli/docker_run.yaml
+++ b/_data/engine-cli/docker_run.yaml
@@ -11,7 +11,7 @@ long: |-
   The `docker run` command can be used in combination with `docker commit` to
   [*change the command that a container runs*](commit.md). There is additional detailed information about `docker run` in the [Docker run reference](../run.md).
 
-  For information on connecting a container to a network, see the ["*Docker network overview*"](https://docs.docker.com/network/).
+  For information on connecting a container to a network, see the ["*Docker network overview*"](/network/).
 usage: docker run [OPTIONS] IMAGE [COMMAND] [ARG...]
 pname: docker
 plink: docker.yaml
@@ -19,7 +19,9 @@ options:
 - option: add-host
   value_type: list
   description: Add a custom host-to-IP mapping (host:ip)
+  details_url: '#add-host'
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -28,7 +30,9 @@ options:
   shorthand: a
   value_type: list
   description: Attach to STDIN, STDOUT or STDERR
+  details_url: '#attach'
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -39,6 +43,7 @@ options:
   description: |
     Block IO (relative weight), between 10 and 1000, or 0 to disable (default 0)
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -48,6 +53,7 @@ options:
   default_value: '[]'
   description: Block IO weight (relative device weight)
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -56,6 +62,7 @@ options:
   value_type: list
   description: Add Linux capabilities
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -64,6 +71,7 @@ options:
   value_type: list
   description: Drop Linux capabilities
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -72,6 +80,7 @@ options:
   value_type: string
   description: Optional parent cgroup for the container
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -85,6 +94,7 @@ options:
     '':        Use the cgroup namespace as configured by the
                default-cgroupns-mode option on the daemon (default)
   deprecated: false
+  hidden: false
   min_api_version: "1.41"
   experimental: false
   experimentalcli: false
@@ -93,7 +103,9 @@ options:
 - option: cidfile
   value_type: string
   description: Write the container ID to the file
+  details_url: '#cidfile'
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -103,6 +115,7 @@ options:
   default_value: "0"
   description: CPU count (Windows only)
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -113,6 +126,7 @@ options:
   default_value: "0"
   description: CPU percent (Windows only)
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -123,6 +137,7 @@ options:
   default_value: "0"
   description: Limit CPU CFS (Completely Fair Scheduler) period
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -132,6 +147,7 @@ options:
   default_value: "0"
   description: Limit CPU CFS (Completely Fair Scheduler) quota
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -141,6 +157,7 @@ options:
   default_value: "0"
   description: Limit CPU real-time period in microseconds
   deprecated: false
+  hidden: false
   min_api_version: "1.25"
   experimental: false
   experimentalcli: false
@@ -151,6 +168,7 @@ options:
   default_value: "0"
   description: Limit CPU real-time runtime in microseconds
   deprecated: false
+  hidden: false
   min_api_version: "1.25"
   experimental: false
   experimentalcli: false
@@ -162,6 +180,7 @@ options:
   default_value: "0"
   description: CPU shares (relative weight)
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -170,6 +189,7 @@ options:
   value_type: decimal
   description: Number of CPUs
   deprecated: false
+  hidden: false
   min_api_version: "1.25"
   experimental: false
   experimentalcli: false
@@ -179,6 +199,7 @@ options:
   value_type: string
   description: CPUs in which to allow execution (0-3, 0,1)
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -187,6 +208,7 @@ options:
   value_type: string
   description: MEMs in which to allow execution (0-3, 0,1)
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -197,6 +219,7 @@ options:
   default_value: "false"
   description: Run container in background and print container ID
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -205,6 +228,7 @@ options:
   value_type: string
   description: Override the key sequence for detaching a container
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -212,7 +236,9 @@ options:
 - option: device
   value_type: list
   description: Add a host device to the container
+  details_url: '#device'
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -220,7 +246,9 @@ options:
 - option: device-cgroup-rule
   value_type: list
   description: Add a rule to the cgroup allowed devices list
+  details_url: '#device-cgroup-rule'
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -230,6 +258,7 @@ options:
   default_value: '[]'
   description: Limit read rate (bytes per second) from a device
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -239,6 +268,7 @@ options:
   default_value: '[]'
   description: Limit read rate (IO per second) from a device
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -248,6 +278,7 @@ options:
   default_value: '[]'
   description: Limit write rate (bytes per second) to a device
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -257,6 +288,7 @@ options:
   default_value: '[]'
   description: Limit write rate (IO per second) to a device
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -266,6 +298,7 @@ options:
   default_value: "true"
   description: Skip image verification
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -274,6 +307,7 @@ options:
   value_type: list
   description: Set custom DNS servers
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -282,6 +316,7 @@ options:
   value_type: list
   description: Set DNS options
   deprecated: false
+  hidden: true
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -290,6 +325,7 @@ options:
   value_type: list
   description: Set DNS options
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -298,6 +334,7 @@ options:
   value_type: list
   description: Set custom DNS search domains
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -306,6 +343,7 @@ options:
   value_type: string
   description: Container NIS domain name
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -314,6 +352,7 @@ options:
   value_type: string
   description: Overwrite the default ENTRYPOINT of the image
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -322,7 +361,9 @@ options:
   shorthand: e
   value_type: list
   description: Set environment variables
+  details_url: '#env'
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -331,6 +372,7 @@ options:
   value_type: list
   description: Read in a file of environment variables
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -339,6 +381,7 @@ options:
   value_type: list
   description: Expose a port or a range of ports
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -346,7 +389,9 @@ options:
 - option: gpus
   value_type: gpu-request
   description: GPU devices to add to the container ('all' to pass all GPUs)
+  details_url: '#gpus'
   deprecated: false
+  hidden: false
   min_api_version: "1.40"
   experimental: false
   experimentalcli: false
@@ -356,6 +401,7 @@ options:
   value_type: list
   description: Add additional groups to join
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -364,6 +410,7 @@ options:
   value_type: string
   description: Command to run to check health
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -373,6 +420,7 @@ options:
   default_value: 0s
   description: Time between running the check (ms|s|m|h) (default 0s)
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -382,6 +430,7 @@ options:
   default_value: "0"
   description: Consecutive failures needed to report unhealthy
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -392,6 +441,7 @@ options:
   description: |
     Start period for the container to initialize before starting health-retries countdown (ms|s|m|h) (default 0s)
   deprecated: false
+  hidden: false
   min_api_version: "1.29"
   experimental: false
   experimentalcli: false
@@ -400,9 +450,9 @@ options:
 - option: health-timeout
   value_type: duration
   default_value: 0s
-  description: |
-    Maximum time to allow one check to run (ms|s|m|h) (default 0s)
+  description: Maximum time to allow one check to run (ms|s|m|h) (default 0s)
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -412,6 +462,7 @@ options:
   default_value: "false"
   description: Print usage
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -421,6 +472,7 @@ options:
   value_type: string
   description: Container host name
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -431,6 +483,7 @@ options:
   description: |
     Run an init inside the container that forwards signals and reaps processes
   deprecated: false
+  hidden: false
   min_api_version: "1.25"
   experimental: false
   experimentalcli: false
@@ -442,6 +495,7 @@ options:
   default_value: "false"
   description: Keep STDIN open even if not attached
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -449,9 +503,9 @@ options:
 - option: io-maxbandwidth
   value_type: bytes
   default_value: "0"
-  description: |
-    Maximum IO bandwidth limit for the system drive (Windows only)
+  description: Maximum IO bandwidth limit for the system drive (Windows only)
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -462,6 +516,7 @@ options:
   default_value: "0"
   description: Maximum IOps limit for the system drive (Windows only)
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -471,6 +526,7 @@ options:
   value_type: string
   description: IPv4 address (e.g., 172.30.100.104)
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -479,6 +535,7 @@ options:
   value_type: string
   description: IPv6 address (e.g., 2001:db8::33)
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -487,6 +544,7 @@ options:
   value_type: string
   description: IPC mode to use
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -494,7 +552,9 @@ options:
 - option: isolation
   value_type: string
   description: Container isolation technology
+  details_url: '#isolation'
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -504,6 +564,7 @@ options:
   default_value: "0"
   description: Kernel memory limit
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -512,7 +573,9 @@ options:
   shorthand: l
   value_type: list
   description: Set meta data on a container
+  details_url: '#label'
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -521,6 +584,7 @@ options:
   value_type: list
   description: Read in a line delimited file of labels
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -529,6 +593,7 @@ options:
   value_type: list
   description: Add link to another container
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -537,6 +602,7 @@ options:
   value_type: list
   description: Container IPv4/IPv6 link-local addresses
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -545,6 +611,7 @@ options:
   value_type: string
   description: Logging driver for the container
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -553,6 +620,7 @@ options:
   value_type: list
   description: Log driver options
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -561,6 +629,7 @@ options:
   value_type: string
   description: Container MAC address (e.g., 92:d0:c6:0a:29:33)
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -570,7 +639,9 @@ options:
   value_type: bytes
   default_value: "0"
   description: Memory limit
+  details_url: '#memory'
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -580,6 +651,7 @@ options:
   default_value: "0"
   description: Memory soft limit
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -590,6 +662,7 @@ options:
   description: |
     Swap limit equal to memory plus swap: '-1' to enable unlimited swap
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -599,6 +672,7 @@ options:
   default_value: "-1"
   description: Tune container memory swappiness (0 to 100)
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -606,7 +680,9 @@ options:
 - option: mount
   value_type: mount
   description: Attach a filesystem mount to the container
+  details_url: '#mount'
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -614,7 +690,9 @@ options:
 - option: name
   value_type: string
   description: Assign a name to the container
+  details_url: '#name'
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -623,6 +701,7 @@ options:
   value_type: network
   description: Connect a container to a network
   deprecated: false
+  hidden: true
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -631,6 +710,7 @@ options:
   value_type: list
   description: Add network-scoped alias for the container
   deprecated: false
+  hidden: true
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -638,7 +718,9 @@ options:
 - option: network
   value_type: network
   description: Connect a container to a network
+  details_url: '#network'
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -647,6 +729,7 @@ options:
   value_type: list
   description: Add network-scoped alias for the container
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -656,6 +739,7 @@ options:
   default_value: "false"
   description: Disable any container-specified HEALTHCHECK
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -665,6 +749,7 @@ options:
   default_value: "false"
   description: Disable OOM Killer
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -674,6 +759,7 @@ options:
   default_value: "0"
   description: Tune host's OOM preferences (-1000 to 1000)
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -682,6 +768,7 @@ options:
   value_type: string
   description: PID namespace to use
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -691,6 +778,7 @@ options:
   default_value: "0"
   description: Tune container pids limit (set -1 for unlimited)
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -699,6 +787,7 @@ options:
   value_type: string
   description: Set platform if server is multi-platform capable
   deprecated: false
+  hidden: false
   min_api_version: "1.32"
   experimental: false
   experimentalcli: false
@@ -708,7 +797,9 @@ options:
   value_type: bool
   default_value: "false"
   description: Give extended privileges to this container
+  details_url: '#privileged'
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -717,7 +808,9 @@ options:
   shorthand: p
   value_type: list
   description: Publish a container's port(s) to the host
+  details_url: '#publish'
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -728,6 +821,7 @@ options:
   default_value: "false"
   description: Publish all exposed ports to random ports
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -736,7 +830,20 @@ options:
   value_type: string
   default_value: missing
   description: Pull image before running ("always"|"missing"|"never")
+  details_url: '#pull'
   deprecated: false
+  hidden: false
+  experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
+- option: quiet
+  shorthand: q
+  value_type: bool
+  default_value: "false"
+  description: Suppress the pull output
+  deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -746,6 +853,7 @@ options:
   default_value: "false"
   description: Mount the container's root filesystem as read only
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -754,7 +862,9 @@ options:
   value_type: string
   default_value: "no"
   description: Restart policy to apply when a container exits
+  details_url: '#restart'
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -764,6 +874,7 @@ options:
   default_value: "false"
   description: Automatically remove the container when it exits
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -772,6 +883,7 @@ options:
   value_type: string
   description: Runtime to use for this container
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -779,7 +891,9 @@ options:
 - option: security-opt
   value_type: list
   description: Security Options
+  details_url: '#security-opt'
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -789,6 +903,7 @@ options:
   default_value: "0"
   description: Size of /dev/shm
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -798,15 +913,17 @@ options:
   default_value: "true"
   description: Proxy received signals to the process
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
   swarm: false
 - option: stop-signal
   value_type: string
-  default_value: SIGTERM
-  description: Signal to stop a container
+  description: Signal to stop the container
+  details_url: '#stop-signal'
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -815,7 +932,9 @@ options:
   value_type: int
   default_value: "0"
   description: Timeout (in seconds) to stop a container
+  details_url: '#stop-timeout'
   deprecated: false
+  hidden: false
   min_api_version: "1.25"
   experimental: false
   experimentalcli: false
@@ -824,7 +943,9 @@ options:
 - option: storage-opt
   value_type: list
   description: Storage driver options for the container
+  details_url: '#storage-opt'
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -833,7 +954,9 @@ options:
   value_type: map
   default_value: map[]
   description: Sysctl options
+  details_url: '#sysctl'
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -841,7 +964,9 @@ options:
 - option: tmpfs
   value_type: list
   description: Mount a tmpfs directory
+  details_url: '#tmpfs'
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -852,6 +977,7 @@ options:
   default_value: "false"
   description: Allocate a pseudo-TTY
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -860,7 +986,9 @@ options:
   value_type: ulimit
   default_value: '[]'
   description: Ulimit options
+  details_url: '#ulimit'
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -870,6 +998,7 @@ options:
   value_type: string
   description: 'Username or UID (format: <name|uid>[:<group|gid>])'
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -878,6 +1007,7 @@ options:
   value_type: string
   description: User namespace to use
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -886,6 +1016,7 @@ options:
   value_type: string
   description: UTS namespace to use
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -894,7 +1025,9 @@ options:
   shorthand: v
   value_type: list
   description: Bind mount a volume
+  details_url: '#volume'
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -903,6 +1036,7 @@ options:
   value_type: string
   description: Optional volume driver for the container
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -910,7 +1044,9 @@ options:
 - option: volumes-from
   value_type: list
   description: Mount volumes from the specified container(s)
+  details_url: '#volumes-from'
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -919,13 +1055,15 @@ options:
   shorthand: w
   value_type: string
   description: Working directory inside the container
+  details_url: '#workdir'
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
   swarm: false
 examples: |-
-  ### Assign name and allocate pseudo-TTY (--name, -it)
+  ### Assign name and allocate pseudo-TTY (--name, -it) {#name}
 
   ```console
   $ docker run --name test -it debian
@@ -944,7 +1082,7 @@ examples: |-
   `exit 13`. This exit code is passed on to the caller of
   `docker run`, and is recorded in the `test` container's metadata.
 
-  ### Capture container ID (--cidfile)
+  ### Capture container ID (--cidfile) {#cidfile}
 
   ```console
   $ docker run --cidfile /tmp/docker_test.cid ubuntu echo "test"
@@ -955,7 +1093,7 @@ examples: |-
   If the file exists already, Docker will return an error. Docker will close this
   file when `docker run` exits.
 
-  ### Full container capabilities (--privileged)
+  ### Full container capabilities (--privileged) {#privileged}
 
   ```console
   $ docker run -t -i --rm ubuntu bash
@@ -980,7 +1118,7 @@ examples: |-
   words, the container can then do almost everything that the host can do. This
   flag exists to allow special use-cases, like running Docker within Docker.
 
-  ### Set working directory (-w)
+  ### Set working directory (-w, --workdir) {#workdir}
 
   ```console
   $ docker  run -w /path/to/dir/ -i -t  ubuntu pwd
@@ -989,7 +1127,7 @@ examples: |-
   The `-w` lets the command being executed inside directory given, here
   `/path/to/dir/`. If the path does not exist it is created inside the container.
 
-  ### Set storage driver options per container
+  ### Set storage driver options per container (--storage-opt) {#storage-opt}
 
   ```console
   $ docker run -it --storage-opt size=120G fedora /bin/bash
@@ -1004,7 +1142,7 @@ examples: |-
   backing fs is `xfs` and mounted with the `pquota` mount option.
   Under these conditions, user can pass any size less than the backing fs size.
 
-  ### Mount tmpfs (--tmpfs)
+  ### Mount tmpfs (--tmpfs) {#tmpfs}
 
   ```console
   $ docker run -d --tmpfs /run:rw,noexec,nosuid,size=65536k my_image
@@ -1013,7 +1151,7 @@ examples: |-
   The `--tmpfs` flag mounts an empty tmpfs into the container with the `rw`,
   `noexec`, `nosuid`, `size=65536k` options.
 
-  ### Mount volume (-v, --read-only)
+  ### Mount volume (-v, --read-only) {#volume}
 
   ```console
   $ docker  run  -v `pwd`:`pwd` -w `pwd` -i -t  ubuntu pwd
@@ -1048,7 +1186,7 @@ examples: |-
   ```
 
   By bind-mounting the docker unix socket and statically linked docker
-  binary (refer to [get the linux binary](https://docs.docker.com/engine/install/binaries/#install-static-binaries)),
+  binary (refer to [get the linux binary](/engine/install/binaries/#install-static-binaries)),
   you give the container the full access to create and manipulate the host's
   Docker daemon.
 
@@ -1076,10 +1214,10 @@ examples: |-
   docker run -v c:\foo:c:\existing-directory-with-contents ...
   ```
 
-  For in-depth information about volumes, refer to [manage data in containers](https://docs.docker.com/storage/volumes/)
+  For in-depth information about volumes, refer to [manage data in containers](/storage/volumes/)
 
 
-  ### Add bind mounts or volumes using the --mount flag
+  ### Add bind mounts or volumes using the --mount flag {#mount}
 
   The `--mount` flag allows you to mount volumes, host-directories and `tmpfs`
   mounts in a container.
@@ -1101,7 +1239,7 @@ examples: |-
   $ docker run -t -i --mount type=bind,src=/data,dst=/data busybox sh
   ```
 
-  ### Publish or expose port (-p, --expose)
+  ### Publish or expose port (-p, --expose) {#publish}
 
   ```console
   $ docker run -p 127.0.0.1:80:8080/tcp ubuntu bash
@@ -1109,13 +1247,13 @@ examples: |-
 
   This binds port `8080` of the container to TCP port `80` on `127.0.0.1` of the host
   machine. You can also specify `udp` and `sctp` ports.
-  The [Docker User Guide](https://docs.docker.com/network/links/)
+  The [Docker User Guide](/network/links/)
   explains in detail how to manipulate ports in Docker.
 
   Note that ports which are not bound to the host (i.e., `-p 80:80` instead of
   `-p 127.0.0.1:80:80`) will be accessible from the outside. This also applies if
-  you configured UFW to block this specific port, as Docker manages his
-  own iptables rules. [Read more](https://docs.docker.com/network/iptables/)
+  you configured UFW to block this specific port, as Docker manages its
+  own iptables rules. [Read more](/network/iptables/)
 
   ```console
   $ docker run --expose 80 ubuntu bash
@@ -1124,7 +1262,49 @@ examples: |-
   This exposes port `80` of the container without publishing the port to the host
   system's interfaces.
 
-  ### Set environment variables (-e, --env, --env-file)
+  ### Set the pull policy (--pull) {#pull}
+
+  Use the `--pull` flag to set the image pull policy when creating (and running)
+  the container.
+
+  The `--pull` flag can take one of these values:
+
+  | Value               | Description                                                                                                       |
+  |:--------------------|:------------------------------------------------------------------------------------------------------------------|
+  | `missing` (default) | Pull the image if it was not found in the image cache, or use the cached image otherwise.                         |
+  | `never`             | Do not pull the image, even if it's missing, and produce an error if the image does not exist in the image cache. |
+  | `always`            | Always perform a pull before creating the container.                                                              |
+
+  When creating (and running) a container from an image, the daemon checks if the
+  image exists in the local image cache. If the image is missing, an error is
+  returned to the cli, allowing it to initiate a pull.
+
+  The default (`missing`) is to only pull the image if it is not present in the
+  daemon's image cache. This default allows you to run images that only exist
+  locally (for example, images you built from a Dockerfile, but that have not
+  been pushed to a registry), and reduces networking.
+
+  The `always` option always initiates a pull before creating the container. This
+  option makes sure the image is up-to-date, and prevents you from using outdated
+  images, but may not be suitable in situations where you want to test a locally
+  built image before pushing (as pulling the image overwrites the existing image
+  in the image cache).
+
+  The `never` option disables (implicit) pulling images when creating containers,
+  and only uses images that are available in the image cache. If the specified
+  image is not found, an error is produced, and the container is not created.
+  This option is useful in situations where networking is not available, or to
+  prevent images from being pulled implicitly when creating containers.
+
+  The following example shows `docker run` with the `--pull=never` option set,
+  which produces en error as the image is missing in the image-cache:
+
+  ```console
+  $ docker run --pull=never hello-world
+  docker: Error response from daemon: No such image: hello-world:latest.
+  ```
+
+  ### Set environment variables (-e, --env, --env-file) {#env}
 
   ```console
   $ docker run -e MYVAR1 --env MYVAR2=foo --env-file ./env.list ubuntu bash
@@ -1169,13 +1349,13 @@ examples: |-
   VAR2=value2
   USER
 
-  $ docker run --env-file env.list ubuntu env | grep VAR
+  $ docker run --env-file env.list ubuntu env | grep -E 'VAR|USER'
   VAR1=value1
   VAR2=value2
-  USER=denis
+  USER=jonzeolla
   ```
 
-  ### Set metadata on container (-l, --label, --label-file)
+  ### Set metadata on container (-l, --label, --label-file) {#label}
 
   A label is a `key=value` pair that applies metadata to a container. To label a container with two labels:
 
@@ -1214,10 +1394,10 @@ examples: |-
   You can load multiple label-files by supplying multiple  `--label-file` flags.
 
   For additional information on working with labels, see [*Labels - custom
-  metadata in Docker*](https://docs.docker.com/config/labels-custom-metadata/) in
+  metadata in Docker*](/config/labels-custom-metadata/) in
   the Docker User Guide.
 
-  ### Connect a container to a network (--network)
+  ### Connect a container to a network (--network) {#network}
 
   When you start a container use the `--network` flag to connect it to a network.
   This adds the `busybox` container to the `my-net` network.
@@ -1250,7 +1430,7 @@ examples: |-
   You can disconnect a container from a network using the `docker network
   disconnect` command.
 
-  ### Mount volumes from container (--volumes-from)
+  ### Mount volumes from container (--volumes-from) {#volumes-from}
 
   ```console
   $ docker run --volumes-from 777f7dc92da7 --volumes-from ba8c0c54f0f2:ro -i -t ubuntu pwd
@@ -1276,11 +1456,11 @@ examples: |-
   The `Z` option tells Docker to label the content with a private unshared label.
   Only the current container can use a private volume.
 
-  ### Attach to STDIN/STDOUT/STDERR (-a)
+  ### Attach to STDIN/STDOUT/STDERR (-a, --attach) {#attach}
 
-  The `-a` flag tells `docker run` to bind to the container's `STDIN`, `STDOUT`
-  or `STDERR`. This makes it possible to manipulate the output and input as
-  needed.
+  The `--attach` (or `-a`) flag tells `docker run` to bind to the container's
+  `STDIN`, `STDOUT` or `STDERR`. This makes it possible to manipulate the output
+  and input as needed.
 
   ```console
   $ echo "test" | docker run -i -a stdin ubuntu cat -
@@ -1307,7 +1487,7 @@ examples: |-
   useful if you need to pipe a file or something else into a container and
   retrieve the container's ID once the container has finished running.
 
-  ### Add host device to container (--device)
+  ### Add host device to container (--device) {#device}
 
   ```console
   $ docker run --device=/dev/sdc:/dev/xvdc \
@@ -1372,15 +1552,37 @@ examples: |-
 
   > **Note**
   >
-  > The `--device` option is only supported on process-isolated Windows containers.
-  > This option fails if the container isolation is `hyperv` or when running Linux
-  > Containers on Windows (LCOW).
+  > The `--device` option is only supported on process-isolated Windows containers,
+  > and produces an error if the container isolation is `hyperv`.
 
-  ### Access an NVIDIA GPU
+  ### Using dynamically created devices (--device-cgroup-rule) {#device-cgroup-rule}
 
-  The `--gpus­` flag allows you to access NVIDIA GPU resources. First you need to
+  Devices available to a container are assigned at creation time. The
+  assigned devices will both be added to the cgroup.allow file and
+  created into the container once it is run. This poses a problem when
+  a new device needs to be added to running container.
+
+  One of the solutions is to add a more permissive rule to a container
+  allowing it access to a wider range of devices. For example, supposing
+  our container needs access to a character device with major `42` and
+  any number of minor number (added as new devices appear), the
+  following rule would be added:
+
+  ```console
+  $ docker run -d --device-cgroup-rule='c 42:* rmw' -name my-container my-image
+  ```
+
+  Then, a user could ask `udev` to execute a script that would `docker exec my-container mknod newDevX c 42 <minor>`
+  the required device when it is added.
+
+  > **Note**: initially present devices still need to be explicitly added to the
+  > `docker run` / `docker create` command.
+
+  ### Access an NVIDIA GPU {#gpus}
+
+  The `--gpus` flag allows you to access NVIDIA GPU resources. First you need to
   install [nvidia-container-runtime](https://nvidia.github.io/nvidia-container-runtime/).
-  Visit [Specify a container's resources](https://docs.docker.com/config/containers/resource_constraints/)
+  Visit [Specify a container's resources](/config/containers/resource_constraints/)
   for more information.
 
   To use `--gpus`, specify which GPUs (or all) to use. If no value is provied, all
@@ -1400,10 +1602,10 @@ examples: |-
   The example below exposes the first and third GPUs.
 
   ```console
-  $ docker run -it --rm --gpus device=0,2 nvidia-smi
+  $ docker run -it --rm --gpus '"device=0,2"' nvidia-smi
   ```
 
-  ### Restart policies (--restart)
+  ### Restart policies (--restart) {#restart}
 
   Use Docker's `--restart` to specify a container's *restart policy*. A restart
   policy controls whether the Docker daemon restarts a container after exit.
@@ -1427,7 +1629,7 @@ examples: |-
   [Restart Policies (--restart)](../run.md#restart-policies---restart)
   section of the Docker run reference page.
 
-  ### Add entries to container hosts file (--add-host)
+  ### Add entries to container hosts file (--add-host) {#add-host}
 
   You can add other hosts into a container's `/etc/hosts` file by using one or
   more `--add-host` flags. This example adds a static address for a host named
@@ -1465,7 +1667,7 @@ examples: |-
   devices, replace `eth0` with the correct device name (for example `docker0`
   for the bridge device).
 
-  ### Set ulimits in container (--ulimit)
+  ### Set ulimits in container (--ulimit) {#ulimit}
 
   Since setting `ulimit` settings in a container requires extra privileges not
   available in the default container, you can set these using the `--ulimit` flag.
@@ -1485,7 +1687,7 @@ examples: |-
   > In other words, the following script is not supported:
   >
   > ```console
-  > $ docker run -it --ulimit as=1024 fedora /bin/bash`
+  > $ docker run -it --ulimit as=1024 fedora /bin/bash
   > ```
 
   The values are sent to the appropriate `syscall` as they are set.
@@ -1511,21 +1713,22 @@ examples: |-
   This fails because the caller set `nproc=3` resulting in the first three containers using up
   the three processes quota set for the `daemon` user.
 
-  ### Stop container with signal (--stop-signal)
+  ### Stop container with signal (--stop-signal) {#stop-signal}
 
   The `--stop-signal` flag sets the system call signal that will be sent to the
   container to exit. This signal can be a signal name in the format `SIG<NAME>`,
   for instance `SIGKILL`, or an unsigned number that matches a position in the
   kernel's syscall table, for instance `9`.
 
-  The default is `SIGTERM` if not specified.
+  The default is defined by [`STOPSIGNAL`](/engine/reference/builder/#stopsignal)
+  in the image, or `SIGTERM` if the image has no `STOPSIGNAL` defined.
 
-  ### Optional security options (--security-opt)
+  ### Optional security options (--security-opt) {#security-opt}
 
   On Windows, this flag can be used to specify the `credentialspec` option.
   The `credentialspec` must be in the format `file://spec.txt` or `registry://keyname`.
 
-  ### Stop container with timeout (--stop-timeout)
+  ### Stop container with timeout (--stop-timeout) {#stop-timeout}
 
   The `--stop-timeout` flag sets the number of seconds to wait for the container
   to stop after sending the pre-defined (see `--stop-signal`) system call signal.
@@ -1538,12 +1741,12 @@ examples: |-
   The default is determined by the daemon, and is 10 seconds for Linux containers,
   and 30 seconds for Windows containers.
 
-  ### Specify isolation technology for container (--isolation)
+  ### Specify isolation technology for container (--isolation) {#isolation}
 
   This option is useful in situations where you are running Docker containers on
-  Windows. The `--isolation <value>` option sets a container's isolation technology.
-  On Linux, the only supported is the `default` option which uses
-  Linux namespaces. These two commands are equivalent on Linux:
+  Windows. The `--isolation=<value>` option sets a container's isolation technology.
+  On Linux, the only supported is the `default` option which uses Linux namespaces.
+  These two commands are equivalent on Linux:
 
   ```console
   $ docker run -d busybox top
@@ -1552,16 +1755,15 @@ examples: |-
 
   On Windows, `--isolation` can take one of these values:
 
+  | Value     | Description                                                                                |
+  |:----------|:-------------------------------------------------------------------------------------------|
+  | `default` | Use the value specified by the Docker daemon's `--exec-opt` or system default (see below). |
+  | `process` | Shared-kernel namespace isolation.                                                         |
+  | `hyperv`  | Hyper-V hypervisor partition-based isolation.                                              |
 
-  | Value     | Description                                                                                                       |
-  |:----------|:------------------------------------------------------------------------------------------------------------------|
-  | `default` | Use the value specified by the Docker daemon's `--exec-opt` or system default (see below).                        |
-  | `process` | Shared-kernel namespace isolation (not supported on Windows client operating systems older than Windows 10 1809). |
-  | `hyperv`  | Hyper-V hypervisor partition-based isolation.                                                                     |
-
-  The default isolation on Windows server operating systems is `process`. The default
-  isolation on Windows client operating systems is `hyperv`. An attempt to start a container on a client
-  operating system older than Windows 10 1809 with `--isolation process` will fail.
+  The default isolation on Windows server operating systems is `process`, and `hyperv`
+  on Windows client operating systems, such as Windows 10. Process isolation is more
+  performant, but requires the image to
 
   On Windows server, assuming the default configuration, these commands are equivalent
   and result in `process` isolation:
@@ -1582,7 +1784,7 @@ examples: |-
   PS C:\> docker run -d --isolation hyperv microsoft/nanoserver powershell echo hyperv
   ```
 
-  ### Specify hard limits on memory available to containers (-m, --memory)
+  ### Specify hard limits on memory available to containers (-m, --memory) {#memory}
 
   These parameters always set an upper limit on the memory available to the container. On Linux, this
   is set on the cgroup and applications in a container can query it at `/sys/fs/cgroup/memory/memory.limit_in_bytes`.
@@ -1620,7 +1822,7 @@ examples: |-
       ```
 
 
-  ### Configure namespaced kernel parameters (sysctls) at runtime
+  ### Configure namespaced kernel parameters (sysctls) at runtime (--sysctl) {#sysctl}
 
   The `--sysctl` sets namespaced kernel parameters (sysctls) in the
   container. For example, to turn on IP forwarding in the containers

--- a/_data/engine-cli/docker_save.yaml
+++ b/_data/engine-cli/docker_save.yaml
@@ -13,6 +13,7 @@ options:
   value_type: string
   description: Write to a file, instead of STDOUT
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false

--- a/_data/engine-cli/docker_search.yaml
+++ b/_data/engine-cli/docker_search.yaml
@@ -1,5 +1,5 @@
 command: docker search
-short: Search the Docker Hub for images
+short: Search Docker Hub for images
 long: Search [Docker Hub](https://hub.docker.com) for images
 usage: docker search [OPTIONS] TERM
 pname: docker
@@ -9,7 +9,9 @@ options:
   shorthand: f
   value_type: filter
   description: Filter output based on conditions provided
+  details_url: '#filter'
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -17,16 +19,20 @@ options:
 - option: format
   value_type: string
   description: Pretty-print search using a Go template
+  details_url: '#format'
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
   swarm: false
 - option: limit
   value_type: int
-  default_value: "25"
+  default_value: "0"
   description: Max number of search results
+  details_url: '#limit'
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -35,7 +41,9 @@ options:
   value_type: bool
   default_value: "false"
   description: Don't truncate output
+  details_url: '#no-trunc'
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -76,7 +84,7 @@ examples: |-
   marclop/busybox-solr
   ```
 
-  ### Display non-truncated description (--no-trunc)
+  ### Display non-truncated description (--no-trunc) {#no-trunc}
 
   This example displays images with a name containing 'busybox',
   at least 3 stars and the description isn't truncated in the output:
@@ -90,12 +98,12 @@ examples: |-
   radial/busyboxplus   Full-chain, Internet enabled, busybox made from scratch. Comes in git and cURL flavors.   8                    [OK]
   ```
 
-  ### Limit search results (--limit)
+  ### Limit search results (--limit) {#limit}
 
-  The flag `--limit` is the maximum number of results returned by a search. This value could
-  be in the range between 1 and 100. The default value of `--limit` is 25.
+  The flag `--limit` is the maximum number of results returned by a search. If no
+  value is set, the default is set by the daemon.
 
-  ### Filtering
+  ### Filtering (--filter) {#filter}
 
   The filtering flag (`-f` or `--filter`) format is a `key=value` pair. If there is more
   than one filter, then pass multiple flags (e.g. `--filter is-automated=true --filter stars=3`)
@@ -145,7 +153,7 @@ examples: |-
   busybox   Busybox base image.   325       [OK]
   ```
 
-  ### Format the output
+  ### Format the output (--format) {#format}
 
   The formatting option (`--format`) pretty-prints search output
   using a Go template.
@@ -153,7 +161,7 @@ examples: |-
   Valid placeholders for the Go template are:
 
   | Placeholder    | Description                       |
-  | -------------- | --------------------------------- |
+  |----------------|-----------------------------------|
   | `.Name`        | Image Name                        |
   | `.Description` | Image description                 |
   | `.StarCount`   | Number of stars for the image     |

--- a/_data/engine-cli/docker_secret_create.yaml
+++ b/_data/engine-cli/docker_secret_create.yaml
@@ -3,13 +3,13 @@ short: Create a secret from a file or STDIN as content
 long: |-
   Creates a secret using standard input or from a file for the secret content.
 
-  For detailed information about using secrets, refer to [manage sensitive data with Docker secrets](https://docs.docker.com/engine/swarm/secrets/).
+  For detailed information about using secrets, refer to [manage sensitive data with Docker secrets](/engine/swarm/secrets/).
 
   > **Note**
   >
   > This is a cluster management command, and must be executed on a swarm
   > manager node. To learn about managers and workers, refer to the
-  > [Swarm mode section](https://docs.docker.com/engine/swarm/) in the
+  > [Swarm mode section](/engine/swarm/) in the
   > documentation.
 usage: docker secret create [OPTIONS] SECRET [file|-]
 pname: docker secret
@@ -20,6 +20,7 @@ options:
   value_type: string
   description: Secret driver
   deprecated: false
+  hidden: false
   min_api_version: "1.31"
   experimental: false
   experimentalcli: false
@@ -29,7 +30,9 @@ options:
   shorthand: l
   value_type: list
   description: Secret labels
+  details_url: '#label'
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -38,6 +41,7 @@ options:
   value_type: string
   description: Template driver
   deprecated: false
+  hidden: false
   min_api_version: "1.37"
   experimental: false
   experimentalcli: false
@@ -70,7 +74,7 @@ examples: |-
   dg426haahpi5ezmkkj5kyl3sn   my_secret           7 seconds ago       7 seconds ago
   ```
 
-  ### Create a secret with labels
+  ### Create a secret with labels (--label) {#label}
 
   ```console
   $ docker secret create \

--- a/_data/engine-cli/docker_secret_inspect.yaml
+++ b/_data/engine-cli/docker_secret_inspect.yaml
@@ -9,13 +9,13 @@ long: |-
   Go's [text/template](https://golang.org/pkg/text/template/) package
   describes all the details of the format.
 
-  For detailed information about using secrets, refer to [manage sensitive data with Docker secrets](https://docs.docker.com/engine/swarm/secrets/).
+  For detailed information about using secrets, refer to [manage sensitive data with Docker secrets](/engine/swarm/secrets/).
 
   > **Note**
   >
   > This is a cluster management command, and must be executed on a swarm
   > manager node. To learn about managers and workers, refer to the
-  > [Swarm mode section](https://docs.docker.com/engine/swarm/) in the
+  > [Swarm mode section](/engine/swarm/) in the
   > documentation.
 usage: docker secret inspect [OPTIONS] SECRET [SECRET...]
 pname: docker secret
@@ -24,8 +24,14 @@ options:
 - option: format
   shorthand: f
   value_type: string
-  description: Format the output using the given Go template
+  description: |-
+    Format output using a custom template:
+    'json':             Print in JSON format
+    'TEMPLATE':         Print output using the given Go template.
+    Refer to https://docs.docker.com/go/formatting/ for more information about formatting output with templates
+  details_url: '#format'
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -35,6 +41,7 @@ options:
   default_value: "false"
   description: Print the information in a human friendly format
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -79,7 +86,7 @@ examples: |-
   ]
   ```
 
-  ### Formatting
+  ### Format the output (--format) {#format}
 
   You can use the --format option to obtain specific information about a
   secret. The following example command outputs the creation time of the

--- a/_data/engine-cli/docker_secret_ls.yaml
+++ b/_data/engine-cli/docker_secret_ls.yaml
@@ -4,13 +4,13 @@ short: List secrets
 long: |-
   Run this command on a manager node to list the secrets in the swarm.
 
-  For detailed information about using secrets, refer to [manage sensitive data with Docker secrets](https://docs.docker.com/engine/swarm/secrets/).
+  For detailed information about using secrets, refer to [manage sensitive data with Docker secrets](/engine/swarm/secrets/).
 
   > **Note**
   >
   > This is a cluster management command, and must be executed on a swarm
   > manager node. To learn about managers and workers, refer to the
-  > [Swarm mode section](https://docs.docker.com/engine/swarm/) in the
+  > [Swarm mode section](/engine/swarm/) in the
   > documentation.
 usage: docker secret ls [OPTIONS]
 pname: docker secret
@@ -20,15 +20,25 @@ options:
   shorthand: f
   value_type: filter
   description: Filter output based on conditions provided
+  details_url: '#filter'
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
   swarm: false
 - option: format
   value_type: string
-  description: Pretty-print secrets using a Go template
+  description: |-
+    Format output using a custom template:
+    'table':            Print output in table format with column headers (default)
+    'table TEMPLATE':   Print output in table format using the given Go template
+    'json':             Print in JSON format
+    'TEMPLATE':         Print output using the given Go template.
+    Refer to https://docs.docker.com/go/formatting/ for more information about formatting output with templates
+  details_url: '#format'
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -39,6 +49,7 @@ options:
   default_value: "false"
   description: Only display IDs
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -53,7 +64,7 @@ examples: |-
   mem02h8n73mybpgqjf0kfi1n0   test_secret                 3 seconds ago       3 seconds ago
   ```
 
-  ### Filtering
+  ### Filtering (--filter) {#filter}
 
   The filtering flag (`-f` or `--filter`) format is a `key=value` pair. If there is more
   than one filter, then pass multiple flags (e.g., `--filter "foo=bar" --filter "bif=baz"`)
@@ -113,7 +124,7 @@ examples: |-
   mem02h8n73mybpgqjf0kfi1n0   test_secret                 About an hour ago   About an hour ago
   ```
 
-  ### Format the output
+  ### Format the output (--format) {#format}
 
   The formatting option (`--format`) pretty prints secrets output
   using a Go template.
@@ -121,7 +132,7 @@ examples: |-
   Valid placeholders for the Go template are listed below:
 
   | Placeholder  | Description                                                                          |
-  | ------------ | ------------------------------------------------------------------------------------ |
+  |--------------|--------------------------------------------------------------------------------------|
   | `.ID`        | Secret ID                                                                            |
   | `.Name`      | Secret name                                                                          |
   | `.CreatedAt` | Time when the secret was created                                                     |
@@ -154,6 +165,12 @@ examples: |-
   77af4d6b9913        secret-1                  5 minutes ago
   b6fa739cedf5        secret-2                  3 hours ago
   78a85c484f71        secret-3                  10 days ago
+  ```
+
+  To list all secrets in JSON format, use the `json` directive:
+  ```console
+  $ docker secret ls --format json
+  {"CreatedAt":"28 seconds ago","Driver":"","ID":"4y7hvwrt1u8e9uxh5ygqj7mzc","Labels":"","Name":"mysecret","UpdatedAt":"28 seconds ago"}
   ```
 deprecated: false
 min_api_version: "1.25"

--- a/_data/engine-cli/docker_secret_rm.yaml
+++ b/_data/engine-cli/docker_secret_rm.yaml
@@ -4,13 +4,13 @@ short: Remove one or more secrets
 long: |-
   Removes the specified secrets from the swarm.
 
-  For detailed information about using secrets, refer to [manage sensitive data with Docker secrets](https://docs.docker.com/engine/swarm/secrets/).
+  For detailed information about using secrets, refer to [manage sensitive data with Docker secrets](/engine/swarm/secrets/).
 
   > **Note**
   >
   > This is a cluster management command, and must be executed on a swarm
   > manager node. To learn about managers and workers, refer to the
-  > [Swarm mode section](https://docs.docker.com/engine/swarm/) in the
+  > [Swarm mode section](/engine/swarm/) in the
   > documentation.
 usage: docker secret rm SECRET [SECRET...]
 pname: docker secret

--- a/_data/engine-cli/docker_service.yaml
+++ b/_data/engine-cli/docker_service.yaml
@@ -7,7 +7,7 @@ long: |-
   >
   > This is a cluster management command, and must be executed on a swarm
   > manager node. To learn about managers and workers, refer to the
-  > [Swarm mode section](https://docs.docker.com/engine/swarm/) in the
+  > [Swarm mode section](/engine/swarm/) in the
   > documentation.
 usage: docker service
 pname: docker

--- a/_data/engine-cli/docker_service_create.yaml
+++ b/_data/engine-cli/docker_service_create.yaml
@@ -7,7 +7,7 @@ long: |-
   >
   > This is a cluster management command, and must be executed on a swarm
   > manager node. To learn about managers and workers, refer to the
-  > [Swarm mode section](https://docs.docker.com/engine/swarm/) in the
+  > [Swarm mode section](/engine/swarm/) in the
   > documentation.
 usage: docker service create [OPTIONS] IMAGE [COMMAND] [ARG...]
 pname: docker service
@@ -17,6 +17,7 @@ options:
   value_type: list
   description: Add Linux capabilities
   deprecated: false
+  hidden: false
   min_api_version: "1.41"
   experimental: false
   experimentalcli: false
@@ -26,6 +27,7 @@ options:
   value_type: list
   description: Drop Linux capabilities
   deprecated: false
+  hidden: false
   min_api_version: "1.41"
   experimental: false
   experimentalcli: false
@@ -34,7 +36,9 @@ options:
 - option: config
   value_type: config
   description: Specify configurations to expose to the service
+  details_url: '#config'
   deprecated: false
+  hidden: false
   min_api_version: "1.30"
   experimental: false
   experimentalcli: false
@@ -43,7 +47,9 @@ options:
 - option: constraint
   value_type: list
   description: Placement constraints
+  details_url: '#constraint'
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -52,6 +58,7 @@ options:
   value_type: list
   description: Container labels
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -60,6 +67,7 @@ options:
   value_type: credential-spec
   description: Credential spec for managed service account (Windows only)
   deprecated: false
+  hidden: false
   min_api_version: "1.29"
   experimental: false
   experimentalcli: false
@@ -69,9 +77,9 @@ options:
   shorthand: d
   value_type: bool
   default_value: "false"
-  description: |
-    Exit immediately instead of waiting for the service to converge
+  description: Exit immediately instead of waiting for the service to converge
   deprecated: false
+  hidden: false
   min_api_version: "1.29"
   experimental: false
   experimentalcli: false
@@ -81,6 +89,7 @@ options:
   value_type: list
   description: Set custom DNS servers
   deprecated: false
+  hidden: false
   min_api_version: "1.25"
   experimental: false
   experimentalcli: false
@@ -90,6 +99,7 @@ options:
   value_type: list
   description: Set DNS options
   deprecated: false
+  hidden: false
   min_api_version: "1.25"
   experimental: false
   experimentalcli: false
@@ -99,6 +109,7 @@ options:
   value_type: list
   description: Set custom DNS search domains
   deprecated: false
+  hidden: false
   min_api_version: "1.25"
   experimental: false
   experimentalcli: false
@@ -109,6 +120,7 @@ options:
   default_value: vip
   description: Endpoint mode (vip or dnsrr)
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -117,6 +129,7 @@ options:
   value_type: command
   description: Overwrite the default ENTRYPOINT of the image
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -125,7 +138,9 @@ options:
   shorthand: e
   value_type: list
   description: Set environment variables
+  details_url: '#env'
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -134,6 +149,7 @@ options:
   value_type: list
   description: Read in a file of environment variables
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -142,6 +158,7 @@ options:
   value_type: list
   description: User defined resources
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -150,6 +167,7 @@ options:
   value_type: list
   description: Set one or more supplementary user groups for the container
   deprecated: false
+  hidden: false
   min_api_version: "1.25"
   experimental: false
   experimentalcli: false
@@ -159,6 +177,7 @@ options:
   value_type: string
   description: Command to run to check health
   deprecated: false
+  hidden: false
   min_api_version: "1.25"
   experimental: false
   experimentalcli: false
@@ -168,6 +187,7 @@ options:
   value_type: duration
   description: Time between running the check (ms|s|m|h)
   deprecated: false
+  hidden: false
   min_api_version: "1.25"
   experimental: false
   experimentalcli: false
@@ -178,6 +198,7 @@ options:
   default_value: "0"
   description: Consecutive failures needed to report unhealthy
   deprecated: false
+  hidden: false
   min_api_version: "1.25"
   experimental: false
   experimentalcli: false
@@ -188,6 +209,7 @@ options:
   description: |
     Start period for the container to initialize before counting retries towards unstable (ms|s|m|h)
   deprecated: false
+  hidden: false
   min_api_version: "1.29"
   experimental: false
   experimentalcli: false
@@ -197,6 +219,7 @@ options:
   value_type: duration
   description: Maximum time to allow one check to run (ms|s|m|h)
   deprecated: false
+  hidden: false
   min_api_version: "1.25"
   experimental: false
   experimentalcli: false
@@ -206,6 +229,7 @@ options:
   value_type: list
   description: Set one or more custom host-to-IP mappings (host:ip)
   deprecated: false
+  hidden: false
   min_api_version: "1.25"
   experimental: false
   experimentalcli: false
@@ -214,7 +238,9 @@ options:
 - option: hostname
   value_type: string
   description: Container hostname
+  details_url: '#hostname'
   deprecated: false
+  hidden: false
   min_api_version: "1.25"
   experimental: false
   experimentalcli: false
@@ -226,6 +252,7 @@ options:
   description: |
     Use an init inside each service container to forward signals and reap processes
   deprecated: false
+  hidden: false
   min_api_version: "1.37"
   experimental: false
   experimentalcli: false
@@ -234,7 +261,9 @@ options:
 - option: isolation
   value_type: string
   description: Service container isolation mode
+  details_url: '#isolation'
   deprecated: false
+  hidden: false
   min_api_version: "1.35"
   experimental: false
   experimentalcli: false
@@ -244,7 +273,9 @@ options:
   shorthand: l
   value_type: list
   description: Service labels
+  details_url: '#label'
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -253,6 +284,7 @@ options:
   value_type: decimal
   description: Limit CPUs
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -262,6 +294,7 @@ options:
   default_value: "0"
   description: Limit Memory
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -271,6 +304,7 @@ options:
   default_value: "0"
   description: Limit maximum number of processes (default 0 = unlimited)
   deprecated: false
+  hidden: false
   min_api_version: "1.41"
   experimental: false
   experimentalcli: false
@@ -280,6 +314,7 @@ options:
   value_type: string
   description: Logging driver for service
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -288,6 +323,7 @@ options:
   value_type: list
   description: Logging driver options
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -297,6 +333,7 @@ options:
   description: |
     Number of job tasks to run concurrently (default equal to --replicas)
   deprecated: false
+  hidden: false
   min_api_version: "1.41"
   experimental: false
   experimentalcli: false
@@ -305,9 +342,9 @@ options:
 - option: mode
   value_type: string
   default_value: replicated
-  description: |
-    Service mode (replicated, global, replicated-job, or global-job)
+  description: Service mode (replicated, global, replicated-job, or global-job)
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -316,6 +353,7 @@ options:
   value_type: mount
   description: Attach a filesystem mount to the service
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -324,6 +362,7 @@ options:
   value_type: string
   description: Service name
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -331,7 +370,9 @@ options:
 - option: network
   value_type: network
   description: Network attachments
+  details_url: '#network'
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -341,6 +382,7 @@ options:
   default_value: "false"
   description: Disable any container-specified HEALTHCHECK
   deprecated: false
+  hidden: false
   min_api_version: "1.25"
   experimental: false
   experimentalcli: false
@@ -352,6 +394,7 @@ options:
   description: |
     Do not query the registry to resolve image digest and supported platforms
   deprecated: false
+  hidden: false
   min_api_version: "1.30"
   experimental: false
   experimentalcli: false
@@ -360,7 +403,9 @@ options:
 - option: placement-pref
   value_type: pref
   description: Add a placement preference
+  details_url: '#placement-pref'
   deprecated: false
+  hidden: false
   min_api_version: "1.28"
   experimental: false
   experimentalcli: false
@@ -370,7 +415,9 @@ options:
   shorthand: p
   value_type: port
   description: Publish a port as a node port
+  details_url: '#publish'
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -381,6 +428,7 @@ options:
   default_value: "false"
   description: Suppress progress output
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -390,6 +438,7 @@ options:
   default_value: "false"
   description: Mount the container's root filesystem as read only
   deprecated: false
+  hidden: false
   min_api_version: "1.28"
   experimental: false
   experimentalcli: false
@@ -398,7 +447,9 @@ options:
 - option: replicas
   value_type: uint
   description: Number of tasks
+  details_url: '#replicas'
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -407,7 +458,9 @@ options:
   value_type: uint64
   default_value: "0"
   description: Maximum number of tasks per node (default 0 = unlimited)
+  details_url: '#replicas-max-per-node'
   deprecated: false
+  hidden: false
   min_api_version: "1.40"
   experimental: false
   experimentalcli: false
@@ -417,6 +470,7 @@ options:
   value_type: decimal
   description: Reserve CPUs
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -425,7 +479,9 @@ options:
   value_type: bytes
   default_value: "0"
   description: Reserve Memory
+  details_url: '#reserve-memory'
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -435,6 +491,7 @@ options:
   description: |
     Restart when condition is met ("none"|"on-failure"|"any") (default "any")
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -443,6 +500,7 @@ options:
   value_type: duration
   description: Delay between restart attempts (ns|us|ms|s|m|h) (default 5s)
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -451,6 +509,7 @@ options:
   value_type: uint
   description: Maximum number of restarts before giving up
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -459,6 +518,7 @@ options:
   value_type: duration
   description: Window used to evaluate the restart policy (ns|us|ms|s|m|h)
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -468,6 +528,7 @@ options:
   default_value: 0s
   description: Delay between task rollbacks (ns|us|ms|s|m|h) (default 0s)
   deprecated: false
+  hidden: false
   min_api_version: "1.28"
   experimental: false
   experimentalcli: false
@@ -475,9 +536,9 @@ options:
   swarm: false
 - option: rollback-failure-action
   value_type: string
-  description: |
-    Action on rollback failure ("pause"|"continue") (default "pause")
+  description: Action on rollback failure ("pause"|"continue") (default "pause")
   deprecated: false
+  hidden: false
   min_api_version: "1.28"
   experimental: false
   experimentalcli: false
@@ -488,6 +549,7 @@ options:
   default_value: "0"
   description: Failure rate to tolerate during a rollback (default 0)
   deprecated: false
+  hidden: false
   min_api_version: "1.28"
   experimental: false
   experimentalcli: false
@@ -499,6 +561,7 @@ options:
   description: |
     Duration after each task rollback to monitor for failure (ns|us|ms|s|m|h) (default 5s)
   deprecated: false
+  hidden: false
   min_api_version: "1.28"
   experimental: false
   experimentalcli: false
@@ -506,9 +569,9 @@ options:
   swarm: false
 - option: rollback-order
   value_type: string
-  description: |
-    Rollback order ("start-first"|"stop-first") (default "stop-first")
+  description: Rollback order ("start-first"|"stop-first") (default "stop-first")
   deprecated: false
+  hidden: false
   min_api_version: "1.29"
   experimental: false
   experimentalcli: false
@@ -520,6 +583,7 @@ options:
   description: |
     Maximum number of tasks rolled back simultaneously (0 to roll back all at once)
   deprecated: false
+  hidden: false
   min_api_version: "1.28"
   experimental: false
   experimentalcli: false
@@ -528,7 +592,9 @@ options:
 - option: secret
   value_type: secret
   description: Specify secrets to expose to the service
+  details_url: '#secret'
   deprecated: false
+  hidden: false
   min_api_version: "1.25"
   experimental: false
   experimentalcli: false
@@ -539,6 +605,7 @@ options:
   description: |
     Time to wait before force killing a container (ns|us|ms|s|m|h) (default 10s)
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -547,6 +614,7 @@ options:
   value_type: string
   description: Signal to stop the container
   deprecated: false
+  hidden: false
   min_api_version: "1.28"
   experimental: false
   experimentalcli: false
@@ -556,6 +624,7 @@ options:
   value_type: list
   description: Sysctl options
   deprecated: false
+  hidden: false
   min_api_version: "1.40"
   experimental: false
   experimentalcli: false
@@ -567,6 +636,7 @@ options:
   default_value: "false"
   description: Allocate a pseudo-TTY
   deprecated: false
+  hidden: false
   min_api_version: "1.25"
   experimental: false
   experimentalcli: false
@@ -577,6 +647,7 @@ options:
   default_value: '[]'
   description: Ulimit options
   deprecated: false
+  hidden: false
   min_api_version: "1.41"
   experimental: false
   experimentalcli: false
@@ -586,7 +657,9 @@ options:
   value_type: duration
   default_value: 0s
   description: Delay between updates (ns|us|ms|s|m|h) (default 0s)
+  details_url: '#update-delay'
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -596,6 +669,7 @@ options:
   description: |
     Action on update failure ("pause"|"continue"|"rollback") (default "pause")
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -605,6 +679,7 @@ options:
   default_value: "0"
   description: Failure rate to tolerate during an update (default 0)
   deprecated: false
+  hidden: false
   min_api_version: "1.25"
   experimental: false
   experimentalcli: false
@@ -616,6 +691,7 @@ options:
   description: |
     Duration after each task update to monitor for failure (ns|us|ms|s|m|h) (default 5s)
   deprecated: false
+  hidden: false
   min_api_version: "1.25"
   experimental: false
   experimentalcli: false
@@ -623,9 +699,9 @@ options:
   swarm: false
 - option: update-order
   value_type: string
-  description: |
-    Update order ("start-first"|"stop-first") (default "stop-first")
+  description: Update order ("start-first"|"stop-first") (default "stop-first")
   deprecated: false
+  hidden: false
   min_api_version: "1.29"
   experimental: false
   experimentalcli: false
@@ -637,6 +713,7 @@ options:
   description: |
     Maximum number of tasks updated simultaneously (0 to update all at once)
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -646,6 +723,7 @@ options:
   value_type: string
   description: 'Username or UID (format: <name|uid>[:<group|gid>])'
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -654,7 +732,9 @@ options:
   value_type: bool
   default_value: "false"
   description: Send registry authentication details to swarm agents
+  details_url: '#with-registry-auth'
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -664,6 +744,7 @@ options:
   value_type: string
   description: Working directory inside the container
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -687,7 +768,7 @@ examples: |-
   a8q9dasaafud  redis2  global      1/1       redis:3.0.6
   ```
 
-  #### Create a service using an image on a private registry
+  #### Create a service using an image on a private registry (--with-registry-auth) {#with-registry-auth}
 
   If your image is available on a private registry which requires login, use the
   `--with-registry-auth` flag with `docker service create`, after logging in. If
@@ -707,7 +788,7 @@ examples: |-
   service is deployed, using the encrypted WAL logs. With this information, the
   nodes are able to log into the registry and pull the image.
 
-  ### Create a service with 5 replica tasks (--replicas)
+  ### Create a service with 5 replica tasks (--replicas) {#replicas}
 
   Use the `--replicas` flag to set the number of replica tasks for a replicated
   service. The following command creates a `redis` service with `5` replica tasks:
@@ -743,7 +824,7 @@ examples: |-
   4cdgfyky7ozw  redis  replicated  5/5       redis:3.0.7
   ```
 
-  ### Create a service with secrets
+  ### Create a service with secrets (--secret) {#secret}
 
   Use the `--secret` flag to give a container access to a
   [secret](secret_create.md).
@@ -775,7 +856,7 @@ examples: |-
   example above, two files are created: `/run/secrets/ssh` and
   `/run/secrets/app` for each of the secret targets specified.
 
-  ### Create a service with configs
+  ### Create a service with configs (--config) {#config}
 
   Use the `--config` flag to give a container access to a
   [config](config_create.md).
@@ -804,7 +885,7 @@ examples: |-
   target is specified, the name of the config is used as the name of the file in
   the container. If a target is specified, that is used as the filename.
 
-  ### Create a service with a rolling update policy
+  ### Create a service with a rolling update policy {#update-delay}
 
   ```console
   $ docker service create \
@@ -818,9 +899,9 @@ examples: |-
   When you run a [service update](service_update.md), the scheduler updates a
   maximum of 2 tasks at a time, with `10s` between updates. For more information,
   refer to the [rolling updates
-  tutorial](https://docs.docker.com/engine/swarm/swarm-tutorial/rolling-update/).
+  tutorial](/engine/swarm/swarm-tutorial/rolling-update/).
 
-  ### Set environment variables (-e, --env)
+  ### Set environment variables (-e, --env) {#env}
 
   This sets an environment variable for all tasks in a service. For example:
 
@@ -844,7 +925,7 @@ examples: |-
     redis:3.0.6
   ```
 
-  ### Create a service with specific hostname (--hostname)
+  ### Create a service with specific hostname (--hostname) {#hostname}
 
   This option sets the docker service containers hostname to a specific string.
   For example:
@@ -853,7 +934,7 @@ examples: |-
   $ docker service create --name redis --hostname myredis redis:3.0.6
   ```
 
-  ### Set metadata on a service (-l, --label)
+  ### Set metadata on a service (-l, --label) {#label}
 
   A label is a `key=value` pair that applies metadata to a service. To label a
   service with two labels:
@@ -867,7 +948,7 @@ examples: |-
   ```
 
   For more information about labels, refer to [apply custom
-  metadata](https://docs.docker.com/config/labels-custom-metadata/).
+  metadata](/config/labels-custom-metadata/).
 
   ### Add bind mounts, volumes or memory filesystems
 
@@ -905,7 +986,7 @@ examples: |-
   update the named volume.
 
   For more information about named volumes, see
-  [Data Volumes](https://docs.docker.com/storage/volumes/).
+  [Data Volumes](/storage/volumes/).
 
   The following table describes options which apply to both bind mounts and named
   volumes in a service:
@@ -922,7 +1003,7 @@ examples: |-
       <td>
         <p>The type of mount, can be either <tt>volume</tt>, <tt>bind</tt>, <tt>tmpfs</tt>, or <tt>npipe</tt>. Defaults to <tt>volume</tt> if no type is specified.</p>
         <ul>
-          <li><tt>volume</tt>: mounts a <a href="https://docs.docker.com/engine/reference/commandline/volume_create/">managed volume</a>
+          <li><tt>volume</tt>: mounts a <a href="/engine/reference/commandline/volume_create/">managed volume</a>
           into the container.</li> <li><tt>bind</tt>:
           bind-mounts a directory or file from the host into the container.</li>
           <li><tt>tmpfs</tt>: mount a tmpfs in the container</li>
@@ -1083,7 +1164,7 @@ examples: |-
         creation. For example,
         <tt>volume-label=mylabel=hello-world,my-other-label=hello-mars</tt>. For more
         information about labels, refer to
-        <a href="https://docs.docker.com/config/labels-custom-metadata/">apply custom metadata</a>.
+        <a href="/config/labels-custom-metadata/">apply custom metadata</a>.
       </td>
     </tr>
     <tr>
@@ -1232,7 +1313,7 @@ examples: |-
    redis:3.0.6
   ```
 
-  ### Specify service constraints (--constraint)
+  ### Specify service constraints (--constraint) {#constraint}
 
   You can limit the set of nodes where a task can be scheduled by defining
   constraint expressions. Constraint expressions can either use a _match_ (`==`)
@@ -1240,16 +1321,15 @@ examples: |-
   expression (AND match). Constraints can match node or Docker Engine labels as
   follows:
 
-  node attribute       | matches                        | example
-  ---------------------|--------------------------------|-----------------------------------------------
-  `node.id`            | Node ID                        | `node.id==2ivku8v2gvtg4`
-  `node.hostname`      | Node hostname                  | `node.hostname!=node-2`
-  `node.role`          | Node role (`manager`/`worker`) | `node.role==manager`
-  `node.platform.os`   | Node operating system          | `node.platform.os==windows`
-  `node.platform.arch` | Node architecture              | `node.platform.arch==x86_64`
-  `node.labels`        | User-defined node labels       | `node.labels.security==high`
-  `engine.labels`      | Docker Engine's labels         | `engine.labels.operatingsystem==ubuntu-14.04`
-
+  | node attribute       | matches                        | example                                       |
+  |----------------------|--------------------------------|-----------------------------------------------|
+  | `node.id`            | Node ID                        | `node.id==2ivku8v2gvtg4`                      |
+  | `node.hostname`      | Node hostname                  | `node.hostname!=node-2`                       |
+  | `node.role`          | Node role (`manager`/`worker`) | `node.role==manager`                          |
+  | `node.platform.os`   | Node operating system          | `node.platform.os==windows`                   |
+  | `node.platform.arch` | Node architecture              | `node.platform.arch==x86_64`                  |
+  | `node.labels`        | User-defined node labels       | `node.labels.security==high`                  |
+  | `engine.labels`      | Docker Engine's labels         | `engine.labels.operatingsystem==ubuntu-14.04` |
 
   `engine.labels` apply to Docker Engine labels like operating system, drivers,
   etc. Swarm administrators add `node.labels` for operational purposes by using
@@ -1300,7 +1380,7 @@ examples: |-
   b6lww17hrr4e        web      replicated   1/1        nginx:alpine
   ```
 
-  ### Specify service placement preferences (--placement-pref)
+  ### Specify service placement preferences (--placement-pref) {#placement-pref}
 
   You can set up the service to divide tasks evenly over different categories of
   nodes. One example of where this can be useful is to balance tasks over a set
@@ -1371,7 +1451,7 @@ examples: |-
   `--placement-pref-rm` removes an existing placement preference that matches the
   argument.
 
-  ### Specify memory requirements and constraints for a service (--reserve-memory and --limit-memory)
+  ### Specify memory requirements and constraints for a service (--reserve-memory and --limit-memory) {#reserve-memory}
 
   If your service needs a minimum amount of memory in order to run correctly,
   you can use `--reserve-memory` to specify that the service should only be
@@ -1439,7 +1519,7 @@ examples: |-
   host at the level of the host operating system, using `cgroups` or other
   relevant operating system tools.
 
-  ### Specify maximum replicas per node (--replicas-max-per-node)
+  ### Specify maximum replicas per node (--replicas-max-per-node) {#replicas-max-per-node}
 
   Use the `--replicas-max-per-node` flag to set the maximum number of replica tasks that can run on a node.
   The following command creates a nginx service with 2 replica tasks but only one replica task per node.
@@ -1459,7 +1539,7 @@ examples: |-
     nginx
   ```
 
-  ### Attach a service to an existing network (--network)
+  ### Attach a service to an existing network (--network) {#network}
 
   You can use overlay networks to connect one or more services within the swarm.
 
@@ -1491,12 +1571,12 @@ examples: |-
   The swarm extends my-network to each node running the service.
 
   Containers on the same network can access each other using
-  [service discovery](https://docs.docker.com/network/overlay/#container-discovery).
+  [service discovery](/network/overlay/#container-discovery).
 
   Long form syntax of `--network` allows to specify list of aliases and driver options:
   `--network name=my-network,alias=web1,driver-opt=field1=value1`
 
-  ### Publish service ports externally to the swarm (-p, --publish)
+  ### Publish service ports externally to the swarm (-p, --publish) {#publish}
 
   You can publish service ports to make them available externally to the swarm
   using the `--publish` flag. The `--publish` flag can take two different styles
@@ -1565,9 +1645,9 @@ examples: |-
   the port is only bound on nodes where the service is running, and a given port
   on a node can only be bound once. You can only set the publication mode using
   the long syntax. For more information refer to
-  [Use swarm mode routing mesh](https://docs.docker.com/engine/swarm/ingress/).
+  [Use swarm mode routing mesh](/engine/swarm/ingress/).
 
-  ### Provide credential specs for managed service accounts (Windows only)
+  ### Provide credential specs for managed service accounts (--credentials-spec) {#credentials-spec}
 
   This option is only used for services using Windows containers. The
   `--credential-spec` must be in the format `file://<filename>` or
@@ -1662,7 +1742,7 @@ examples: |-
   x3ti0erg11rjpg64m75kej2mz-hosttempl
   ```
 
-  ### Specify isolation mode (Windows)
+  ### Specify isolation mode on Windows (--isolation) {#isolation}
 
   By default, tasks scheduled on Windows nodes are run using the default isolation mode
   configured for this particular node. To force a specific isolation mode, you can use
@@ -1677,7 +1757,7 @@ examples: |-
   - `process`: use process isolation (Windows server only)
   - `hyperv`: use Hyper-V isolation
 
-  ### Create services requesting Generic Resources
+  ### Create services requesting Generic Resources (--generic-resources) {#generic-resources}
 
   You can narrow the kind of nodes your task can land on through the using the
   `--generic-resource` flag (if the nodes advertise these resources):

--- a/_data/engine-cli/docker_service_inspect.yaml
+++ b/_data/engine-cli/docker_service_inspect.yaml
@@ -13,7 +13,7 @@ long: |-
   >
   > This is a cluster management command, and must be executed on a swarm
   > manager node. To learn about managers and workers, refer to the
-  > [Swarm mode section](https://docs.docker.com/engine/swarm/) in the
+  > [Swarm mode section](/engine/swarm/) in the
   > documentation.
 usage: docker service inspect [OPTIONS] SERVICE [SERVICE...]
 pname: docker service
@@ -22,8 +22,13 @@ options:
 - option: format
   shorthand: f
   value_type: string
-  description: Format the output using the given Go template
+  description: |-
+    Format output using a custom template:
+    'json':             Print in JSON format
+    'TEMPLATE':         Print output using the given Go template.
+    Refer to https://docs.docker.com/go/formatting/ for more information about formatting output with templates
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -32,7 +37,9 @@ options:
   value_type: bool
   default_value: "false"
   description: Print the information in a human friendly format
+  details_url: '#pretty'
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -115,7 +122,7 @@ examples: |-
   ]
   ```
 
-  ### Formatting
+  ### Formatting (--pretty) {#pretty}
 
   You can print the inspect output in a human-readable format instead of the default
   JSON output, by using the `--pretty` option:

--- a/_data/engine-cli/docker_service_logs.yaml
+++ b/_data/engine-cli/docker_service_logs.yaml
@@ -7,7 +7,7 @@ long: |-
   >
   > This is a cluster management command, and must be executed on a swarm
   > manager node. To learn about managers and workers, refer to the
-  > [Swarm mode section](https://docs.docker.com/engine/swarm/) in the
+  > [Swarm mode section](/engine/swarm/) in the
   > documentation.
 
   The `docker service logs` command can be used with either the name or ID of a
@@ -21,7 +21,7 @@ long: |-
   > the `json-file` or `journald` logging driver.
 
   For more information about selecting and configuring logging drivers, refer to
-  [Configure logging drivers](https://docs.docker.com/config/containers/logging/configure/).
+  [Configure logging drivers](/config/containers/logging/configure/).
 
   The `docker service logs --follow` command will continue streaming the new output from
   the service's `STDOUT` and `STDERR`.
@@ -59,6 +59,7 @@ options:
   default_value: "false"
   description: Show extra details provided to logs
   deprecated: false
+  hidden: false
   min_api_version: "1.30"
   experimental: false
   experimentalcli: false
@@ -70,6 +71,7 @@ options:
   default_value: "false"
   description: Follow log output
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -79,6 +81,7 @@ options:
   default_value: "false"
   description: Do not map IDs to Names in output
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -88,6 +91,7 @@ options:
   default_value: "false"
   description: Do not include task IDs in output
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -97,6 +101,7 @@ options:
   default_value: "false"
   description: Do not truncate output
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -106,6 +111,7 @@ options:
   default_value: "false"
   description: Do not neatly format logs
   deprecated: false
+  hidden: false
   min_api_version: "1.30"
   experimental: false
   experimentalcli: false
@@ -116,6 +122,7 @@ options:
   description: |
     Show logs since timestamp (e.g. 2013-01-02T13:23:37Z) or relative (e.g. 42m for 42 minutes)
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -126,6 +133,7 @@ options:
   default_value: all
   description: Number of lines to show from the end of the logs
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -136,6 +144,7 @@ options:
   default_value: "false"
   description: Show timestamps
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false

--- a/_data/engine-cli/docker_service_ls.yaml
+++ b/_data/engine-cli/docker_service_ls.yaml
@@ -8,7 +8,7 @@ long: |-
   >
   > This is a cluster management command, and must be executed on a swarm
   > manager node. To learn about managers and workers, refer to the
-  > [Swarm mode section](https://docs.docker.com/engine/swarm/) in the
+  > [Swarm mode section](/engine/swarm/) in the
   > documentation.
 usage: docker service ls [OPTIONS]
 pname: docker service
@@ -18,15 +18,25 @@ options:
   shorthand: f
   value_type: filter
   description: Filter output based on conditions provided
+  details_url: '#filter'
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
   swarm: false
 - option: format
   value_type: string
-  description: Pretty-print services using a Go template
+  description: |-
+    Format output using a custom template:
+    'table':            Print output in table format with column headers (default)
+    'table TEMPLATE':   Print output in table format using the given Go template
+    'json':             Print in JSON format
+    'TEMPLATE':         Print output using the given Go template.
+    Refer to https://docs.docker.com/go/formatting/ for more information about formatting output with templates
+  details_url: '#format'
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -37,6 +47,7 @@ options:
   default_value: "false"
   description: Only display IDs
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -59,7 +70,7 @@ examples: |-
   additionally show the completion status of the job as completed tasks over
   total tasks the job will execute.
 
-  ### Filtering
+  ### Filtering (--filter) {#filter}
 
   The filtering flag (`-f` or `--filter`) format is of "key=value". If there is more
   than one filter, then pass multiple flags (e.g., `--filter "foo=bar" --filter "bif=baz"`)
@@ -131,21 +142,21 @@ examples: |-
   0bcjwfh8ychr  redis  replicated  1/1       redis:3.0.6
   ```
 
-  ### Formatting
+  ### Format the output (--format) {#format}
 
   The formatting options (`--format`) pretty-prints services output
   using a Go template.
 
   Valid placeholders for the Go template are listed below:
 
-  Placeholder | Description
-  ------------|------------------------------------------------------------------------------------------
-  `.ID`       | Service ID
-  `.Name`     | Service name
-  `.Mode`     | Service mode (replicated, global)
-  `.Replicas` | Service replicas
-  `.Image`    | Service image
-  `.Ports`    | Service ports published in ingress mode
+  | Placeholder | Description                             |
+  |-------------|-----------------------------------------|
+  | `.ID`       | Service ID                              |
+  | `.Name`     | Service name                            |
+  | `.Mode`     | Service mode (replicated, global)       |
+  | `.Replicas` | Service replicas                        |
+  | `.Image`    | Service image                           |
+  | `.Ports`    | Service ports published in ingress mode |
 
   When using the `--format` option, the `service ls` command will either
   output the data exactly as the template declares or, when using the
@@ -159,6 +170,13 @@ examples: |-
 
   0zmvwuiu3vue: replicated 10/10
   fm6uf97exkul: global 5/5
+  ```
+
+  To list all services in JSON format, use the `json` directive:
+
+  ```console
+  $ docker service ls --format json
+  {"ID":"ssniordqolsi","Image":"hello-world:latest","Mode":"replicated","Name":"hello","Ports":"","Replicas":"0/1"}
   ```
 deprecated: false
 min_api_version: "1.24"

--- a/_data/engine-cli/docker_service_ps.yaml
+++ b/_data/engine-cli/docker_service_ps.yaml
@@ -7,7 +7,7 @@ long: |-
   >
   > This is a cluster management command, and must be executed on a swarm
   > manager node. To learn about managers and workers, refer to the
-  > [Swarm mode section](https://docs.docker.com/engine/swarm/) in the
+  > [Swarm mode section](/engine/swarm/) in the
   > documentation.
 usage: docker service ps [OPTIONS] SERVICE [SERVICE...]
 pname: docker service
@@ -17,7 +17,9 @@ options:
   shorthand: f
   value_type: filter
   description: Filter output based on conditions provided
+  details_url: '#filter'
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -25,7 +27,9 @@ options:
 - option: format
   value_type: string
   description: Pretty-print tasks using a Go template
+  details_url: '#format'
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -35,6 +39,7 @@ options:
   default_value: "false"
   description: Do not map IDs to Names
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -44,6 +49,7 @@ options:
   default_value: "false"
   description: Do not truncate output
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -54,6 +60,7 @@ options:
   default_value: "false"
   description: Only display task IDs
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -118,7 +125,7 @@ examples: |-
   nvjljf7rmor4htv7l8rwcx7i7   \_ redis.2   redis:3.0.6@sha256:6a692a76c2081888b589e26e6ec835743119fe453d67ecf03df7de5b73d69842  worker2   Shutdown       Rejected 5 minutes ago   "No such image: redis@sha256:6a692a76c2081888b589e26e6ec835743119fe453d67ecf03df7de5b73d69842"
   ```
 
-  ### Filtering
+  ### Filtering (--filter) {#filter}
 
   The filtering flag (`-f` or `--filter`) format is a `key=value` pair. If there
   is more than one filter, then pass multiple flags (e.g. `--filter "foo=bar" --filter "bif=baz"`).
@@ -175,23 +182,23 @@ examples: |-
 
   The `desired-state` filter can take the values `running`, `shutdown`, or `accepted`.
 
-  ### Formatting
+  ### Format the output (--format) {#format}
 
   The formatting options (`--format`) pretty-prints tasks output
   using a Go template.
 
   Valid placeholders for the Go template are listed below:
 
-  Placeholder     | Description
-  ----------------|------------------------------------------------------------------------------------------
-  `.ID`           | Task ID
-  `.Name`         | Task name
-  `.Image`        | Task image
-  `.Node`         | Node ID
-  `.DesiredState` | Desired state of the task (`running`, `shutdown`, or `accepted`)
-  `.CurrentState` | Current state of the task
-  `.Error`        | Error
-  `.Ports`        | Task published ports
+  | Placeholder     | Description                                                      |
+  |-----------------|------------------------------------------------------------------|
+  | `.ID`           | Task ID                                                          |
+  | `.Name`         | Task name                                                        |
+  | `.Image`        | Task image                                                       |
+  | `.Node`         | Node ID                                                          |
+  | `.DesiredState` | Desired state of the task (`running`, `shutdown`, or `accepted`) |
+  | `.CurrentState` | Current state of the task                                        |
+  | `.Error`        | Error                                                            |
+  | `.Ports`        | Task published ports                                             |
 
   When using the `--format` option, the `service ps` command will either
   output the data exactly as the template declares or, when using the

--- a/_data/engine-cli/docker_service_rm.yaml
+++ b/_data/engine-cli/docker_service_rm.yaml
@@ -8,7 +8,7 @@ long: |-
   >
   > This is a cluster management command, and must be executed on a swarm
   > manager node. To learn about managers and workers, refer to the
-  > [Swarm mode section](https://docs.docker.com/engine/swarm/) in the
+  > [Swarm mode section](/engine/swarm/) in the
   > documentation.
 usage: docker service rm SERVICE [SERVICE...]
 pname: docker service

--- a/_data/engine-cli/docker_service_rollback.yaml
+++ b/_data/engine-cli/docker_service_rollback.yaml
@@ -7,7 +7,7 @@ long: |-
   >
   > This is a cluster management command, and must be executed on a swarm
   > manager node. To learn about managers and workers, refer to the
-  > [Swarm mode section](https://docs.docker.com/engine/swarm/) in the
+  > [Swarm mode section](/engine/swarm/) in the
   > documentation.
 usage: docker service rollback [OPTIONS] SERVICE
 pname: docker service
@@ -17,9 +17,9 @@ options:
   shorthand: d
   value_type: bool
   default_value: "false"
-  description: |
-    Exit immediately instead of waiting for the service to converge
+  description: Exit immediately instead of waiting for the service to converge
   deprecated: false
+  hidden: false
   min_api_version: "1.29"
   experimental: false
   experimentalcli: false
@@ -31,6 +31,7 @@ options:
   default_value: "false"
   description: Suppress progress output
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false

--- a/_data/engine-cli/docker_service_scale.yaml
+++ b/_data/engine-cli/docker_service_scale.yaml
@@ -11,7 +11,7 @@ long: |-
   >
   > This is a cluster management command, and must be executed on a swarm
   > manager node. To learn about managers and workers, refer to the
-  > [Swarm mode section](https://docs.docker.com/engine/swarm/) in the
+  > [Swarm mode section](/engine/swarm/) in the
   > documentation.
 usage: docker service scale SERVICE=REPLICAS [SERVICE=REPLICAS...]
 pname: docker service
@@ -21,9 +21,9 @@ options:
   shorthand: d
   value_type: bool
   default_value: "false"
-  description: |
-    Exit immediately instead of waiting for the service to converge
+  description: Exit immediately instead of waiting for the service to converge
   deprecated: false
+  hidden: false
   min_api_version: "1.29"
   experimental: false
   experimentalcli: false

--- a/_data/engine-cli/docker_service_update.yaml
+++ b/_data/engine-cli/docker_service_update.yaml
@@ -15,7 +15,7 @@ long: |-
   >
   > This is a cluster management command, and must be executed on a swarm
   > manager node. To learn about managers and workers, refer to the
-  > [Swarm mode section](https://docs.docker.com/engine/swarm/) in the
+  > [Swarm mode section](/engine/swarm/) in the
   > documentation.
 usage: docker service update [OPTIONS] SERVICE
 pname: docker service
@@ -25,6 +25,7 @@ options:
   value_type: command
   description: Service command args
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -33,6 +34,7 @@ options:
   value_type: list
   description: Add Linux capabilities
   deprecated: false
+  hidden: false
   min_api_version: "1.41"
   experimental: false
   experimentalcli: false
@@ -42,6 +44,7 @@ options:
   value_type: list
   description: Drop Linux capabilities
   deprecated: false
+  hidden: false
   min_api_version: "1.41"
   experimental: false
   experimentalcli: false
@@ -51,6 +54,7 @@ options:
   value_type: config
   description: Add or update a config file on a service
   deprecated: false
+  hidden: false
   min_api_version: "1.30"
   experimental: false
   experimentalcli: false
@@ -60,6 +64,7 @@ options:
   value_type: list
   description: Remove a configuration file
   deprecated: false
+  hidden: false
   min_api_version: "1.30"
   experimental: false
   experimentalcli: false
@@ -69,6 +74,7 @@ options:
   value_type: list
   description: Add or update a placement constraint
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -77,6 +83,7 @@ options:
   value_type: list
   description: Remove a constraint
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -85,6 +92,7 @@ options:
   value_type: list
   description: Add or update a container label
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -93,6 +101,7 @@ options:
   value_type: list
   description: Remove a container label by its key
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -101,6 +110,7 @@ options:
   value_type: credential-spec
   description: Credential spec for managed service account (Windows only)
   deprecated: false
+  hidden: false
   min_api_version: "1.29"
   experimental: false
   experimentalcli: false
@@ -110,9 +120,9 @@ options:
   shorthand: d
   value_type: bool
   default_value: "false"
-  description: |
-    Exit immediately instead of waiting for the service to converge
+  description: Exit immediately instead of waiting for the service to converge
   deprecated: false
+  hidden: false
   min_api_version: "1.29"
   experimental: false
   experimentalcli: false
@@ -122,6 +132,7 @@ options:
   value_type: list
   description: Add or update a custom DNS server
   deprecated: false
+  hidden: false
   min_api_version: "1.25"
   experimental: false
   experimentalcli: false
@@ -131,6 +142,7 @@ options:
   value_type: list
   description: Add or update a DNS option
   deprecated: false
+  hidden: false
   min_api_version: "1.25"
   experimental: false
   experimentalcli: false
@@ -140,6 +152,7 @@ options:
   value_type: list
   description: Remove a DNS option
   deprecated: false
+  hidden: false
   min_api_version: "1.25"
   experimental: false
   experimentalcli: false
@@ -149,6 +162,7 @@ options:
   value_type: list
   description: Remove a custom DNS server
   deprecated: false
+  hidden: false
   min_api_version: "1.25"
   experimental: false
   experimentalcli: false
@@ -158,6 +172,7 @@ options:
   value_type: list
   description: Add or update a custom DNS search domain
   deprecated: false
+  hidden: false
   min_api_version: "1.25"
   experimental: false
   experimentalcli: false
@@ -167,6 +182,7 @@ options:
   value_type: list
   description: Remove a DNS search domain
   deprecated: false
+  hidden: false
   min_api_version: "1.25"
   experimental: false
   experimentalcli: false
@@ -176,6 +192,7 @@ options:
   value_type: string
   description: Endpoint mode (vip or dnsrr)
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -184,6 +201,7 @@ options:
   value_type: command
   description: Overwrite the default ENTRYPOINT of the image
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -192,6 +210,7 @@ options:
   value_type: list
   description: Add or update an environment variable
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -200,6 +219,7 @@ options:
   value_type: list
   description: Remove an environment variable
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -209,6 +229,7 @@ options:
   default_value: "false"
   description: Force update even if no changes require it
   deprecated: false
+  hidden: false
   min_api_version: "1.25"
   experimental: false
   experimentalcli: false
@@ -218,6 +239,7 @@ options:
   value_type: list
   description: Add a Generic resource
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -226,6 +248,7 @@ options:
   value_type: list
   description: Remove a Generic resource
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -234,6 +257,7 @@ options:
   value_type: list
   description: Add an additional supplementary user group to the container
   deprecated: false
+  hidden: false
   min_api_version: "1.25"
   experimental: false
   experimentalcli: false
@@ -244,6 +268,7 @@ options:
   description: |
     Remove a previously added supplementary user group from the container
   deprecated: false
+  hidden: false
   min_api_version: "1.25"
   experimental: false
   experimentalcli: false
@@ -253,6 +278,7 @@ options:
   value_type: string
   description: Command to run to check health
   deprecated: false
+  hidden: false
   min_api_version: "1.25"
   experimental: false
   experimentalcli: false
@@ -262,6 +288,7 @@ options:
   value_type: duration
   description: Time between running the check (ms|s|m|h)
   deprecated: false
+  hidden: false
   min_api_version: "1.25"
   experimental: false
   experimentalcli: false
@@ -272,6 +299,7 @@ options:
   default_value: "0"
   description: Consecutive failures needed to report unhealthy
   deprecated: false
+  hidden: false
   min_api_version: "1.25"
   experimental: false
   experimentalcli: false
@@ -282,6 +310,7 @@ options:
   description: |
     Start period for the container to initialize before counting retries towards unstable (ms|s|m|h)
   deprecated: false
+  hidden: false
   min_api_version: "1.29"
   experimental: false
   experimentalcli: false
@@ -291,6 +320,7 @@ options:
   value_type: duration
   description: Maximum time to allow one check to run (ms|s|m|h)
   deprecated: false
+  hidden: false
   min_api_version: "1.25"
   experimental: false
   experimentalcli: false
@@ -300,6 +330,7 @@ options:
   value_type: list
   description: Add a custom host-to-IP mapping (host:ip)
   deprecated: false
+  hidden: false
   min_api_version: "1.32"
   experimental: false
   experimentalcli: false
@@ -309,6 +340,7 @@ options:
   value_type: list
   description: Remove a custom host-to-IP mapping (host:ip)
   deprecated: false
+  hidden: false
   min_api_version: "1.25"
   experimental: false
   experimentalcli: false
@@ -318,6 +350,7 @@ options:
   value_type: string
   description: Container hostname
   deprecated: false
+  hidden: false
   min_api_version: "1.25"
   experimental: false
   experimentalcli: false
@@ -327,6 +360,7 @@ options:
   value_type: string
   description: Service image tag
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -337,6 +371,7 @@ options:
   description: |
     Use an init inside each service container to forward signals and reap processes
   deprecated: false
+  hidden: false
   min_api_version: "1.37"
   experimental: false
   experimentalcli: false
@@ -345,7 +380,9 @@ options:
 - option: isolation
   value_type: string
   description: Service container isolation mode
+  details_url: '#isolation'
   deprecated: false
+  hidden: false
   min_api_version: "1.35"
   experimental: false
   experimentalcli: false
@@ -355,6 +392,7 @@ options:
   value_type: list
   description: Add or update a service label
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -363,6 +401,7 @@ options:
   value_type: list
   description: Remove a label by its key
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -371,6 +410,7 @@ options:
   value_type: decimal
   description: Limit CPUs
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -380,6 +420,7 @@ options:
   default_value: "0"
   description: Limit Memory
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -389,6 +430,7 @@ options:
   default_value: "0"
   description: Limit maximum number of processes (default 0 = unlimited)
   deprecated: false
+  hidden: false
   min_api_version: "1.41"
   experimental: false
   experimentalcli: false
@@ -398,6 +440,7 @@ options:
   value_type: string
   description: Logging driver for service
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -406,6 +449,7 @@ options:
   value_type: list
   description: Logging driver options
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -415,6 +459,7 @@ options:
   description: |
     Number of job tasks to run concurrently (default equal to --replicas)
   deprecated: false
+  hidden: false
   min_api_version: "1.41"
   experimental: false
   experimentalcli: false
@@ -423,7 +468,9 @@ options:
 - option: mount-add
   value_type: mount
   description: Add or update a mount on a service
+  details_url: '#mount-add'
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -432,6 +479,7 @@ options:
   value_type: list
   description: Remove a mount by its target path
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -439,7 +487,9 @@ options:
 - option: network-add
   value_type: network
   description: Add a network
+  details_url: '#network-add'
   deprecated: false
+  hidden: false
   min_api_version: "1.29"
   experimental: false
   experimentalcli: false
@@ -449,6 +499,7 @@ options:
   value_type: list
   description: Remove a network
   deprecated: false
+  hidden: false
   min_api_version: "1.29"
   experimental: false
   experimentalcli: false
@@ -459,6 +510,7 @@ options:
   default_value: "false"
   description: Disable any container-specified HEALTHCHECK
   deprecated: false
+  hidden: false
   min_api_version: "1.25"
   experimental: false
   experimentalcli: false
@@ -470,6 +522,7 @@ options:
   description: |
     Do not query the registry to resolve image digest and supported platforms
   deprecated: false
+  hidden: false
   min_api_version: "1.30"
   experimental: false
   experimentalcli: false
@@ -479,6 +532,7 @@ options:
   value_type: pref
   description: Add a placement preference
   deprecated: false
+  hidden: false
   min_api_version: "1.28"
   experimental: false
   experimentalcli: false
@@ -488,6 +542,7 @@ options:
   value_type: pref
   description: Remove a placement preference
   deprecated: false
+  hidden: false
   min_api_version: "1.28"
   experimental: false
   experimentalcli: false
@@ -496,7 +551,9 @@ options:
 - option: publish-add
   value_type: port
   description: Add or update a published port
+  details_url: '#publish-add'
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -505,6 +562,7 @@ options:
   value_type: port
   description: Remove a published port by its target port
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -515,6 +573,7 @@ options:
   default_value: "false"
   description: Suppress progress output
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -524,6 +583,7 @@ options:
   default_value: "false"
   description: Mount the container's root filesystem as read only
   deprecated: false
+  hidden: false
   min_api_version: "1.28"
   experimental: false
   experimentalcli: false
@@ -533,6 +593,7 @@ options:
   value_type: uint
   description: Number of tasks
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -542,6 +603,7 @@ options:
   default_value: "0"
   description: Maximum number of tasks per node (default 0 = unlimited)
   deprecated: false
+  hidden: false
   min_api_version: "1.40"
   experimental: false
   experimentalcli: false
@@ -551,6 +613,7 @@ options:
   value_type: decimal
   description: Reserve CPUs
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -560,6 +623,7 @@ options:
   default_value: "0"
   description: Reserve Memory
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -568,6 +632,7 @@ options:
   value_type: string
   description: Restart when condition is met ("none"|"on-failure"|"any")
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -576,6 +641,7 @@ options:
   value_type: duration
   description: Delay between restart attempts (ns|us|ms|s|m|h)
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -584,6 +650,7 @@ options:
   value_type: uint
   description: Maximum number of restarts before giving up
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -592,6 +659,7 @@ options:
   value_type: duration
   description: Window used to evaluate the restart policy (ns|us|ms|s|m|h)
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -600,7 +668,9 @@ options:
   value_type: bool
   default_value: "false"
   description: Rollback to previous specification
+  details_url: '#rollback'
   deprecated: false
+  hidden: false
   min_api_version: "1.25"
   experimental: false
   experimentalcli: false
@@ -611,6 +681,7 @@ options:
   default_value: 0s
   description: Delay between task rollbacks (ns|us|ms|s|m|h)
   deprecated: false
+  hidden: false
   min_api_version: "1.28"
   experimental: false
   experimentalcli: false
@@ -620,6 +691,7 @@ options:
   value_type: string
   description: Action on rollback failure ("pause"|"continue")
   deprecated: false
+  hidden: false
   min_api_version: "1.28"
   experimental: false
   experimentalcli: false
@@ -630,6 +702,7 @@ options:
   default_value: "0"
   description: Failure rate to tolerate during a rollback
   deprecated: false
+  hidden: false
   min_api_version: "1.28"
   experimental: false
   experimentalcli: false
@@ -641,6 +714,7 @@ options:
   description: |
     Duration after each task rollback to monitor for failure (ns|us|ms|s|m|h)
   deprecated: false
+  hidden: false
   min_api_version: "1.28"
   experimental: false
   experimentalcli: false
@@ -650,6 +724,7 @@ options:
   value_type: string
   description: Rollback order ("start-first"|"stop-first")
   deprecated: false
+  hidden: false
   min_api_version: "1.29"
   experimental: false
   experimentalcli: false
@@ -661,6 +736,7 @@ options:
   description: |
     Maximum number of tasks rolled back simultaneously (0 to roll back all at once)
   deprecated: false
+  hidden: false
   min_api_version: "1.28"
   experimental: false
   experimentalcli: false
@@ -669,7 +745,9 @@ options:
 - option: secret-add
   value_type: secret
   description: Add or update a secret on a service
+  details_url: '#secret-add'
   deprecated: false
+  hidden: false
   min_api_version: "1.25"
   experimental: false
   experimentalcli: false
@@ -679,6 +757,7 @@ options:
   value_type: list
   description: Remove a secret
   deprecated: false
+  hidden: false
   min_api_version: "1.25"
   experimental: false
   experimentalcli: false
@@ -686,9 +765,9 @@ options:
   swarm: false
 - option: stop-grace-period
   value_type: duration
-  description: |
-    Time to wait before force killing a container (ns|us|ms|s|m|h)
+  description: Time to wait before force killing a container (ns|us|ms|s|m|h)
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -697,6 +776,7 @@ options:
   value_type: string
   description: Signal to stop the container
   deprecated: false
+  hidden: false
   min_api_version: "1.28"
   experimental: false
   experimentalcli: false
@@ -706,6 +786,7 @@ options:
   value_type: list
   description: Add or update a Sysctl option
   deprecated: false
+  hidden: false
   min_api_version: "1.40"
   experimental: false
   experimentalcli: false
@@ -715,6 +796,7 @@ options:
   value_type: list
   description: Remove a Sysctl option
   deprecated: false
+  hidden: false
   min_api_version: "1.40"
   experimental: false
   experimentalcli: false
@@ -726,6 +808,7 @@ options:
   default_value: "false"
   description: Allocate a pseudo-TTY
   deprecated: false
+  hidden: false
   min_api_version: "1.25"
   experimental: false
   experimentalcli: false
@@ -736,6 +819,7 @@ options:
   default_value: '[]'
   description: Add or update a ulimit option
   deprecated: false
+  hidden: false
   min_api_version: "1.41"
   experimental: false
   experimentalcli: false
@@ -745,6 +829,7 @@ options:
   value_type: list
   description: Remove a ulimit option
   deprecated: false
+  hidden: false
   min_api_version: "1.41"
   experimental: false
   experimentalcli: false
@@ -755,6 +840,7 @@ options:
   default_value: 0s
   description: Delay between updates (ns|us|ms|s|m|h)
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -763,6 +849,7 @@ options:
   value_type: string
   description: Action on update failure ("pause"|"continue"|"rollback")
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -772,6 +859,7 @@ options:
   default_value: "0"
   description: Failure rate to tolerate during an update
   deprecated: false
+  hidden: false
   min_api_version: "1.25"
   experimental: false
   experimentalcli: false
@@ -783,6 +871,7 @@ options:
   description: |
     Duration after each task update to monitor for failure (ns|us|ms|s|m|h)
   deprecated: false
+  hidden: false
   min_api_version: "1.25"
   experimental: false
   experimentalcli: false
@@ -792,6 +881,7 @@ options:
   value_type: string
   description: Update order ("start-first"|"stop-first")
   deprecated: false
+  hidden: false
   min_api_version: "1.29"
   experimental: false
   experimentalcli: false
@@ -802,7 +892,9 @@ options:
   default_value: "0"
   description: |
     Maximum number of tasks updated simultaneously (0 to update all at once)
+  details_url: '#update-parallelism'
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -812,6 +904,7 @@ options:
   value_type: string
   description: 'Username or UID (format: <name|uid>[:<group|gid>])'
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -821,6 +914,7 @@ options:
   default_value: "false"
   description: Send registry authentication details to swarm agents
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -830,6 +924,7 @@ options:
   value_type: string
   description: Working directory inside the container
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -841,7 +936,7 @@ examples: |-
   $ docker service update --limit-cpu 2 redis
   ```
 
-  ### Perform a rolling restart with no parameter changes
+  ### Perform a rolling restart with no parameter changes {#update-parallelism}
 
   ```console
   $ docker service update --force --update-parallelism 1 --update-delay 30s redis
@@ -854,7 +949,7 @@ examples: |-
   `--update-delay 30s` setting introduces a 30 second delay between tasks, so
   that the rolling restart happens gradually.
 
-  ### Add or remove mounts
+  ### Add or remove mounts (--mount-add, --mount-rm) {#mount-add}
 
   Use the `--mount-add` or `--mount-rm` options add or remove a service's bind mounts
   or volumes.
@@ -890,7 +985,7 @@ examples: |-
   myservice
   ```
 
-  ### Add or remove published service ports
+  ### Add or remove published service ports (--publish-add, --publish-rm) {#publish-add}
 
   Use the `--publish-add` or `--publish-rm` flags to add or remove a published
   port for a service. You can use the short or long syntax discussed in the
@@ -905,7 +1000,7 @@ examples: |-
     myservice
   ```
 
-  ### Add or remove network
+  ### Add or remove network (--network-add, --network-rm) {#network-add}
 
   Use the `--network-add` or `--network-rm` flags to add or remove a network for
   a service. You can use the short or long syntax discussed in the
@@ -921,7 +1016,7 @@ examples: |-
     myservice
   ```
 
-  ### Roll back to the previous version of a service
+  ### Roll back to the previous version of a service (--rollback) {#rollback}
 
   Use the `--rollback` option to roll back to the previous version of the service.
 
@@ -987,7 +1082,7 @@ examples: |-
   tasks at a time will get rolled back. These rollback parameters are respected both
   during automatic rollbacks and for rollbacks initiated manually using `--rollback`.
 
-  ### Add or remove secrets
+  ### Add or remove secrets (--secret-add, --secret-rm) {#secret-add}
 
   Use the `--secret-add` or `--secret-rm` options add or remove a service's
   secrets.
@@ -1007,7 +1102,7 @@ examples: |-
   See [`service create`](service_create.md#create-services-using-templates) for the reference.
 
 
-  ### Specify isolation mode (Windows)
+  ### Specify isolation mode on Windows (--isolation) {#isolation}
 
   `service update` supports the same `--isolation` flag as `service create`
   See [`service create`](service_create.md) for the reference.

--- a/_data/engine-cli/docker_stack.yaml
+++ b/_data/engine-cli/docker_stack.yaml
@@ -17,18 +17,11 @@ clink:
 - docker_stack_rm.yaml
 - docker_stack_services.yaml
 options:
-- option: kubeconfig
-  value_type: string
-  description: Kubernetes config file
-  deprecated: true
-  experimental: false
-  experimentalcli: false
-  kubernetes: true
-  swarm: false
 - option: orchestrator
   value_type: string
-  description: Orchestrator to use (swarm|kubernetes|all)
+  description: Orchestrator to use (swarm|all)
   deprecated: true
+  hidden: true
   experimental: false
   experimentalcli: false
   kubernetes: false

--- a/_data/engine-cli/docker_stack_deploy.yaml
+++ b/_data/engine-cli/docker_stack_deploy.yaml
@@ -8,7 +8,7 @@ long: |-
   >
   > This is a cluster management command, and must be executed on a swarm
   > manager node. To learn about managers and workers, refer to the
-  > [Swarm mode section](https://docs.docker.com/engine/swarm/) in the
+  > [Swarm mode section](/engine/swarm/) in the
   > documentation.
 usage: docker stack deploy [OPTIONS] STACK
 pname: docker stack
@@ -19,25 +19,20 @@ options:
   value_type: stringSlice
   default_value: '[]'
   description: Path to a Compose file, or "-" to read from stdin
+  details_url: '#compose-file'
   deprecated: false
+  hidden: false
   min_api_version: "1.25"
   experimental: false
   experimentalcli: false
   kubernetes: false
-  swarm: false
-- option: namespace
-  value_type: string
-  description: Kubernetes namespace to use
-  deprecated: true
-  experimental: false
-  experimentalcli: false
-  kubernetes: true
   swarm: false
 - option: prune
   value_type: bool
   default_value: "false"
   description: Prune services that are no longer referenced
   deprecated: false
+  hidden: false
   min_api_version: "1.27"
   experimental: false
   experimentalcli: false
@@ -49,6 +44,7 @@ options:
   description: |
     Query the registry to resolve image digest and supported platforms ("always"|"changed"|"never")
   deprecated: false
+  hidden: false
   min_api_version: "1.30"
   experimental: false
   experimentalcli: false
@@ -59,29 +55,23 @@ options:
   default_value: "false"
   description: Send registry authentication details to Swarm agents
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
   swarm: true
 inherited_options:
-- option: kubeconfig
-  value_type: string
-  description: Kubernetes config file
-  deprecated: true
-  experimental: false
-  experimentalcli: false
-  kubernetes: true
-  swarm: false
 - option: orchestrator
   value_type: string
-  description: Orchestrator to use (swarm|kubernetes|all)
+  description: Orchestrator to use (swarm|all)
   deprecated: true
+  hidden: true
   experimental: false
   experimentalcli: false
   kubernetes: false
   swarm: false
 examples: |-
-  ### Compose file
+  ### Compose file (--compose-file) {#compose-file}
 
   The `deploy` command supports compose file version `3.0` and above.
 

--- a/_data/engine-cli/docker_stack_ls.yaml
+++ b/_data/engine-cli/docker_stack_ls.yaml
@@ -8,51 +8,34 @@ long: |-
   >
   > This is a cluster management command, and must be executed on a swarm
   > manager node. To learn about managers and workers, refer to the
-  > [Swarm mode section](https://docs.docker.com/engine/swarm/) in the
+  > [Swarm mode section](/engine/swarm/) in the
   > documentation.
 usage: docker stack ls [OPTIONS]
 pname: docker stack
 plink: docker_stack.yaml
 options:
-- option: all-namespaces
-  value_type: bool
-  default_value: "false"
-  description: List stacks from all Kubernetes namespaces
-  deprecated: true
-  experimental: false
-  experimentalcli: false
-  kubernetes: true
-  swarm: false
 - option: format
   value_type: string
-  description: Pretty-print stacks using a Go template
+  description: |-
+    Format output using a custom template:
+    'table':            Print output in table format with column headers (default)
+    'table TEMPLATE':   Print output in table format using the given Go template
+    'json':             Print in JSON format
+    'TEMPLATE':         Print output using the given Go template.
+    Refer to https://docs.docker.com/go/formatting/ for more information about formatting output with templates
+  details_url: '#format'
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
   swarm: false
-- option: namespace
-  value_type: stringSlice
-  default_value: '[]'
-  description: Kubernetes namespaces to use
-  deprecated: true
-  experimental: false
-  experimentalcli: false
-  kubernetes: true
-  swarm: false
 inherited_options:
-- option: kubeconfig
-  value_type: string
-  description: Kubernetes config file
-  deprecated: true
-  experimental: false
-  experimentalcli: false
-  kubernetes: true
-  swarm: false
 - option: orchestrator
   value_type: string
-  description: Orchestrator to use (swarm|kubernetes|all)
+  description: Orchestrator to use (swarm|all)
   deprecated: true
+  hidden: true
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -68,14 +51,14 @@ examples: |-
   vossibility-stack  6                   Swarm
   ```
 
-  ### Formatting
+  ### Format the output (--format) {#format}
 
   The formatting option (`--format`) pretty-prints stacks using a Go template.
 
   Valid placeholders for the Go template are listed below:
 
   | Placeholder     | Description        |
-  | --------------- | ------------------ |
+  |-----------------|--------------------|
   | `.Name`         | Stack name         |
   | `.Services`     | Number of services |
   | `.Orchestrator` | Orchestrator name  |
@@ -92,6 +75,13 @@ examples: |-
   $ docker stack ls --format "{{.Name}}: {{.Services}}"
   web-server: 1
   web-cache: 4
+  ```
+
+  To list all stacks in JSON format, use the `json` directive:
+
+  ```console
+  $ docker stack ls --format json
+  {"Name":"myapp","Namespace":"","Orchestrator":"Swarm","Services":"3"}
   ```
 deprecated: false
 min_api_version: "1.25"

--- a/_data/engine-cli/docker_stack_ps.yaml
+++ b/_data/engine-cli/docker_stack_ps.yaml
@@ -7,7 +7,7 @@ long: |-
   >
   > This is a cluster management command, and must be executed on a swarm
   > manager node. To learn about managers and workers, refer to the
-  > [Swarm mode section](https://docs.docker.com/engine/swarm/) in the
+  > [Swarm mode section](/engine/swarm/) in the
   > documentation.
 usage: docker stack ps [OPTIONS] STACK
 pname: docker stack
@@ -17,32 +17,36 @@ options:
   shorthand: f
   value_type: filter
   description: Filter output based on conditions provided
+  details_url: '#filter'
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
   swarm: false
 - option: format
   value_type: string
-  description: Pretty-print tasks using a Go template
+  description: |-
+    Format output using a custom template:
+    'table':            Print output in table format with column headers (default)
+    'table TEMPLATE':   Print output in table format using the given Go template
+    'json':             Print in JSON format
+    'TEMPLATE':         Print output using the given Go template.
+    Refer to https://docs.docker.com/go/formatting/ for more information about formatting output with templates
+  details_url: '#format'
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
-  swarm: false
-- option: namespace
-  value_type: string
-  description: Kubernetes namespace to use
-  deprecated: true
-  experimental: false
-  experimentalcli: false
-  kubernetes: true
   swarm: false
 - option: no-resolve
   value_type: bool
   default_value: "false"
   description: Do not map IDs to Names
+  details_url: '#no-resolve'
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -51,7 +55,9 @@ options:
   value_type: bool
   default_value: "false"
   description: Do not truncate output
+  details_url: '#no-trunc'
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -61,24 +67,19 @@ options:
   value_type: bool
   default_value: "false"
   description: Only display task IDs
+  details_url: '#quiet'
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
   swarm: false
 inherited_options:
-- option: kubeconfig
-  value_type: string
-  description: Kubernetes config file
-  deprecated: true
-  experimental: false
-  experimentalcli: false
-  kubernetes: true
-  swarm: false
 - option: orchestrator
   value_type: string
-  description: Orchestrator to use (swarm|kubernetes|all)
+  description: Orchestrator to use (swarm|all)
   deprecated: true
+  hidden: true
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -102,7 +103,7 @@ examples: |-
   t72q3z038jeh        voting_redis.2        redis:alpine                                   node3  Running        Running 3 minutes ago
   ```
 
-  ### Filtering
+  ### Filtering (--filter) {#filter}
 
   The filtering flag (`-f` or `--filter`) format is a `key=value` pair. If there
   is more than one filter, then pass multiple flags (e.g. `--filter "foo=bar" --filter "bif=baz"`).
@@ -171,22 +172,22 @@ examples: |-
   t72q3z038jeh        voting_redis.2        redis:alpine                                   node3  Running        Running 21 minutes ago
   ```
 
-  ### Formatting
+  ### Format the output (--format) {#format}
 
   The formatting options (`--format`) pretty-prints tasks output using a Go template.
 
   Valid placeholders for the Go template are listed below:
 
-  Placeholder     | Description
-  ----------------|------------------------------------------------------------------------------------------
-  `.ID`           | Task ID
-  `.Name`         | Task name
-  `.Image`        | Task image
-  `.Node`         | Node ID
-  `.DesiredState` | Desired state of the task (`running`, `shutdown`, or `accepted`)
-  `.CurrentState` | Current state of the task
-  `.Error`        | Error
-  `.Ports`        | Task published ports
+  | Placeholder     | Description                                                      |
+  |-----------------|------------------------------------------------------------------|
+  | `.ID`           | Task ID                                                          |
+  | `.Name`         | Task name                                                        |
+  | `.Image`        | Task image                                                       |
+  | `.Node`         | Node ID                                                          |
+  | `.DesiredState` | Desired state of the task (`running`, `shutdown`, or `accepted`) |
+  | `.CurrentState` | Current state of the task                                        |
+  | `.Error`        | Error                                                            |
+  | `.Ports`        | Task published ports                                             |
 
   When using the `--format` option, the `stack ps` command will either
   output the data exactly as the template declares or, when using the
@@ -208,7 +209,15 @@ examples: |-
   voting_redis.2: redis:alpine
   ```
 
-  ### Do not map IDs to Names
+  To list all tasks in JSON format, use the `json` directive:
+  ```console
+  $ docker stack ps --format json myapp
+  {"CurrentState":"Preparing 23 seconds ago","DesiredState":"Running","Error":"","ID":"2ufjubh79tn0","Image":"localstack/localstack:latest","Name":"myapp_localstack.1","Node":"docker-desktop","Ports":""}
+  {"CurrentState":"Running 20 seconds ago","DesiredState":"Running","Error":"","ID":"roee387ngf5r","Image":"redis:6.0.9-alpine3.12","Name":"myapp_redis.1","Node":"docker-desktop","Ports":""}
+  {"CurrentState":"Preparing 13 seconds ago","DesiredState":"Running","Error":"","ID":"yte68ouq7glh","Image":"postgres:13.2-alpine","Name":"myapp_repos-db.1","Node":"docker-desktop","Ports":""}
+  ```
+
+  ### Do not map IDs to Names (--no-resolve) {#no-resolve}
 
   The `--no-resolve` option shows IDs for task name, without mapping IDs to Names.
 
@@ -226,7 +235,7 @@ examples: |-
   t72q3z038jeh        tg61x8myx563ueo3urmn1ic6m.2   redis:alpine                                   kanqcxfajd1r16wlnqcblobmm   Running        Running 31 minutes ago
   ```
 
-  ### Do not truncate output
+  ### Do not truncate output (--no-trunc) {#no-trunc}
 
   When deploying a service, docker resolves the digest for the service's
   image, and pins the service to that digest. The digest is not shown by
@@ -247,7 +256,7 @@ examples: |-
   t72q3z038jehe1wbh9gdum076   voting_redis.2        redis:alpine@sha256:9cd405cd1ec1410eaab064a1383d0d8854d1ef74a54e1e4a92fb4ec7bdc3ee7                                   node3  Running        Runnin 32 minutes ago
   ```
 
-  ### Only display task IDs
+  ### Only display task IDs (-q, --quiet) {#quiet}
 
   The `-q ` or `--quiet` option only shows IDs of the tasks in the stack.
   This example outputs all task IDs of the "voting" stack;

--- a/_data/engine-cli/docker_stack_rm.yaml
+++ b/_data/engine-cli/docker_stack_rm.yaml
@@ -8,33 +8,17 @@ long: |-
   >
   > This is a cluster management command, and must be executed on a swarm
   > manager node. To learn about managers and workers, refer to the
-  > [Swarm mode section](https://docs.docker.com/engine/swarm/) in the
+  > [Swarm mode section](/engine/swarm/) in the
   > documentation.
 usage: docker stack rm [OPTIONS] STACK [STACK...]
 pname: docker stack
 plink: docker_stack.yaml
-options:
-- option: namespace
-  value_type: string
-  description: Kubernetes namespace to use
-  deprecated: true
-  experimental: false
-  experimentalcli: false
-  kubernetes: true
-  swarm: false
 inherited_options:
-- option: kubeconfig
-  value_type: string
-  description: Kubernetes config file
-  deprecated: true
-  experimental: false
-  experimentalcli: false
-  kubernetes: true
-  swarm: false
 - option: orchestrator
   value_type: string
-  description: Orchestrator to use (swarm|kubernetes|all)
+  description: Orchestrator to use (swarm|all)
   deprecated: true
+  hidden: true
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -42,7 +26,8 @@ inherited_options:
 examples: |-
   ### Remove a stack
 
-  This will remove the stack with the name `myapp`. Services, networks, and secrets associated with the stack will be removed.
+  This will remove the stack with the name `myapp`. Services, networks, and secrets
+  associated with the stack will be removed.
 
   ```console
   $ docker stack rm myapp
@@ -56,7 +41,8 @@ examples: |-
 
   ### Remove multiple stacks
 
-  This will remove all the specified stacks, `myapp` and `vossibility`. Services, networks, and secrets associated with all the specified stacks will be removed.
+  This will remove all the specified stacks, `myapp` and `vossibility`. Services,
+  networks, and secrets associated with all the specified stacks will be removed.
 
   ```console
   $ docker stack rm myapp vossibility

--- a/_data/engine-cli/docker_stack_services.yaml
+++ b/_data/engine-cli/docker_stack_services.yaml
@@ -7,7 +7,7 @@ long: |-
   >
   > This is a cluster management command, and must be executed on a swarm
   > manager node. To learn about managers and workers, refer to the
-  > [Swarm mode section](https://docs.docker.com/engine/swarm/) in the
+  > [Swarm mode section](/engine/swarm/) in the
   > documentation.
 usage: docker stack services [OPTIONS] STACK
 pname: docker stack
@@ -17,26 +17,28 @@ options:
   shorthand: f
   value_type: filter
   description: Filter output based on conditions provided
+  details_url: '#filter'
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
   swarm: false
 - option: format
   value_type: string
-  description: Pretty-print services using a Go template
+  description: |-
+    Format output using a custom template:
+    'table':            Print output in table format with column headers (default)
+    'table TEMPLATE':   Print output in table format using the given Go template
+    'json':             Print in JSON format
+    'TEMPLATE':         Print output using the given Go template.
+    Refer to https://docs.docker.com/go/formatting/ for more information about formatting output with templates
+  details_url: '#format'
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
-  swarm: false
-- option: namespace
-  value_type: string
-  description: Kubernetes namespace to use
-  deprecated: true
-  experimental: false
-  experimentalcli: false
-  kubernetes: true
   swarm: false
 - option: quiet
   shorthand: q
@@ -44,23 +46,17 @@ options:
   default_value: "false"
   description: Only display IDs
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
   swarm: false
 inherited_options:
-- option: kubeconfig
-  value_type: string
-  description: Kubernetes config file
-  deprecated: true
-  experimental: false
-  experimentalcli: false
-  kubernetes: true
-  swarm: false
 - option: orchestrator
   value_type: string
-  description: Orchestrator to use (swarm|kubernetes|all)
+  description: Orchestrator to use (swarm|all)
   deprecated: true
+  hidden: true
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -76,7 +72,7 @@ examples: |-
   dn7m7nhhfb9y  myapp_db        1/1       mysql@sha256:a9a5b559f8821fe73d58c3606c812d1c044868d42c63817fa5125fd9d8b7b539
   ```
 
-  ### Filtering
+  ### Filtering (--filter) {#filter}
 
   The filtering flag (`-f` or `--filter`) format is a `key=value` pair. If there
   is more than one filter, then pass multiple flags (e.g. `--filter "foo=bar" --filter "bif=baz"`).
@@ -95,38 +91,29 @@ examples: |-
   The currently supported filters are:
 
   * id / ID (`--filter id=7be5ei6sqeye`, or `--filter ID=7be5ei6sqeye`)
-    * Swarm: supported
-    * Kubernetes: not supported
   * label (`--filter label=key=value`)
-    * Swarm: supported
-    * Kubernetes: supported
   * mode (`--filter mode=replicated`, or `--filter mode=global`)
     * Swarm: not supported
-    * Kubernetes: supported
   * name (`--filter name=myapp_web`)
-    * Swarm: supported
-    * Kubernetes: supported
   * node (`--filter node=mynode`)
     * Swarm: not supported
-    * Kubernetes: supported
   * service (`--filter service=web`)
     * Swarm: not supported
-    * Kubernetes: supported
 
-  ### Formatting
+  ### Format the output (--format) {#format}
 
   The formatting options (`--format`) pretty-prints services output
   using a Go template.
 
   Valid placeholders for the Go template are listed below:
 
-  Placeholder | Description
-  ------------|-------------------------------------------------------------------
-  `.ID`       | Service ID
-  `.Name`     | Service name
-  `.Mode`     | Service mode (replicated, global)
-  `.Replicas` | Service replicas
-  `.Image`    | Service image
+  | Placeholder | Description                       |
+  |-------------|-----------------------------------|
+  | `.ID`       | Service ID                        |
+  | `.Name`     | Service name                      |
+  | `.Mode`     | Service mode (replicated, global) |
+  | `.Replicas` | Service replicas                  |
+  | `.Image`    | Service image                     |
 
   When using the `--format` option, the `stack services` command will either
   output the data exactly as the template declares or, when using the
@@ -140,6 +127,15 @@ examples: |-
 
   0zmvwuiu3vue: replicated 10/10
   fm6uf97exkul: global 5/5
+  ```
+
+  To list all services in JSON format, use the `json` directive:
+
+  ```console
+  $ docker stack services ls --format json
+  {"ID":"0axqbl293vwm","Image":"localstack/localstack:latest","Mode":"replicated","Name":"myapp_localstack","Ports":"*:4566-\u003e4566/tcp, *:8080-\u003e8080/tcp","Replicas":"0/1"}
+  {"ID":"384xvtzigz3p","Image":"redis:6.0.9-alpine3.12","Mode":"replicated","Name":"myapp_redis","Ports":"*:6379-\u003e6379/tcp","Replicas":"1/1"}
+  {"ID":"hyujct8cnjkk","Image":"postgres:13.2-alpine","Mode":"replicated","Name":"myapp_repos-db","Ports":"*:5432-\u003e5432/tcp","Replicas":"0/1"}
   ```
 deprecated: false
 min_api_version: "1.25"

--- a/_data/engine-cli/docker_start.yaml
+++ b/_data/engine-cli/docker_start.yaml
@@ -11,6 +11,7 @@ options:
   default_value: "false"
   description: Attach STDOUT/STDERR and forward signals
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -19,6 +20,7 @@ options:
   value_type: string
   description: Restore from this checkpoint
   deprecated: false
+  hidden: false
   experimental: true
   experimentalcli: false
   kubernetes: false
@@ -28,6 +30,7 @@ options:
   value_type: string
   description: Use a custom checkpoint storage directory
   deprecated: false
+  hidden: false
   experimental: true
   experimentalcli: false
   kubernetes: false
@@ -37,6 +40,7 @@ options:
   value_type: string
   description: Override the key sequence for detaching a container
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -47,6 +51,7 @@ options:
   default_value: "false"
   description: Attach container's STDIN
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false

--- a/_data/engine-cli/docker_stats.yaml
+++ b/_data/engine-cli/docker_stats.yaml
@@ -38,14 +38,23 @@ options:
   default_value: "false"
   description: Show all containers (default shows just running)
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
   swarm: false
 - option: format
   value_type: string
-  description: Pretty-print images using a Go template
+  description: |-
+    Format output using a custom template:
+    'table':            Print output in table format with column headers (default)
+    'table TEMPLATE':   Print output in table format using the given Go template
+    'json':             Print in JSON format
+    'TEMPLATE':         Print output using the given Go template.
+    Refer to https://docs.docker.com/go/formatting/ for more information about formatting output with templates
+  details_url: '#format'
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -55,6 +64,7 @@ options:
   default_value: "false"
   description: Disable streaming stats and only pull the first result
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -64,6 +74,7 @@ options:
   default_value: "false"
   description: Do not truncate output
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -89,8 +100,8 @@ examples: |-
   | `CONTAINER ID` and `Name` | the ID and name of the container                                                              |
   | `CPU %` and `MEM %`       | the percentage of the host's CPU and memory the container is using                            |
   | `MEM USAGE / LIMIT`       | the total memory the container is using, and the total amount of memory it is allowed to use  |
-  | `NET I/O`                 | The amount of data the container has sent and received over its network interface             |
-  | `BLOCK I/O`               | The amount of data the container has read to and written from block devices on the host       |
+  | `NET I/O`                 | The amount of data the container has received and sent over its network interface             |
+  | `BLOCK I/O`               | The amount of data the container has written to and read from block devices on the host       |
   | `PIDs`                    | the number of processes or threads the container has created                                  |
 
   Running `docker stats` on multiple containers by name and id against a Linux daemon.
@@ -101,6 +112,13 @@ examples: |-
   CONTAINER ID        NAME                CPU %               MEM USAGE / LIMIT     MEM %               NET I/O             BLOCK I/O           PIDS
   b95a83497c91        awesome_brattain    0.28%               5.629MiB / 1.952GiB   0.28%               916B / 0B           147kB / 0B          9
   67b2525d8ad1        foobar              0.00%               1.727MiB / 1.952GiB   0.09%               2.48kB / 0B         4.11MB / 0B         2
+  ```
+
+  Running `docker stats` on container with name nginx and getting output in `json` format.
+
+  ```console
+  $ docker stats nginx --no-stream --format "{{ json . }}"
+  {"BlockIO":"0B / 13.3kB","CPUPerc":"0.03%","Container":"nginx","ID":"ed37317fbf42","MemPerc":"0.24%","MemUsage":"2.352MiB / 982.5MiB","Name":"nginx","NetIO":"539kB / 606kB","PIDs":"2"}
   ```
 
   Running `docker stats` with customized format on all (Running and Stopped) containers.
@@ -142,25 +160,24 @@ examples: |-
   9db7aa4d986d        mad_wilson          9.59%               40.09 MiB           27.6 kB / 8.81 kB   17 MB / 20.1 MB
   ```
 
-  ### Formatting
+  ### Format the output (--format) {#format}
 
   The formatting option (`--format`) pretty prints container output
   using a Go template.
 
   Valid placeholders for the Go template are listed below:
 
-  Placeholder  | Description
-  ------------ | --------------------------------------------
-  `.Container` | Container name or ID (user input)
-  `.Name`      | Container name
-  `.ID`        | Container ID
-  `.CPUPerc`   | CPU percentage
-  `.MemUsage`  | Memory usage
-  `.NetIO`     | Network IO
-  `.BlockIO`   | Block IO
-  `.MemPerc`   | Memory percentage (Not available on Windows)
-  `.PIDs`      | Number of PIDs (Not available on Windows)
-
+  | Placeholder  | Description                                  |
+  |--------------|----------------------------------------------|
+  | `.Container` | Container name or ID (user input)            |
+  | `.Name`      | Container name                               |
+  | `.ID`        | Container ID                                 |
+  | `.CPUPerc`   | CPU percentage                               |
+  | `.MemUsage`  | Memory usage                                 |
+  | `.NetIO`     | Network IO                                   |
+  | `.BlockIO`   | Block IO                                     |
+  | `.MemPerc`   | Memory percentage (Not available on Windows) |
+  | `.PIDs`      | Number of PIDs (Not available on Windows)    |
 
   When using the `--format` option, the `stats` command either
   outputs the data exactly as the template declares or, when using the

--- a/_data/engine-cli/docker_stop.yaml
+++ b/_data/engine-cli/docker_stop.yaml
@@ -15,6 +15,7 @@ options:
   default_value: "10"
   description: Seconds to wait for stop before killing it
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false

--- a/_data/engine-cli/docker_swarm_ca.yaml
+++ b/_data/engine-cli/docker_swarm_ca.yaml
@@ -7,7 +7,7 @@ long: |-
   >
   > This is a cluster management command, and must be executed on a swarm
   > manager node. To learn about managers and workers, refer to the
-  > [Swarm mode section](https://docs.docker.com/engine/swarm/) in the
+  > [Swarm mode section](/engine/swarm/) in the
   > documentation.
 usage: docker swarm ca [OPTIONS]
 pname: docker swarm
@@ -18,15 +18,16 @@ options:
   description: |
     Path to the PEM-formatted root CA certificate to use for the new cluster
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
   swarm: false
 - option: ca-key
   value_type: pem-file
-  description: |
-    Path to the PEM-formatted root CA key to use for the new cluster
+  description: Path to the PEM-formatted root CA key to use for the new cluster
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -36,6 +37,7 @@ options:
   default_value: 2160h0m0s
   description: Validity period for node certificates (ns|us|ms|s|m|h)
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -46,7 +48,9 @@ options:
   default_value: "false"
   description: |
     Exit immediately instead of waiting for the root rotation to converge
+  details_url: '#detach'
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -55,6 +59,7 @@ options:
   value_type: external-ca
   description: Specifications of one or more certificate signing endpoints
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -65,6 +70,7 @@ options:
   default_value: "false"
   description: Suppress progress output
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -74,7 +80,9 @@ options:
   default_value: "false"
   description: |
     Rotate the swarm CA - if no certificate or key are provided, new ones will be generated
+  details_url: '#rotate'
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -128,7 +136,7 @@ examples: |-
   -----END CERTIFICATE-----
   ```
 
-  ### `--rotate`
+  ### Root CA rotation (--rotate) {#rotate}
 
   Root CA Rotation is recommended if one or more of the swarm managers have been
   compromised, so that those managers can no longer connect to or be trusted by
@@ -151,7 +159,7 @@ examples: |-
   see if any nodes are down or otherwise unable to rotate TLS certificates.
 
 
-  ### `--detach`
+  ### Run root CA rotation in detached mode (--detach) {#detach}
 
   Initiate the root CA rotation, but do not wait for the completion of or display the
   progress of the rotation.

--- a/_data/engine-cli/docker_swarm_init.yaml
+++ b/_data/engine-cli/docker_swarm_init.yaml
@@ -11,6 +11,7 @@ options:
   value_type: string
   description: 'Advertised address (format: <ip|interface>[:port])'
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -21,6 +22,7 @@ options:
   description: |
     Enable manager autolocking (requiring an unlock key to start a stopped manager)
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -30,6 +32,7 @@ options:
   default_value: active
   description: Availability of the node ("active"|"pause"|"drain")
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -39,6 +42,7 @@ options:
   default_value: 2160h0m0s
   description: Validity period for node certificates (ns|us|ms|s|m|h)
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -48,6 +52,7 @@ options:
   description: |
     Address or interface to use for data path traffic (format: <ip|interface>)
   deprecated: false
+  hidden: false
   min_api_version: "1.31"
   experimental: false
   experimentalcli: false
@@ -59,6 +64,7 @@ options:
   description: |
     Port number to use for data path traffic (1024 - 49151). If no value is set or is set to 0, the default port (4789) is used.
   deprecated: false
+  hidden: false
   min_api_version: "1.40"
   experimental: false
   experimentalcli: false
@@ -69,6 +75,7 @@ options:
   default_value: '[]'
   description: default address pool in CIDR format
   deprecated: false
+  hidden: false
   min_api_version: "1.39"
   experimental: false
   experimentalcli: false
@@ -79,6 +86,7 @@ options:
   default_value: "24"
   description: default address pool subnet mask length
   deprecated: false
+  hidden: false
   min_api_version: "1.39"
   experimental: false
   experimentalcli: false
@@ -89,6 +97,7 @@ options:
   default_value: 5s
   description: Dispatcher heartbeat period (ns|us|ms|s|m|h)
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -97,6 +106,7 @@ options:
   value_type: external-ca
   description: Specifications of one or more certificate signing endpoints
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -106,6 +116,7 @@ options:
   default_value: "false"
   description: Force create a new cluster from current state
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -115,6 +126,7 @@ options:
   default_value: 0.0.0.0:2377
   description: 'Listen address (format: <ip|interface>[:port])'
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -124,6 +136,7 @@ options:
   default_value: "0"
   description: Number of additional Raft snapshots to retain
   deprecated: false
+  hidden: false
   min_api_version: "1.25"
   experimental: false
   experimentalcli: false
@@ -134,6 +147,7 @@ options:
   default_value: "10000"
   description: Number of log entries between Raft snapshots
   deprecated: false
+  hidden: false
   min_api_version: "1.25"
   experimental: false
   experimentalcli: false
@@ -144,6 +158,7 @@ options:
   default_value: "5"
   description: Task history retention limit
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false

--- a/_data/engine-cli/docker_swarm_join-token.yaml
+++ b/_data/engine-cli/docker_swarm_join-token.yaml
@@ -11,7 +11,7 @@ long: |-
   >
   > This is a cluster management command, and must be executed on a swarm
   > manager node. To learn about managers and workers, refer to the
-  > [Swarm mode section](https://docs.docker.com/engine/swarm/) in the
+  > [Swarm mode section](/engine/swarm/) in the
   > documentation.
 usage: docker swarm join-token [OPTIONS] (worker|manager)
 pname: docker swarm
@@ -23,6 +23,7 @@ options:
   default_value: "false"
   description: Only display token
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -32,6 +33,7 @@ options:
   default_value: "false"
   description: Rotate join token
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false

--- a/_data/engine-cli/docker_swarm_join.yaml
+++ b/_data/engine-cli/docker_swarm_join.yaml
@@ -12,6 +12,7 @@ options:
   value_type: string
   description: 'Advertised address (format: <ip|interface>[:port])'
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -21,6 +22,7 @@ options:
   default_value: active
   description: Availability of the node ("active"|"pause"|"drain")
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -30,6 +32,7 @@ options:
   description: |
     Address or interface to use for data path traffic (format: <ip|interface>)
   deprecated: false
+  hidden: false
   min_api_version: "1.31"
   experimental: false
   experimentalcli: false
@@ -40,6 +43,7 @@ options:
   default_value: 0.0.0.0:2377
   description: 'Listen address (format: <ip|interface>[:port])'
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -48,6 +52,7 @@ options:
   value_type: string
   description: Token for entry into the swarm
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false

--- a/_data/engine-cli/docker_swarm_leave.yaml
+++ b/_data/engine-cli/docker_swarm_leave.yaml
@@ -19,6 +19,7 @@ options:
   default_value: "false"
   description: Force this node to leave the swarm, ignoring warnings
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false

--- a/_data/engine-cli/docker_swarm_unlock-key.yaml
+++ b/_data/engine-cli/docker_swarm_unlock-key.yaml
@@ -12,7 +12,7 @@ long: |-
   >
   > This is a cluster management command, and must be executed on a swarm
   > manager node. To learn about managers and workers, refer to the
-  > [Swarm mode section](https://docs.docker.com/engine/swarm/) in the
+  > [Swarm mode section](/engine/swarm/) in the
   > documentation.
 usage: docker swarm unlock-key [OPTIONS]
 pname: docker swarm
@@ -24,6 +24,7 @@ options:
   default_value: "false"
   description: Only display token
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -33,6 +34,7 @@ options:
   default_value: "false"
   description: Rotate unlock key
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false

--- a/_data/engine-cli/docker_swarm_unlock.yaml
+++ b/_data/engine-cli/docker_swarm_unlock.yaml
@@ -10,7 +10,7 @@ long: |-
   >
   > This is a cluster management command, and must be executed on a swarm
   > manager node. To learn about managers and workers, refer to the
-  > [Swarm mode section](https://docs.docker.com/engine/swarm/) in the
+  > [Swarm mode section](/engine/swarm/) in the
   > documentation.
 usage: docker swarm unlock
 pname: docker swarm

--- a/_data/engine-cli/docker_swarm_update.yaml
+++ b/_data/engine-cli/docker_swarm_update.yaml
@@ -7,7 +7,7 @@ long: |-
   >
   > This is a cluster management command, and must be executed on a swarm
   > manager node. To learn about managers and workers, refer to the
-  > [Swarm mode section](https://docs.docker.com/engine/swarm/) in the
+  > [Swarm mode section](/engine/swarm/) in the
   > documentation.
 usage: docker swarm update [OPTIONS]
 pname: docker swarm
@@ -18,6 +18,7 @@ options:
   default_value: "false"
   description: Change manager autolocking setting (true|false)
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -27,6 +28,7 @@ options:
   default_value: 2160h0m0s
   description: Validity period for node certificates (ns|us|ms|s|m|h)
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -36,6 +38,7 @@ options:
   default_value: 5s
   description: Dispatcher heartbeat period (ns|us|ms|s|m|h)
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -44,6 +47,7 @@ options:
   value_type: external-ca
   description: Specifications of one or more certificate signing endpoints
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -53,6 +57,7 @@ options:
   default_value: "0"
   description: Number of additional Raft snapshots to retain
   deprecated: false
+  hidden: false
   min_api_version: "1.25"
   experimental: false
   experimentalcli: false
@@ -63,6 +68,7 @@ options:
   default_value: "10000"
   description: Number of log entries between Raft snapshots
   deprecated: false
+  hidden: false
   min_api_version: "1.25"
   experimental: false
   experimentalcli: false
@@ -73,6 +79,7 @@ options:
   default_value: "5"
   description: Task history retention limit
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false

--- a/_data/engine-cli/docker_system_df.yaml
+++ b/_data/engine-cli/docker_system_df.yaml
@@ -9,8 +9,15 @@ plink: docker_system.yaml
 options:
 - option: format
   value_type: string
-  description: Pretty-print images using a Go template
+  description: |-
+    Format output using a custom template:
+    'table':            Print output in table format with column headers (default)
+    'table TEMPLATE':   Print output in table format using the given Go template
+    'json':             Print in JSON format
+    'TEMPLATE':         Print output using the given Go template.
+    Refer to https://docs.docker.com/go/formatting/ for more information about formatting output with templates
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -21,6 +28,7 @@ options:
   default_value: "false"
   description: Show detailed information on space usage
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false

--- a/_data/engine-cli/docker_system_events.yaml
+++ b/_data/engine-cli/docker_system_events.yaml
@@ -97,7 +97,7 @@ long: |-
   seconds (aka Unix epoch or Unix time), and the optional .nanoseconds field is a
   fraction of a second no more than nine digits long.
 
-  #### Filtering
+  #### Filtering (--filter) {#filter}
 
   The filtering flag (`-f` or `--filter`) format is of "key=value". If you would
   like to use multiple filters, pass multiple flags (e.g.,
@@ -122,16 +122,6 @@ long: |-
   * plugin (`plugin=<name or id>`)
   * type (`type=<container or image or volume or network or daemon or plugin>`)
   * volume (`volume=<name or id>`)
-
-  #### Format
-
-  If a format (`--format`) is specified, the given template will be executed
-  instead of the default
-  format. Go's [text/template](https://golang.org/pkg/text/template/) package
-  describes all the details of the format.
-
-  If a format is set to `{{json .}}`, the events are streamed as valid JSON
-  Lines. For information about JSON Lines, please refer to https://jsonlines.org/ .
 usage: docker system events [OPTIONS]
 pname: docker system
 plink: docker_system.yaml
@@ -141,6 +131,7 @@ options:
   value_type: filter
   description: Filter output based on conditions provided
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -148,7 +139,9 @@ options:
 - option: format
   value_type: string
   description: Format the output using the given Go template
+  details_url: '#format'
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -157,6 +150,7 @@ options:
   value_type: string
   description: Show all events created since timestamp
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -165,6 +159,7 @@ options:
   value_type: string
   description: Stream events until this timestamp
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -329,7 +324,11 @@ examples: |-
   2016-07-25T17:30:14.888127370Z plugin enable ec7b87f2ce84330fe076e666f17dfc049d2d7ae0b8190763de94e1f2d105993f (name=tiborvass/sample-volume-plugin:latest)
   ```
 
-  ### Format the output
+  ### Format the output (--format) {#format}
+
+  If a format (`--format`) is specified, the given template will be executed
+  instead of the default format. Go's [text/template](https://golang.org/pkg/text/template/)
+  package describes all the details of the format.
 
   ```console
   $ docker system events --filter 'type=container' --format 'Type={{.Type}}  Status={{.Status}}  ID={{.ID}}'
@@ -343,6 +342,9 @@ examples: |-
   ```
 
   #### Format as JSON
+
+  If a format is set to `{{json .}}`, the events are streamed as valid JSON
+  Lines. For information about JSON Lines, please refer to https://jsonlines.org/ .
 
   ```console
   $ docker system events --format '{{json .}}'

--- a/_data/engine-cli/docker_system_info.yaml
+++ b/_data/engine-cli/docker_system_info.yaml
@@ -10,6 +10,7 @@ options:
   value_type: string
   description: Format the output using the given Go template
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false

--- a/_data/engine-cli/docker_system_prune.yaml
+++ b/_data/engine-cli/docker_system_prune.yaml
@@ -13,6 +13,7 @@ options:
   default_value: "false"
   description: Remove all unused images not just dangling ones
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -20,7 +21,9 @@ options:
 - option: filter
   value_type: filter
   description: Provide filter values (e.g. 'label=<key>=<value>')
+  details_url: '#filter'
   deprecated: false
+  hidden: false
   min_api_version: "1.28"
   experimental: false
   experimentalcli: false
@@ -32,6 +35,7 @@ options:
   default_value: "false"
   description: Do not prompt for confirmation
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -41,6 +45,7 @@ options:
   default_value: "false"
   description: Prune volumes
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -117,7 +122,7 @@ examples: |-
   Total reclaimed space: 13.5 MB
   ```
 
-  ### Filtering
+  ### Filtering (--filter) {#filter}
 
   The filtering flag (`--filter`) format is of "key=value". If there is more
   than one filter, then pass multiple flags (e.g., `--filter "foo=bar" --filter "bif=baz"`)

--- a/_data/engine-cli/docker_tag.yaml
+++ b/_data/engine-cli/docker_tag.yaml
@@ -7,15 +7,15 @@ long: |-
   followed by a port number in the format `:8080`. If not present, the command
   uses Docker's public registry located at `registry-1.docker.io` by default. Name
   components may contain lowercase letters, digits and separators. A separator
-  is defined as a period, one or two underscores, or one or more dashes. A name
+  is defined as a period, one or two underscores, or one or more hyphens. A name
   component may not start or end with a separator.
 
   A tag name must be valid ASCII and may contain lowercase and uppercase letters,
-  digits, underscores, periods and dashes. A tag name may not start with a
-  period or a dash and may contain a maximum of 128 characters.
+  digits, underscores, periods and hyphens. A tag name may not start with a
+  period or a hyphen and may contain a maximum of 128 characters.
 
   You can group your images together using names and tags, and then upload them
-  to [*Share images on Docker Hub*](https://docs.docker.com/get-started/part3/).
+  to [*Share images on Docker Hub*](/get-started/part3/).
 usage: docker tag SOURCE_IMAGE[:TAG] TARGET_IMAGE[:TAG]
 pname: docker
 plink: docker.yaml

--- a/_data/engine-cli/docker_trust_inspect.yaml
+++ b/_data/engine-cli/docker_trust_inspect.yaml
@@ -13,6 +13,7 @@ options:
   default_value: "false"
   description: Print the information in a human friendly format
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false

--- a/_data/engine-cli/docker_trust_key_generate.yaml
+++ b/_data/engine-cli/docker_trust_key_generate.yaml
@@ -11,6 +11,7 @@ options:
   value_type: string
   description: Directory to generate key in, defaults to current directory
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false

--- a/_data/engine-cli/docker_trust_key_load.yaml
+++ b/_data/engine-cli/docker_trust_key_load.yaml
@@ -13,6 +13,7 @@ options:
   default_value: signer
   description: Name for the loaded key
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false

--- a/_data/engine-cli/docker_trust_revoke.yaml
+++ b/_data/engine-cli/docker_trust_revoke.yaml
@@ -11,6 +11,7 @@ options:
   default_value: "false"
   description: Do not prompt for confirmation
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false

--- a/_data/engine-cli/docker_trust_sign.yaml
+++ b/_data/engine-cli/docker_trust_sign.yaml
@@ -10,6 +10,7 @@ options:
   default_value: "false"
   description: Sign a locally tagged image
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false

--- a/_data/engine-cli/docker_trust_signer_add.yaml
+++ b/_data/engine-cli/docker_trust_signer_add.yaml
@@ -9,6 +9,7 @@ options:
   value_type: list
   description: Path to the signer's public key file
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false

--- a/_data/engine-cli/docker_trust_signer_remove.yaml
+++ b/_data/engine-cli/docker_trust_signer_remove.yaml
@@ -12,6 +12,7 @@ options:
   description: |
     Do not prompt for confirmation before removing the most recent signer
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false

--- a/_data/engine-cli/docker_update.yaml
+++ b/_data/engine-cli/docker_update.yaml
@@ -27,6 +27,7 @@ options:
   description: |
     Block IO (relative weight), between 10 and 1000, or 0 to disable (default 0)
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -36,6 +37,7 @@ options:
   default_value: "0"
   description: Limit CPU CFS (Completely Fair Scheduler) period
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -45,6 +47,7 @@ options:
   default_value: "0"
   description: Limit CPU CFS (Completely Fair Scheduler) quota
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -54,6 +57,7 @@ options:
   default_value: "0"
   description: Limit the CPU real-time period in microseconds
   deprecated: false
+  hidden: false
   min_api_version: "1.25"
   experimental: false
   experimentalcli: false
@@ -64,6 +68,7 @@ options:
   default_value: "0"
   description: Limit the CPU real-time runtime in microseconds
   deprecated: false
+  hidden: false
   min_api_version: "1.25"
   experimental: false
   experimentalcli: false
@@ -74,7 +79,9 @@ options:
   value_type: int64
   default_value: "0"
   description: CPU shares (relative weight)
+  details_url: '#cpu-shares'
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -83,6 +90,7 @@ options:
   value_type: decimal
   description: Number of CPUs
   deprecated: false
+  hidden: false
   min_api_version: "1.29"
   experimental: false
   experimentalcli: false
@@ -92,6 +100,7 @@ options:
   value_type: string
   description: CPUs in which to allow execution (0-3, 0,1)
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -100,6 +109,7 @@ options:
   value_type: string
   description: MEMs in which to allow execution (0-3, 0,1)
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -108,7 +118,9 @@ options:
   value_type: bytes
   default_value: "0"
   description: Kernel memory limit
+  details_url: '#kernel-memory'
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -118,7 +130,9 @@ options:
   value_type: bytes
   default_value: "0"
   description: Memory limit
+  details_url: '#memory'
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -128,6 +142,7 @@ options:
   default_value: "0"
   description: Memory soft limit
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -138,6 +153,7 @@ options:
   description: |
     Swap limit equal to memory plus swap: '-1' to enable unlimited swap
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -147,6 +163,7 @@ options:
   default_value: "0"
   description: Tune container pids limit (set -1 for unlimited)
   deprecated: false
+  hidden: false
   min_api_version: "1.40"
   experimental: false
   experimentalcli: false
@@ -155,7 +172,9 @@ options:
 - option: restart
   value_type: string
   description: Restart policy to apply when a container exits
+  details_url: '#restart'
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -163,7 +182,7 @@ options:
 examples: |-
   The following sections illustrate ways to use this command.
 
-  ### Update a container's cpu-shares
+  ### Update a container's cpu-shares (--cpu-shares) {#cpu-shares}
 
   To limit a container's cpu-shares to 512, first identify the container
   name or ID. You can use `docker ps` to find these values. You can also
@@ -173,7 +192,7 @@ examples: |-
   $ docker update --cpu-shares 512 abebf7571666
   ```
 
-  ### Update a container with cpu-shares and memory
+  ### Update a container with cpu-shares and memory (-m, --memory) {#memory}
 
   To update multiple resource configurations for multiple containers:
 
@@ -181,7 +200,7 @@ examples: |-
   $ docker update --cpu-shares 512 -m 300M abebf7571666 hopeful_morse
   ```
 
-  ### Update a container's kernel memory constraints
+  ### Update a container's kernel memory constraints (--kernel-memory) {#kernel-memory}
 
   You can update a container's kernel memory limit using the `--kernel-memory`
   option. On kernel version older than 4.6, this option can be updated on a
@@ -218,7 +237,7 @@ examples: |-
   Kernel version newer than (include) 4.6 does not have this limitation, you
   can use `--kernel-memory` the same way as other options.
 
-  ### Update a container's restart policy
+  ### Update a container's restart policy (--restart) {#restart}
 
   You can change a container's restart policy on a running container. The new
   restart policy takes effect instantly after you run `docker update` on a

--- a/_data/engine-cli/docker_version.yaml
+++ b/_data/engine-cli/docker_version.yaml
@@ -15,17 +15,10 @@ options:
   value_type: string
   description: Format the output using the given Go template
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
-  swarm: false
-- option: kubeconfig
-  value_type: string
-  description: Kubernetes config file
-  deprecated: true
-  experimental: false
-  experimentalcli: false
-  kubernetes: true
   swarm: false
 examples: |-
   ### Default output

--- a/_data/engine-cli/docker_volume_create.yaml
+++ b/_data/engine-cli/docker_volume_create.yaml
@@ -13,6 +13,7 @@ options:
   default_value: local
   description: Specify volume driver name
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -21,6 +22,7 @@ options:
   value_type: list
   description: Set metadata for a volume
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -29,6 +31,7 @@ options:
   value_type: string
   description: Specify volume name
   deprecated: false
+  hidden: true
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -38,7 +41,9 @@ options:
   value_type: map
   default_value: map[]
   description: Set driver specific options
+  details_url: '#opt'
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -72,7 +77,7 @@ examples: |-
   If you specify a volume name already in use on the current driver, Docker
   assumes you want to re-use the existing volume and does not return an error.
 
-  ### Driver-specific options
+  ### Driver-specific options (-o, --opt) {#opt}
 
   Some volume drivers may take options to customize the volume creation. Use the
   `-o` or `--opt` flags to pass driver options:

--- a/_data/engine-cli/docker_volume_inspect.yaml
+++ b/_data/engine-cli/docker_volume_inspect.yaml
@@ -13,8 +13,14 @@ options:
 - option: format
   shorthand: f
   value_type: string
-  description: Format the output using the given Go template
+  description: |-
+    Format output using a custom template:
+    'json':             Print in JSON format
+    'TEMPLATE':         Print output using the given Go template.
+    Refer to https://docs.docker.com/go/formatting/ for more information about formatting output with templates
+  details_url: '#format'
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -47,6 +53,8 @@ examples: |-
     }
   ]
   ```
+
+  ### Format the output (--format) {#format}
 
   Use the `--format` flag to format the output using a Go template, for example,
   to print the `Mountpoint` property:

--- a/_data/engine-cli/docker_volume_ls.yaml
+++ b/_data/engine-cli/docker_volume_ls.yaml
@@ -14,14 +14,23 @@ options:
   value_type: filter
   description: Provide filter values (e.g. 'dangling=true')
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
   swarm: false
 - option: format
   value_type: string
-  description: Pretty-print volumes using a Go template
+  description: |-
+    Format output using a custom template:
+    'table':            Print output in table format with column headers (default)
+    'table TEMPLATE':   Print output in table format using the given Go template
+    'json':             Print in JSON format
+    'TEMPLATE':         Print output using the given Go template.
+    Refer to https://docs.docker.com/go/formatting/ for more information about formatting output with templates
+  details_url: '#format'
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -32,6 +41,7 @@ options:
   default_value: "false"
   description: Only display volume names
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -155,21 +165,21 @@ examples: |-
   local               rosemary
   ```
 
-  ### Formatting
+  ### Format the output (--format) {#format}
 
   The formatting options (`--format`) pretty-prints volumes output
   using a Go template.
 
   Valid placeholders for the Go template are listed below:
 
-  Placeholder   | Description
-  --------------|------------------------------------------------------------------------------------------
-  `.Name`       | Volume name
-  `.Driver`     | Volume driver
-  `.Scope`      | Volume scope (local, global)
-  `.Mountpoint` | The mount point of the volume on the host
-  `.Labels`     | All labels assigned to the volume
-  `.Label`      | Value of a specific label for this volume. For example `{{.Label "project.version"}}`
+  | Placeholder   | Description                                                                           |
+  |---------------|---------------------------------------------------------------------------------------|
+  | `.Name`       | Volume name                                                                           |
+  | `.Driver`     | Volume driver                                                                         |
+  | `.Scope`      | Volume scope (local, global)                                                          |
+  | `.Mountpoint` | The mount point of the volume on the host                                             |
+  | `.Labels`     | All labels assigned to the volume                                                     |
+  | `.Label`      | Value of a specific label for this volume. For example `{{.Label "project.version"}}` |
 
   When using the `--format` option, the `volume ls` command will either
   output the data exactly as the template declares or, when using the
@@ -184,6 +194,13 @@ examples: |-
   vol1: local
   vol2: local
   vol3: local
+  ```
+
+  To list all volumes in JSON format, use the `json` directive:
+
+  ```console
+  $ docker volume ls --format json
+  {"Driver":"local","Labels":"","Links":"N/A","Mountpoint":"/var/lib/docker/volumes/docker-cli-dev-cache/_data","Name":"docker-cli-dev-cache","Scope":"local","Size":"N/A"}
   ```
 deprecated: false
 min_api_version: "1.21"

--- a/_data/engine-cli/docker_volume_prune.yaml
+++ b/_data/engine-cli/docker_volume_prune.yaml
@@ -1,7 +1,7 @@
 command: docker volume prune
 short: Remove all unused local volumes
-long: Remove all unused local volumes. Unused local volumes are those which are not
-  referenced by any containers
+long: |
+  Remove all unused local volumes. Unused local volumes are those which are not referenced by any containers
 usage: docker volume prune [OPTIONS]
 pname: docker volume
 plink: docker_volume.yaml
@@ -9,7 +9,9 @@ options:
 - option: filter
   value_type: filter
   description: Provide filter values (e.g. 'label=<label>')
+  details_url: '#filter'
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -20,6 +22,7 @@ options:
   default_value: "false"
   description: Do not prompt for confirmation
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -36,6 +39,20 @@ examples: |-
 
   Total reclaimed space: 36 B
   ```
+
+  ### Filtering (--filter) {#filter}
+
+  The filtering flag (`--filter`) format is of "key=value". If there is more
+  than one filter, then pass multiple flags (e.g., `--filter "foo=bar" --filter "bif=baz"`)
+
+  The currently supported filters are:
+
+  * label (`label=<key>`, `label=<key>=<value>`, `label!=<key>`, or `label!=<key>=<value>`) - only remove volumes with (or without, in case `label!=...` is used) the specified labels.
+
+  The `label` filter accepts two formats. One is the `label=...` (`label=<key>` or `label=<key>=<value>`),
+  which removes volumes with the specified labels. The other
+  format is the `label!=...` (`label!=<key>` or `label!=<key>=<value>`), which removes
+  volumes without the specified labels.
 deprecated: false
 min_api_version: "1.25"
 experimental: false

--- a/_data/engine-cli/docker_volume_rm.yaml
+++ b/_data/engine-cli/docker_volume_rm.yaml
@@ -1,7 +1,8 @@
 command: docker volume rm
 aliases: remove
 short: Remove one or more volumes
-long: Remove one or more volumes. You cannot remove a volume that is in use by a container.
+long: |
+  Remove one or more volumes. You cannot remove a volume that is in use by a container.
 usage: docker volume rm [OPTIONS] VOLUME [VOLUME...]
 pname: docker volume
 plink: docker_volume.yaml
@@ -12,6 +13,7 @@ options:
   default_value: "false"
   description: Force the removal of one or more volumes
   deprecated: false
+  hidden: false
   min_api_version: "1.25"
   experimental: false
   experimentalcli: false


### PR DESCRIPTION
This updates the yamldocs for the engine cli reference with updated
sources that include anchor tags for flags; this should make the
flags in the "options" table clickable and scroll to the relevant
section on the page (where present).

This was built from https://github.com/docker/cli/pull/3509, which
is not yet merged (and has changes for the upcoming engine release,
so cannot yet be published here).

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

<!--Tell us what you did and why-->

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
