### PR TITLE
Update versions of actions used in the workflow

### DIFF
--- a/ci-cd/github-actions.md
+++ b/ci-cd/github-actions.md
@@ -109,19 +109,19 @@ BuildKit container under the hood.
     steps:
       -
         name: Checkout 
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       -
         name: Login to Docker Hub
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
       -
         name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
       -
         name: Build and push
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           context: .
           file: ./Dockerfile
@@ -150,13 +150,13 @@ step:
 ```yaml
       -
         name: Login to Docker Hub
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
       -
         name: Build and push
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           context: ./
           file: ./Dockerfile
@@ -243,7 +243,7 @@ Now let's change the Docker Hub login with the GitHub Container Registry one:
 {% raw %}
 ```yaml
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           registry: ghcr.io
           username: ${{ github.actor }}


### PR DESCRIPTION
### Proposed changes

In the [page about GitHub Actions Docker workflow](https://docs.docker.com/ci-cd/github-actions/), update versions of actions used.

For reference, here are the links to the actions themselves:
- [`actions/checkout`](https://github.com/actions/checkout)
- [`docker/login-action`](https://github.com/docker/login-action)
- [`docker/setup-buildx-action`](https://github.com/docker/setup-buildx-action)
- [`docker/build-push-action`](https://github.com/docker/build-push-action)
