### PR TITLE
display reading time and tags in toc nav

### DIFF
--- a/_includes/read_time.html
+++ b/_includes/read_time.html
@@ -1,6 +1,0 @@
-{%- unless page.skip_read_time == true -%}
-{%- assign words = content | number_of_words -%}
-{%- if words >= 360 -%}
-<em class="reading-time">Estimated reading time: {{ words | divided_by:180 }} minutes</em>
-{%- endif -%}
-{%- endunless -%}

--- a/_layouts/docs.html
+++ b/_layouts/docs.html
@@ -28,20 +28,8 @@
                             {%- if page.advisory -%}
                             <blockquote>{{ site.data.advisories.texts[page.advisory] | markdownify }}</blockquote>
                             {%- endif -%}
-                            <p>{%- include read_time.html -%}</p>
+                            <p></p>
                             {{ content }}
-                            {%- unless page.notags == true -%}
-                            {%- assign keywords = page.keywords | split:"," -%}
-                            {%- if keywords.size > 0 -%}
-                            <span class="glyphicon glyphicon-tags" style="padding-right: 10px"></span><span style="vertical-align: 2px">
-                                {%- for keyword in keywords -%}
-                                {%- assign strippedKeyword = keyword | strip -%}
-                                <a href="/search/?q={{ strippedKeyword }}">{{ strippedKeyword }}</a>
-                                {%- unless forloop.last %}, {% endunless -%}
-                                {%- endfor -%}
-                            </span>
-                            {%- endif -%}
-                            {%- endunless %}
                         </section>
                     </main>
                     <nav class="col-nav">
@@ -64,18 +52,35 @@
                                 {%- assign my_min = page.toc_min | default: site.toc_min | default: 2 -%}
                                 {%- assign my_max = page.toc_max | default: site.toc_max | default: 3 -%}
                                 {%- assign my_name = page.url | default: "unnamed" -%}
-                                <div id="side-toc-title">Contents:</div>
+                                <div class="side-toc-title">Page details</div>
+                                <div class="metadata-items">
+                                    <ul>
+                                      {%- unless page.skip_read_time == true %}{% assign words = content | number_of_words %}{% if words >= 360 -%}
+                                      <li title="Estimated reading time"><i class="fa fa-clock" aria-hidden="true"></i> {{ words | divided_by:180 }} minutes read</span></li>
+                                      {%- endif %}{% endunless -%}
+                                      {%- if edit_url != "" -%}
+                                      <li><a href="{{ edit_url }}"><i class="fa fa-pencil" aria-hidden="true"></i> Edit this page</a></li>
+                                      {%- endif -%}
+                                      {%- if issue_url != "" -%}
+                                      <li><a href="{{ issue_url }}" class="nomunge"><i class="fa fa-check" aria-hidden="true"></i> Request changes</a></li>
+                                      {%- endif -%}
+                                    </ul>
+                                </div>
+                                {%- unless page.notags == true -%}
+                                {%- assign keywords = page.keywords | split:"," -%}
+                                {%- if keywords.size > 0 -%}
+                                <div class="side-toc-title">Tags</div>
+                                <div class="keywords-items">
+                                {%- for keyword in keywords -%}
+                                {%- assign strippedKeyword = keyword | strip -%}
+                                <a href="/search/?q={{ strippedKeyword }}" class="nomunge"><i class="fa fa-tag" aria-hidden="true"></i> {{ strippedKeyword }}</a>
+                                {%- endfor -%}
+                                </div>
+                                {%- endif -%}
+                                {%- endunless %}
+                                <div class="side-toc-title">Contents</div>
                                 {%- include toc_pure_liquid.html html=content sanitize=true class="inline_toc" id="my_toc" toc_min=my_min toc_max=my_max page_name=my_name -%}
                                 {%- endunless -%}
-                                <div class="feedback-links">
-                                    <ul>
-                                        {%- if edit_url != "" -%}
-                                        <li><a href="{{ edit_url }}"><i class="fa fa-pencil" aria-hidden="true"></i> Edit this page</a></li>
-                                        {%- endif -%}
-                                        {%- if issue_url != "" -%}
-                                        <li><a href="{{ issue_url }}" class="nomunge"><i class="fa fa-check" aria-hidden="true"></i> Request changes</a></li>
-                                        {%- endif -%}
-                                    </ul>
                             </div>
                         </div>
                     </div>

--- a/_scss/_navigation.scss
+++ b/_scss/_navigation.scss
@@ -163,7 +163,7 @@
     color: #677285;
 }
 
-div#side-toc-title {
+div.side-toc-title {
     font-size: 12px;
     font-weight: bold;
     margin: 11px 0 10px 13px;
@@ -281,12 +281,38 @@ input:checked+.slider:before {
   }
 }
 
-/*
- * feedback links **************************************************************
- */
+div.feedback-links {
+  margin: 15px 0 10px 0;
+}
 
-.feedback-links {
-    margin: 15px 0 10px 0;
+div.metadata-items {
+  margin: 15px 0 10px 0;
+  ul {
+    list-style: none;
+    margin: 0;
+    padding-left: 20px;
+    line-height: 20px;
+    li {
+      padding: 2px 8px 2px 0;
+      width: 100%;
+      font-size: 12px;
+      a {
+        padding: 0;
+      }
+    }
+  }
+}
+
+div.keywords-items {
+  padding-left: 20px;
+  font-size: 12px;
+  a {
+    display: inline-block;
+    margin-right: 8px;
+    i.fa {
+      margin: 0;
+    }
+  }
 }
 
 /*


### PR DESCRIPTION
~needs #15993~
~needs #15998~

Move tags and reading time from content body to the toc nav as it seems more appropriate to have it there. I also took the opportunity to move the edit page and request changes links to the metadata block instead of having it under "Contents" as it's not visible at first sight on some pages like https://docs.docker.com/engine/reference/builder/.

![image](https://user-images.githubusercontent.com/1951866/200316608-a387c8a2-97d5-44c3-8531-fc1512e20a63.png)

![image](https://user-images.githubusercontent.com/1951866/200316642-def21588-4430-4650-b951-94d4f6ec7a87.png)
