### PR TITLE
create-invalidation retries

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -120,6 +120,7 @@ jobs:
           aws cloudfront create-invalidation --distribution-id ${{ env.DOCS_CLOUDFRONT_ID }} --paths "/*"
         env:
           AWS_REGION: us-east-1 # cloudfront is only available in us-east-1 region
+          AWS_MAX_ATTEMPTS: 5
       -
         name: Send Slack notification
         if: ${{ env.SEND_SLACK_MSG == 'true' }}


### PR DESCRIPTION
Sometimes, we encounter that a step in the publish workflow fails when trying to invalidate files on CloudFront.

https://github.com/docker/docs/actions/runs/3159034042/jobs/5141759854#step:10:24

```
An error occurred (ServiceUnavailable) when calling the CreateInvalidation operation (reached max retries: 2): CloudFront encountered an internal error. Please try again.
Error: Process completed with exit code 254.
```

[AWS docs][1] suggest that we can set the AWS_MAX_RETRIES variable to increase the number of retries (which currently seems to be 2, judging from the error message.)

[1]: https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-retries.html#cli-usage-retries-configure