### PR TITLE
Remove $ prompt from code copy

### DIFF
--- a/assets/js/copy.js
+++ b/assets/js/copy.js
@@ -15,7 +15,9 @@ function copyCodeBlock(event) {
   const copyButton = event.currentTarget
   const codeBlock = copyButton.parentElement.querySelector("pre.highlight code")
   const code = codeBlock.innerText.trim()
-  window.navigator.clipboard.writeText(code)
+  // remove "$ " prompt at start of lines in code
+  const strippedCode = code.replace(/^[\s]?\$\s+/gm, "")
+  window.navigator.clipboard.writeText(strippedCode)
 
   // change the button text temporarily
   copyButton.textContent = "Copied!"


### PR DESCRIPTION
### Proposed changes

For the code copy feature, remove "$ " from start of lines when copying.
Also remove " $ " from start of lines. I'm not sure why it adds the space before the prompt with multiple lines.

