### PR TITLE
Refine a paragraph of docker ps in Go and Python

### DIFF
--- a/language/golang/run-containers.md
+++ b/language/golang/run-containers.md
@@ -88,7 +88,7 @@ Hello, Docker! <3
 
 ## List containers
 
-Since we ran our container in the background, how do we know if our container is running or what other containers are running on our machine? Well, we can run the `docker ps` command. Just like on Linux, to see a list of processes on your machine we would run the `ps` command. In the same spirit, we can run the `docker ps` command which will show us a list of containers running on our machine.
+Since we ran our container in the background, how do we know if our container is running or what other containers are running on our machine? Well, to see a list of containers running on our machine, run `docker ps`. This is similar to how ps command is used to see a list of processes on a Linux machine.
 
 ```console
 $ docker ps

--- a/language/python/run-containers.md
+++ b/language/python/run-containers.md
@@ -78,7 +78,7 @@ Hello, Docker!
 
 ## List containers
 
-Since we ran our container in the background, how do we know if our container is running or what other containers are running on our machine? Well, we can run the `docker ps` command. Just like on Linux to see a list of processes on your machine, we would run the `ps` command. In the same spirit, we can run the `docker ps` command which displays a list of containers running on our machine.
+Since we ran our container in the background, how do we know if our container is running or what other containers are running on our machine? Well, to see a list of containers running on our machine, run `docker ps`. This is similar to how ps command is used to see a list of processes on a Linux machine.
 
 ```console
 $ docker ps


### PR DESCRIPTION
### Proposed changes

I changed a paragraph about `docker ps` in Node.js tutorial (#15839). It turns out there is the exactly same paragraph in Go and Python tutorial as well, so I propose to change them as well.

By the way, Java tutorial also has a similar paragraph, but not exactly. So I didn't change it in this PR.

### Related issues (optional)

#15839
