### PR TITLE
Fix documentation command to install .deb package

### DIFF
--- a/desktop/install/ubuntu.md
+++ b/desktop/install/ubuntu.md
@@ -54,7 +54,7 @@ Recommended approach to install Docker Desktop on Ubuntu:
 
 ```console
 $ sudo apt-get update
-$ sudo apt-get install ./docker-desktop-<version>-<arch>.deb
+$ sudo dpkg -i ./docker-desktop-<version>-<arch>.deb
 ```
 
 > **Note**


### PR DESCRIPTION
<!--We’d like to make it as easy as possible for you to contribute to the Docker documentation repository. Before you submit the pull request, we recommend that you review the [Contribution guidelines](/contribute/overview.md). Remove these comments as you go.-->

### Proposed changes
The command to install .deb packages is wrong
