### PR TITLE
docs: fix typo

### DIFF
--- a/desktop/use-desktop/images.md
+++ b/desktop/use-desktop/images.md
@@ -47,7 +47,7 @@ Inspecting an image displays detailed information about the image such as the:
 - Image history
 - Image ID
 - Date the image was created
-- Size of the imag
+- Size of the image
 
 To inspect an image, hover over an image, select the **More options** button and then select **Inspect** from the dropdown menu. 
 


### PR DESCRIPTION
### Proposed changes

Fixed typo in `Explore Image` of `Explore Docker Desktop` part, closes #15834 

