### PR TITLE
Update Linux instructions for Docker & Prometheus

### DIFF
--- a/config/daemon/prometheus.md
+++ b/config/daemon/prometheus.md
@@ -42,7 +42,7 @@ If the file is currently empty, paste the following:
 
 ```json
 {
-  "metrics-addr" : "127.0.0.1:9323",
+  "metrics-addr" : "0.0.0.0:9323",
   "experimental" : true
 }
 ```
@@ -109,7 +109,7 @@ scrape_configs:
          # scheme defaults to 'http'.
 
     static_configs:
-      - targets: ['localhost:9323']
+      - targets: ['host.docker.internal:9323']
 ```
 
 </div><!-- linux -->
@@ -212,6 +212,7 @@ Next, start a single-replica Prometheus service using this configuration.
 $ docker service create --replicas 1 --name my-prometheus \
     --mount type=bind,source=/tmp/prometheus.yml,destination=/etc/prometheus/prometheus.yml \
     --publish published=9090,target=9090,protocol=tcp \
+    --host host.docker.internal:host-gateway \
     prom/prometheus
 ```
 


### PR DESCRIPTION
The instructions for Linux do not work. Prometheus running in the container cannot access docker metrics on the host machine using `localhost:9323`, as localhost refers to the container itself.

Using Docker v 20.10 or greater, `host.docker.internal` will reference the host machine when `host.docker.internal:host-gateway` is passed in as a host mapping.

The only thing that needs to be checked is if using `0.0.0.0:9323` for `metrics_addr` will work for Windows and Mac platforms as well. I found that using `localhost:9323` and `127.0.0.1:9323` did not work on Linux.

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.-->

### Proposed changes

<!--Tell us what you did and why-->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
