### PR TITLE
Extreme nit: Apple silicon

### DIFF
--- a/desktop/install/mac-install.md
+++ b/desktop/install/mac-install.md
@@ -48,7 +48,7 @@ Your Mac must meet the following requirements to install Docker Desktop successf
 </div>
 <div id="mac-apple-silicon" class="tab-pane fade" markdown="1">
 
-### Mac with Apple silicon
+### Mac with Apple Silicon
 
 - Beginning with Docker Desktop 4.3.0, we have removed the hard requirement to install **Rosetta 2**. There are a few optional command line tools that still require Rosetta 2 when using Darwin/AMD64. See the [Known issues section](../mac/apple-silicon.md#known-issues). However, to get the best experience, we recommend that you install Rosetta 2. To install Rosetta 2 manually from the command line, run the following command:
 
@@ -56,7 +56,7 @@ Your Mac must meet the following requirements to install Docker Desktop successf
   $ softwareupdate --install-rosetta
   ```
 
- For more information, see [Docker Desktop for Apple silicon](../mac/apple-silicon.md).
+ For more information, see [Docker Desktop for Apple Silicon](../mac/apple-silicon.md).
 
 </div>
 </div>

--- a/desktop/install/mac-install.md
+++ b/desktop/install/mac-install.md
@@ -18,7 +18,7 @@ redirect_from:
 This page contains information about system requirements, download URLs, and instructions on how to install Docker Desktop for Mac.
 
 [Mac with Intel chip](https://desktop.docker.com/mac/main/amd64/Docker.dmg?utm_source=docker&utm_medium=webreferral&utm_campaign=docs-driven-download-mac-amd64){: .button .primary-btn }
-[Mac with Apple chip](https://desktop.docker.com/mac/main/arm64/Docker.dmg?utm_source=docker&utm_medium=webreferral&utm_campaign=docs-driven-download-mac-arm64){: .button .primary-btn }
+[Mac with Apple silicon](https://desktop.docker.com/mac/main/arm64/Docker.dmg?utm_source=docker&utm_medium=webreferral&utm_campaign=docs-driven-download-mac-arm64){: .button .primary-btn }
 
 *For checksums, see [Release notes](../release-notes.md)*
 
@@ -28,7 +28,7 @@ Your Mac must meet the following requirements to install Docker Desktop successf
 
 <ul class="nav nav-tabs">
 <li class="active"><a data-toggle="tab" data-target="#mac-intel">Mac with Intel chip</a></li>
-<li><a data-toggle="tab" data-target="#mac-apple-silicon">Mac with Apple chip</a></li>
+<li><a data-toggle="tab" data-target="#mac-apple-silicon">Mac with Apple silicon</a></li>
 </ul>
 <div class="tab-content">
 <div id="mac-intel" class="tab-pane fade in active" markdown="1">
@@ -48,7 +48,7 @@ Your Mac must meet the following requirements to install Docker Desktop successf
 </div>
 <div id="mac-apple-silicon" class="tab-pane fade" markdown="1">
 
-### Mac with Apple Silicon
+### Mac with Apple silicon
 
 - Beginning with Docker Desktop 4.3.0, we have removed the hard requirement to install **Rosetta 2**. There are a few optional command line tools that still require Rosetta 2 when using Darwin/AMD64. See the [Known issues section](../mac/apple-silicon.md#known-issues). However, to get the best experience, we recommend that you install Rosetta 2. To install Rosetta 2 manually from the command line, run the following command:
 
@@ -56,7 +56,7 @@ Your Mac must meet the following requirements to install Docker Desktop successf
   $ softwareupdate --install-rosetta
   ```
 
- For more information, see [Docker Desktop for Apple Silicon](../mac/apple-silicon.md).
+ For more information, see [Docker Desktop for Apple silicon](../mac/apple-silicon.md).
 
 </div>
 </div>

--- a/desktop/install/mac-install.md
+++ b/desktop/install/mac-install.md
@@ -28,7 +28,7 @@ Your Mac must meet the following requirements to install Docker Desktop successf
 
 <ul class="nav nav-tabs">
 <li class="active"><a data-toggle="tab" data-target="#mac-intel">Mac with Intel chip</a></li>
-<li><a data-toggle="tab" data-target="#mac-apple-silicon">Mac with Apple silicon</a></li>
+<li><a data-toggle="tab" data-target="#mac-apple-silicon">Mac with Apple chip</a></li>
 </ul>
 <div class="tab-content">
 <div id="mac-intel" class="tab-pane fade in active" markdown="1">

--- a/desktop/mac/apple-silicon.md
+++ b/desktop/mac/apple-silicon.md
@@ -1,17 +1,17 @@
 ---
-description: Docker Desktop for Apple Silicon
+description: Docker Desktop for Apple silicon
 keywords: Docker Desktop, M1, Silicon, Apple,
-title: Docker Desktop for Apple Silicon
+title: Docker Desktop for Apple silicon
 redirect_from:
 - /docker-for-mac/apple-m1/
 - /docker-for-mac/apple-silicon/
 ---
 
-Docker Desktop for Mac on Apple Silicon is now available as a GA release. This enables you to develop applications with your choice of local development environments, and extends development pipelines for ARM-based applications.
+Docker Desktop for Mac on Apple silicon is now available as a GA release. This enables you to develop applications with your choice of local development environments, and extends development pipelines for ARM-based applications.
 
-Docker Desktop for Apple Silicon also supports multi-platform images, which allows you to build and run images for both x86 and ARM architectures without having to set up a complex cross-compilation development environment. Additionally, you can use [docker buildx](../../engine/reference/commandline/buildx.md){:target="_blank" rel="noopener" class="_"} to seamlessly integrate multi-platform builds into your build pipeline, and use [Docker Hub](https://hub.docker.com/){:target="_blank" rel="noopener" class="_"} to identify and share repositories that provide multi-platform images.
+Docker Desktop for Apple silicon also supports multi-platform images, which allows you to build and run images for both x86 and ARM architectures without having to set up a complex cross-compilation development environment. Additionally, you can use [docker buildx](../../engine/reference/commandline/buildx.md){:target="_blank" rel="noopener" class="_"} to seamlessly integrate multi-platform builds into your build pipeline, and use [Docker Hub](https://hub.docker.com/){:target="_blank" rel="noopener" class="_"} to identify and share repositories that provide multi-platform images.
 
-Download Docker Desktop for Mac on Apple Silicon:
+Download Docker Desktop for Mac on Apple silicon:
 
 > Download Docker Desktop
 >
@@ -34,9 +34,9 @@ $ softwareupdate --install-rosetta
   - The `docker-credential-ecr-login` credential helper.
 - Some images do not support the ARM64 architecture. You can add `--platform linux/amd64` to run (or build) an Intel image using emulation.
 
-   However, attempts to run Intel-based containers on Apple Silicon machines under emulation can crash as qemu sometimes fails to run the container. In addition, filesystem change notification APIs (`inotify`) do not work under qemu emulation. Even when the containers do run correctly under emulation, they will be slower and use more memory than the native equivalent.
+   However, attempts to run Intel-based containers on Apple silicon machines under emulation can crash as qemu sometimes fails to run the container. In addition, filesystem change notification APIs (`inotify`) do not work under qemu emulation. Even when the containers do run correctly under emulation, they will be slower and use more memory than the native equivalent.
 
-   In summary, running Intel-based containers on Arm-based machines should be regarded as "best effort" only. We recommend running arm64 containers on Apple Silicon machines whenever possible, and encouraging container authors to produce arm64, or multi-arch, versions of their containers. We expect this issue to become less common over time, as more and more images are rebuilt [supporting multiple architectures](https://www.docker.com/blog/multi-arch-build-and-images-the-simple-way/).
+   In summary, running Intel-based containers on Arm-based machines should be regarded as "best effort" only. We recommend running arm64 containers on Apple silicon machines whenever possible, and encouraging container authors to produce arm64, or multi-arch, versions of their containers. We expect this issue to become less common over time, as more and more images are rebuilt [supporting multiple architectures](https://www.docker.com/blog/multi-arch-build-and-images-the-simple-way/).
 - `ping` from inside a container to the Internet does not work as expected.  To test the network, we recommend using `curl` or `wget`. See [docker/for-mac#5322](https://github.com/docker/for-mac/issues/5322#issuecomment-809392861).
 - Users may occasionally experience data drop when a TCP stream is half-closed.
 
@@ -58,7 +58,7 @@ $ softwareupdate --install-rosetta
 - The build should update automatically to future versions.
 - HTTP proxy support is working, including support for domain name based `no_proxy` rules via TLS SNI. Fixes [docker/for-mac#2732](https://github.com/docker/for-mac/issues/2732).
 
-### Fixes since the Apple Silicon preview 7
+### Fixes since the Apple silicon preview 7
 
 - Kubernetes now works (although you might need to reset the cluster in our Troubleshoot menu one time to regenerate the certificates).
 - osxfs file sharing works.

--- a/desktop/mac/apple-silicon.md
+++ b/desktop/mac/apple-silicon.md
@@ -1,17 +1,17 @@
 ---
-description: Docker Desktop for Apple silicon
+description: Docker Desktop for Apple Silicon
 keywords: Docker Desktop, M1, Silicon, Apple,
-title: Docker Desktop for Apple silicon
+title: Docker Desktop for Apple Silicon
 redirect_from:
 - /docker-for-mac/apple-m1/
 - /docker-for-mac/apple-silicon/
 ---
 
-Docker Desktop for Mac on Apple silicon is now available as a GA release. This enables you to develop applications with your choice of local development environments, and extends development pipelines for ARM-based applications.
+Docker Desktop for Mac on Apple Silicon is now available as a GA release. This enables you to develop applications with your choice of local development environments, and extends development pipelines for ARM-based applications.
 
-Docker Desktop for Apple silicon also supports multi-platform images, which allows you to build and run images for both x86 and ARM architectures without having to set up a complex cross-compilation development environment. Additionally, you can use [docker buildx](../../engine/reference/commandline/buildx.md){:target="_blank" rel="noopener" class="_"} to seamlessly integrate multi-platform builds into your build pipeline, and use [Docker Hub](https://hub.docker.com/){:target="_blank" rel="noopener" class="_"} to identify and share repositories that provide multi-platform images.
+Docker Desktop for Apple Silicon also supports multi-platform images, which allows you to build and run images for both x86 and ARM architectures without having to set up a complex cross-compilation development environment. Additionally, you can use [docker buildx](../../engine/reference/commandline/buildx.md){:target="_blank" rel="noopener" class="_"} to seamlessly integrate multi-platform builds into your build pipeline, and use [Docker Hub](https://hub.docker.com/){:target="_blank" rel="noopener" class="_"} to identify and share repositories that provide multi-platform images.
 
-Download Docker Desktop for Mac on Apple silicon:
+Download Docker Desktop for Mac on Apple Silicon:
 
 > Download Docker Desktop
 >
@@ -34,9 +34,9 @@ $ softwareupdate --install-rosetta
   - The `docker-credential-ecr-login` credential helper.
 - Some images do not support the ARM64 architecture. You can add `--platform linux/amd64` to run (or build) an Intel image using emulation.
 
-   However, attempts to run Intel-based containers on Apple silicon machines under emulation can crash as qemu sometimes fails to run the container. In addition, filesystem change notification APIs (`inotify`) do not work under qemu emulation. Even when the containers do run correctly under emulation, they will be slower and use more memory than the native equivalent.
+   However, attempts to run Intel-based containers on Apple Silicon machines under emulation can crash as qemu sometimes fails to run the container. In addition, filesystem change notification APIs (`inotify`) do not work under qemu emulation. Even when the containers do run correctly under emulation, they will be slower and use more memory than the native equivalent.
 
-   In summary, running Intel-based containers on Arm-based machines should be regarded as "best effort" only. We recommend running arm64 containers on Apple silicon machines whenever possible, and encouraging container authors to produce arm64, or multi-arch, versions of their containers. We expect this issue to become less common over time, as more and more images are rebuilt [supporting multiple architectures](https://www.docker.com/blog/multi-arch-build-and-images-the-simple-way/).
+   In summary, running Intel-based containers on Arm-based machines should be regarded as "best effort" only. We recommend running arm64 containers on Apple Silicon machines whenever possible, and encouraging container authors to produce arm64, or multi-arch, versions of their containers. We expect this issue to become less common over time, as more and more images are rebuilt [supporting multiple architectures](https://www.docker.com/blog/multi-arch-build-and-images-the-simple-way/).
 - `ping` from inside a container to the Internet does not work as expected.  To test the network, we recommend using `curl` or `wget`. See [docker/for-mac#5322](https://github.com/docker/for-mac/issues/5322#issuecomment-809392861).
 - Users may occasionally experience data drop when a TCP stream is half-closed.
 


### PR DESCRIPTION
This bugged me a lot while reading

<img width="610" alt="Screen Shot 2022-10-30 at 7 22 54 PM" src="https://user-images.githubusercontent.com/8399069/198918273-b7e3628c-0ada-4a7c-8b75-50c1b9e13718.png">

because it's not parallel ("Apple chip" and "Apple silicon" used right next to each other!)

Initially I changed both to "Apple chip" but it turns out that it's referenced it as "Apple silicon" elsewhere in the docs (this is also what Apple calls it), I initially capitalized each change (i.e. Apple silicon --> Apple silicon) but the latter is used on their site and these docs only have one instance of it (which I changed the case of)