### PR TITLE
Remove sample redirect

### DIFF
--- a/_samples/library/ruby.md
+++ b/_samples/library/ruby.md
@@ -1,5 +1,4 @@
 ---
 redirect_to: https://hub.docker.com/_/ruby/
-redirect_from:
-- /samples/ruby/
+
 ---


### PR DESCRIPTION
/samples/ruby/ currently redirects to the Hub image.
This update removed the redirect.