### PR TITLE
increased sidenav width (+2em)

### DIFF
--- a/_scss/_layout.scss
+++ b/_scss/_layout.scss
@@ -75,7 +75,7 @@
 @media only screen and (min-width: 1000px) {
     .col-nav,
     .col-toc {
-        flex: 0 0 19em;
+        flex: 0 0 21em;
     }
 }
 


### PR DESCRIPTION
<!--
  Thank you for contributing to Docker documentation!

  Here are a few things to keep in mind:

  - Links between pages should use a relative path
  - Remember to add an alt text for images

  ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
  ┃     Review our contribution guidelines:       ┃
  ┃                                               ┃
  ┃ https://docs.docker.com/contribute/overview/  ┃
  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
-->

### Proposed changes

Increasing the sidebar navigation width a little to accommodate for longer
titles in the table of contents.

Minor difference but improves aesthetic in some cases IMHO.

#### Examples

Before:
<img width="326" alt="image" src="https://user-images.githubusercontent.com/35727626/199500802-39a63c08-fe77-4950-b27c-35109338af55.png">



After: 
<img width="325" alt="image" src="https://user-images.githubusercontent.com/35727626/199500548-338ec57f-bb46-4cb6-a522-c1ac22441bbb.png">

