### PR TITLE
dockerfile ref: use custom ref to fix links issue

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -190,7 +190,7 @@ fetch-remote:
 
   - repo: "https://github.com/moby/buildkit"
     default_branch: "master"
-    ref: "master"
+    ref: "8bc51649bc7e712a8e2ff90412f48fdc35f602a9"
     paths:
       - dest: "engine/reference/builder.md"
         src:


### PR DESCRIPTION
Changes merged in https://github.com/moby/buildkit/pull/3220 cause htmlproofer errors: https://github.com/docker/docs/actions/runs/3319903637/jobs/5485635979#step:5:57

![image](https://user-images.githubusercontent.com/1951866/197751783-518353f0-d0c3-4ef0-8dfd-f58bad287434.png)

```
- ./_site/engine/reference/builder/index.html
  *  internally linking to /build/buildkit/, which does not exist (line 269)
     <a href="/build/buildkit/">BuildKit</a>
  *  internally linking to /build/buildkit/, which does not exist (line 2478)
     <a href="/build/buildkit/">BuildKit</a>
  *  internally linking to /build/buildkit/dockerfile-frontend/, which does not exist (line 272)
     <a href="/build/buildkit/dockerfile-frontend/">Custom Dockerfile syntax</a>
  *  linking to internal hash #getting-started that does not exist (line 3000)
     <a href="/build/buildkit/#getting-started">BuildKit</a>
- ./_site/engine/reference/commandline/build/index.html
  *  linking to internal hash #buildkit that does not exist (line 849)
     <a href="/engine/reference/builder/#buildkit">BuildKit backend</a>
  *  linking to internal hash #buildkit that does not exist (line 1114)
     <a href="/engine/reference/builder/#buildkit">enable BuildKit</a>
  *  linking to internal hash #buildkit that does not exist (line 1156)
     <a href="/engine/reference/builder/#buildkit">enable BuildKit</a>
```

While waiting for https://github.com/docker/docs/pull/15958 and https://github.com/docker/cli/pull/3832 to be merged, use a custom ref for the Dockerfile reference before these changes.

Signed-off-by: CrazyMax <crazy-max@users.noreply.github.com>