### PR TITLE
Update ubuntu.md

### DIFF
--- a/engine/install/ubuntu.md
+++ b/engine/install/ubuntu.md
@@ -120,7 +120,7 @@ from the repository.
 
     ```console
     $ sudo apt-get update
-    $ sudo apt-get install docker-ce docker-ce-cli containerd.io docker-compose-plugin
+    $ sudo apt-get install containerd.io docker-ce docker-ce-cli docker-compose-plugin
     ```
 
     > Receiving a GPG error when running `apt-get update`?


### PR DESCRIPTION
Change the install order to make the docker service start during docker-ce installation

### Proposed changes

Changed the install order of Ubuntu apt packages to make the docker systemctl service start during installation of docker-ce.
Tested on Ubuntu 22.04