### PR TITLE
Add Zsh autocompletion step for Zsh shipped with Catalina

### DIFF
--- a/desktop/faqs/macfaqs.md
+++ b/desktop/faqs/macfaqs.md
@@ -282,8 +282,8 @@ Or if you installed Zsh via [Homebrew](https://brew.sh){:target="_blank" rel="no
 
 ```bash
 etc=/Applications/Docker.app/Contents/Resources/etc
-ln -s $etc/docker.zsh-completion /usr/local/share/zsh/site-functions/_docker
-ln -s $etc/docker-compose.zsh-completion /usr/local/share/zsh/site-functions/_docker-compose
+ln -s $etc/docker.zsh-completion $(brew --prefix)/share/zsh/site-functions/_docker
+ln -s $etc/docker-compose.zsh-completion $(brew --prefix)/share/zsh/site-functions/_docker-compose
 ```
 
 #### Fish-Shell
@@ -306,4 +306,3 @@ Now add fish completions from docker.
 $ ln -shi /Applications/Docker.app/Contents/Resources/etc/docker.fish-completion ~/.config/fish/completions/docker.fish
 $ ln -shi /Applications/Docker.app/Contents/Resources/etc/docker-compose.fish-completion ~/.config/fish/completions/docker-compose.fish
 ```
-

--- a/desktop/faqs/macfaqs.md
+++ b/desktop/faqs/macfaqs.md
@@ -254,7 +254,31 @@ In Zsh, the [completion
 system](http://zsh.sourceforge.net/Doc/Release/Completion-System.html){:target="_blank" rel="nooopener" class="_"}
 takes care of things. To activate completion for Docker commands,
 these files need to be copied or symlinked to your Zsh `site-functions/`
-directory. For example, if you installed Zsh via [Homebrew](https://brew.sh){:target="_blank" rel="nooopener" class="_"}:
+directory.
+
+If you are using Zsh from MacOS (starting with MacOS Catalina):
+
+Create the `completions` directory:
+```bash
+mkdir -p ~/.zsh/completions
+```
+ 
+Enable autocompletion for Zsh:
+
+```bash
+cat ~/.zshrc | grep 'fpath=(~/.zsh/completions $fpath)' > /dev/null || echo 'fpath=(~/.zsh/completions $fpath)' >> ~/.zshrc
+cat ~/.zshrc | grep 'autoload -Uz compinit && compinit' > /dev/null || echo 'autoload -Uz compinit && compinit' >> ~/.zshrc
+```
+ 
+Now add the completion for Docker:
+
+```
+etc=/Applications/Docker.app/Contents/Resources/etc
+ln -s $etc/docker.zsh-completion  ~/.zsh/completions/_docker
+ln -s $etc/docker-compose.zsh-completion ~/.zsh/completions/_docker-compose
+```
+ 
+Or if you installed Zsh via [Homebrew](https://brew.sh){:target="_blank" rel="nooopener" class="_"}:
 
 ```bash
 etc=/Applications/Docker.app/Contents/Resources/etc
@@ -282,3 +306,4 @@ Now add fish completions from docker.
 $ ln -shi /Applications/Docker.app/Contents/Resources/etc/docker.fish-completion ~/.config/fish/completions/docker.fish
 $ ln -shi /Applications/Docker.app/Contents/Resources/etc/docker-compose.fish-completion ~/.config/fish/completions/docker-compose.fish
 ```
+

--- a/desktop/mac/index.md
+++ b/desktop/mac/index.md
@@ -191,8 +191,8 @@ Or if you installed Zsh via [Homebrew](https://brew.sh){:target="_blank" rel="no
 
 ```bash
 etc=/Applications/Docker.app/Contents/Resources/etc
-ln -s $etc/docker.zsh-completion /usr/local/share/zsh/site-functions/_docker
-ln -s $etc/docker-compose.zsh-completion /usr/local/share/zsh/site-functions/_docker-compose
+ln -s $etc/docker.zsh-completion $(brew --prefix)/share/zsh/site-functions/_docker
+ln -s $etc/docker-compose.zsh-completion $(brew --prefix)/share/zsh/site-functions/_docker-compose
 ```
 
 ### Fish-Shell

--- a/desktop/mac/index.md
+++ b/desktop/mac/index.md
@@ -162,7 +162,32 @@ In Zsh, the [completion
 system](http://zsh.sourceforge.net/Doc/Release/Completion-System.html){:target="_blank" rel="nooopener" class="_"}
 takes care of things. To activate completion for Docker commands,
 these files need to be copied or symlinked to your Zsh `site-functions/`
-directory. For example, if you installed Zsh via [Homebrew](https://brew.sh){:target="_blank" rel="nooopener" class="_"}:
+directory. 
+
+If you are using Zsh from MacOS (starting with MacOS Catalina):
+
+Create the `completions` directory:
+
+```bash
+mkdir -p ~/.zsh/completions
+```
+
+Enable autocompletion for Zsh:
+
+```bash
+cat ~/.zshrc | grep 'fpath=(~/.zsh/completions $fpath)' > /dev/null || echo 'fpath=(~/.zsh/completions $fpath)' >> ~/.zshrc
+cat ~/.zshrc | grep 'autoload -Uz compinit && compinit' > /dev/null || echo 'autoload -Uz compinit && compinit' >> ~/.zshrc
+```
+
+Now add the completion for Docker:
+
+```
+etc=/Applications/Docker.app/Contents/Resources/etc
+ln -s $etc/docker.zsh-completion  ~/.zsh/completions/_docker
+ln -s $etc/docker-compose.zsh-completion ~/.zsh/completions/_docker-compose
+```
+
+Or if you installed Zsh via [Homebrew](https://brew.sh){:target="_blank" rel="nooopener" class="_"}:
 
 ```bash
 etc=/Applications/Docker.app/Contents/Resources/etc


### PR DESCRIPTION
Zsh is now shipped starting with MacOS Catalina and the auto completion need more step to have it running out of the box.

### Proposed changes

Add information for enabling the autocompletion for MacOS Catalina and after as the step for homebrew is no more needed and doesn't use the same path as Zsh shipped with MacOS.

### Related issues (optional)

None, I see the problem this morning with a coworker and I didn't create an issue for that and no issue exist for that yet.