### PR TITLE
Update django.md

### DIFF
--- a/samples/django.md
+++ b/samples/django.md
@@ -41,6 +41,8 @@ and a `docker-compose.yml` file. (You can use either a `.yml` or `.yaml` extensi
    This `Dockerfile` starts with a [Python 3 parent image](https://hub.docker.com/r/library/python/tags/3/).
    The parent image is modified by adding a new `code` directory. The parent image is further modified
    by installing the Python requirements defined in the `requirements.txt` file.
+   The requirements are copied and installed before copying the entire current
+   directory simply to fail fast if the installation fails.
 
 4. Save and close the `Dockerfile`.
 


### PR DESCRIPTION
I believe this is the reason but was only guessing as I went through this example. Please let me know if this is an inaccurate statement and I can update with a better explanation.

### Proposed changes

Add explanation for why `requirements.txt` is copied and installed before copying the entire directory over.
Does this effectively `COPY` the `requirements.txt` into the destination twice? Or will Docker or the operating system detect that it's the same file. I don't see anywhere in the [COPY documentation](https://docs.docker.com/engine/reference/builder/#copy)  anything explicitly saying it will overwrite existing files either.
