### PR TITLE
Fixed the description for handling the GitHub Container Registry

### DIFF
--- a/ci-cd/github-actions.md
+++ b/ci-cd/github-actions.md
@@ -247,18 +247,18 @@ Now let's change the Docker Hub login with the GitHub Container Registry one:
 ```
 {% endraw %}
 
-Remember to change how the image is tagged. The following example keeps ‘latest'
-as the only tag. However, you can add any logic to this if you prefer:
+Remember to change how the image is tagged and where it's cached. The following example is a
+functional equivalent for the aforementioned logic against the GitHub Container Registry:
 
 {% raw %}
 ```yaml
-  tags: ghcr.io/<username>/simplewhale:latest
+  tags: ghcr.io/${{ secrets.GITHUB_USERNAME }}/simplewhale:latest
+  cache-from: type=registry,ref=ghcr.io/${{ secrets.GITHUB_USERNAME }}/simplewhale:buildcache
+  cache-to: type=registry,ref=ghcr.io/${{ secrets.GITHUB_USERNAME }}/simplewhale:buildcache,mode=max
 ```
 {% endraw %}
 
-> **Note**: Replace `<username>` with the repository owner. We could use
-> {% raw %}`${{ github.repository_owner }}`{% endraw %} but this value can be mixed-case, so it could
-> fail as [repository name must be lowercase](https://github.com/docker/build-push-action/blob/master/TROUBLESHOOTING.md#repository-name-must-be-lowercase){:target="_blank" rel="noopener" class="_"}.
+> **Note**: The repository owner's username needs to be lowercase.
 
 ![Update tagged images](images/ghcr-logic.png){:width="500px"}
 

--- a/ci-cd/github-actions.md
+++ b/ci-cd/github-actions.md
@@ -247,7 +247,7 @@ Now let's change the Docker Hub login with the GitHub Container Registry one:
 ```
 {% endraw %}
 
-Remember to change how the image is tagged and where it's cached. The following example is a
+And remember to change how the image is tagged and where it's cached. The following example is a
 functional equivalent for the aforementioned logic against the GitHub Container Registry:
 
 {% raw %}
@@ -258,7 +258,7 @@ functional equivalent for the aforementioned logic against the GitHub Container 
 ```
 {% endraw %}
 
-> **Note**: The repository owner's username needs to be lowercase.
+> **Note**: The [repository name must be lowercase](https://github.com/docker/build-push-action/blob/master/TROUBLESHOOTING.md#repository-name-must-be-lowercase){:target="_blank" rel="noopener" class="_"}.
 
 ![Update tagged images](images/ghcr-logic.png){:width="500px"}
 


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.-->

### Proposed changes

The documentation did not mention to also change where an image should be cached when pointing to the GitHub Container Registry instead of Docker Hub.

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
