### PR TITLE
Remove redirects for samples

### DIFF
--- a/_samples/library/adminer.md
+++ b/_samples/library/adminer.md
@@ -1,5 +1,3 @@
 ---
 redirect_to: https://hub.docker.com/_/adminer/
-redirect_from:
-- /samples/adminer/
 ---

--- a/_samples/library/elasticsearch.md
+++ b/_samples/library/elasticsearch.md
@@ -1,5 +1,3 @@
 ---
 redirect_to: https://hub.docker.com/_/elasticsearch/
-redirect_from:
-- /samples/elasticsearch/
 ---

--- a/_samples/library/mariadb.md
+++ b/_samples/library/mariadb.md
@@ -1,5 +1,3 @@
 ---
 redirect_to: https://hub.docker.com/_/mariadb/
-redirect_from:
-- /samples/mariadb/
 ---

--- a/_samples/library/mysql.md
+++ b/_samples/library/mysql.md
@@ -1,5 +1,3 @@
 ---
 redirect_to: https://hub.docker.com/_/mysql/
-redirect_from:
-- /samples/mysql/
 ---

--- a/_samples/library/nextcloud.md
+++ b/_samples/library/nextcloud.md
@@ -1,5 +1,3 @@
 ---
 redirect_to: https://hub.docker.com/_/nextcloud/
-redirect_from:
-- /samples/nextcloud/
 ---

--- a/_samples/library/nginx.md
+++ b/_samples/library/nginx.md
@@ -1,5 +1,3 @@
 ---
 redirect_to: https://hub.docker.com/_/nginx/
-redirect_from:
-- /samples/nginx/
 ---

--- a/_samples/library/php.md
+++ b/_samples/library/php.md
@@ -1,5 +1,3 @@
 ---
 redirect_to: https://hub.docker.com/_/php/
-redirect_from:
-- /samples/php/
 ---

--- a/_samples/library/postgres.md
+++ b/_samples/library/postgres.md
@@ -1,5 +1,3 @@
 ---
 redirect_to: https://hub.docker.com/_/postgres/
-redirect_from:
-- /samples/postgres/
 ---

--- a/_samples/library/python.md
+++ b/_samples/library/python.md
@@ -1,5 +1,3 @@
 ---
 redirect_to: https://hub.docker.com/_/python/
-redirect_from:
-- /samples/python/
 ---

--- a/_samples/library/redis.md
+++ b/_samples/library/redis.md
@@ -1,5 +1,3 @@
 ---
 redirect_to: https://hub.docker.com/_/redis/
-redirect_from:
-- /samples/redis/
 ---

--- a/_samples/library/rust.md
+++ b/_samples/library/rust.md
@@ -1,5 +1,3 @@
 ---
 redirect_to: https://hub.docker.com/_/rust/
-redirect_from:
-- /samples/rust/
 ---

--- a/_samples/library/traefik.md
+++ b/_samples/library/traefik.md
@@ -1,5 +1,3 @@
 ---
 redirect_to: https://hub.docker.com/_/traefik/
-redirect_from:
-- /samples/traefik/
 ---


### PR DESCRIPTION
### Proposed changes
New samples pages were added but some paths had old redirects.
This removes redirects for the new samples pages that have been added.
