### PR TITLE
Fix typo in Wasm compose example's runtime value

### DIFF
--- a/desktop/wasm/index.md
+++ b/desktop/wasm/index.md
@@ -62,7 +62,7 @@ services:
   app:
     image: michaelirwin244/wasm-example
     platform: wasi/wasm32
-    runtime: io.container.wasmedge.v1
+    runtime: io.containerd.wasmedge.v1
     ports:
       - 8080:8080
 ```


### PR DESCRIPTION
### Proposed changes

Fixed a minor typo in an example in the Wasm docs.
