### PR TITLE
Enable dark mode in browser UI

### DIFF
--- a/_scss/_base.scss
+++ b/_scss/_base.scss
@@ -4,6 +4,7 @@ html {
         -ms-text-size-adjust: 100%;
     -moz-osx-font-smoothing: grayscale;
      -webkit-font-smoothing: antialiased;
+    color-scheme: light;
 }
 
 body {

--- a/_scss/_night-mode.scss
+++ b/_scss/_night-mode.scss
@@ -1,18 +1,22 @@
-body.night {
-    background-color: $bg-body-night;
-    color:            $body-text-night;
+html.night {
+    color-scheme: dark;
+  
+    body {
+        background-color: $bg-body-night;
+        color: $body-text-night;
 
-    &.landing {
-        background-color: $bg-body-landing-night;
-        .header > .container {
-            background-color: $bg-header-night;
-        }
-        .card, .cardlet {
-            color: inherit;
-            background-color: $bg-card-night;
-        }
-        footer {
-            background-color: $bg-footer-landing-night;
+        &.landing {
+            background-color: $bg-body-landing-night;
+            .header > .container {
+                background-color: $bg-header-night;
+            }
+            .card, .cardlet {
+                color: inherit;
+                background-color: $bg-card-night;
+            }
+            footer {
+                background-color: $bg-footer-landing-night;
+            }
         }
     }
 

--- a/_scss/_notes.scss
+++ b/_scss/_notes.scss
@@ -53,7 +53,7 @@ The available classes are:
 
 
 blockquote {
-  body.night & {
+  html.night & {
     // DARK THEME
 
     &:not(.important):not(.warning):not(.restricted):not(.experimental) {
@@ -102,7 +102,7 @@ blockquote {
     }
   }
 
-  body:not(.night) & {
+  html:not(.night) & {
     // LIGHT THEME
 
     &:not(.important):not(.warning):not(.restricted):not(.experimental) {

--- a/_scss/_upgrade-cta.scss
+++ b/_scss/_upgrade-cta.scss
@@ -1,11 +1,11 @@
 .docker-upgrade-cta {
-  body.night & {
+  html.night & {
     background-color: change-color($orange-10, $alpha: 0.3);
     border: 1px solid $orange-10;
     p, .docker-upgrade-cta__heading { color: $white-0; }
   }
 
-  body:not(.night) & {
+  html:not(.night) & {
     background-color: $orange-10;
     border: 1px solid $orange-20;
     p, .docker-upgrade-cta__heading { color: inherit; }

--- a/assets/js/theme-switcher.js
+++ b/assets/js/theme-switcher.js
@@ -22,17 +22,17 @@ const darkMode = window.matchMedia && window.matchMedia("(prefers-color-scheme: 
 const selectedTheme = window.localStorage ? localStorage.getItem("theme") : null;
 
 if (selectedTheme !== null) {
-    if (selectedTheme === "night") _("body").classList.add("night");
+    if (selectedTheme === "night") _("html").classList.add("night");
 } else if (darkMode) {
-    _("body").classList.add("night");
+    _("html").classList.add("night");
 }
 
 function themeToggler() {
-    const sw = _("#switch-style"), b = _("body");
-    if (sw && b) {
-        sw.checked = b.classList.contains("night")
+    const sw = _("#switch-style"), h = _("html");
+    if (sw && h) {
+        sw.checked = h.classList.contains("night")
         sw.addEventListener("change", function (){
-            b.classList.toggle("night", this.checked)
+            h.classList.toggle("night", this.checked)
             if (window.localStorage) {
                 this.checked ? localStorage.setItem("theme", "night") : localStorage.setItem("theme", "day")
             }


### PR DESCRIPTION
<!--We’d like to make it as easy as possible for you to contribute to the Docker documentation repository. Before you submit the pull request, we recommend that you review the [Contribution guidelines](/contribute/overview.md). Remove these comments as you go.-->

### Proposed changes

<!--Tell us what you did and why-->

We can change a browser's color scheme in according with used dark mode on the website. For example, then scrollbars will use dark colors which is good for the eyes, just fell the difference:


| Before   | After    |
| -------- | -------- |
| ![image](https://user-images.githubusercontent.com/4408379/198868049-a75e8c78-4371-41e3-be3d-b8221b0759ea.png) | ![image](https://user-images.githubusercontent.com/4408379/198868024-000c08eb-a668-4194-a72d-7a43396c2b99.png)|

PS: `color-scheme` will only work on the root `html` element, so I had to make appropriate replaces, but it should not be breaking changes.

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
