### PR TITLE
mark explicitly published port as string to avoid user confusion

### DIFF
--- a/compose/cli-command-compatibility.md
+++ b/compose/cli-command-compatibility.md
@@ -54,7 +54,7 @@ services:
     ports:
     - mode: ingress
       target: 80
-      published: 80
+      published: "80"
       protocol: tcp
 networks:
   default:


### PR DESCRIPTION
Signed-off-by: Guillaume Lours <guillaume.lours@docker.com>

### Proposed changes
As string can be unquoted in Yaml, our example may confused user and let them assume that the `ports.published` attribut can be an integer. 

I explicitly wrapped the value with quotes to remove ambiguity 

### Related issues (optional)
https://github.com/docker/compose/issues/9306