### PR TITLE
Update restart policy for docker-compose document

### DIFF
--- a/compose/compose-file/compose-file-v3.md
+++ b/compose/compose-file/compose-file-v3.md
@@ -914,7 +914,7 @@ and see [Understand the risks of running out of memory](../../config/containers/
 Configures if and how to restart containers when they exit. Replaces
 [`restart`](compose-file-v2.md#orig-resources).
 
-  - `condition`: One of `no`, `on-failure`, `always` or `unless-stopped` (default: `no`).
+- `condition`: One of `no`, `on-failure`, `always` or `unless-stopped` (default: `no`).
 - `delay`: How long to wait between restart attempts, specified as a
   [duration](#specifying-durations) (default: 5s).
 - `max_attempts`: How many times to attempt to restart a container before giving

--- a/compose/compose-file/compose-file-v3.md
+++ b/compose/compose-file/compose-file-v3.md
@@ -914,7 +914,7 @@ and see [Understand the risks of running out of memory](../../config/containers/
 Configures if and how to restart containers when they exit. Replaces
 [`restart`](compose-file-v2.md#orig-resources).
 
-- `condition`: One of `none`, `on-failure` or `any` (default: `any`).
+  - `condition`: One of `no`, `on-failure`, `always` or `unless-stopped` (default: `no`).
 - `delay`: How long to wait between restart attempts, specified as a
   [duration](#specifying-durations) (default: 5s).
 - `max_attempts`: How many times to attempt to restart a container before giving


### PR DESCRIPTION
<!--We’d like to make it as easy as possible for you to contribute to the Docker documentation repository. Before you submit the pull request, we recommend that you review the [Contribution guidelines](/contribute/overview.md). Remove these comments as you go.-->

### Proposed changes

This restart policy section in docker-compose document was out of date and really miss leading (for example https://github.com/docker/compose/issues/8756#issuecomment-937984773)

Updated this to be consistent with: https://docs.docker.com/engine/reference/run/#restart-policies---restart

### Related issues (optional)
https://github.com/docker/compose/issues/8756#issuecomment-937984773

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
