### PR TITLE
mac/prometheus: updated DNS name for host internal IP

### DIFF
--- a/config/daemon/prometheus.md
+++ b/config/daemon/prometheus.md
@@ -149,7 +149,7 @@ scrape_configs:
          # scheme defaults to 'http'.
 
     static_configs:
-      - targets: ['docker.for.mac.host.internal:9323']
+      - targets: ['host.docker.internal:9323']
 ```
 
 </div><!-- mac -->


### PR DESCRIPTION
<!--We’d like to make it as easy as possible for you to contribute to the Docker documentation repository. Before you submit the pull request, we recommend that you review the [Contribution guidelines](/contribute/overview.md). Remove these comments as you go.-->

### Proposed changes

Updated the reference to the internal DNS name for the host's IP for the Prometheus mac instruction.

### Related issues (optional)

Follow-up to #16024
