### PR TITLE
Rename default branch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,7 @@ on:
   push:
     # needs push event on default branch otherwise cache is evicted when pull request is merged
     branches:
-      - master
+      - main
   pull_request:
 
 permissions:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,7 +5,7 @@ on:
   push:
     branches:
       - lab
-      - master
+      - main
       - published
 
 # these permissions are needed to interact with GitHub's OIDC Token endpoint.
@@ -22,14 +22,14 @@ jobs:
         run: |
           JEKYLL_ENV=development
           DOCS_AWS_REGION=us-east-1
-          if [ "${{ github.ref }}" = "refs/heads/master" ]; then
+          if [ "${{ github.ref }}" = "refs/heads/main" ]; then
             DOCS_URL="https://docs-stage.docker.com"
             DOCS_AWS_IAM_ROLE="arn:aws:iam::710015040892:role/stage-docs-docs.docker.com-20220818202135984800000001"
             DOCS_S3_BUCKET="stage-docs-docs.docker.com"
             DOCS_S3_CONFIG="s3-config.json"
             DOCS_CLOUDFRONT_ID="E1R7CSW3F0X4H8"
             DOCS_LAMBDA_FUNCTION_REDIRECTS="DockerDocsRedirectFunction-stage"
-            DOCS_SLACK_MSG="Successfully deployed docs-stage from master branch. $DOCS_URL"
+            DOCS_SLACK_MSG="Successfully deployed docs-stage from main branch. $DOCS_URL"
           elif [ "${{ github.ref }}" = "refs/heads/published" ]; then
             JEKYLL_ENV=production
             DOCS_URL="https://docs.docker.com"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1
 
 # This Dockerfile builds the docs for https://docs.docker.com/
-# from the master branch of https://github.com/docker/docs
+# from the main branch of https://github.com/docker/docs
 
 # Use same ruby version as the one in .ruby-version
 # that is used by Netlify

--- a/_includes/analytics/polldaddy.html
+++ b/_includes/analytics/polldaddy.html
@@ -7,7 +7,7 @@
         "font_family": "Open Sans, sans serif",
         "font_color": "b9c2cc",
         "font_align": "center",
-        "permalink": "{{ site.repo }}/blob/master/{{ page.path }}"
+        "permalink": "{{ site.repo }}/blob/main/{{ page.path }}"
     };
     (function (d, c, j) {
         if (!document.getElementById(j)) {

--- a/_layouts/docs.html
+++ b/_layouts/docs.html
@@ -3,7 +3,7 @@
 {%- if page.edit_url -%}
     {%- assign edit_url = page.edit_url -%}
 {%- else -%}
-    {% capture edit_url %}{{ site.repo }}/edit/master/{{ page.path }}{% endcapture %}
+    {% capture edit_url %}{{ site.repo }}/edit/main/{{ page.path }}{% endcapture %}
 {%- endif -%}
 {%- if page.issue_url -%}
     {%- assign issue_url = page.issue_url -%}

--- a/contribute/contribute-guide.md
+++ b/contribute/contribute-guide.md
@@ -4,7 +4,7 @@ description: Guidelines for contributing to Docker's docs
 keywords: contribute, guide, style guide
 ---
 
-The live docs are published from the `master` branch. Therefore, you must create pull requests against the `master` branch for all content updates. This includes:
+The live docs are published from the `main` branch. Therefore, you must create pull requests against the `main` branch for all content updates. This includes:
 
 - Conceptual and task-based information
 - Restructuring / rewriting
@@ -17,7 +17,7 @@ There are two ways to contribute a pull request to the docs repository:
 
     This opens the GitHub editor, which means you don't need to know a lot about Git, or even about Markdown. When you save, Git prompts you to create a fork if you don't already have one, and to create a branch in your fork and submit the pull request.
 
-2. Fork the [docs GitHub repository]({{ site.repo }}). Suggest changes or add new content on your local branch, and submit a pull request (PR) to the `master` branch.
+2. Fork the [docs GitHub repository]({{ site.repo }}). Suggest changes or add new content on your local branch, and submit a pull request (PR) to the `main` branch.
 
     This is the manual, more advanced version of clicking 'Edit this page' on a published docs page. Initiating a docs changes in a PR from your own branch gives you more flexibility, as you can submit changes to multiple pages or files under a single pull request, and even create new topics.
 
@@ -44,7 +44,7 @@ Help us review your PRs more quickly by following these guidelines.
 - Don't change whitespace or line wrapping in parts of a file you are not editing for other reasons. Make sure your text editor is not configured to
   automatically reformat the whole file when saving.
 - We highly recommend that you [build](#build-and-preview-the-docs-locally) and [test](#test-the-docs-locally) the docs locally before submitting a PR. 
-- A Netlify test runs for each PR that is against the `master` branch, and deploys the result of your PR to a staging site. The URL will be available at in the **Conversation** tab. Check the staging site to verify how your changes look and fix issues, if necessary.
+- A Netlify test runs for each PR that is against the `main` branch, and deploys the result of your PR to a staging site. The URL will be available at in the **Conversation** tab. Check the staging site to verify how your changes look and fix issues, if necessary.
 
 ### Collaborate on a pull request
 
@@ -56,11 +56,11 @@ given file in the **Files** view.
 
 If a PR consists of multiple small addendum commits on top of a more significant
 one, the commit will usually be "squash-merged", so that only one commit is
-merged into the `master` branch. In some scenarios where a squash and merge isn't appropriate, all commits are kept separate when merging.
+merged into the `main` branch. In some scenarios where a squash and merge isn't appropriate, all commits are kept separate when merging.
 
 ### Per-PR staging on GitHub
 
-A Netlify test runs for each PR created against the `master` branch and deploys the result of your PR to a staging site. When the site builds successfully, you will see a comment in the **Conversation** tab in the PR stating **Deploy Preview for docsdocker ready!**. Click the **Browse the preview** URL and check the staging site to verify how your changes look and fix issues, if necessary. Reviewers also check the staged site before merging the PR to protect the integrity of the docs site.
+A Netlify test runs for each PR created against the `main` branch and deploys the result of your PR to a staging site. When the site builds successfully, you will see a comment in the **Conversation** tab in the PR stating **Deploy Preview for docsdocker ready!**. Click the **Browse the preview** URL and check the staging site to verify how your changes look and fix issues, if necessary. Reviewers also check the staged site before merging the PR to protect the integrity of the docs site.
 
 ## Build and preview the docs locally
 

--- a/engine/reference/commandline/README.md
+++ b/engine/reference/commandline/README.md
@@ -25,5 +25,5 @@ The process for generating the YAML files is still in flux. Check with
 release branch of `docker/cli`, for example, the `19.03` branch.
 
 After generating the YAML files, replace the YAML files in
-[https://github.com/docker/docs/tree/master/_data/engine-cli](https://github.com/docker/docs/tree/master/_data/engine-cli)
+[https://github.com/docker/docs/tree/main/_data/engine-cli](https://github.com/docker/docs/tree/main/_data/engine-cli)
 with the newly-generated files. Submit a pull request.

--- a/glossary.md
+++ b/glossary.md
@@ -11,7 +11,7 @@ redirect_from:
 ---
 <!--
 To edit/add/remove glossary entries, visit the YAML file at:
-https://github.com/docker/docs/blob/master/_data/glossary.yaml
+https://github.com/docker/docs/blob/main/_data/glossary.yaml
 
 To get a specific entry while writing a page in the docs, enter Liquid text
 like so:


### PR DESCRIPTION
### Proposed changes

This PR updates the name of the default branch (from `master` to `main`) in files of the docs repository.

In addition to this PR, three additional changes must take place:

- [x] Update the ref name in the subject claim of the `website_docs_docker_com` Terraform module
- [x] Rename the branch on GitHub
- [x] Update the production branch name in Netlify

Only when the above changes are completed should this branch be merged. We should coordinate the changes as such that this PR is the first to get merged after the changes are made.
