### PR TITLE
[ENGDOCS-1048] Get started navigation

### DIFF
--- a/_data/toc.yaml
+++ b/_data/toc.yaml
@@ -29,9 +29,9 @@ guides:
   path: /get-docker/
 - sectiontitle: Get started
   section:
-    - title: "Part 1: Getting started"
+    - title: "Part 1: Orientation and setup"
       path: /get-started/
-    - title: "Part 2: Sample application"
+    - title: "Part 2: Containerize an application"
       path: /get-started/02_our_app/
     - title: "Part 3: Update the application"
       path: /get-started/03_updating_app/

--- a/get-started/02_our_app.md
+++ b/get-started/02_our_app.md
@@ -1,9 +1,9 @@
 ---
-title: "Sample application"
+title: "Containerize an application"
 keywords: get started, setup, orientation, quickstart, intro, concepts, containers, docker desktop
 redirect_from:
 - /get-started/part2/
-description: overview of our simple application for learning docker
+description: Containerize and run a simple application to learn Docker
 ---
 
 
@@ -111,10 +111,12 @@ If you take a quick look at the Docker Dashboard, you should see your two contai
 
 ![Docker Dashboard with tutorial and app containers running](images/dashboard-two-containers.png)
 
-## Recap
+## Next steps
 
-In this short section, we learned the very basics about building a container image and created a
-Dockerfile to do so. Once we built an image, we started the container and saw the running app.
+In this short section, you learned the basics about building a container image and created a
+Dockerfile to do so. Once you built an image, you started the container and saw the running app.
 
-Next, we're going to make a modification to our app and learn how to update our running application
-with a new image. Along the way, we'll learn a few other useful commands.
+Next, you're going to make a modification to your app and learn how to update your running application
+with a new image. Along the way, you'll learn a few other useful commands.
+
+[Update the application](03_updating_app.md){: .button .primary-btn}

--- a/get-started/03_updating_app.md
+++ b/get-started/03_updating_app.md
@@ -105,13 +105,15 @@ much easier than having to look up the container ID and remove it.
 ![Updated application with updated empty text](images/todo-list-updated-empty-text.png){: style="width:55%" }
 {: .text-center }
 
-## Recap
+## Next steps
 
-While we were able to build an update, there were two things you might have noticed:
+While you were able to build an update, there were two things you might have noticed:
 
-- All of the existing items in our todo list are gone! That's not a very good app! We'll talk about that
+- All of the existing items in your todo list are gone! That's not a very good app! You'll fix that
 shortly.
-- There were _a lot_ of steps involved for such a small change. In an upcoming section, we'll talk about 
-how to see code updates without needing to rebuild and start a new container every time we make a change.
+- There were a lot of steps involved for such a small change. In an upcoming section, you'll learn
+how to see code updates without needing to rebuild and start a new container every time you make a change.
 
-Before talking about persistence, we'll quickly see how to share these images with others.
+Before talking about persistence, you'll see how to share these images with others.
+
+[Sharing the application](04_sharing_app.md){: .button .primary-btn}

--- a/get-started/04_sharing_app.md
+++ b/get-started/04_sharing_app.md
@@ -94,14 +94,16 @@ new instance that has never seen this container image! To do this, we will use P
 6. Click on the 3000 badge when it comes up and you should see the app with your modifications! Hooray!
     If the 3000 badge doesn't show up, you can click on the "Open Port" button and type in 3000.
 
-## Recap
 
-In this section, we learned how to share our images by pushing them to a registry. We then went to a
+## Next steps
+
+In this section, you learned how to share your images by pushing them to a registry. You then went to a
 brand new instance and were able to run the freshly pushed image. This is quite common in CI pipelines,
 where the pipeline will create the image and push it to a registry and then the production environment
 can use the latest version of the image.
 
-Now that we have that figured out, let's circle back around to what we noticed at the end of the last
-section. As a reminder, we noticed that when we restarted the app, we lost all of our todo list items.
-That's obviously not a great user experience, so let's learn how we can persist the data across 
-restarts!
+Now you can circle back around to what you noticed at the end of the last
+section. As a reminder, you noticed that when you restarted the app, you lost all of your todo list items.
+That's obviously not a great user experience, so next you'll learn how you can persist the data across restarts!
+
+[Persist the DB](05_persisting_data.md){: .button  .primary-btn}

--- a/get-started/05_persisting_data.md
+++ b/get-started/05_persisting_data.md
@@ -156,10 +156,11 @@ need to have root access to access this directory from the host. But, that's whe
 >If you wanted to look at the actual contents of the Mountpoint directory, you would need to first get inside
 >of the VM.
 
-## Recap
+## Next steps
 
-At this point, we have a functioning application that can survive restarts! We can show it off to our investors and
-hope they can catch our vision!
+At this point, you have a functioning application that can survive restarts! You can show it off to your investors and hope they can catch your vision!
 
-However, we saw earlier that rebuilding images for every change takes quite a bit of time. There's got to be a better
-way to make changes, right? With bind mounts (which we hinted at earlier), there is a better way! Let's take a look at that now!
+However, you saw earlier that rebuilding images for every change takes quite a bit of time. There's got to be a better
+way to make changes, right? With bind mounts (which was hinted at earlier), there is a better way!
+
+[Use bind mounts](06_bind_mounts.md){: .button  .primary-btn}

--- a/get-started/06_bind_mounts.md
+++ b/get-started/06_bind_mounts.md
@@ -118,13 +118,13 @@ all of the build tools and environments installed. With a single `docker run` co
 to go. We'll talk about Docker Compose in a future step, as this will help simplify our commands (we're already getting a lot
 of flags).
 
-## Recap
+## Next steps
 
-At this point, we can persist our database and respond rapidly to the needs and demands of our investors and founders. Hooray!
-But, guess what? We received great news!
+At this point, you can persist your database and respond rapidly to the needs and demands of your investors and founders. Hooray!
+But, guess what? You received great news! Your project has been selected for future development!
 
-**Your project has been selected for future development!** 
+In order to prepare for production, you need to migrate your database from working in SQLite to something that can scale a
+little better. For simplicity, you'll keep with a relational database and switch your application to use MySQL. But, how 
+should you run MySQL? How do you allow the containers to talk to each other? You'll learn about that next!
 
-In order to prepare for production, we need to migrate our database from working in SQLite to something that can scale a
-little better. For simplicity, we'll keep with a relational database and switch our application to use MySQL. But, how 
-should we run MySQL? How do we allow the containers to talk to each other? We'll talk about that next!
+[Multi container apps](07_multi_container.md){: .button .primary-btn}

--- a/get-started/07_multi_container.md
+++ b/get-started/07_multi_container.md
@@ -281,15 +281,16 @@ no real indication that they are grouped together in a single app. We'll see how
 
 ![Docker Dashboard showing two ungrouped app containers](images/dashboard-multi-container-app.png)
 
-## Recap
+## Next steps
 
-At this point, we have an application that now stores its data in an external database running in a separate
-container. We learned a little bit about container networking and saw how service discovery can be performed
-using DNS.
+At this point, you have an application that now stores its data in an external database running in a separate
+container. You learned a little bit about container networking and service discovery using DNS.
 
 But, there's a good chance you are starting to feel a little overwhelmed with everything you need to do to start up
-this application. We have to create a network, start containers, specify all of the environment variables, expose
+this application. You have to create a network, start containers, specify all of the environment variables, expose
 ports, and more! That's a lot to remember and it's certainly making things harder to pass along to someone else.
 
-In the next section, we'll talk about Docker Compose. With Docker Compose, we can share our application stacks in a
+In the next section, you'll learn about Docker Compose. With Docker Compose, you can share your application stacks in a
 much easier way and let others spin them up with a single (and simple) command!
+
+[Use Docker Compose](08_using_compose.md){: .button  .primary-btn}

--- a/get-started/08_using_compose.md
+++ b/get-started/08_using_compose.md
@@ -352,12 +352,13 @@ for the entire app. The containers will stop and the network will be removed.
 Once torn down, you can switch to another project, run `docker compose up` and be ready to contribute to that project! It really
 doesn't get much simpler than that!
 
-## Recap
+## Next steps
 
-In this section, we learned about Docker Compose and how it helps us dramatically simplify the defining and
-sharing of multi-service applications. We created a Compose file by translating the commands we were
+In this section, you learned about Docker Compose and how it helps you dramatically simplify the defining and
+sharing of multi-service applications. You created a Compose file by translating the commands you were
 using into the appropriate compose format.
 
-At this point, we're starting to wrap up the tutorial. However, there are a few best practices about
-image building we want to cover, as there is a big issue with the Dockerfile we've been using. So,
-let's take a look!
+At this point, you're starting to wrap up the tutorial. However, there are a few best practices about
+image building you should cover, as there is a big issue with the Dockerfile you've been using. 
+
+[Image-building best practices](09_image_best.md){: .button  .primary-btn}

--- a/get-started/09_image_best.md
+++ b/get-started/09_image_best.md
@@ -275,9 +275,13 @@ COPY --from=build /app/build /usr/share/nginx/html
 Here, we are using a `node:12` image to perform the build (maximizing layer caching) and then copying the output
 into an nginx container. Cool, huh?
 
-## Recap
+## Next steps
 
-By understanding a little bit about how images are structured, we can build images faster and ship fewer changes.
-Scanning images gives us confidence that the containers we are running and distributing are secure.
-Multi-stage builds also help us reduce overall image size and increase final container security by separating
+By understanding a little bit about the structure of images, you can build images faster and ship fewer changes.
+Scanning images gives you confidence that the containers you are running and distributing are secure.
+Multi-stage builds also help you reduce overall image size and increase final container security by separating
 build-time dependencies from runtime dependencies.
+
+In the next section, you'll learn about additional resources you can use to continue learning about containers.
+
+[What next](11_what_next.md){: .button  .primary-btn}

--- a/get-started/index.md
+++ b/get-started/index.md
@@ -187,3 +187,11 @@ Refer to the following topics for further documentation on all CLI commands used
 - [docker image](../engine/reference/commandline/image.md)
 - [docker container](../engine/reference/commandline/container.md)
 
+## Next steps
+
+In this section, you installed Docker, learned about Docker, and learned about containers and images.
+
+In the next section, you'll containerize your first application.
+
+[Containerize an application](02_our_app.md){: .button  .primary-btn}
+


### PR DESCRIPTION
### Proposed changes

- Users have trouble navigating to the next topic.
   Renamed "Recap" to "Next steps" and added buttons to navigate to the next topic.
- The topic name and TOC name for `Orientation and setup` are inconsistent.
   Aligned TOC name with topic name.
- `Sample application` is not descriptive and action-oriented.
   Renamed topic to `Containerize an application`.

### Related issues (optional)

ENGDOCS-1048
