### PR TITLE
upstream: bump distribution ref

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -178,7 +178,7 @@ fetch-remote:
 
   - repo: "https://github.com/distribution/distribution"
     default_branch: "main"
-    ref: "release/2.7"
+    ref: "main"
     paths:
       - dest: "registry/spec"
         src:


### PR DESCRIPTION
The upstream ref pointer for `distribution/distribution` was hard-coded to 2.7.

Changed the ref pointer to `main`.

Closes distribution/distribution#3750