### PR TITLE
dockerfile: switch location and release notes

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -178,6 +178,6 @@ fetch-remote:
     default_branch: "master"
     ref: "master"
     paths:
-      - dest: "engine/reference/builder.md"
+      - dest: "reference/dockerfile"
         src:
           - "frontend/dockerfile/docs/reference.md"

--- a/_data/toc.yaml
+++ b/_data/toc.yaml
@@ -1039,8 +1039,14 @@ reference:
         title: ExecResultV0
       - path: /desktop/extensions-sdk/dev/api/reference/interfaces/BackendV0/
         title: BackendV0  
-- title: Dockerfile reference
-  path: /reference/dockerfile/
+
+- sectiontitle: Dockerfile reference
+  section:
+    - path: /reference/dockerfile/
+      title: Dockerfile specification
+    - path: /reference/dockerfile/release-notes/
+      title: Release notes
+
 - sectiontitle: Compose file reference
   section:
     - path: /compose/compose-file/

--- a/_data/toc.yaml
+++ b/_data/toc.yaml
@@ -1040,7 +1040,7 @@ reference:
       - path: /desktop/extensions-sdk/dev/api/reference/interfaces/BackendV0/
         title: BackendV0  
 - title: Dockerfile reference
-  path: /engine/reference/builder/
+  path: /reference/dockerfile/
 - sectiontitle: Compose file reference
   section:
     - path: /compose/compose-file/

--- a/_includes/guides/create-dockerfile.md
+++ b/_includes/guides/create-dockerfile.md
@@ -23,10 +23,10 @@ your text editor.
 > We recommend using the default (`Dockerfile`) for your project's primary
 > Dockerfile, which is what we'll use for most examples in this guide.
 
-The first line to add to a Dockerfile is a [`# syntax` parser directive](/engine/reference/builder/#syntax).
+The first line to add to a Dockerfile is a [`# syntax` parser directive](/reference/dockerfile/index.md#syntax).
 While _optional_, this directive instructs the Docker builder what syntax to use
 when parsing the Dockerfile, and allows older Docker versions with BuildKit enabled
-to upgrade the parser before starting the build. [Parser directives](/engine/reference/builder/#parser-directives)
+to upgrade the parser before starting the build. [Parser directives](/reference/dockerfile/index.md#parser-directives)
 must appear before any other comment, whitespace, or Dockerfile instruction in
 your Dockerfile, and should be the first line in Dockerfiles.
 

--- a/_layouts/landing.html
+++ b/_layouts/landing.html
@@ -126,7 +126,7 @@
           </div>
           <div class="row">
             <div class="col-xs-12 col-md-6"><a href="/language/">Containerize language-specific apps using Docker</a></div>
-            <div class="col-xs-12 col-md-6"><a href="/engine/reference/builder/">Write a Dockerfile</a></div>
+            <div class="col-xs-12 col-md-6"><a href="/reference/dockerfile/">Write a Dockerfile</a></div>
             <div class="col-xs-12 col-md-6"><a href="/network/">Manage container networking</a></div>
             <div class="col-xs-12 col-md-6"><a href="/compose/compose-file/">Write a Docker Compose file</a></div>
             <div class="col-xs-12 col-md-6"><a href="/storage/">Work with volumes and bind mounts</a></div>
@@ -288,7 +288,7 @@
               <h6>Popular articles</h6>
               <p><a href="/engine/install/ubuntu/">Install Docker Engine on Ubuntu</a></p>
               <p><a href="/engine/reference/commandline/run/">Run a command in a container</a></p>
-              <p><a href="/engine/reference/builder/">Dockerfile reference</a></p>
+              <p><a href="/reference/dockerfile/">Dockerfile reference</a></p>
               <p><a href="/engine/reference/commandline/dockerd/#description">Docker daemon reference</a></p>
               <p><a href="/engine/reference/commandline/build/">Docker build reference</a></p>
             </div>

--- a/compose/compose-file/compose-file-v2.md
+++ b/compose/compose-file/compose-file-v2.md
@@ -215,7 +215,7 @@ build:
 > In your Dockerfile, if you specify `ARG` before the `FROM` instruction,
 > `ARG` is not available in the build instructions under `FROM`.
 > If you need an argument to be available in both places, also specify it under
-> the `FROM` instruction. Refer to the [understand how ARGS and FROM interact](../../engine/reference/builder.md#understand-how-arg-and-from-interact)
+> the `FROM` instruction. Refer to the [understand how ARGS and FROM interact](../../reference/dockerfile/index.md#understand-how-arg-and-from-interact)
 > section in the documentation for usage details.
 
 You can omit the value when specifying a build argument, in which case its value
@@ -397,7 +397,7 @@ command: bundle exec thin -p 3000
 ```
 
 The command can also be a list, in a manner similar to
-[dockerfile](../../engine/reference/builder.md#cmd):
+[dockerfile](../../reference/dockerfile/index.md#cmd):
 
 ```yaml
 command: ["bundle", "exec", "thin", "-p", "3000"]
@@ -572,7 +572,7 @@ entrypoint: /code/entrypoint.sh
 ```
 
 The entrypoint can also be a list, in a manner similar to
-[dockerfile](../../engine/reference/builder.md#entrypoint):
+[dockerfile](../../reference/dockerfile/index.md#entrypoint):
 
 ```yaml
 entrypoint: ["php", "-d", "memory_limit=-1", "vendor/bin/phpunit"]
@@ -800,7 +800,7 @@ used.
 
 Configure a check that's run to determine whether or not containers for this
 service are "healthy". See the docs for the
-[HEALTHCHECK Dockerfile instruction](../../engine/reference/builder.md#healthcheck)
+[HEALTHCHECK Dockerfile instruction](../../reference/dockerfile/index.md#healthcheck)
 for details on how healthchecks work.
 
 ```yaml

--- a/compose/compose-file/compose-file-v3.md
+++ b/compose/compose-file/compose-file-v3.md
@@ -280,7 +280,7 @@ build:
 > In your Dockerfile, if you specify `ARG` before the `FROM` instruction,
 > `ARG` is not available in the build instructions under `FROM`.
 > If you need an argument to be available in both places, also specify it under
-> the `FROM` instruction. Refer to the [understand how ARGS and FROM interact](../../engine/reference/builder.md#understand-how-arg-and-from-interact)
+> the `FROM` instruction. Refer to the [understand how ARGS and FROM interact](../../reference/dockerfile/index.md#understand-how-arg-and-from-interact)
 > section in the documentation for usage details.
 
 You can omit the value when specifying a build argument, in which case its value
@@ -444,7 +444,7 @@ command: bundle exec thin -p 3000
 ```
 
 The command can also be a list, in a manner similar to
-[dockerfile](../../engine/reference/builder.md#cmd):
+[dockerfile](../../reference/dockerfile/index.md#cmd):
 
 ```yaml
 command: ["bundle", "exec", "thin", "-p", "3000"]
@@ -1063,7 +1063,7 @@ entrypoint: /code/entrypoint.sh
 ```
 
 The entrypoint can also be a list, in a manner similar to
-[dockerfile](../../engine/reference/builder.md#entrypoint):
+[dockerfile](../../reference/dockerfile/index.md#entrypoint):
 
 ```yaml
 entrypoint: ["php", "-d", "memory_limit=-1", "vendor/bin/phpunit"]
@@ -1247,7 +1247,7 @@ An entry with the ip address and hostname is created in `/etc/hosts` inside cont
 
 Configure a check that's run to determine whether or not containers for this
 service are "healthy". See the docs for the
-[HEALTHCHECK Dockerfile instruction](../../engine/reference/builder.md#healthcheck)
+[HEALTHCHECK Dockerfile instruction](../../reference/dockerfile/index.md#healthcheck)
 for details on how healthchecks work.
 
 ```yaml

--- a/compose/compose-file/index.md
+++ b/compose/compose-file/index.md
@@ -433,7 +433,7 @@ cgroup_parent: m-executor-abcd
 command: bundle exec thin -p 3000
 ```
 
-The command can also be a list, in a manner similar to [Dockerfile](https://docs.docker.com/engine/reference/builder/#cmd):
+The command can also be a list, in a manner similar to [Dockerfile](https://docs.docker.com/reference/dockerfile/#cmd):
 
 ```
 command: [ "bundle", "exec", "thin", "-p", "3000" ]
@@ -737,7 +737,7 @@ entrypoint: /code/entrypoint.sh
 ```
 
 The entrypoint can also be a list, in a manner similar to
-[Dockerfile](https://docs.docker.com/engine/reference/builder/#cmd):
+[Dockerfile](https://docs.docker.com/reference/dockerfile/#cmd):
 
 ```yml
 entrypoint:
@@ -1082,7 +1082,7 @@ been the case if `group_add` were not declared.
 
 `healthcheck` declares a check that's run to determine whether or not containers for this
 service are "healthy". This overrides
-[HEALTHCHECK Dockerfile instruction](https://docs.docker.com/engine/reference/builder/#healthcheck)
+[HEALTHCHECK Dockerfile instruction](https://docs.docker.com/reference/dockerfile/#healthcheck)
 set by the service's Docker image.
 
 ```yml

--- a/compose/gettingstarted.md
+++ b/compose/gettingstarted.md
@@ -111,7 +111,7 @@ This tells Docker to:
 
 For more information on how to write Dockerfiles, see the
 [Docker user guide](../develop/index.md)
-and the [Dockerfile reference](/engine/reference/builder/).
+and the [Dockerfile reference](/reference/dockerfile/).
 
 
 ## Step 3: Define services in a Compose file

--- a/compose/samples-for-compose.md
+++ b/compose/samples-for-compose.md
@@ -16,7 +16,7 @@ The samples should help you to:
   [Compose files](compose-file/index.md) `docker-compose.yml` and
   `docker-stack.yml` files
 - understand the relationship between `docker-compose.yml` and
-  [Dockerfiles](/engine/reference/builder/)
+  [Dockerfiles](/reference/dockerfile/)
 - learn how to make calls to your application services from Compose files
 - learn how to deploy applications and services to a [swarm](../engine/swarm/index.md)
 

--- a/config/containers/logging/index.md
+++ b/config/containers/logging/index.md
@@ -50,4 +50,4 @@ its errors to `/proc/self/fd/2` (which is `STDERR`). See the
 ## Next steps
 
 - Configure [logging drivers](configure.md).
-- Write a [Dockerfile](../../../engine/reference/builder.md).
+- Write a [Dockerfile](../../../reference/dockerfile/index.md).

--- a/config/labels-custom-metadata.md
+++ b/config/labels-custom-metadata.md
@@ -78,7 +78,7 @@ the lifetime of the object. To change these labels you must recreate the object.
 Labels on swarm nodes and services can be updated dynamically.
 
 - Images and containers
-  - [Adding labels to images](../engine/reference/builder.md#label)
+  - [Adding labels to images](../reference/dockerfile/index.md#label)
   - [Overriding a container's labels at runtime](../engine/reference/commandline/run.md#set-metadata-on-container--l---label---label-file)
   - [Inspecting labels on images or containers](../engine/reference/commandline/inspect.md)
   - [Filtering images by label](../engine/reference/commandline/images.md#filtering)

--- a/desktop/extensions-sdk/extensions/labels.md
+++ b/desktop/extensions-sdk/extensions/labels.md
@@ -4,7 +4,7 @@ description: Docker extension labels
 keywords: Docker, extensions, sdk, labels
 ---
 
-[Labels](https://docs.docker.com/engine/reference/builder/#label) are specified in the extension's `Dockerfile` and used to provide information about the extension.
+[Labels](https://docs.docker.com/reference/dockerfile/#label) are specified in the extension's `Dockerfile` and used to provide information about the extension.
 
 | Label | Required | Description | Example |
 | --- | --- | --- | ---|

--- a/develop/develop-images/baseimages.md
+++ b/develop/develop-images/baseimages.md
@@ -107,7 +107,7 @@ If you want to test it out, you can clone
 
 There are lots of resources available to help you write your `Dockerfile`.
 
-* There's a [complete guide to all the instructions](../../engine/reference/builder.md) available for use in a `Dockerfile` in the reference section.
+* There's a [complete guide to all the instructions](../../reference/dockerfile/index.md) available for use in a `Dockerfile` in the reference section.
 * To help you write a clear, readable, maintainable `Dockerfile`, we've also
 written a [`Dockerfile` best practices guide](dockerfile_best-practices.md).
 * If your goal is to create a new Docker Official Image, read [Docker Official Images](../../docker-hub/official_images.md).

--- a/develop/develop-images/build_enhancements.md
+++ b/develop/develop-images/build_enhancements.md
@@ -20,7 +20,7 @@ on performance, storage management, feature functionality, and security.
 
 For more information on build options, see the reference guide on the
 [command line build options](../../engine/reference/commandline/build.md) and
-the [Dockerfile reference](/engine/reference/builder/) page.
+the [Dockerfile reference](/reference/dockerfile/) page.
 
 
 ## Requirements
@@ -124,7 +124,7 @@ version 1.2.0 and up. We recommend using `docker/dockerfile:1`, which always
 points to the latest release of the version 1 syntax. BuildKit automatically
 checks for updates of the syntax before building, making sure you are using the
 most current version. Learn more about the `syntax` directive in the
-[Dockerfile reference](/engine/reference/builder/#syntax).
+[Dockerfile reference](/reference/dockerfile/#syntax).
 
 ## New Docker Build secret information
 

--- a/develop/develop-images/dockerfile_best-practices.md
+++ b/develop/develop-images/dockerfile_best-practices.md
@@ -16,7 +16,7 @@ efficient images.
 Docker builds images automatically by reading the instructions from a
 `Dockerfile` -- a text file that contains all commands, in order, needed to
 build a given image. A `Dockerfile` adheres to a specific format and set of
-instructions which you can find at [Dockerfile reference](../../engine/reference/builder.md).
+instructions which you can find at [Dockerfile reference](../../reference/dockerfile/index.md).
 
 A Docker image consists of read-only layers each of which represents a
 Dockerfile  instruction. The layers are stacked and each one is a delta of the
@@ -248,7 +248,7 @@ EOF
 To exclude files not relevant to the build (without restructuring your source
 repository) use a `.dockerignore` file. This file supports exclusion patterns
 similar to `.gitignore` files. For information on creating one, see the
-[.dockerignore file](../../engine/reference/builder.md#dockerignore-file).
+[.dockerignore file](../../reference/dockerfile/index.md#dockerignore-file).
 
 ### Use multi-stage builds
 
@@ -402,7 +402,7 @@ maintainable `Dockerfile`.
 
 ### FROM
 
-[Dockerfile reference for the FROM instruction](../../engine/reference/builder.md#from)
+[Dockerfile reference for the FROM instruction](../../reference/dockerfile/index.md#from)
 
 Whenever possible, use current official images as the basis for your
 images. We recommend the [Alpine image](https://hub.docker.com/_/alpine/) as it
@@ -455,11 +455,11 @@ See [Understanding object labels](../../config/labels-custom-metadata.md)
 for guidelines about acceptable label keys and values. For information about
 querying labels, refer to the items related to filtering in
 [Managing labels on objects](../../config/labels-custom-metadata.md#manage-labels-on-objects).
-See also [LABEL](../../engine/reference/builder.md#label) in the Dockerfile reference.
+See also [LABEL](../../reference/dockerfile/index.md#label) in the Dockerfile reference.
 
 ### RUN
 
-[Dockerfile reference for the RUN instruction](../../engine/reference/builder.md#run)
+[Dockerfile reference for the RUN instruction](../../reference/dockerfile/index.md#run)
 
 Split long or complex `RUN` statements on multiple lines separated with
 backslashes to make your `Dockerfile` more readable, understandable, and
@@ -592,7 +592,7 @@ RUN set -o pipefail && wget -O - https://some.site | wc -l > /number
 
 ### CMD
 
-[Dockerfile reference for the CMD instruction](../../engine/reference/builder.md#cmd)
+[Dockerfile reference for the CMD instruction](../../reference/dockerfile/index.md#cmd)
 
 The `CMD` instruction should be used to run the software contained in your
 image, along with any arguments. `CMD` should almost always be used in the form
@@ -606,13 +606,13 @@ python and perl. For example, `CMD ["perl", "-de0"]`, `CMD ["python"]`, or `CMD
 ["php", "-a"]`. Using this form means that when you execute something like
 `docker run -it python`, you’ll get dropped into a usable shell, ready to go.
 `CMD` should rarely be used in the manner of `CMD ["param", "param"]` in
-conjunction with [`ENTRYPOINT`](../../engine/reference/builder.md#entrypoint), unless
+conjunction with [`ENTRYPOINT`](../../reference/dockerfile/index.md#entrypoint), unless
 you and your expected users are already quite familiar with how `ENTRYPOINT`
 works.
 
 ### EXPOSE
 
-[Dockerfile reference for the EXPOSE instruction](../../engine/reference/builder.md#expose)
+[Dockerfile reference for the EXPOSE instruction](../../reference/dockerfile/index.md#expose)
 
 The `EXPOSE` instruction indicates the ports on which a container listens
 for connections. Consequently, you should use the common, traditional port for
@@ -627,7 +627,7 @@ the recipient container back to the source (ie, `MYSQL_PORT_3306_TCP`).
 
 ### ENV
 
-[Dockerfile reference for the ENV instruction](../../engine/reference/builder.md#env)
+[Dockerfile reference for the ENV instruction](../../reference/dockerfile/index.md#env)
 
 To make new software easier to run, you can use `ENV` to update the
 `PATH` environment variable for the software your container installs. For
@@ -696,8 +696,8 @@ $ docker run --rm test sh -c 'echo $ADMIN_USER'
 
 ### ADD or COPY
 
-- [Dockerfile reference for the ADD instruction](../../engine/reference/builder.md#add)
-- [Dockerfile reference for the COPY instruction](../../engine/reference/builder.md#copy)
+- [Dockerfile reference for the ADD instruction](../../reference/dockerfile/index.md#add)
+- [Dockerfile reference for the COPY instruction](../../reference/dockerfile/index.md#copy)
 
 Although `ADD` and `COPY` are functionally similar, generally speaking, `COPY`
 is preferred. That’s because it’s more transparent than `ADD`. `COPY` only
@@ -748,7 +748,7 @@ auto-extraction capability, you should always use `COPY`.
 
 ### ENTRYPOINT
 
-[Dockerfile reference for the ENTRYPOINT instruction](../../engine/reference/builder.md#entrypoint)
+[Dockerfile reference for the ENTRYPOINT instruction](../../reference/dockerfile/index.md#entrypoint)
 
 The best use for `ENTRYPOINT` is to set the image's main command, allowing that
 image to be run as though it was that command (and then use `CMD` as the
@@ -805,7 +805,7 @@ exec "$@"
 > This script uses [the `exec` Bash command](https://wiki.bash-hackers.org/commands/builtin/exec)
 > so that the final running application becomes the container's PID 1. This
 > allows the application to receive any Unix signals sent to the container.
-> For more, see the [`ENTRYPOINT` reference](../../engine/reference/builder.md#entrypoint).
+> For more, see the [`ENTRYPOINT` reference](../../reference/dockerfile/index.md#entrypoint).
 
 The helper script is copied into the container and run via `ENTRYPOINT` on
 container start:
@@ -838,7 +838,7 @@ $ docker run --rm -it postgres bash
 
 ### VOLUME
 
-[Dockerfile reference for the VOLUME instruction](../../engine/reference/builder.md#volume)
+[Dockerfile reference for the VOLUME instruction](../../reference/dockerfile/index.md#volume)
 
 The `VOLUME` instruction should be used to expose any database storage area,
 configuration storage, or files/folders created by your docker container. You
@@ -847,7 +847,7 @@ parts of your image.
 
 ### USER
 
-[Dockerfile reference for the USER instruction](../../engine/reference/builder.md#user)
+[Dockerfile reference for the USER instruction](../../reference/dockerfile/index.md#user)
 
 If a service can run without privileges, use `USER` to change to a non-root
 user. Start by creating the user and group in the `Dockerfile` with something
@@ -880,7 +880,7 @@ frequently.
 
 ### WORKDIR
 
-[Dockerfile reference for the WORKDIR instruction](../../engine/reference/builder.md#workdir)
+[Dockerfile reference for the WORKDIR instruction](../../reference/dockerfile/index.md#workdir)
 
 For clarity and reliability, you should always use absolute paths for your
 `WORKDIR`. Also, you should use `WORKDIR` instead of  proliferating instructions
@@ -889,7 +889,7 @@ maintain.
 
 ### ONBUILD
 
-[Dockerfile reference for the ONBUILD instruction](../../engine/reference/builder.md#onbuild)
+[Dockerfile reference for the ONBUILD instruction](../../reference/dockerfile/index.md#onbuild)
 
 An `ONBUILD` command executes after the current `Dockerfile` build completes.
 `ONBUILD` executes in any child image derived `FROM` the current image.  Think
@@ -923,7 +923,7 @@ These Official Images have exemplary `Dockerfile`s:
 
 ## Additional resources:
 
-* [Dockerfile Reference](../../engine/reference/builder.md)
+* [Dockerfile Reference](../../reference/dockerfile/index.md)
 * [More about Base Images](baseimages.md)
 * [More about Automated Builds](../../docker-hub/builds/index.md)
 * [Guidelines for Creating Docker Official Images](../../docker-hub/official_images.md)

--- a/develop/index.md
+++ b/develop/index.md
@@ -16,7 +16,7 @@ If you're just getting started developing a brand new app on Docker, check out
 these resources to understand some of the most common patterns for getting the
 most benefits from Docker.
 
-- Learn how to [build an image](../engine/reference/builder/){: target="_blank" rel="noopener" class="_"} using a Dockerfile
+- Learn how to [build an image](../reference/dockerfile/){: target="_blank" rel="noopener" class="_"} using a Dockerfile
 - Use [multi-stage builds](develop-images/multistage-build.md){: target="_blank" rel="noopener" class="_"} to keep your images lean
 - Manage application data using [volumes](../storage/volumes.md) and [bind mounts](../storage/bind-mounts.md){: target="_blank" rel="noopener" class="_"}
 - [Scale your app with Kubernetes](../get-started/kube-deploy.md){: target="_blank" rel="noopener" class="_"} 

--- a/docker-hub/index.md
+++ b/docker-hub/index.md
@@ -134,7 +134,7 @@ Docker Hub.
 
 ### Step 4: Build and push a container image to Docker Hub from your computer
 
-1. Start by creating a [Dockerfile](../engine/reference/builder/) to specify your application as shown below:
+1. Start by creating a [Dockerfile](../reference/dockerfile/) to specify your application as shown below:
 
    ```dockerfile
    # syntax=docker/dockerfile:1

--- a/engine/faq.md
+++ b/engine/faq.md
@@ -43,7 +43,7 @@ offers a high-level tool with several powerful functionalities:
 
  - *Automatic build.* Docker includes [*a tool for developers to automatically
  assemble a container from their source
- code*](/engine/reference/builder/), with full control over application
+ code*](/reference/dockerfile/), with full control over application
  dependencies, build tools, packaging etc. They are free to use `make`, `maven`,
  `chef`, `puppet`, `salt,` Debian packages, RPMs, source tarballs, or any
  combination of the above, regardless of the configuration of the machines.

--- a/get-started/09_image_best.md
+++ b/get-started/09_image_best.md
@@ -142,7 +142,7 @@ a change to the `package.json`. Make sense?
 
     `.dockerignore` files are an easy way to selectively copy only image relevant files.
     You can read more about this
-    [here](../engine/reference/builder.md#dockerignore-file).
+    [here](../reference/dockerfile/index.md#dockerignore-file).
     In this case, the `node_modules` folder should be omitted in the second `COPY` step because otherwise,
     it would possibly overwrite files which were created by the command in the `RUN` step.
     For further details on why this is recommended for Node.js applications and other best practices,

--- a/js/docs.js
+++ b/js/docs.js
@@ -229,7 +229,7 @@ ready(() => {
         title: function() {
             let c = this.textContent;
             this.style.cursor = 'help';
-            $(this).on('click', () => { window.location.href = "/engine/reference/builder/#"+c.toLowerCase()});
+            $(this).on('click', () => { window.location.href = "/reference/dockerfile/#"+c.toLowerCase()});
             return 'Learn more about the "'+ c + '" Dockerfile command.'
         },
         placement: "auto"

--- a/reference/dockerfile/index.md
+++ b/reference/dockerfile/index.md
@@ -1,0 +1,11 @@
+---
+title: Dockerfile reference
+description: "Dockerfiles use a simple DSL which allows you to automate the steps you would normally manually take to create an image."
+keywords: build, dockerfile, reference
+toc_max: 3
+redirect_from:
+- /engine/reference/builder/
+- /reference/builder/
+---
+
+{% include_relative reference.md %}

--- a/reference/dockerfile/release-notes.md
+++ b/reference/dockerfile/release-notes.md
@@ -1,0 +1,231 @@
+---
+title: Dockerfile reference release notes
+description: Release notes for Dockerfile reference
+keywords: build, dockerfile, reference, release notes
+toc_max: 2
+---
+
+This page contains information about the new features, improvements, known
+issues, and bug fixes in [Dockerfile reference](index.md).
+
+## Dockerfile 1.4.2
+
+* Release date: **2022-05-06**
+* Usage: [`docker/dockerfile:1.4.2`](index.md#syntax)
+
+### Notable changes
+
+* Fix loading certain environment variables from an image passed with built
+  context
+
+> See [full release notes](https://github.com/moby/buildkit/releases/tag/dockerfile%2F1.4.2){:target="_blank" rel="noopener" class="_"} for more details.
+
+## Dockerfile 1.4.1
+
+* Release date: **2022-04-08**
+* Usage: [`docker/dockerfile:1.4.1`](index.md#syntax)
+
+### Notable changes
+
+* Fix named context resolution for cross-compilation cases from input when input
+  is built for a different platform
+
+> See [full release notes](https://github.com/moby/buildkit/releases/tag/dockerfile%2F1.4.1){:target="_blank" rel="noopener" class="_"} for more details.
+
+## Dockerfile 1.4.0
+
+* Release date: **2022-03-09**
+* Usage: [`docker/dockerfile:1.4.0`](index.md#syntax)
+
+### Notable changes
+
+* [`COPY --link` and `ADD --link`](index.md#copy---link) allow copying
+  files with increased cache efficiency and rebase images without requiring them
+  to be rebuilt. `--link` copies files to a separate layer and then uses new LLB
+  MergeOp implementation to chain independent layers together
+* [Heredocs](index.md#here-documents) support have been promoted from labs
+  channel to stable. This feature allows writing multiline inline scripts and
+  files
+* Additional [named build contexts](https://docs.docker.com/engine/reference/commandline/buildx_build/#build-context)
+  can be passed to build to add or overwrite a stage or an image inside the
+  build. A source for the context can be a local source, image, Git, or HTTP URL
+* When using a cross-compilation stage, the target platform for a step is now
+  seen on progress output
+* [`BUILDKIT_SANDBOX_HOSTNAME` build-arg](index.md#buildkit-built-in-build-args)
+  can be used to set the default hostname for the `RUN` steps
+* Fix some cases where Heredocs incorrectly removed quotes from content
+
+> See [full release notes](https://github.com/moby/buildkit/releases/tag/dockerfile%2F1.4.0){:target="_blank" rel="noopener" class="_"} for more details.
+
+## Dockerfile 1.3.1
+
+* Release date: **2022-10-04**
+* Usage: [`docker/dockerfile:1.3.1`](index.md#syntax)
+
+### Notable changes
+
+* Fix parsing "required" mount key without a value
+
+> See [full release notes](https://github.com/moby/buildkit/releases/tag/dockerfile%2F1.3.1){:target="_blank" rel="noopener" class="_"} for more details.
+
+## Dockerfile 1.3.0 (labs)
+
+* Release date: **2021-07-16**
+* Usage: [`docker/dockerfile:1.3.0-labs`](index.md#syntax)
+
+> **Note**
+>
+> The "labs" channel provides early access to Dockerfile features that are not
+> yet available in the stable channel.
+
+### Notable changes
+
+* `RUN` and `COPY` commands now support [Here-document syntax](index.md#here-documents)
+  allowing writing multiline inline scripts and files
+
+> See [full release notes](https://github.com/moby/buildkit/releases/tag/dockerfile%2F1.3.0-labs){:target="_blank" rel="noopener" class="_"} for more details.
+
+## Dockerfile 1.3.0
+
+* Release date: **2021-07-16**
+* Usage: [`docker/dockerfile:1.3.0`](index.md#syntax)
+
+### Notable changes
+
+* `RUN` command allows [`--network` flag](index.md#run---network) for
+  requesting a specific type of network conditions. `--network=host` requires
+  allowing `network.host` entitlement. This feature was previously only available on labs channel
+* `ADD` command with a remote URL input now correctly handles the `--chmod` flag
+* Values for [`RUN --mount` flag](index.md#run---mount) now support variable
+  expansion, except for the `from` field
+* Allow [`BUILDKIT_MULTI_PLATFORM` build arg](index.md#buildkit-built-in-build-args)
+  to force always creating multi-platform image, even if only contains single
+  platform
+
+> See [full release notes](https://github.com/moby/buildkit/releases/tag/dockerfile%2F1.3.0){:target="_blank" rel="noopener" class="_"} for more details.
+
+## Dockerfile 1.2.1 (labs)
+
+* Release date: **2020-12-12**
+* Usage: [`docker/dockerfile:1.2.1-labs`](index.md#syntax)
+
+> **Note**
+>
+> The "labs" channel provides early access to Dockerfile features that are not
+> yet available in the stable channel.
+
+### Notable changes
+
+* `RUN` command allows [`--network` flag](index.md#run---network) for
+  requesting a specific type of network conditions. `--network=host` requires
+  allowing `network.host` entitlement
+
+> See [full release notes](https://github.com/moby/buildkit/releases/tag/dockerfile%2F1.2.1-labs){:target="_blank" rel="noopener" class="_"} for more details.
+
+## Dockerfile 1.2.1
+
+* Release date: **2020-12-12**
+* Usage: [`docker/dockerfile:1.2.1`](index.md#syntax)
+
+### Notable changes
+
+* Revert "Ensure ENTRYPOINT command has at least one argument"
+* Optimize processing `COPY` calls on multi-platform cross-compilation builds
+
+> See [full release notes](https://github.com/moby/buildkit/releases/tag/dockerfile%2F1.2.1){:target="_blank" rel="noopener" class="_"} for more details.
+
+## Dockerfile 1.2.0 (labs)
+
+* Release date: **2020-12-03**
+* Usage: [`docker/dockerfile:1.2.0-labs`](index.md#syntax)
+
+> **Note**
+>
+> The "labs" channel provides early access to Dockerfile features that are not
+> yet available in the stable channel.
+
+### Notable changes
+
+* Experimental channel has been renamed to *labs*
+
+> See [full release notes](https://github.com/moby/buildkit/releases/tag/dockerfile%2F1.2.0-labs){:target="_blank" rel="noopener" class="_"} for more details.
+
+## Dockerfile 1.2.0
+
+* Release date: **2020-12-03**
+* Usage: [`docker/dockerfile:1.2.0`](index.md#syntax)
+
+### Notable changes
+
+* [`RUN --mount` syntax](index.md#run---mount) for creating secret, ssh,
+  bind, and cache mounts have been moved to mainline channel
+* Metadata load errors are now handled as fatal to avoid incorrect build results
+* [`ARG` command](index.md#arg) now supports defining multiple build args
+  on the same line similarly to `ENV`
+* `--chown` flag in `ADD` now allows parameter expansion
+* Allow lowercase Dockerfile name
+* `ENTRYPOINT` requires at least one argument to avoid creating broken images
+
+> See [full release notes](https://github.com/moby/buildkit/releases/tag/dockerfile%2F1.2.0){:target="_blank" rel="noopener" class="_"} for more details.
+
+## Dockerfile 1.1.7
+
+* Release date: **2020-04-18**
+* Usage: [`docker/dockerfile:1.1.7`](index.md#syntax)
+
+### Notable changes
+
+* Forward `FrontendInputs` to the gateway
+
+> See [full release notes](https://github.com/moby/buildkit/releases/tag/dockerfile%2F1.1.7){:target="_blank" rel="noopener" class="_"} for more details.
+
+## Dockerfile 1.1.2 (experimental)
+
+* Release date: **2019-07-31**
+* Usage: [`docker/dockerfile-upstream:1.1.2-experimental`](index.md#syntax)
+
+> **Note**
+>
+> The "experimental" channel provides early access to Dockerfile features that
+> are not yet available in the stable channel.
+
+### Notable changes
+
+* Allow setting security mode for a process with `RUN --security=sandbox|insecure`
+* Allow setting uid/gid for [cache mounts](index.md#run---mounttypecache)
+* Avoid requesting internally linked paths to be pulled to build context
+* Ensure missing cache IDs default to target paths
+* Allow setting namespace for cache mounts with [`BUILDKIT_CACHE_MOUNT_NS` build arg](index.md#buildkit-built-in-build-args)
+
+> See [full release notes](https://github.com/moby/buildkit/releases/tag/dockerfile%2F1.1.2-experimental){:target="_blank" rel="noopener" class="_"} for more details.
+
+## Dockerfile 1.1.2
+
+* Release date: **2019-07-31**
+* Usage: [`docker/dockerfile:1.1.1`](index.md#syntax)
+
+### Notable changes
+
+* Fix workdir creation with correct user and don't reset custom ownership
+* Fix handling empty build args also used as `ENV`
+* Detect circular dependencies
+
+> See [full release notes](https://github.com/moby/buildkit/releases/tag/dockerfile%2F1.1.2){:target="_blank" rel="noopener" class="_"} for more details.
+
+## Dockerfile 1.1.0
+
+* Release date: **2019-04-27**
+* Usage: [`docker/dockerfile:1.1.0`](index.md#syntax)
+
+### Notable changes
+
+* `ADD/COPY` commands now support implementation based on `llb.FileOp` and do
+  not require helper image if builtin file operations support is available
+* To find the files ignored from the build context Dockerfile frontend will
+  first look for a file `<path/to/Dockerfile>.dockerignore` and if it is not
+  found `.dockerignore` file will be looked up from the root of the build
+  context. This allows projects with multiple Dockerfiles to use different
+  `.dockerignore` definitions
+* `--chown` flag for `COPY` command now supports variable expansion
+
+> See [full release notes](https://github.com/moby/buildkit/releases/tag/dockerfile%2F1.1.0){:target="_blank" rel="noopener" class="_"} for more details.

--- a/reference/index.md
+++ b/reference/index.md
@@ -11,7 +11,7 @@ various APIs, CLIs, and file formats.
 
 | File format                                                         | Description                                                     |
 |:--------------------------------------------------------------------|:----------------------------------------------------------------|
-| [Dockerfile](/engine/reference/builder/)                            | Defines the contents and startup behavior of a single container |
+| [Dockerfile](/reference/dockerfile/)                                | Defines the contents and startup behavior of a single container |
 | [Compose file](/compose/compose-file/)                              | Defines a multi-container application                           |
 
 

--- a/samples/django.md
+++ b/samples/django.md
@@ -23,7 +23,7 @@ and a `docker-compose.yml` file. (You can use either a `.yml` or `.yaml` extensi
     The Dockerfile defines an application's image content via one or more build
     commands that configure that image. Once built, you can run the image in a
     container.  For more information on `Dockerfile`, see the [Docker user guide](../get-started/index.md)
-    and the [Dockerfile reference](/engine/reference/builder/).
+    and the [Dockerfile reference](/reference/dockerfile/).
 
 3. Add the following content to the `Dockerfile`.
 

--- a/samples/dotnetcore.md
+++ b/samples/dotnetcore.md
@@ -64,7 +64,7 @@ ENTRYPOINT ["dotnet", "aspnetapp.dll"]
 ```
 
 4.  To make your build context as small as possible add a [`.dockerignore`
-   file](/engine/reference/builder/#dockerignore-file)
+   file](/reference/dockerfile/#dockerignore-file)
    to your project folder and copy the following into it.
 
 ```dockerignore
@@ -96,7 +96,7 @@ obj/
       ```
   
 4.  To make your build context as small as possible add a [`.dockerignore`
-   file](/engine/reference/builder/#dockerignore-file)
+   file](/reference/dockerfile/#dockerignore-file)
    to your project folder.
    
 ## Build and run the Docker image

--- a/samples/rails.md
+++ b/samples/rails.md
@@ -38,7 +38,7 @@ CMD ["rails", "server", "-b", "0.0.0.0"]
 That'll put your application code inside an image that builds a container
 with Ruby, Bundler and all your dependencies inside it. For more information on
 how to write Dockerfiles, see the [Docker user guide](../get-started/index.md)
-and the [Dockerfile reference](/engine/reference/builder/).
+and the [Dockerfile reference](/reference/dockerfile/).
 
 Next, open an editor and create a bootstrap `Gemfile` which just loads Rails. This will be overwritten in a moment by `rails new`.
 

--- a/test.md
+++ b/test.md
@@ -107,7 +107,7 @@ culpa qui officia deserunt mollit anim id est laborum.
   - You can specify `org=foo` to use a Github organization other than Docker
 
 - A link to an auto-generated reference page that we pull in during docs builds:
-[/engine/reference/builder/#env](/engine/reference/builder/#env).
+[/reference/dockerfile/#env](/reference/dockerfile/#env).
 
   - If you can't find a reference page in the `docker.github.io`
   GitHub repository, but see it out on `docs.docker.com`, you can


### PR DESCRIPTION
needs https://github.com/docker/docker.github.io/pull/15151 (for proper redirects)

adds a release notes page for the dockerfile reference. needs to create a subsection for release notes and therefore also needs to change the reference location from `/engine/reference/builder` to `/reference/dockerfile/` as discussed in https://github.com/docker/docker.github.io/pull/14948#issuecomment-1167230746.

preview: https://deploy-preview-15110--docsdocker.netlify.app/reference/dockerfile/

![image](https://user-images.githubusercontent.com/1951866/178737286-d9e7c217-26da-4d45-9454-c7620d255ed7.png)
