### PR TITLE
Update rootless.md

### DIFF
--- a/engine/security/rootless.md
+++ b/engine/security/rootless.md
@@ -217,6 +217,8 @@ Removed /home/testuser/.config/systemd/user/default.target.wants/docker.service.
 
 Unset environment variables PATH and DOCKER_HOST if you have added them to `~/.bashrc`.
 
+Remove directory `~/.docker`.
+
 To remove the data directory, run `rootlesskit rm -rf ~/.local/share/docker`.
 
 To remove the binaries, remove `docker-ce-rootless-extras` package if you installed Docker with package managers.


### PR DESCRIPTION
### Proposed changes

After installing (and using) docker rootless, I had a ~/.docker directory that I needed to delete since I was getting

`Current context "rootless" is not found on the file system, please check your config file at /home/docker/.docker/config.json`