### PR TITLE
Allow providing buildkit secrets with env

### DIFF
--- a/develop/develop-images/build_enhancements.md
+++ b/develop/develop-images/build_enhancements.md
@@ -188,6 +188,18 @@ $ docker build --no-cache --progress=plain --secret id=mysecret,src=mysecret.txt
 ...
 ```
 
+Starting from Docker 20.10, you can now provide secrets with `env` as an alternative for storing a secret value to a file. For example, if you have an environment variable MY_ENV, you can build the image with:
+```console
+docker build --secret id=foo,env=MY_ENV
+```
+
+or you can use the shorthand:
+```console
+docker build --secret id=MY_ENV
+```
+
+Note that the secret will still be exposed inside the build as a file in `/run/secrets`.
+
 ## Using SSH to access private data in builds
 
 > **Acknowledgment**


### PR DESCRIPTION
Wrote about functionality added in 20.10.0, that allows providing build secrets with env

### Proposed changes

- Starting with Docker v20.10.0, buildkit secrets allows providing build secrets with `env`, however this wasn't mentioned in the documentation and I only discovered it from [this](https://pythonspeed.com/articles/docker-build-secrets/) blog post.
- Ergo, this PR.
