### PR TITLE
Included an easy way to clone the app directory

### DIFF
--- a/get-started/02_our_app.md
+++ b/get-started/02_our_app.md
@@ -24,7 +24,7 @@ Before we can run the application, we need to get the application source code on
 our machine. For real projects, you will typically clone the repo. But, for this tutorial,
 we have created a ZIP file containing the application.
 
-1. Download the App contents from the [getting-started repository](https://github.com/docker/getting-started/tree/master){:target="_blank" rel="noopener" class="_"}. You can either pull the entire project or [download it as a zip](https://github.com/docker/getting-started/archive/refs/heads/master.zip) and extract the app folder out to get started with.
+1. Download the App contents from the [getting-started repository](https://github.com/docker/getting-started/tree/master){:target="_blank" rel="noopener" class="_"}. You can either pull the entire project, use [degit](https://www.npmjs.com/package/degit) to clone the app directory (`npx degit https://github.com/docker/getting-started/app`) or [download it as a zip](https://github.com/docker/getting-started/archive/refs/heads/master.zip) and extract the app folder out to get started with.
 
 2. Once extracted, use your favorite code editor to open the project. If you're in need of
     an editor, you can use [Visual Studio Code](https://code.visualstudio.com/){:target="_blank" rel="noopener" class="_"}. You should


### PR DESCRIPTION
I included a line that describes how to use degit to clone the app directory in the getting started repo.

<!--We’d like to make it as easy as possible for you to contribute to the Docker documentation repository. Before you submit the pull request, we recommend that you review the [Contribution guidelines](/contribute/overview.md). Remove these comments as you go.-->

### Proposed changes

Use degit to clone the app directory from the getting-started repo. I did because degit has the ability to clone just the app directory without cloning the entire repo which is more intuisive.

