### PR TITLE
desktop: windows: fix highlighting of some command-line examples

### DIFF
--- a/_includes/configure-registry-json.md
+++ b/_includes/configure-registry-json.md
@@ -9,7 +9,9 @@ Desktop and access all their organizations.
 
 ### Windows
 
-On Windows, run the following command in a terminal to install Docker Desktop:
+After downloading **Docker Desktop Installer.exe**, open a terminal, and change
+to the directory in which you downloaded the installer, then run the following
+command to install Docker Desktop:
 
 ```console
 C:\Users\Admin> "Docker Desktop Installer.exe" install
@@ -18,7 +20,7 @@ C:\Users\Admin> "Docker Desktop Installer.exe" install
 If you’re using PowerShell, you should run it as:
 
 ```console
-PS> Start-Process '.\win\build\Docker Desktop Installer.exe' -Wait install
+PS> Start-Process '.\Docker Desktop Installer.exe' -Wait install
 ```
 
 If using the Windows Command Prompt:

--- a/desktop/windows/install.md
+++ b/desktop/windows/install.md
@@ -124,22 +124,24 @@ Log out and log back in for the changes to take effect.
 
 ### Install from the command line
 
-After downloading **Docker Desktop Installer.exe**, run the following command in a terminal to install Docker Desktop:
+After downloading **Docker Desktop Installer.exe**, open a terminal, and change
+to the directory in which you downloaded the installer, then run the following
+command to install Docker Desktop:
 
-```
-"Docker Desktop Installer.exe" install
+```console
+C:\> "Docker Desktop Installer.exe" install
 ```
 
 If you’re using PowerShell you should run it as:
 
-```
-Start-Process '.\win\build\Docker Desktop Installer.exe' -Wait install
+```console
+PS> Start-Process '.\Docker Desktop Installer.exe' -Wait install
 ```
 
 If using the Windows Command Prompt:
 
-```
-start /w "" "Docker Desktop Installer.exe" install
+```console
+C:\> start /w "" "Docker Desktop Installer.exe" install
 ```
 
 The install command accepts the following flags:
@@ -149,8 +151,9 @@ The install command accepts the following flags:
 - `--backend=<backend name>`: selects the backend to use for Docker Desktop, `hyper-v` or `wsl-2` (default)
 
 If your admin account is different to your user account, you must add the user to the **docker-users** group:
-```
-net localgroup docker-users <user> /add
+
+```console
+C:\> net localgroup docker-users <user> /add
 ```
 
 ## Start Docker Desktop


### PR DESCRIPTION
Before:

<img width="1010" alt="Screenshot 2022-04-19 at 11 58 37" src="https://user-images.githubusercontent.com/1804568/163980116-50b412b6-2697-431c-8231-86a9e8f6a89d.png">



After:

<img width="1002" alt="Screenshot 2022-04-19 at 12 01 55" src="https://user-images.githubusercontent.com/1804568/163980148-6e27e7ca-5f0e-4b8e-8c34-afedbd632eee.png">
