### PR TITLE
fix: incorrect default edit URL

### DIFF
--- a/_layouts/docs.html
+++ b/_layouts/docs.html
@@ -3,7 +3,7 @@
 {%- if page.edit_url -%}
     {%- assign edit_url = page.edit_url -%}
 {%- else -%}
-    {% capture edit_url %}{{ site.repo }}/edit/edit/master/{{ page.path }}{% endcapture %}
+    {% capture edit_url %}{{ site.repo }}/edit/master/{{ page.path }}{% endcapture %}
 {%- endif -%}
 {%- if page.issue_url -%}
     {%- assign issue_url = page.issue_url -%}


### PR DESCRIPTION
### Proposed changes
Fix the default edit URL after the repo rename.

The current URL includes the `/edit` path component twice, resulting in a 404.

### Related issues (optional)
Introduced in: #15774
