### PR TITLE
Speed up inner loop

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,6 +40,11 @@ RUN bundle update \
 FROM scratch AS vendor
 COPY --from=vendored /out /
 
+# Serve the files using jekyll to enable file watching
+# and livereload for a faster inner loop
+FROM gem AS dev
+CMD ["./dev-start.sh"]
+
 # Build the static HTML for the current docs.
 # After building with jekyll, fix up some links
 FROM gem AS generate

--- a/_config.yml
+++ b/_config.yml
@@ -123,6 +123,7 @@ defaults:
 # Fetch upstream resources (reference documentation) used by _plugins/fetch_remote.rb
 # - repo is the GitHub repository to fetch from
 # - ref the Git reference
+# - completion_marker is a file path that, if it exists, will prevent a redownload from occurring
 # - paths is a list to the resources within the remote repository
 #   - dest is the destination path within the working tree
 #   - src is a list of glob source paths within the remote repository
@@ -130,6 +131,7 @@ fetch-remote:
   - repo: "https://github.com/docker/cli"
     default_branch: "master"
     ref: "20.10"
+    completion_marker: "engine/deprecated.md"
     paths:
       - dest: "engine/extend"
         src:
@@ -148,6 +150,7 @@ fetch-remote:
   - repo: "https://github.com/docker/docker"
     default_branch: "master"
     ref: "20.10"
+    completion_marker: "engine/api/version-history.md"
     paths:
       - dest: "engine/api"
         src:
@@ -156,6 +159,7 @@ fetch-remote:
   - repo: "https://github.com/docker/compose-cli"
     default_branch: "main"
     ref: "main"
+    completion_marker: "cloud/ecs-integration.md"
     paths:
       - dest: "cloud"
         src:
@@ -166,6 +170,7 @@ fetch-remote:
   - repo: "https://github.com/docker/buildx"
     default_branch: "master"
     ref: "master"
+    completion_marker: "build/bake/index.md"
     paths:
       - dest: "build/bake"
         src:
@@ -174,6 +179,7 @@ fetch-remote:
   - repo: "https://github.com/distribution/distribution"
     default_branch: "main"
     ref: "release/2.7"
+    completion_marker: "registry/spec/index.md"
     paths:
       - dest: "registry/spec"
         src:
@@ -186,6 +192,7 @@ fetch-remote:
   - repo: "https://github.com/moby/buildkit"
     default_branch: "master"
     ref: "master"
+    completion_marker: "engine/reference/builder.md"
     paths:
       - dest: "engine/reference/builder.md"
         src:

--- a/_config.yml
+++ b/_config.yml
@@ -159,7 +159,7 @@ fetch-remote:
   - repo: "https://github.com/docker/compose-cli"
     default_branch: "main"
     ref: "main"
-    completion_marker: "cloud/ecs-integration.md"
+    completion_marker: "cloud/ecs-compose-features.md"
     paths:
       - dest: "cloud"
         src:

--- a/_plugins/fetch_remote.rb
+++ b/_plugins/fetch_remote.rb
@@ -49,79 +49,83 @@ module Jekyll
       puts "Starting plugin fetch_remote.rb..."
       site.config['fetch-remote'].each do |entry|
         puts "  Repo #{entry['repo']} (#{entry['ref']})"
-        Dir.mktmpdir do |tmpdir|
-          tmpfile = FetchRemote.download("#{entry['repo']}/archive/#{entry['ref']}.zip", tmpdir)
-          Dir.mktmpdir do |ztmpdir|
-            puts "    Extracting #{tmpfile}"
-            Archive::Zip.extract(
-              tmpfile,
-              ztmpdir,
-              :create => true
-            )
-            entry['paths'].each do |path|
-              if File.extname(path['dest']) != ""
-                if path['src'].size > 1
-                  raise "Cannot use file destination #{path['dest']} with multiple sources"
-                end
-                FileUtils.mkdir_p File.dirname(path['dest'])
-              else
-                FileUtils.mkdir_p path['dest']
-              end
 
-              puts "    Copying files"
-
-              # prepare file list to be copied
-              files = FileList[]
-              path['src'].each do |src|
-                if "#{src}".start_with?("!")
-                  files.exclude(File.join(ztmpdir, "*/"+"#{src}".delete_prefix("!")))
+        if(File.exist?(entry['completion_marker']))
+          puts "    Skipping fetch as #{entry['completion_marker']} exists"
+        else
+          Dir.mktmpdir do |tmpdir|
+            tmpfile = FetchRemote.download("#{entry['repo']}/archive/#{entry['ref']}.zip", tmpdir)
+            Dir.mktmpdir do |ztmpdir|
+              puts "    Extracting #{tmpfile}"
+              Archive::Zip.extract(
+                tmpfile,
+                ztmpdir,
+                :create => true
+              )
+              entry['paths'].each do |path|
+                if File.extname(path['dest']) != ""
+                  if path['src'].size > 1
+                    raise "Cannot use file destination #{path['dest']} with multiple sources"
+                  end
+                  FileUtils.mkdir_p File.dirname(path['dest'])
                 else
-                  files.include(File.join(ztmpdir, "*/#{src}"))
+                  FileUtils.mkdir_p path['dest']
                 end
-              end
 
-              files.each do |file|
-                FetchRemote.copy(file, path['dest']) do |s, d|
-                  s = File.realpath(s)
-                  # traverse source directory
-                  FileUtils::Entry_.new(s, nil, false).wrap_traverse(proc do |ent|
-                    file_clean = ent.path.delete_prefix(ztmpdir).split("/").drop(2).join("/")
-                    destent = FileUtils::Entry_.new(d, ent.rel, false)
-                    puts "      #{file_clean} => #{destent.path}"
+                puts "    Copying files"
 
-                    if File.file?(destent.path)
-                      fmp = FrontMatterParser::Parser.parse_file(destent.path)
-                      if fmp['fetch_remote'].nil?
-                        raise "Local file #{destent.path} already exists"
+                # prepare file list to be copied
+                files = FileList[]
+                path['src'].each do |src|
+                  if "#{src}".start_with?("!")
+                    files.exclude(File.join(ztmpdir, "*/"+"#{src}".delete_prefix("!")))
+                  else
+                    files.include(File.join(ztmpdir, "*/#{src}"))
+                  end
+                end
+
+                files.each do |file|
+                  FetchRemote.copy(file, path['dest']) do |s, d|
+                    s = File.realpath(s)
+                    # traverse source directory
+                    FileUtils::Entry_.new(s, nil, false).wrap_traverse(proc do |ent|
+                      file_clean = ent.path.delete_prefix(ztmpdir).split("/").drop(2).join("/")
+                      destent = FileUtils::Entry_.new(d, ent.rel, false)
+                      puts "      #{file_clean} => #{destent.path}"
+
+                      if File.file?(destent.path)
+                        fmp = FrontMatterParser::Parser.parse_file(destent.path)
+                        if fmp['fetch_remote'].nil?
+                          raise "Local file #{destent.path} already exists"
+                        end
+                        line_start, line_end = FetchRemote.resolve_line_numbers(fmp['fetch_remote'].kind_of?(Hash) ? fmp['fetch_remote']['line_start'] : nil, fmp['fetch_remote'].kind_of?(Hash) ? fmp['fetch_remote']['line_end'] : nil)
+                        lines = File.readlines(ent.path)[line_start..line_end]
+                        File.open(destent.path, "a") { |fow| fow.puts lines.join }
+                      else
+                        ent.copy destent.path
                       end
-                      line_start, line_end = FetchRemote.resolve_line_numbers(fmp['fetch_remote'].kind_of?(Hash) ? fmp['fetch_remote']['line_start'] : nil, fmp['fetch_remote'].kind_of?(Hash) ? fmp['fetch_remote']['line_end'] : nil)
-                      lines = File.readlines(ent.path)[line_start..line_end]
-                      File.open(destent.path, "a") { |fow| fow.puts lines.join }
-                    else
-                      ent.copy destent.path
-                    end
 
-                    next unless File.file?(ent.path) && File.extname(ent.path) == ".md"
-                    # set edit and issue url and remote info for markdown files in site config defaults
-                    edit_url = "#{entry['repo']}/edit/#{entry['default_branch']}/#{file_clean}"
-                    issue_url = "#{entry['repo']}/issues/new?body=File: [#{file_clean}](https://docs.docker.com/#{destent.path.sub(/#{File.extname(destent.path)}$/, '')}/)"
-                    puts "        edit_url:  #{edit_url}"
-                    puts "        issue_url: #{issue_url}"
-                    site.config['defaults'] << {
-                      "scope" => { "path" => destent.path },
-                      "values" => {
-                        "edit_url" => edit_url,
-                        "issue_url" => issue_url
-                      },
-                    }
-                  end, proc do |_| end)
+                      next unless File.file?(ent.path) && File.extname(ent.path) == ".md"
+                      # set edit and issue url and remote info for markdown files in site config defaults
+                      edit_url = "#{entry['repo']}/edit/#{entry['default_branch']}/#{file_clean}"
+                      issue_url = "#{entry['repo']}/issues/new?body=File: [#{file_clean}](https://docs.docker.com/#{destent.path.sub(/#{File.extname(destent.path)}$/, '')}/)"
+                      puts "        edit_url:  #{edit_url}"
+                      puts "        issue_url: #{issue_url}"
+                      site.config['defaults'] << {
+                        "scope" => { "path" => destent.path },
+                        "values" => {
+                          "edit_url" => edit_url,
+                          "issue_url" => issue_url
+                        },
+                      }
+                    end, proc do |_| end)
+                  end
                 end
               end
             end
           end
         end
       end
-
       end_time = Time.now
       puts "done in #{(end_time - beginning_time)} seconds"
     end

--- a/_plugins/fix_urls.rb
+++ b/_plugins/fix_urls.rb
@@ -9,10 +9,14 @@ module Jekyll
 
       Jekyll.logger.info "  Fixing up URLs in swagger files"
       Dir.glob(%w[./docker-hub/api/*.yaml ./engine/api/*.yaml]) do |file_name|
-        Jekyll.logger.info "    #{file_name}"
         text = File.read(file_name)
         replace = text.gsub("https://docs.docker.com", "")
-        File.open(file_name, "w") { |file| file.puts replace }
+        if text == replace
+          Jekyll.logger.info "    #{file_name} (skipped - no change)"
+        else
+          Jekyll.logger.info "    #{file_name}"
+          File.open(file_name, "w") { |file| file.puts replace }
+        end
       end
 
       end_time = Time.now

--- a/_plugins/update_api_toc.rb
+++ b/_plugins/update_api_toc.rb
@@ -13,8 +13,10 @@ module Jekyll
         engine_ver = site.config['latest_engine_api_version']
         toc_file = File.read("_data/toc.yaml")
         replace = toc_file.gsub!("{{ site.latest_engine_api_version }}", engine_ver)
-        Jekyll.logger.info "  Replacing '{{ site.latest_engine_api_version }}' with #{engine_ver} in _data/toc.yaml"
-        File.open("_data/toc.yaml", "w") { |file| file.puts replace }
+        if toc_file != replace
+          Jekyll.logger.info "  Replacing '{{ site.latest_engine_api_version }}' with #{engine_ver} in _data/toc.yaml"
+          File.open("_data/toc.yaml", "w") { |file| file.puts replace }
+        end
       end
 
       end_time = Time.now

--- a/dev-start.sh
+++ b/dev-start.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+if [ "$JEKYLL_ENV" == "production" ]; then
+  echo "Starting in production mode"
+  exec bundle exec jekyll serve --host=0.0.0.0 -l --config _config.yml,_config_production.yml
+else
+  exec bundle exec jekyll serve --host=0.0.0.0 -l 
+fi

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,10 @@ services:
       args:
         - JEKYLL_ENV
       context: .
+      target: dev
     image: docs/docstage
     ports:
-     - "4000:4000"
+      - 4000:4000
+      - 35729:35729
+    volumes:
+      - ./:/src


### PR DESCRIPTION
### Proposed changes

After playing around with some docs changes, I was getting tired of having to rebuild and restart my containers every time I made a change. So, I decided to take a look at how to fix this. After all, it is a Jekyll project so we _should_ be able to use `jekyll serve`, right?

- Update our custom plugins to not produce file changes if nothing is being changed. Otherwise, we get in a constant file update loop
    - For the fetch_remote plugin, I added a `completion_marker` config option that serves as a filepath to determine if the fetch has already occurred. This prevents resource download from occurring on every file change.
- Add a new `dev` stage to the Dockerfile that starts jekyll serve. It uses a new `dev-start.sh` script to still support the production test use case (which adds the production config file)
- Update the `docker-compose.yaml` file to target this new `dev` stage and expose the livereload port

### Related issues (optional)

None