### PR TITLE
update Compose release notes for versions 2.12.0, 2.12.1 and 2.12.2

### DIFF
--- a/compose/release-notes.md
+++ b/compose/release-notes.md
@@ -29,17 +29,17 @@ For the full change log or additional information, check the [Compose repository
 (2022-10-18)
 
 ### Enhancements
-- Added a `quiet` option when pushing image. Fixed [compose#9089](https://github.com/docker/compose/issues/9089){:target="_blank" rel="noopener" class="_"}
+- Added a `quiet` option when pushing an image. Fixed [compose#9089](https://github.com/docker/compose/issues/9089){:target="_blank" rel="noopener" class="_"}
 - Fixed a misleading error message for `port` command. Pull Request [compose#9909](https://github.com/docker/compose/pull/9909){:target="_blank" rel="noopener" class="_"}
 
 ### Bug fixes
-- Fixed a bug to prevent failure when Compose try to remove a non-existing container. Fixed by [compose#9896](https://github.com/docker/compose/pull/9896/){:target="_blank" rel="noopener" class="_"}
+- Fixed a bug to prevent failure when Compose tries to remove a non-existing container. Fixed by [compose#9896](https://github.com/docker/compose/pull/9896/){:target="_blank" rel="noopener" class="_"}
 
 ### Changes
-- CI update the documentation repository path
+- CI update to the documentation repository path
 - Upgraded to compose-go from [1.5.1 to 1.6.0](https://github.com/compose-spec/compose-go/releases/tag/v1.6.0){:target="_blank" rel="noopener" class="_"}
-- Switch GitHub issue template form
-- Update to go 1.19.2 to address CVE-2022-2879, CVE-2022-2880, CVE-2022-41715
+- Switched GitHub issue template form
+- Updated to go 1.19.2 to address CVE-2022-2879, CVE-2022-2880, CVE-2022-41715
 
 
 For the full change log or additional information, check the [Compose repository 2.12.0 release page](https://github.com/docker/compose/releases/tag/v2.12.0){:target="_blank" rel="noopener" class="_"}.

--- a/compose/release-notes.md
+++ b/compose/release-notes.md
@@ -6,6 +6,44 @@ toc_max: 2
 redirect_from:
   - /release-notes/docker-compose/
 ---
+## 2.12.2
+
+(2022-10-21)
+
+### Changes
+- Updated Docker Engine API to restore compatibility with Golang 1.18 needed for Linux packaging. Pull Request [compose#9940](https://github.com/docker/compose/pull/9940){:target="_blank" rel="noopener" class="_"}
+
+For the full change log or additional information, check the [Compose repository 2.12.2 release page](https://github.com/docker/compose/releases/tag/v2.12.2){:target="_blank" rel="noopener" class="_"}.
+
+## 2.12.1
+
+(2022-10-21)
+
+### Security Fixes
+- Updated Docker Engine API to apply fix of [CVE-2022-39253](https://nvd.nist.gov/vuln/detail/CVE-2022-39253). Pull Request [compose#9934](https://github.com/docker/compose/pull/9934){:target="_blank" rel="noopener" class="_"}
+
+For the full change log or additional information, check the [Compose repository 2.12.1 release page](https://github.com/docker/compose/releases/tag/v2.12.1){:target="_blank" rel="noopener" class="_"}.
+
+## 2.12.0
+
+(2022-10-18)
+
+### Enhancements
+- Added a `quiet` option when pushing image. Fixed [compose#9089](https://github.com/docker/compose/issues/9089){:target="_blank" rel="noopener" class="_"}
+- Fixed a misleading error message for `port` command. Pull Request [compose#9909](https://github.com/docker/compose/pull/9909){:target="_blank" rel="noopener" class="_"}
+
+### Bug fixes
+- Fixed a bug to prevent failure when Compose try to remove a non-existing container. Fixed by [compose#9896](https://github.com/docker/compose/pull/9896/){:target="_blank" rel="noopener" class="_"}
+
+### Changes
+- CI update the documentation repository path
+- Upgraded to compose-go from [1.5.1 to 1.6.0](https://github.com/compose-spec/compose-go/releases/tag/v1.6.0){:target="_blank" rel="noopener" class="_"}
+- Switch GitHub issue template form
+- Update to go 1.19.2 to address CVE-2022-2879, CVE-2022-2880, CVE-2022-41715
+
+
+For the full change log or additional information, check the [Compose repository 2.12.0 release page](https://github.com/docker/compose/releases/tag/v2.12.0){:target="_blank" rel="noopener" class="_"}.
+
 ## 2.11.2
 
 (2022-09-27)


### PR DESCRIPTION
Signed-off-by: Guillaume Lours <705411+glours@users.noreply.github.com>

<!--We’d like to make it as easy as possible for you to contribute to the Docker documentation repository. Before you submit the pull request, we recommend that you review the [Contribution guidelines](/contribute/overview.md). Remove these comments as you go.-->

### Proposed changes
Update Compose release notes page to include version `2.12.0`, `2.12.1` and `2.12.2`

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
