### PR TITLE
Update prometheus.md

### DIFF
--- a/config/daemon/prometheus.md
+++ b/config/daemon/prometheus.md
@@ -189,7 +189,7 @@ scrape_configs:
          # scheme defaults to 'http'.
 
     static_configs:
-      - targets: ['192.168.65.1:9323']
+      - targets: ['host.docker.internal:9323']
 ```
 
 </div><!-- windows -->


### PR DESCRIPTION
Replacing some strange IP host.docker.internal for windows

### Proposed changes

There was some internal IP wich wasn't working for me. Using `host.docker.internal`  should be the right way to contact host.