### PR TITLE
Fix typo and remove redundant phrasing in awslogs.md

### DIFF
--- a/config/containers/logging/awslogs.md
+++ b/config/containers/logging/awslogs.md
@@ -223,10 +223,8 @@ This option is ignored if `awslogs-datetime-format` is also configured.
 > Multiline logging performs regular expression parsing and matching of all log
 > messages. This may have a negative impact on logging performance.
 
-For example, to process the following log stream where new log messages start with the pattern `INFO`:
-
 Consider the following log stream, where each log message should start with the
-patther `INFO`:
+pattern `INFO`:
 
 ```console
 INFO A message was logged


### PR DESCRIPTION
* patther -> pattern
* Removed line which was redundant phrasing. (Now inline with multiline timestamp example)

Signed-off-by: Austin Vazquez <macedonv@amazon.com>

### Proposed changes

Fixed a typo in awslogs.md and removed a line which was redundant phrasing.
