### PR TITLE
[Issue 13140][Issue 13141] Add reminders to stop containers in Python lang-specific guide

### DIFF
--- a/language/python/develop.md
+++ b/language/python/develop.md
@@ -156,6 +156,8 @@ Now we can build our image.
 $ docker build --tag python-docker-dev .
 ```
 
+If you have any containers running from the previous sections using the name `rest-server` or port 8000, [stop](./run-containers.md/#stop-start-and-name-containers) them now.
+
 Now, let’s add the container to the database network and then run our container. This allows us to access the database by its container name.
 
 ```console
@@ -220,6 +222,8 @@ We expose port 8000 so that we can reach the dev web server inside the container
 Another really cool feature of using a Compose file is that we have service resolution set up to use the service names. Therefore, we are now able to use “mysqldb” in our connection string. The reason we use “mysqldb” is because that is what we've named our MySQL service as in the Compose file.
 
 Note that we did not specify a network for those 2 services. When we use docker-compose it automatically creates a network and connect the services to it. For more information see [Networking in Compose](../../compose/networking.md)
+
+If you have any containers running from the previous sections, [stop](./run-containers.md/#stop-start-and-name-containers) them now.
 
 Now, to start our application and to confirm that it is running properly, run the following command:
 


### PR DESCRIPTION
### Proposed changes

If trying to run a container on the same port or with the same name, users get an error.
Added reminders in the Python language-specific guide to stop containers before running new ones.

### Related issues (optional)

Fixes #13140 
Fixes #13141
