### PR TITLE
registry.json: show how to query file ACLs on Windows

### DIFF
--- a/_includes/configure-registry-json.md
+++ b/_includes/configure-registry-json.md
@@ -66,7 +66,19 @@ To manually create a `registry.json` file, run the following PowerShell command 
 PS>  Set-Content /ProgramData/DockerDesktop/registry.json '{"allowedOrgs":["myorg"]}'
 ```
 
-This creates the `registry.json` file at `C:\ProgramData\DockerDesktop\registry.json` and includes the organization information the user belongs to. Make sure this file can't be edited by the user, only by the administrator.
+This creates the `registry.json` file at `C:\ProgramData\DockerDesktop\registry.json` and includes the organization information the user belongs to. Make sure this file can't be edited by the user, only by the administrator:
+
+```console
+PS C:\ProgramData\DockerDesktop> Get-Acl .\registry.json
+
+
+    Directory: C:\ProgramData\DockerDesktop
+
+
+Path          Owner                  Access
+----          -----                  ------
+registry.json BUILTIN\Administrators NT AUTHORITY\SYSTEM Allow  FullControl...
+```
 
 </div>
 <div id="mac" class="tab-pane fade" markdown="1">


### PR DESCRIPTION

<!--We’d like to make it as easy as possible for you to contribute to the Docker documentation repository. Before you submit the pull request, we recommend that you review the [Contribution guidelines](/contribute/overview.md). Remove these comments as you go.-->

### Proposed changes

<!--Tell us what you did and why-->
On the `registry.json` page we described how to check the file permissions on Mac and Linux but not Windows. This patch shows how to check the ACLs on Windows.


### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
