### PR TITLE
jekyll(last_modified_at): fix for remote resources and data files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ ARG BUNDLER_VERSION=2.3.13
 
 ARG JEKYLL_ENV=development
 ARG DOCS_URL=http://localhost:4000
+ARG DOCS_ENFORCE_GIT_LOG_HISTORY=0
 
 # Base stage for building
 FROM ruby:${RUBY_VERSION}-alpine AS base
@@ -45,6 +46,7 @@ COPY --from=vendored /out /
 FROM gem AS generate
 ARG JEKYLL_ENV
 ARG DOCS_URL
+ARG DOCS_ENFORCE_GIT_LOG_HISTORY
 ENV TARGET=/out
 RUN --mount=type=bind,target=.,rw \
     --mount=type=cache,target=/tmp/docker-docs-clone \

--- a/_plugins/last_modified_at.rb
+++ b/_plugins/last_modified_at.rb
@@ -29,21 +29,27 @@ module Jekyll
         next unless File.extname(page.relative_path) == ".md" || File.extname(page.relative_path) == ".html"
         page.data['last_modified_at'] = current_last_modified_at(site, page)
         set_mode = "frontmatter"
+        path_override = ""
         if page.data['last_modified_at'].nil?
+          page_relative_path = page.relative_path
+          if page.data.key?('datafolder') && page.data.key?('datafile')
+            page_relative_path = File.join('_data',  page.data['datafolder'], "#{page.data['datafile']}.yaml")
+            path_override = "\n    override: #{page_relative_path}"
+          end
           begin
             if use_file_mtime
               # Use file's mtime for local development
-              page.data['last_modified_at'] = File.mtime(page.relative_path).strftime(DATE_FORMAT)
+              page.data['last_modified_at'] = File.mtime(page_relative_path).strftime(DATE_FORMAT)
               set_mode = "mtime"
             else
-              page.data['last_modified_at'] = git.log.path(page.relative_path).first.date.strftime(DATE_FORMAT)
+              page.data['last_modified_at'] = git.log.path(page_relative_path).first.date.strftime(DATE_FORMAT)
               set_mode = "git"
             end
           rescue => e
             # Ignored
           end
         end
-        puts"  #{page.relative_path}\n    last_modified_at(#{set_mode}): #{page.data['last_modified_at']}"
+        puts"  #{page.relative_path}#{path_override}\n    last_modified_at(#{set_mode}): #{page.data['last_modified_at']}"
       end
 
       end_time = Time.now

--- a/_plugins/last_modified_at.rb
+++ b/_plugins/last_modified_at.rb
@@ -6,26 +6,27 @@ module Jekyll
   class LastModifiedAt < Octopress::Hooks::Site
     DATE_FORMAT = '%Y-%m-%d %H:%M:%S %z'
     def pre_render(site)
-      if get_docs_url == "http://localhost:4000"
-        # Do not generate last_modified_at for local development
-        return
-      end
-
       beginning_time = Time.now
       Jekyll.logger.info "Starting plugin last_modified_at.rb..."
 
       git = Git.open(site.source)
+      use_file_mtime = get_docs_url == "http://localhost:4000" && ENV['DOCS_ENFORCE_GIT_LOG_HISTORY'] == "0"
       site.pages.each do |page|
         next if page.relative_path == "redirect.html"
         next unless File.extname(page.relative_path) == ".md" || File.extname(page.relative_path) == ".html"
         unless page.data.key?('last_modified_at')
           begin
-            page.data['last_modified_at'] = git.log.path(page.relative_path).first.date.strftime(DATE_FORMAT)
+            if use_file_mtime
+              # Use file's mtime for local development
+              page.data['last_modified_at'] = File.mtime(page.relative_path).strftime(DATE_FORMAT)
+            else
+              page.data['last_modified_at'] = git.log.path(page.relative_path).first.date.strftime(DATE_FORMAT)
+            end
           rescue => e
             # Ignored
           end
         end
-        puts"  #{page.relative_path}\n    last_modified_at: #{page.data['last_modified_at']}"
+        puts"  #{page.relative_path}\n    last_modified_at(#{use_file_mtime ? 'mtime': 'git'}): #{page.data['last_modified_at']}"
       end
 
       end_time = Time.now

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -7,11 +7,15 @@ variable "DOCS_URL" {
 variable "DOCS_SITE_DIR" {
   default = "_site"
 }
+variable "DOCS_ENFORCE_GIT_LOG_HISTORY" {
+  default = "0"
+}
 
 target "_common" {
   args = {
     JEKYLL_ENV = JEKYLL_ENV
     DOCS_URL = DOCS_URL
+    DOCS_ENFORCE_GIT_LOG_HISTORY = DOCS_ENFORCE_GIT_LOG_HISTORY
   }
   no-cache-filter = ["generate"]
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,7 @@ services:
       args:
         - JEKYLL_ENV
         - DOCS_URL
+        - DOCS_ENFORCE_GIT_LOG_HISTORY
       context: .
     image: docs/docstage
     ports:

--- a/subscription/faq.md
+++ b/subscription/faq.md
@@ -96,7 +96,7 @@ When you downgrade your Pro or Team plan, changes are applied at the end of your
 
 ### How do I downgrade from a Team plan to a Free Team plan?
 
-Before you downgrade to a Free plan, ensure that your organization details are updated to reflect features available in the Free plan. For example, you may need to reduce the number of team members and convert any private repositories to public repositories. For information on what’s included in the Free plan, see the [billing](index.md#pricing-plans){:target="blank" rel="noopener" class=""} page.
+Before you downgrade to a Free plan, ensure that your organization details are updated to reflect features available in the Free plan. For example, you may need to reduce the number of team members and convert any private repositories to public repositories. For information on what’s included in the Free plan, see the [billing](index.md){:target="blank" rel="noopener" class=""} page.
 
 ### How do I downgrade from Pro to a Free plan?
 
@@ -141,8 +141,7 @@ Team starts at $25 per month for the first five users and $7 per month for each 
 ### How will the new pricing plan impact existing Docker Hub customers?
 
 Legacy individual and organizational repository customers have until their January 2021 billing cycle to switch to the new pricing plans.
-To view the status of your individual repository plan, see [the billing](https://
-hub.docker.com/billing/plan/update){:target="blank" rel="noopener" class=""} page.
+To view the status of your individual repository plan, see [the billing](https://hub.docker.com/billing/plan/update){:target="blank" rel="noopener" class=""} page.
 To view the status of your organizational repository plan, see [Docker Hub Orgs](https://hub.docker.com/orgs){:target="blank" rel="noopener" class=""} page.
 
 ### What is the difference between the legacy repository plans and the newly announced plans?


### PR DESCRIPTION
follow-up https://github.com/docker/docs/pull/15994#issuecomment-1293214919

Fix last_modified_at plugin that overrides `last_modified_at` frontmatter value for remote resources. And use data files for commands reference instead of stub files to compute the correct last modification date.

Also adds `DOCS_ENFORCE_GIT_LOG_HISTORY` option to enforce git log history for local dev for testing purpose.