### PR TITLE
jekyll: fix fetch depth for last_modification_date on deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -68,6 +68,8 @@ jobs:
       -
         name: Checkout
         uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
       -
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2

--- a/_plugins/fetch_remote.rb
+++ b/_plugins/fetch_remote.rb
@@ -40,6 +40,8 @@ module Jekyll
     def pre_read(site)
       beginning_time = Time.now
       puts "Starting plugin fetch_remote.rb..."
+
+      fetch_depth = get_docs_url == "http://localhost:4000" ? 1 : 0
       site.config['fetch-remote'].each do |entry|
         puts "  Repo #{entry['repo']}"
 
@@ -55,11 +57,11 @@ module Jekyll
           rescue => e
             FileUtils.rm_rf(clonedir)
             puts "    Cloning repository into #{clonedir}"
-            git = Git.clone("#{entry['repo']}.git", Pathname.new(clonedir), branch: entry['ref'], depth: 1)
+            git = Git.clone("#{entry['repo']}.git", Pathname.new(clonedir), branch: entry['ref'], depth: fetch_depth)
           end
         else
           puts "    Cloning repository into #{clonedir}"
-          git = Git.clone("#{entry['repo']}.git", Pathname.new(clonedir), branch: entry['ref'], depth: 1)
+          git = Git.clone("#{entry['repo']}.git", Pathname.new(clonedir), branch: entry['ref'], depth: fetch_depth)
         end
 
         entry['paths'].each do |path|


### PR DESCRIPTION
Changes introduced by https://github.com/docker/docs/pull/15267 for `last_modification_date` don't pick up the right commit date for pages in the `deploy` workflow: https://docs-stage.docker.com/sitemap.xml. That's because `actions/checkout` doesn't fetch the history by default but [Netlify does for previews](https://deploy-preview-15267--docsdocker.netlify.app/sitemap.xml). That's why we didn't catch this issue. Same applies with `fetch_depth` plugin, we need the history when deployed but we can keep `depth: 1` with local builds for performance.

Signed-off-by: CrazyMax <crazy-max@users.noreply.github.com>