### PR TITLE
doc review: update ubuntu (and debian) installlation guides

### DIFF
--- a/.github/vale/Vocab/Industry/accept.txt
+++ b/.github/vale/Vocab/Industry/accept.txt
@@ -25,6 +25,7 @@ Kubernetes
 Lightstreamer
 Linux
 Logstash
+LTS
 Mac
 Mail(chimp|gun)
 Microsoft
@@ -38,9 +39,11 @@ Postgres
 PowerShell
 Python
 QEMU
+Raspbian
 RHEL
 S3
 SQLite
+SLES
 Slack
 Snyk
 Solr

--- a/.github/vale/Vocab/Technology/accept.txt
+++ b/.github/vale/Vocab/Technology/accept.txt
@@ -1,6 +1,7 @@
 APIs?
 Ethernet
 Git
+GPG
 HTTP
 IPs?
 IPv[46]
@@ -43,6 +44,7 @@ stdout
 subnet
 swappable
 systemd
+umask
 ungated
 virtiofs
 virtualize

--- a/_includes/install-script.md
+++ b/_includes/install-script.md
@@ -1,16 +1,17 @@
-<!-- This file is included in Docker Engine - Community or EE installation docs for Linux. -->
-
 ### Install using the convenience script
 
-Docker provides a convenience script at [get.docker.com](https://get.docker.com/)
-to install Docker into development environments quickly and non-interactively.
-The convenience script is not recommended for production environments, but can be
-used as an example to create a provisioning script that is tailored to your needs.
-Also refer to the [install using the repository](#install-using-the-repository)
-steps to learn about installation steps to install using the package repository.
-The source code for the script is open source, and can be found in the
-[`docker-install` repository on GitHub](https://github.com/docker/docker-install){:target="_blank" rel="noopener" class="_"}.
+Docker provides a convenience script at
+[https://get.docker.com/](https://get.docker.com/) to install Docker into
+development environments non-interactively. The convenience script isn't
+recommended for production environments, but it's useful for creating a
+provisioning script tailored to your needs. Also refer to the
+[install using the repository](#install-using-the-repository) steps to learn
+about installation steps to install using the package repository. The source
+code for the script is open source, and can be found in the
+[`docker-install` repository on GitHub](https://github.com/docker/docker-install){:target="_blank"
+rel="noopener" class="_"}.
 
+<!-- prettier-ignore -->
 Always examine scripts downloaded from the internet before running them locally.
 Before installing, make yourself familiar with potential risks and limitations
 of the convenience script:
@@ -18,31 +19,32 @@ of the convenience script:
 
 - The script requires `root` or `sudo` privileges to run.
 - The script attempts to detect your Linux distribution and version and
-  configure your package management system for you, and does not allow you to
-  customize most installation parameters.
+  configure your package management system for you.
+- The script doesn't allow you to customize most installation parameters.
 - The script installs dependencies and recommendations without asking for
   confirmation. This may install a large number of packages, depending on the
   current configuration of your host machine.
-- By default, the script installs the latest stable release of Docker, containerd,
-  and runc. When using this script to provision a machine, this may result in
-  unexpected major version upgrades of Docker. Always test (major) upgrades in
+- By default, the script installs the latest stable release of Docker,
+  containerd, and runc. When using this script to provision a machine, this may
+  result in unexpected major version upgrades of Docker. Always test upgrades in
   a test environment before deploying to your production systems.
-- The script is not designed to upgrade an existing Docker installation. When
+- The script isn't designed to upgrade an existing Docker installation. When
   using the script to update an existing installation, dependencies may not be
-  updated to the expected version, causing outdated versions to be used.
+  updated to the expected version, resulting in outdated versions.
 
 > Tip: preview script steps before running
 >
 > You can run the script with the `DRY_RUN=1` option to learn what steps the
-> script will execute during installation:
+> script will run when invoked:
 >
 > ```console
 > $ curl -fsSL https://get.docker.com -o get-docker.sh
 > $ DRY_RUN=1 sh ./get-docker.sh
 > ```
 
-This example downloads the script from [get.docker.com](https://get.docker.com/)
-and runs it to install the latest stable release of Docker on Linux:
+This example downloads the script from
+[https://get.docker.com/](https://get.docker.com/) and runs it to install the
+latest stable release of Docker on Linux:
 
 ```console
 $ curl -fsSL https://get.docker.com -o get-docker.sh
@@ -51,41 +53,42 @@ Executing docker install script, commit: 7cae5f8b0decc17d6571f9f52eb840fbc13b273
 <...>
 ```
 
-Docker is installed. The `docker` service starts automatically on Debian based
-distributions. On `RPM` based distributions, such as CentOS, Fedora, RHEL or SLES,
-you need to start it manually using the appropriate `systemctl` or `service` command.
-As the message indicates, non-root users cannot run Docker commands by default.
+You have now successfully installed and started Docker Engine. The `docker`
+service starts automatically on Debian based distributions. On `RPM` based
+distributions, such as CentOS, Fedora, RHEL or SLES, you need to start it
+manually using the appropriate `systemctl` or `service` command. As the message
+indicates, non-root users can't run Docker commands by default.
 
 > **Use Docker as a non-privileged user, or install in rootless mode?**
 >
 > The installation script requires `root` or `sudo` privileges to install and
 > use Docker. If you want to grant non-root users access to Docker, refer to the
 > [post-installation steps for Linux](/engine/install/linux-postinstall/#manage-docker-as-a-non-root-user).
-> Docker can also be installed without `root` privileges, or configured to run
-> in rootless mode. For instructions on running Docker in rootless mode, refer to
+> You can also install Docker without `root` privileges, or configured to run in
+> rootless mode. For instructions on running Docker in rootless mode, refer to
 > [run the Docker daemon as a non-root user (rootless mode)](/engine/security/rootless/).
 
 #### Install pre-releases
 
-Docker also provides a convenience script at [test.docker.com](https://test.docker.com/)
-to install pre-releases of Docker on Linux. This script is equivalent to the
-script at `get.docker.com`, but configures your package manager to enable the
-"test" channel from our package repository, which includes both stable and
-pre-releases (beta versions, release-candidates) of Docker. Use this script to
-get early access to new releases, and to evaluate them in a testing environment
-before they are released as stable.
+Docker also provides a convenience script at
+[https://test.docker.com/](https://test.docker.com/) to install pre-releases of
+Docker on Linux. This script is equal to the script at `get.docker.com`, but
+configures your package manager to use the test channel of the Docker package
+repository. The test channel includes both stable and pre-releases (beta
+versions, release-candidates) of Docker. Use this script to get early access to
+new releases, and to evaluate them in a testing environment before they're
+released as stable.
 
-To install the latest version of Docker on Linux from the "test" channel, run:
+To install the latest version of Docker on Linux from the test channel, run:
 
 ```console
 $ curl -fsSL https://test.docker.com -o test-docker.sh
 $ sudo sh test-docker.sh
-<...>
 ```
 
 #### Upgrade Docker after using the convenience script
 
 If you installed Docker using the convenience script, you should upgrade Docker
-using your package manager directly. There is no advantage to re-running the
-convenience script, and it can cause issues if it attempts to re-add
-repositories which have already been added to the host machine.
+using your package manager directly. There's no advantage to re-running the
+convenience script. Re-running it can cause issues if it attempts to re-install
+repositories which already exist on the host machine.

--- a/_includes/install-script.md
+++ b/_includes/install-script.md
@@ -39,7 +39,7 @@ of the convenience script:
 >
 > ```console
 > $ curl -fsSL https://get.docker.com -o get-docker.sh
-> $ DRY_RUN=1 sh ./get-docker.sh
+> $ DRY_RUN=1 sudo sh ./get-docker.sh
 > ```
 
 This example downloads the script from

--- a/engine/install/debian.md
+++ b/engine/install/debian.md
@@ -179,7 +179,6 @@ Raspbian.
    `hello-world` image:
 
    ```console
-   $ sudo service docker start
    $ sudo docker run hello-world
    ```
 

--- a/engine/install/debian.md
+++ b/engine/install/debian.md
@@ -59,11 +59,10 @@ You can install Docker Engine in different ways, depending on your needs:
 - You can also set up and install Docker Engine from
   [Docker's `apt` repository](#install-using-the-repository).
 
-- [Install it manually](#install-from-a-package) and manage upgrades completely
-  manually.
+- [Install it manually](#install-from-a-package) and manage upgrades manually.
 
-- Using a [convenience scripts](#install-using-the-convenience-script) (only
-  recommended for testing and development environments). This is the only
+- Using a [convenience scripts](#install-using-the-convenience-script). Only
+  recommended for testing and development environments. This is the only
   approach available for Raspbian.
 
 ### Install using the repository
@@ -72,7 +71,7 @@ Before you install Docker Engine for the first time on a new host machine, you
 need to set up the Docker repository. Afterward, you can install and update
 Docker from the repository.
 
-> **Raspbian users can't use this method!**
+> **Raspbian users can't use this method.**
 >
 > For Raspbian, installing using the repository isn't yet supported. You must
 > instead use the [convenience script](#install-using-the-convenience-script).
@@ -160,8 +159,8 @@ Raspbian.
 
    5:18.09.1~3-0~debian-stretch
    5:18.09.0~3-0~debian-stretch
-   18.06.1~ce~3-0~debian       
-   18.06.0~ce~3-0~debian       
+   18.06.1~ce~3-0~debian
+   18.06.0~ce~3-0~debian
    ```
 
    Select the desired version and install:
@@ -175,7 +174,7 @@ Raspbian.
    <hr>
    </div>
 
-3. Verify that the Docker Engine installation was successful by running the
+3. Verify that the Docker Engine installation is successful by running the
    `hello-world` image:
 
    ```console
@@ -231,7 +230,7 @@ download a new file each time you want to upgrade Docker Engine.
 
    The Docker daemon starts automatically.
 
-6. Verify that the Docker Engine installation was successful by running the
+6. Verify that the Docker Engine installation is successful by running the
    `hello-world` image:
 
    ```console

--- a/engine/install/debian.md
+++ b/engine/install/debian.md
@@ -1,12 +1,13 @@
 ---
 description: Instructions for installing Docker Engine on Debian
-keywords: requirements, apt, installation, debian, install, uninstall, upgrade, update
+keywords:
+  requirements, apt, installation, debian, install, uninstall, upgrade, update
 redirect_from:
-- /engine/installation/debian/
-- /engine/installation/linux/raspbian/
-- /engine/installation/linux/debian/
-- /engine/installation/linux/docker-ce/debian/
-- /install/linux/docker-ce/debian/
+  - /engine/installation/debian/
+  - /engine/installation/linux/raspbian/
+  - /engine/installation/linux/debian/
+  - /engine/installation/linux/docker-ce/debian/
+  - /install/linux/docker-ce/debian/
 title: Install Docker Engine on Debian
 toc_max: 4
 ---
@@ -27,12 +28,14 @@ Raspbian versions:
 - Raspbian Bullseye 11 (stable)
 - Raspbian Buster 10 (oldstable)
 
-Docker Engine is supported on `x86_64` (or `amd64`), `armhf`, and `arm64` architectures.
+Docker Engine is compatible with `x86_64` (or `amd64`), `armhf`, and `arm64`
+architectures.
 
 ### Uninstall old versions
 
-Older versions of Docker were called `docker`, `docker.io`, or `docker-engine`.
-If these are installed, uninstall them:
+Older versions of Docker went by the names of `docker`, `docker.io`, or
+`docker-engine`. Uninstall any such older versions before attempting to install
+a new version:
 
 ```console
 $ sudo apt-get remove docker docker-engine docker.io containerd runc
@@ -40,38 +43,38 @@ $ sudo apt-get remove docker docker-engine docker.io containerd runc
 
 It's OK if `apt-get` reports that none of these packages are installed.
 
-The contents of `/var/lib/docker/`, including images, containers, volumes, and
-networks, are preserved. If you do not need to save your existing data, and want to
-start with a clean installation, refer to the [uninstall Docker Engine](#uninstall-docker-engine)
-section at the bottom of this page.
+Images, containers, volumes, and networks stored in `/var/lib/docker/` aren't
+automatically removed when you uninstall Docker. If you want to start with a
+clean installation, and prefer to clean up any existing data, refer to the
+[uninstall Docker Engine](#uninstall-docker-engine) section.
 
 ## Installation methods
 
 You can install Docker Engine in different ways, depending on your needs:
 
-- Most users
-  [set up Docker's repositories](#install-using-the-repository) and install
-  from them, for ease of installation and upgrade tasks. This is the
-  recommended approach, except for Raspbian.
+- Docker Engine comes bundled with
+  [Docker Desktop for Linux](../../desktop/install/linux-install.md). This is
+  the easiest and quickest way to get started.
 
-- Some users download the DEB package and
-  [install it manually](#install-from-a-package) and manage
-  upgrades completely manually. This is useful in situations such as installing
-  Docker on air-gapped systems with no access to the internet.
+- You can also set up and install Docker Engine from
+  [Docker's `apt` repository](#install-using-the-repository).
 
-- In testing and development environments, some users choose to use automated
-  [convenience scripts](#install-using-the-convenience-script) to install Docker.
-  This is currently the only approach for Raspbian.
+- [Install it manually](#install-from-a-package) and manage upgrades completely
+  manually.
+
+- Using a [convenience scripts](#install-using-the-convenience-script) (only
+  recommended for testing and development environments). This is the only
+  approach available for Raspbian.
 
 ### Install using the repository
 
-Before you install Docker Engine for the first time on a new host machine, you need
-to set up the Docker repository. Afterward, you can install and update Docker
-from the repository.
+Before you install Docker Engine for the first time on a new host machine, you
+need to set up the Docker repository. Afterward, you can install and update
+Docker from the repository.
 
-> **Raspbian users cannot use this method!**
+> **Raspbian users can't use this method!**
 >
-> For Raspbian, installing using the repository is not yet supported. You must
+> For Raspbian, installing using the repository isn't yet supported. You must
 > instead use the [convenience script](#install-using-the-convenience-script).
 
 #### Set up the repository
@@ -108,99 +111,143 @@ from the repository.
 
 #### Install Docker Engine
 
-This procedure works for Debian on `x86_64` / `amd64`, `armhf`, `arm64`, and Raspbian.
+This procedure works for Debian on `x86_64` / `amd64`, `armhf`, `arm64`, and
+Raspbian.
 
-1. Update the `apt` package index, and install the _latest version_ of Docker
-   Engine, containerd, and Docker Compose, or go to the next step to install a specific version:
+1. Update the `apt` package index:
 
-    ```console
-    $ sudo apt-get update
+   ```console
+   $ sudo apt-get update
+   ```
+
+   > Receiving a GPG error when running `apt-get update`?
+   >
+   > Your default [umask](https://en.wikipedia.org/wiki/Umask){: target="blank"
+   > rel="noopener" } may be incorrectly configured, preventing detection of the
+   > repository public key file. Try granting read permission for the Docker
+   > public key file before updating the package index:
+   >
+   > ```console
+   > $ sudo chmod a+r /etc/apt/keyrings/docker.gpg
+   > $ sudo apt-get update
+   > ```
+
+2. Install Docker Engine, containerd, and Docker Compose.
+
+   <ul class="nav nav-tabs">
+    <li class="active"><a data-toggle="tab" data-target="#tab-latest">Latest</a></li>
+    <li><a data-toggle="tab" data-target="#tab-version">Specific version</a></li>
+   </ul>
+   <div class="tab-content">
+   <br>
+   <div id="tab-latest" class="tab-pane fade in active" markdown="1">
+
+   To install the latest version, run:
+
+   ```console
     $ sudo apt-get install docker-ce docker-ce-cli containerd.io docker-compose-plugin
-    ```
+   ```
 
-    > Receiving a GPG error when running `apt-get update`?
-    >  
-    > Your default umask may not be set correctly, causing the public key file
-    > for the repo to not be detected. Run the following command and then try to
-    > update your repo again: `sudo chmod a+r /etc/apt/keyrings/docker.gpg`.
+   </div>
+   <div id="tab-version" class="tab-pane fade" markdown="1">
 
-2.  To install a _specific version_ of Docker Engine, list the available versions
-    in the repo, then select and install:
+   To install a specific version of Docker Engine, start by list the available
+   versions in the repository:
 
-    a. List the versions available in your repo:
+   ```console
+   # List the available versions:
+   $ apt-cache madison docker-ce | awk '{ print $3 }'
 
-    ```console
-    $ apt-cache madison docker-ce
+   5:18.09.1~3-0~debian-stretch
+   5:18.09.0~3-0~debian-stretch
+   18.06.1~ce~3-0~debian       
+   18.06.0~ce~3-0~debian       
+   ```
 
-      docker-ce | 5:18.09.1~3-0~debian-stretch | {{ download-url-base }} stretch/stable amd64 Packages
-      docker-ce | 5:18.09.0~3-0~debian-stretch | {{ download-url-base }} stretch/stable amd64 Packages
-      docker-ce | 18.06.1~ce~3-0~debian        | {{ download-url-base }} stretch/stable amd64 Packages
-      docker-ce | 18.06.0~ce~3-0~debian        | {{ download-url-base }} stretch/stable amd64 Packages
-    ```
+   Select the desired version and install:
 
-    b. Install a specific version using the version string from the second column,
-       for example, `5:18.09.1~3-0~debian-stretch`.
+   ```console
+   $ VERSION_STRING=5:18.09.0~3-0~debian-stretch
+   $ sudo apt-get install docker-ce=$VERSION_STRING docker-ce-cli=$VERSION_STRING containerd.io docker-compose-plugin
+   ```
 
-    ```console
-    $ sudo apt-get install docker-ce=<VERSION_STRING> docker-ce-cli=<VERSION_STRING> containerd.io docker-compose-plugin
-    ```
+   </div>
+   <hr>
+   </div>
 
-3.  Verify that Docker Engine is installed correctly by running the `hello-world`
-    image.
+3. Verify that the Docker Engine installation was successful by running the
+   `hello-world` image:
 
-    ```console
-    $ sudo docker run hello-world
-    ```
+   ```console
+   $ sudo service docker start
+   $ sudo docker run hello-world
+   ```
 
-    This command downloads a test image and runs it in a container. When the
-    container runs, it prints a message and exits.
+   This command downloads a test image and runs it in a container. When the
+   container runs, it prints a confirmation message and exits.
 
-Docker Engine is installed and running. The `docker` group is created but no users
-are added to it. You need to use `sudo` to run Docker commands.
-Continue to [Linux postinstall](linux-postinstall.md) to allow non-privileged
-users to run Docker commands and for other optional configuration steps.
+You have now successfully installed and started Docker Engine. The `docker` user
+group exists but contains no users, which is why you're required to use `sudo`
+to run Docker commands. Continue to [Linux post-install](linux-postinstall.md)
+to allow non-privileged users to run Docker commands and for other optional
+configuration steps.
 
 #### Upgrade Docker Engine
 
-To upgrade Docker Engine, first run `sudo apt-get update`, then follow the
-[installation instructions](#install-using-the-repository), choosing the new
-version you want to install.
+To upgrade Docker Engine, follow the
+[installation instructions](#install-docker-engine), choosing the new version
+you want to install.
 
 ### Install from a package
 
-If you cannot use Docker's repository to install Docker Engine, you can download the
-`.deb` file for your release and install it manually. You need to download
-a new file each time you want to upgrade Docker.
+If you can't use Docker's `apt` repository to install Docker Engine, you can
+download the `deb` file for your release and install it manually. You need to
+download a new file each time you want to upgrade Docker Engine.
 
-1.  Go to [`{{ download-url-base }}/dists/`]({{ download-url-base }}/dists/){: target="_blank" rel="noopener" class="_" },
-    choose your Debian version, then browse to `pool/stable/`, choose `amd64`,
-    `armhf`, or `arm64`, and download the `.deb` file for the Docker Engine
-    version you want to install.
+1. Go to [`{{ download-url-base }}/dists/`]({{ download-url-base }}/dists/){:
+   target="_blank" rel="noopener" class="_" }.
 
-2.  Install Docker Engine, changing the path below to the path where you downloaded
-    the Docker package.
+2. Select your Debian version in the list.
 
-    ```console
-    $ sudo dpkg -i /path/to/package.deb
-    ```
+3. Go to `pool/stable/` and select the applicable architecture (`amd64`,
+   `armhf`, `arm64`, or `s390x`).
 
-    The Docker daemon starts automatically.
+4. Download the following `deb` files for the Docker Engine, CLI, containerd,
+   and Docker Compose packages:
 
-3.  Verify that Docker Engine is installed correctly by running the `hello-world`
-    image.
+   - `containerd.io_<version>_<arch>.deb`
+   - `docker-ce_<version>_<arch>.deb`
+   - `docker-ce-cli_<version>_<arch>.deb`
+   - `docker-compose-plugin_<version>_<arch>.deb`
 
-    ```console
-    $ sudo docker run hello-world
-    ```
+5. Install the `.deb` packages. Update the paths in the following example to
+   where you downloaded the Docker packages.
 
-    This command downloads a test image and runs it in a container. When the
-    container runs, it prints a message and exits.
+   ```console
+   $ sudo dpkg -i ./containerd.io_<version>_<arch>.deb \
+     ./docker-ce_<version>_<arch>.deb \
+     ./docker-ce-cli_<version>_<arch>.deb \
+     ./docker-compose-plugin_<version>_<arch>.deb
+   ```
 
-Docker Engine is installed and running. The `docker` group is created but no users
-are added to it. You need to use `sudo` to run Docker commands.
-Continue to [Post-installation steps for Linux](linux-postinstall.md) to allow
-non-privileged users to run Docker commands and for other optional configuration
-steps.
+   The Docker daemon starts automatically.
+
+6. Verify that the Docker Engine installation was successful by running the
+   `hello-world` image:
+
+   ```console
+   $ sudo service docker start
+   $ sudo docker run hello-world
+   ```
+
+   This command downloads a test image and runs it in a container. When the
+   container runs, it prints a confirmation message and exits.
+
+You have now successfully installed and started Docker Engine. The `docker` user
+group exists but contains no users, which is why you're required to use `sudo`
+to run Docker commands. Continue to [Linux post-install](linux-postinstall.md)
+to allow non-privileged users to run Docker commands and for other optional
+configuration steps.
 
 #### Upgrade Docker Engine
 
@@ -211,15 +258,14 @@ To upgrade Docker Engine, download the newer package file and repeat the
 
 ## Uninstall Docker Engine
 
-1.  Uninstall the Docker Engine, CLI, Containerd, and Docker Compose packages:
+1.  Uninstall the Docker Engine, CLI, containerd, and Docker Compose packages:
 
     ```console
     $ sudo apt-get purge docker-ce docker-ce-cli containerd.io docker-compose-plugin
     ```
 
-2.  Images, containers, volumes, or customized configuration files on your host
-    are not automatically removed. To delete all images, containers, and
-    volumes:
+2.  Images, containers, volumes, or custom configuration files on your host
+    aren't automatically removed. To delete all images, containers, and volumes:
 
     ```console
     $ sudo rm -rf /var/lib/docker
@@ -231,4 +277,5 @@ You must delete any edited configuration files manually.
 ## Next steps
 
 - Continue to [Post-installation steps for Linux](linux-postinstall.md).
-- Review the topics in [Develop with Docker](../../develop/index.md) to learn how to build new applications using Docker.
+- Review the topics in [Develop with Docker](../../develop/index.md) to learn
+  how to build new applications using Docker.

--- a/engine/install/ubuntu.md
+++ b/engine/install/ubuntu.md
@@ -175,7 +175,6 @@ Docker from the repository.
    `hello-world` image:
 
    ```console
-   $ sudo service docker start
    $ sudo docker run hello-world
    ```
 
@@ -232,7 +231,6 @@ download a new file each time you want to upgrade Docker Engine.
    `hello-world` image:
 
    ```console
-   $ sudo service docker start
    $ sudo docker run hello-world
    ```
 

--- a/engine/install/ubuntu.md
+++ b/engine/install/ubuntu.md
@@ -1,28 +1,21 @@
 ---
 description: Instructions for installing Docker Engine on Ubuntu
-keywords: requirements, apt, installation, ubuntu, install, uninstall, upgrade, update
+keywords:
+  requirements, apt, installation, ubuntu, install, uninstall, upgrade, update
 redirect_from:
-- /ee/docker-ee/ubuntu/
-- /engine/installation/linux/docker-ce/ubuntu/
-- /engine/installation/linux/docker-ee/ubuntu/
-- /engine/installation/linux/ubuntu/
-- /engine/installation/linux/ubuntulinux/
-- /engine/installation/ubuntulinux/
-- /install/linux/docker-ce/ubuntu/
-- /install/linux/docker-ee/ubuntu/
-- /install/linux/ubuntu/
-- /installation/ubuntulinux/
+  - /ee/docker-ee/ubuntu/
+  - /engine/installation/linux/docker-ce/ubuntu/
+  - /engine/installation/linux/docker-ee/ubuntu/
+  - /engine/installation/linux/ubuntu/
+  - /engine/installation/linux/ubuntulinux/
+  - /engine/installation/ubuntulinux/
+  - /install/linux/docker-ce/ubuntu/
+  - /install/linux/docker-ee/ubuntu/
+  - /install/linux/ubuntu/
+  - /installation/ubuntulinux/
 title: Install Docker Engine on Ubuntu
 toc_max: 4
 ---
-
-> **Docker Desktop for Linux**
->
-> Docker Desktop helps you build, share, and run containers easily on Mac and
-> Windows as you do on Linux. We are excited to share that Docker Desktop for
-> Linux is now GA. For more information, see
-[Docker Desktop for Linux](../../desktop/install/linux-install.md).
-{: .important}
 
 To get started with Docker Engine on Ubuntu, make sure you
 [meet the prerequisites](#prerequisites), then
@@ -40,12 +33,14 @@ versions:
 - Ubuntu Focal 20.04 (LTS)
 - Ubuntu Bionic 18.04 (LTS)
 
-Docker Engine is supported on `x86_64` (or `amd64`), `armhf`, `arm64`, and `s390x` architectures.
+Docker Engine is compatible with `x86_64` (or `amd64`), `armhf`, `arm64`, and `s390x`
+architectures.
 
 ### Uninstall old versions
 
-Older versions of Docker were called `docker`, `docker.io`, or `docker-engine`.
-If these are installed, uninstall them:
+Older versions of Docker went by the names of `docker`, `docker.io`, or
+`docker-engine`. Uninstall any such older versions before attempting to install
+a new version:
 
 ```console
 $ sudo apt-get remove docker docker-engine docker.io containerd runc
@@ -53,33 +48,33 @@ $ sudo apt-get remove docker docker-engine docker.io containerd runc
 
 It's OK if `apt-get` reports that none of these packages are installed.
 
-The contents of `/var/lib/docker/`, including images, containers, volumes, and
-networks, are preserved. If you do not need to save your existing data, and want to
-start with a clean installation, refer to the [uninstall Docker Engine](#uninstall-docker-engine)
-section at the bottom of this page.
+Images, containers, volumes, and networks stored in `/var/lib/docker/` aren't
+automatically removed when you uninstall Docker. If you want to start with a
+clean installation, and prefer to clean up any existing data, refer to the
+[uninstall Docker Engine](#uninstall-docker-engine) section.
 
 ## Installation methods
 
 You can install Docker Engine in different ways, depending on your needs:
 
-- Most users
-  [set up Docker's repositories](#install-using-the-repository) and install
-  from them, for ease of installation and upgrade tasks. This is the
-  recommended approach.
+- Docker Engine comes bundled with
+  [Docker Desktop for Linux](../../desktop/install/linux-install.md). This is
+  the easiest and quickest way to get started.
 
-- Some users download the DEB package and
-  [install it manually](#install-from-a-package) and manage
-  upgrades completely manually. This is useful in situations such as installing
-  Docker on air-gapped systems with no access to the internet.
+- You can also set up and install Docker Engine from
+  [Docker's `apt` repository](#install-using-the-repository).
 
-- In testing and development environments, some users choose to use automated
-  [convenience scripts](#install-using-the-convenience-script) to install Docker.
+- [Install it manually](#install-from-a-package) and manage upgrades completely
+  manually.
+
+- Using a [convenience scripts](#install-using-the-convenience-script) (only
+  recommended for testing and development environments).
 
 ### Install using the repository
 
-Before you install Docker Engine for the first time on a new host machine, you need
-to set up the Docker repository. Afterward, you can install and update Docker
-from the repository.
+Before you install Docker Engine for the first time on a new host machine, you
+need to set up the Docker repository. Afterward, you can install and update
+Docker from the repository.
 
 #### Set up the repository
 
@@ -115,98 +110,140 @@ from the repository.
 
 #### Install Docker Engine
 
-1. Update the `apt` package index, and install the _latest version_ of Docker
-   Engine, containerd, and Docker Compose, or go to the next step to install a specific version:
+1. Update the `apt` package index:
 
-    ```console
-    $ sudo apt-get update
+   ```console
+   $ sudo apt-get update
+   ```
+
+   > Receiving a GPG error when running `apt-get update`?
+   >
+   > Your default [umask](https://en.wikipedia.org/wiki/Umask){: target="blank"
+   > rel="noopener" } may be incorrectly configured, preventing detection of the
+   > repository public key file. Try granting read permission for the Docker
+   > public key file before updating the package index:
+   >
+   > ```console
+   > $ sudo chmod a+r /etc/apt/keyrings/docker.gpg
+   > $ sudo apt-get update
+   > ```
+
+2. Install Docker Engine, containerd, and Docker Compose.
+
+   <ul class="nav nav-tabs">
+    <li class="active"><a data-toggle="tab" data-target="#tab-latest">Latest</a></li>
+    <li><a data-toggle="tab" data-target="#tab-version">Specific version</a></li>
+   </ul>
+   <div class="tab-content">
+   <br>
+   <div id="tab-latest" class="tab-pane fade in active" markdown="1">
+
+   To install the latest version, run:
+
+   ```console
     $ sudo apt-get install docker-ce docker-ce-cli containerd.io docker-compose-plugin
-    ```
+   ```
 
-    > Receiving a GPG error when running `apt-get update`?
-    >  
-    > Your default umask may not be set correctly, causing the public key file
-    > for the repo to not be detected. Run the following command and then try to
-    > update your repo again: `sudo chmod a+r /etc/apt/keyrings/docker.gpg`.
+   </div>
+   <div id="tab-version" class="tab-pane fade" markdown="1">
 
-2.  To install a _specific version_ of Docker Engine, list the available versions
-    in the repo, then select and install:
+   To install a specific version of Docker Engine, start by list the available
+   versions in the repository:
 
-    a. List the versions available in your repo:
+   ```console
+   # List the available versions:
+   $ apt-cache madison docker-ce | awk '{ print $3 }'
 
-    ```console
-    $ apt-cache madison docker-ce
+   5:20.10.16~3-0~ubuntu-jammy
+   5:20.10.15~3-0~ubuntu-jammy
+   5:20.10.14~3-0~ubuntu-jammy
+   5:20.10.13~3-0~ubuntu-jammy
+   ```
 
-    docker-ce | 5:20.10.16~3-0~ubuntu-jammy | https://download.docker.com/linux/ubuntu jammy/stable amd64 Packages
-    docker-ce | 5:20.10.15~3-0~ubuntu-jammy | https://download.docker.com/linux/ubuntu jammy/stable amd64 Packages
-    docker-ce | 5:20.10.14~3-0~ubuntu-jammy | https://download.docker.com/linux/ubuntu jammy/stable amd64 Packages
-    docker-ce | 5:20.10.13~3-0~ubuntu-jammy | https://download.docker.com/linux/ubuntu jammy/stable amd64 Packages
-    ```
+   Select the desired version and install:
 
-    b. Install a specific version using the version string from the second column,
-       for example, `5:20.10.16~3-0~ubuntu-jammy`.
+   ```console
+   $ VERSION_STRING=5:20.10.13~3-0~ubuntu-jammy
+   $ sudo apt-get install docker-ce=$VERSION_STRING docker-ce-cli=$VERSION_STRING containerd.io docker-compose-plugin
+   ```
 
-    ```console
-    $ sudo apt-get install docker-ce=<VERSION_STRING> docker-ce-cli=<VERSION_STRING> containerd.io docker-compose-plugin
-    ```
+   </div>
+   <hr>
+   </div>
 
-3.  Verify that Docker Engine is installed correctly by running the `hello-world`
-    image.
+3. Verify that the Docker Engine installation was successful by running the
+   `hello-world` image:
 
-    ```console
-    $ sudo service docker start
-    $ sudo docker run hello-world
-    ```
+   ```console
+   $ sudo service docker start
+   $ sudo docker run hello-world
+   ```
 
-    This command downloads a test image and runs it in a container. When the
-    container runs, it prints a message and exits.
+   This command downloads a test image and runs it in a container. When the
+   container runs, it prints a confirmation message and exits.
 
-Docker Engine is installed and running. The `docker` group is created but no users
-are added to it. You need to use `sudo` to run Docker commands.
-Continue to [Linux postinstall](linux-postinstall.md) to allow non-privileged
-users to run Docker commands and for other optional configuration steps.
+You have now successfully installed and started Docker Engine. The `docker` user
+group exists but contains no users, which is why you're required to use `sudo`
+to run Docker commands. Continue to [Linux post-install](linux-postinstall.md)
+to allow non-privileged users to run Docker commands and for other optional
+configuration steps.
 
 #### Upgrade Docker Engine
 
-To upgrade Docker Engine, first run `sudo apt-get update`, then follow the
-[installation instructions](#install-using-the-repository), choosing the new
-version you want to install.
+To upgrade Docker Engine, follow the
+[installation instructions](#install-docker-engine), choosing the new version
+you want to install.
 
 ### Install from a package
 
-If you cannot use Docker's repository to install Docker Engine, you can download the
-`.deb` file for your release and install it manually. You need to download
-a new file each time you want to upgrade Docker.
+If you can't use Docker's `apt` repository to install Docker Engine, you can
+download the `deb` file for your release and install it manually. You need to
+download a new file each time you want to upgrade Docker Engine.
 
-1.  Go to [`{{ download-url-base }}/dists/`]({{ download-url-base }}/dists/){: target="_blank" rel="noopener" class="_" },
-    choose your Ubuntu version, then browse to `pool/stable/`, choose `amd64`,
-    `armhf`, `arm64`, or `s390x`, and download the `.deb` file for the Docker Engine
-    version you want to install.
+1. Go to [`{{ download-url-base }}/dists/`]({{ download-url-base }}/dists/){:
+   target="_blank" rel="noopener" class="_" }.
 
-2.  Install Docker Engine, changing the path below to the path where you downloaded
-    the Docker package.
+2. Select your Ubuntu version in the list.
 
-    ```console
-    $ sudo dpkg -i /path/to/package.deb
-    ```
+3. Go to `pool/stable/` and select the applicable architecture (`amd64`,
+   `armhf`, `arm64`, or `s390x`).
 
-    The Docker daemon starts automatically.
+4. Download the following `deb` files for the Docker Engine, CLI, containerd,
+   and Docker Compose packages:
 
-3.  Verify that Docker Engine is installed correctly by running the `hello-world`
-    image.
+   - `containerd.io_<version>_<arch>.deb`
+   - `docker-ce_<version>_<arch>.deb`
+   - `docker-ce-cli_<version>_<arch>.deb`
+   - `docker-compose-plugin_<version>_<arch>.deb`
 
-    ```console
-    $ sudo docker run hello-world
-    ```
+5. Install the `.deb` packages. Update the paths in the following example to
+   where you downloaded the Docker packages.
 
-    This command downloads a test image and runs it in a container. When the
-    container runs, it prints a message and exits.
+   ```console
+   $ sudo dpkg -i ./containerd.io_<version>_<arch>.deb \
+     ./docker-ce_<version>_<arch>.deb \
+     ./docker-ce-cli_<version>_<arch>.deb \
+     ./docker-compose-plugin_<version>_<arch>.deb
+   ```
 
-Docker Engine is installed and running. The `docker` group is created but no users
-are added to it. You need to use `sudo` to run Docker commands.
-Continue to [Post-installation steps for Linux](linux-postinstall.md) to allow
-non-privileged users to run Docker commands and for other optional configuration
-steps.
+   The Docker daemon starts automatically.
+
+6. Verify that the Docker Engine installation was successful by running the
+   `hello-world` image:
+
+   ```console
+   $ sudo service docker start
+   $ sudo docker run hello-world
+   ```
+
+   This command downloads a test image and runs it in a container. When the
+   container runs, it prints a confirmation message and exits.
+
+You have now successfully installed and started Docker Engine. The `docker` user
+group exists but contains no users, which is why you're required to use `sudo`
+to run Docker commands. Continue to [Linux post-install](linux-postinstall.md)
+to allow non-privileged users to run Docker commands and for other optional
+configuration steps.
 
 #### Upgrade Docker Engine
 
@@ -217,15 +254,14 @@ To upgrade Docker Engine, download the newer package file and repeat the
 
 ## Uninstall Docker Engine
 
-1.  Uninstall the Docker Engine, CLI, Containerd, and Docker Compose packages:
+1.  Uninstall the Docker Engine, CLI, containerd, and Docker Compose packages:
 
     ```console
     $ sudo apt-get purge docker-ce docker-ce-cli containerd.io docker-compose-plugin
     ```
 
-2.  Images, containers, volumes, or customized configuration files on your host
-    are not automatically removed. To delete all images, containers, and
-    volumes:
+2.  Images, containers, volumes, or custom configuration files on your host
+    aren't automatically removed. To delete all images, containers, and volumes:
 
     ```console
     $ sudo rm -rf /var/lib/docker
@@ -237,4 +273,5 @@ You must delete any edited configuration files manually.
 ## Next steps
 
 - Continue to [Post-installation steps for Linux](linux-postinstall.md).
-- Review the topics in [Develop with Docker](../../develop/index.md) to learn how to build new applications using Docker.
+- Review the topics in [Develop with Docker](../../develop/index.md) to learn
+  how to build new applications using Docker.

--- a/engine/install/ubuntu.md
+++ b/engine/install/ubuntu.md
@@ -33,8 +33,8 @@ versions:
 - Ubuntu Focal 20.04 (LTS)
 - Ubuntu Bionic 18.04 (LTS)
 
-Docker Engine is compatible with `x86_64` (or `amd64`), `armhf`, `arm64`, and `s390x`
-architectures.
+Docker Engine is compatible with `x86_64` (or `amd64`), `armhf`, `arm64`, and
+`s390x` architectures.
 
 ### Uninstall old versions
 
@@ -64,11 +64,10 @@ You can install Docker Engine in different ways, depending on your needs:
 - You can also set up and install Docker Engine from
   [Docker's `apt` repository](#install-using-the-repository).
 
-- [Install it manually](#install-from-a-package) and manage upgrades completely
-  manually.
+- [Install it manually](#install-from-a-package) and manage upgrades manually.
 
-- Using a [convenience scripts](#install-using-the-convenience-script) (only
-  recommended for testing and development environments).
+- Using a [convenience scripts](#install-using-the-convenience-script). Only
+  recommended for testing and development environments.
 
 ### Install using the repository
 
@@ -171,7 +170,7 @@ Docker from the repository.
    <hr>
    </div>
 
-3. Verify that the Docker Engine installation was successful by running the
+3. Verify that the Docker Engine installation is successful by running the
    `hello-world` image:
 
    ```console
@@ -227,7 +226,7 @@ download a new file each time you want to upgrade Docker Engine.
 
    The Docker daemon starts automatically.
 
-6. Verify that the Docker Engine installation was successful by running the
+6. Verify that the Docker Engine installation is successful by running the
    `hello-world` image:
 
    ```console


### PR DESCRIPTION
Documentation review of the Ubuntu installation guide.

This is a part of the effort of keeping our most popular content up to date and useful. The Ubuntu installation page is in the list of our top 20 most visited pages.

Also updating the corresponding Debian page as a result of these two being near-identical.
