### PR TITLE
ci: validate upstream reusable workflow

### DIFF
--- a/.github/workflows/validate-upstream.yml
+++ b/.github/workflows/validate-upstream.yml
@@ -1,0 +1,87 @@
+# reusable workflow to validate docs from upstream repository for which pages are remotely fetched
+# - repo: repository to handle from fetch-remote in _config.yml (e.g., https://github.com/docker/buildx)
+# - data-files-id: id of the artifact (using actions/upload-artifact) containing the YAML data files to validate (optional)
+# - data-files-folder: folder in _data containing the files to download and copy to (e.g., buildx)
+name: validate-upstream
+
+on:
+  workflow_call:
+    inputs:
+      repo:
+        required: true
+        type: string
+      data-files-id:
+        required: false
+        type: string
+      data-files-folder:
+        required: false
+        type: string
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v3
+        with:
+          repository: docker/docs
+      -
+        name: Install js-yaml
+        run: npm install js-yaml
+      -
+        name: Set correct ref to fetch remote resources
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const fs = require('fs');
+            const yaml = require('js-yaml');
+
+            const configFile = '_config.yml'
+            const config = yaml.load(fs.readFileSync(configFile, 'utf8'));
+            for (const remote of config['fetch-remote']) {
+              if (remote['repo'] != '${{ inputs.repo }}') {
+                continue;
+              }
+              if ("${{ github.event_name }}" == "pull_request") {
+                remote['repo'] = "${{ github.event.pull_request.head.repo.html_url }}";
+                remote['ref'] = "${{ github.event.pull_request.head.ref }}"
+              } else {
+                remote['ref'] = "${{ github.ref }}";
+              }
+            }
+
+            try {
+              fs.writeFileSync(configFile, yaml.dump(config), 'utf8')
+            } catch (err) {
+              console.error(err.message)
+              process.exit(1)
+            }
+      -
+        name: Prepare
+        run: |
+          # print docs jekyll config updated in previous step
+          yq _config.yml
+          # cleanup js-yaml module and data files
+          rm -rf ./node_modules
+          if [ -n "./_data/${{ inputs.data-files-folder }}" ]; then
+            rm -rf ./_data/${{ inputs.data-files-folder }}/*
+          fi
+      -
+        name: Download data files
+        uses: actions/download-artifact@v3
+        if: ${{ inputs.data-files-id != '' && inputs.data-files-dest != '' }}
+        with:
+          name: ${{ inputs.data-files-id }}
+          path: ./_data/${{ inputs.data-files-dest }}
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      -
+        name: Validate
+        uses: docker/bake-action@v2
+        with:
+          targets: validate
+          set: |
+            *.cache-from=type=gha,scope=docs-upstream
+            *.cache-to=type=gha,scope=docs-upstream,mode=max


### PR DESCRIPTION
As discussed with @dvdksn, here is a reusable workflow to validate docs from upstream repos from which we fetch remote resources like we do in buildx: https://github.com/docker/buildx/blob/master/.github/workflows/docs-upstream.yml

When this PR is merged, we can have a workflow of this type on buildx repo:

```yaml
name: docs-upstream

concurrency:
  group: ${{ github.workflow }}-${{ github.ref }}
  cancel-in-progress: true

on:
  push:
    branches:
      - 'master'
      - 'v[0-9]*'
    paths:
      - '.github/workflows/docs-upstream.yml'
      - 'docs/**'
  pull_request:
    paths:
      - '.github/workflows/docs-upstream.yml'
      - 'docs/**'

jobs:
  docs-yaml:
    runs-on: ubuntu-latest
    steps:
      -
        name: Checkout
        uses: actions/checkout@v3
      -
        name: Set up Docker Buildx
        uses: docker/setup-buildx-action@v2
        with:
          version: latest
      -
        name: Build reference YAML docs
        uses: docker/bake-action@v2
        with:
          targets: update-docs
          set: |
            *.output=/tmp/buildx-docs
            *.cache-from=type=gha,scope=docs-yaml
            *.cache-to=type=gha,scope=docs-yaml,mode=max
        env:
          DOCS_FORMATS: yaml
      -
        name: Upload reference YAML docs
        uses: actions/upload-artifact@v3
        with:
          name: docs-yaml
          path: /tmp/buildx-docs/out/reference
          retention-days: 1

  validate:
    uses: docker/docs/.github/workflows/validate-upstream.yml@main
    needs:
      - docs-yaml
    with:
      repo: https://github.com/${{ github.repository }}
      data-files-id: docs-yaml
      data-files-dest: ./_data/buildx
```

Same could be done on compose, buildkit and other repositories that we depend on in: https://github.com/docker/docs/blob/5ba43eff1d75a58bad66a8078e031afe21db3a1e/_config.yml#L151-L223

Has been tested here: https://github.com/crazy-max/buildx/actions/runs/3371310635

More info about reusable workflows: https://docs.github.com/en/actions/using-workflows/reusing-workflows

Signed-off-by: CrazyMax <crazy-max@users.noreply.github.com>