### PR TITLE
Update 05_persisting_data.md

### DIFF
--- a/get-started/05_persisting_data.md
+++ b/get-started/05_persisting_data.md
@@ -45,7 +45,12 @@ What you'll see is that the files created in one container aren't available in a
     ```console
     $ docker exec <container-id> cat /data.txt
     ```
+    
+    Windows bash users add second /
 
+    ```console
+    $ docker exec <container-id> cat //data.txt
+    ```
     You should see a random number!
 
 3. Now, let's start another `ubuntu` container (the same image) and we'll see we don't have the same
@@ -53,6 +58,11 @@ What you'll see is that the files created in one container aren't available in a
 
     ```console
     $ docker run -it ubuntu ls /
+    ```
+    Windows bash users add second /
+    
+    ```console
+    $ docker run -it ubuntu ls //
     ```
 
     And look! There's no `data.txt` file there! That's because it was written to the scratch space for


### PR DESCRIPTION
Windows bash users need to add a second `/` to the path or they will get the error `cat: 'C:/Program Files/Git/data.txt': No such file or directory` and `ls: cannot access 'C:/Program Files/Git/': No such file or directory`

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.-->

### Proposed changes

<!--Tell us what you did and why-->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
