### PR TITLE
volume-type-comparisons-mismatches

### DIFF
--- a/get-started/06_bind_mounts.md
+++ b/get-started/06_bind_mounts.md
@@ -25,8 +25,8 @@ volume drivers are available to support other use cases ([SFTP](https://github.c
 | - | ------------- | ----------- |
 | Host Location | Docker chooses | You control |
 | Mount Example (using `-v`) | my-volume:/usr/local/data | /path/to/data:/usr/local/data |
-| Populates new volume with container contents | Yes | No |
-| Supports Volume Drivers | Yes | No |
+| Populates new volume with container contents | No | Yes |
+| Supports Volume Drivers | No | Yes |
 
 ## Start a dev-mode container
 


### PR DESCRIPTION
### Proposed changes
The volume type comparisons for "Populates new volume with container contents"	and Supports Volume Drivers had "No" for bind mounts instead of "Yes".
As bind mounts particularly control the exact mount-point on the host and used to provide additional data into containers like source code into the container for monitoring code changes.
