### PR TITLE
Fix typo in bind-mounts.md

### DIFF
--- a/storage/bind-mounts.md
+++ b/storage/bind-mounts.md
@@ -396,7 +396,7 @@ services:
     volumes:
       - type: bind
         source: ./static
-        target: /opt/app/staticvolumes:
+        target: /opt/app/staticvolumes
   myapp:
 ```
 


### PR DESCRIPTION
### Proposed changes

A typo in the given example, under the "Use a bind mount with compose" section.




