### PR TITLE
Clarify bind-mount obscuring of non-empty directories in container

### DIFF
--- a/storage/bind-mounts.md
+++ b/storage/bind-mounts.md
@@ -158,7 +158,7 @@ $ docker container rm devtest
 
 ### Mount into a non-empty directory on the container
 
-If you bind-mount into a non-empty directory on the container, the directory's
+If you bind-mount a directory into a non-empty directory on the container, the directory's
 existing contents are obscured by the bind mount. This can be beneficial,
 such as when you want to test a new version of your application without
 building a new image. However, it can also be surprising and this behavior


### PR DESCRIPTION
The current wording implies that ANY bind mount into a non-empty directory will obscure the files in that directory, but while that's true of bind mounting a directory, it's not true if bind-mounting a single file (from my testing, in a linux container running Docker Desktop for Windows).

I simply added that minor (but important) clarification of "a directory".

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.-->

### Proposed changes

<!--Tell us what you did and why-->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
