### PR TITLE
jekyll: set liquid error mode to strict

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -24,6 +24,10 @@ kramdown:
   syntax_highlighter: rouge
   toc_levels: 2..3
 
+# https://jekyllrb.com/docs/configuration/liquid/
+liquid:
+  error_mode: strict
+
 exclude:
   - _releaser
   - _samples

--- a/_includes/cli.md
+++ b/_includes/cli.md
@@ -133,7 +133,8 @@ For example uses of this command, refer to the [examples section](#examples) bel
   {%- endif -%}
   {% capture flag-orchestrator %}{% if option.swarm %}<span class="badge badge-info" data-toggle="tooltip" title="This option works for the Swarm orchestrator.">Swarm</span>{% endif %}{% if option.kubernetes %}<span class="badge badge-info" data-toggle="tooltip" title="This option works for the Kubernetes orchestrator.">Kubernetes</span>{% endif %}{% endcapture %}
   {% capture all-badges %}{{ deprecated-badge }}{{ experimental-daemon-badge }}{{ experimental-cli-badge }}{{ min-api }}{{ flag-orchestrator }}{% endcapture %}
-  {% assign defaults-to-skip = "[],map[],false,0,0s,default,'',\"\"" | split: ',' %}
+  {% capture defaults-to-skip-str %}[],map[],false,0,0s,default,'',""{% endcapture %}
+  {% capture defaults-to-skip %}{{ defaults-to-skip-str | split: ',' }}{% endcapture %}
   {% capture option-default %}{% if option.default_value %}{% unless defaults-to-skip contains option.default_value or defaults-to-skip == blank %}`{{ option.default_value }}`{% endunless %}{% endif %}{% endcapture %}
   <tr>
     {% if option.details_url and option.details_url != '' -%}

--- a/compose/install/uninstall.md
+++ b/compose/install/uninstall.md
@@ -57,6 +57,8 @@ $ rm /usr/local/lib/docker/cli-plugins/docker-compose
 
 To check where Compose is installed, use:
 
+{% raw %}
 ```console
 $ docker info --format '{{range .ClientInfo.Plugins}}{{if eq .Name "compose"}}{{.Path}}{{end}}{{end}}'
 ```
+{% endraw %}


### PR DESCRIPTION
While working on another PR I found out there are liquid warnings introduced by https://github.com/docker/docker.github.io/pull/15494 in the logs: https://github.com/docker/docker.github.io/runs/8288660605?check_suite_focus=true#step:4:491

```
#15 44.17     Liquid Warning: Liquid syntax error (line 59): Expected end_of_string but found id in "{{if eq .Name "compose"}}" in compose/install/uninstall.md
#15 44.17     Liquid Warning: Liquid syntax error (line 59): [:dot, "."] is not a valid expression in "{{.Path}}" in compose/install/uninstall.md
```

Looking at this page https://docs.docker.com/compose/install/uninstall/#inspect-the-location-of-the-compose-cli-plugin, format is indeed broken:

![image](https://user-images.githubusercontent.com/1951866/189524168-e06edfc1-abf6-47d1-94f6-93c511e3787f.png)

To avoid this kind of issues in the future, sets Liquid error mode to strict.

Also got the following issue while enabling new error mode for Liquid:

```
#16 17.79   Liquid Exception: Liquid syntax error (/src/_includes/cli.md line 136): Unexpected character \ in "{{'[],map[],false,0,0s,default,\'\',""' | split: ',' }}" in engine/reference/commandline/app.md
#16 17.79                     ------------------------------------------------
#16 17.79       Jekyll 4.2.2   Please append `--trace` to the `build` command
#16 17.79                      for any additional information or backtrace.
#16 17.79                     ------------------------------------------------
```

This is fixed with last commit by using `capture` instead of `assign`.