### PR TITLE
Remove shell prompts ($) from commands

### DIFF
--- a/engine/install/ubuntu.md
+++ b/engine/install/ubuntu.md
@@ -48,7 +48,7 @@ Older versions of Docker were called `docker`, `docker.io`, or `docker-engine`.
 If these are installed, uninstall them:
 
 ```console
-$ sudo apt-get remove docker docker-engine docker.io containerd runc
+sudo apt-get remove docker docker-engine docker.io containerd runc
 ```
 
 It's OK if `apt-get` reports that none of these packages are installed.
@@ -89,9 +89,9 @@ from the repository.
     repository over HTTPS:
 
     ```console
-    $ sudo apt-get update
+    sudo apt-get update
 
-    $ sudo apt-get install \
+    sudo apt-get install \
         ca-certificates \
         curl \
         gnupg \
@@ -101,14 +101,14 @@ from the repository.
 2.  Add Docker's official GPG key:
 
     ```console
-    $ sudo mkdir -p /etc/apt/keyrings
-    $ curl -fsSL {{ download-url-base }}/gpg | sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg
+    sudo mkdir -p /etc/apt/keyrings
+    curl -fsSL {{ download-url-base }}/gpg | sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg
     ```
 
 3.  Use the following command to set up the repository:
 
     ```console
-    $ echo \
+    echo \
       "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] {{ download-url-base }} \
       $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
     ```
@@ -119,8 +119,8 @@ from the repository.
    Engine, containerd, and Docker Compose, or go to the next step to install a specific version:
 
     ```console
-    $ sudo apt-get update
-    $ sudo apt-get install docker-ce docker-ce-cli containerd.io docker-compose-plugin
+    sudo apt-get update
+    sudo apt-get install docker-ce docker-ce-cli containerd.io docker-compose-plugin
     ```
 
     > Receiving a GPG error when running `apt-get update`?
@@ -135,8 +135,9 @@ from the repository.
     a. List the versions available in your repo:
 
     ```console
-    $ apt-cache madison docker-ce
-
+    apt-cache madison docker-ce
+    ```
+    ```console
     docker-ce | 5:20.10.16~3-0~ubuntu-jammy | https://download.docker.com/linux/ubuntu jammy/stable amd64 Packages
     docker-ce | 5:20.10.15~3-0~ubuntu-jammy | https://download.docker.com/linux/ubuntu jammy/stable amd64 Packages
     docker-ce | 5:20.10.14~3-0~ubuntu-jammy | https://download.docker.com/linux/ubuntu jammy/stable amd64 Packages
@@ -147,15 +148,15 @@ from the repository.
        for example, `5:20.10.16~3-0~ubuntu-jammy`.
 
     ```console
-    $ sudo apt-get install docker-ce=<VERSION_STRING> docker-ce-cli=<VERSION_STRING> containerd.io docker-compose-plugin
+    sudo apt-get install docker-ce=<VERSION_STRING> docker-ce-cli=<VERSION_STRING> containerd.io docker-compose-plugin
     ```
 
 3.  Verify that Docker Engine is installed correctly by running the `hello-world`
     image.
 
     ```console
-    $ sudo service docker start
-    $ sudo docker run hello-world
+    sudo service docker start
+    sudo docker run hello-world
     ```
 
     This command downloads a test image and runs it in a container. When the
@@ -187,7 +188,7 @@ a new file each time you want to upgrade Docker.
     the Docker package.
 
     ```console
-    $ sudo dpkg -i /path/to/package.deb
+    sudo dpkg -i /path/to/package.deb
     ```
 
     The Docker daemon starts automatically.
@@ -196,7 +197,7 @@ a new file each time you want to upgrade Docker.
     image.
 
     ```console
-    $ sudo docker run hello-world
+    sudo docker run hello-world
     ```
 
     This command downloads a test image and runs it in a container. When the
@@ -220,7 +221,7 @@ To upgrade Docker Engine, download the newer package file and repeat the
 1.  Uninstall the Docker Engine, CLI, Containerd, and Docker Compose packages:
 
     ```console
-    $ sudo apt-get purge docker-ce docker-ce-cli containerd.io docker-compose-plugin
+    sudo apt-get purge docker-ce docker-ce-cli containerd.io docker-compose-plugin
     ```
 
 2.  Images, containers, volumes, or customized configuration files on your host
@@ -228,8 +229,8 @@ To upgrade Docker Engine, download the newer package file and repeat the
     volumes:
 
     ```console
-    $ sudo rm -rf /var/lib/docker
-    $ sudo rm -rf /var/lib/containerd
+    sudo rm -rf /var/lib/docker
+    sudo rm -rf /var/lib/containerd
     ```
 
 You must delete any edited configuration files manually.


### PR DESCRIPTION
Remove shell prompts from commands so that they can be copied/pasted without edits.

### Proposed changes

It is easier to copy commands from the document if the command is not prefixed by the shell prompt $.

### Related issues (optional)

