### PR TITLE
Include support for absolute secret path

### DIFF
--- a/compose/compose-file/index.md
+++ b/compose/compose-file/index.md
@@ -1654,7 +1654,7 @@ the service's containers.
 
 - `source`: The name of the secret as it exists on the platform.
 - `target`: The name of the file to be mounted in `/run/secrets/` in the
-  service's task containers. Defaults to `source` if not specified.
+  service's task containers, or absolute path of the file if an alternate location is required.  Defaults to `source` if not specified.
 - `uid` and `gid`: The numeric UID or GID that owns the file within
   `/run/secrets/` in the service's task containers. Default value is USER running container.
 - `mode`: The [permissions](https://web.archive.org/web/20220310140126/http://permissions-calculator.org/) for the file to be mounted in `/run/secrets/`


### PR DESCRIPTION
### Proposed changes

Added a note to compose docs that absolute path can be set with secret long syntax. This has been supported by the engine for a while.

### Related issues (optional)

#4101