### PR TITLE
Replace docker/desktop-reclaim-space that doesn't work on Apple Silicon

### DIFF
--- a/desktop/faqs/macfaqs.md
+++ b/desktop/faqs/macfaqs.md
@@ -93,7 +93,7 @@ It might take a few minutes to reclaim space on the host depending on the format
 Space is only freed when images are deleted. Space is not freed automatically when files are deleted inside running containers. To trigger a space reclamation at any point, run the command:
 
 ```console
-$ docker run --privileged --pid=host docker/desktop-reclaim-space
+$ docker run -it --rm --privileged --pid=host justincormack/nsenter1 /sbin/fstrim -v /var/lib/docker
 ```
 
 Note that many tools report the maximum file size, not the actual file size.


### PR DESCRIPTION
### Proposed changes

I purpose to replace the docker/desktop-reclaim-space that doesn't work on Apple Silicon.
Instead of a custom build image, I use the nsenter image from justincormack and use the full command:
```
docker run -it --rm --privileged --pid=host justincormack/nsenter1 /sbin/fstrim -v /var/lib/docker
```

### Related issues (optional)

Resolve https://github.com/samoshkin/docker-reclaim-disk-space/issues/1