### PR TITLE
Update examples.md for golang

### DIFF
--- a/engine/api/sdk/examples.md
+++ b/engine/api/sdk/examples.md
@@ -57,6 +57,7 @@ func main() {
 	if err != nil {
 		panic(err)
 	}
+  defer cli.Close()
 
 	reader, err := cli.ImagePull(ctx, "docker.io/library/alpine", types.ImagePullOptions{})
 	if err != nil {
@@ -177,6 +178,7 @@ func main() {
 	if err != nil {
 		panic(err)
 	}
+  defer cli.Close()
 
 	imageName := "bfirsh/reticulate-splines"
 
@@ -261,6 +263,7 @@ func main() {
 	if err != nil {
 		panic(err)
 	}
+  defer cli.Close()
 
 	containers, err := cli.ContainerList(ctx, types.ContainerListOptions{})
 	if err != nil {
@@ -337,6 +340,7 @@ func main() {
 	if err != nil {
 		panic(err)
 	}
+  defer cli.Close()
 
 	containers, err := cli.ContainerList(ctx, types.ContainerListOptions{})
 	if err != nil {
@@ -418,6 +422,7 @@ func main() {
 	if err != nil {
 		panic(err)
 	}
+  defer cli.Close()
 
 	options := types.ContainerLogsOptions{ShowStdout: true}
 	// Replace this ID with a container that really exists
@@ -488,6 +493,7 @@ func main() {
 	if err != nil {
 		panic(err)
 	}
+  defer cli.Close()
 
 	images, err := cli.ImageList(ctx, types.ImageListOptions{})
 	if err != nil {
@@ -559,6 +565,7 @@ func main() {
 	if err != nil {
 		panic(err)
 	}
+  defer cli.Close()
 
 	out, err := cli.ImagePull(ctx, "alpine", types.ImagePullOptions{})
 	if err != nil {
@@ -635,6 +642,7 @@ func main() {
 	if err != nil {
 		panic(err)
 	}
+  defer cli.Close()
 
 	authConfig := types.AuthConfig{
 		Username: "username",
@@ -732,6 +740,7 @@ func main() {
 	if err != nil {
 		panic(err)
 	}
+  defer cli.Close()
 
 	createResp, err := cli.ContainerCreate(ctx, &container.Config{
 		Image: "alpine",

--- a/engine/api/sdk/examples.md
+++ b/engine/api/sdk/examples.md
@@ -57,7 +57,7 @@ func main() {
 	if err != nil {
 		panic(err)
 	}
-  defer cli.Close()
+	defer cli.Close()
 
 	reader, err := cli.ImagePull(ctx, "docker.io/library/alpine", types.ImagePullOptions{})
 	if err != nil {
@@ -178,7 +178,7 @@ func main() {
 	if err != nil {
 		panic(err)
 	}
-  defer cli.Close()
+	defer cli.Close()
 
 	imageName := "bfirsh/reticulate-splines"
 
@@ -263,7 +263,7 @@ func main() {
 	if err != nil {
 		panic(err)
 	}
-  defer cli.Close()
+	defer cli.Close()
 
 	containers, err := cli.ContainerList(ctx, types.ContainerListOptions{})
 	if err != nil {
@@ -340,7 +340,7 @@ func main() {
 	if err != nil {
 		panic(err)
 	}
-  defer cli.Close()
+	defer cli.Close()
 
 	containers, err := cli.ContainerList(ctx, types.ContainerListOptions{})
 	if err != nil {
@@ -422,7 +422,7 @@ func main() {
 	if err != nil {
 		panic(err)
 	}
-  defer cli.Close()
+	defer cli.Close()
 
 	options := types.ContainerLogsOptions{ShowStdout: true}
 	// Replace this ID with a container that really exists
@@ -493,7 +493,7 @@ func main() {
 	if err != nil {
 		panic(err)
 	}
-  defer cli.Close()
+	defer cli.Close()
 
 	images, err := cli.ImageList(ctx, types.ImageListOptions{})
 	if err != nil {
@@ -565,7 +565,7 @@ func main() {
 	if err != nil {
 		panic(err)
 	}
-  defer cli.Close()
+	defer cli.Close()
 
 	out, err := cli.ImagePull(ctx, "alpine", types.ImagePullOptions{})
 	if err != nil {
@@ -642,7 +642,7 @@ func main() {
 	if err != nil {
 		panic(err)
 	}
-  defer cli.Close()
+	defer cli.Close()
 
 	authConfig := types.AuthConfig{
 		Username: "username",
@@ -740,7 +740,7 @@ func main() {
 	if err != nil {
 		panic(err)
 	}
-  defer cli.Close()
+	defer cli.Close()
 
 	createResp, err := cli.ContainerCreate(ctx, &container.Config{
 		Image: "alpine",

--- a/engine/api/sdk/index.md
+++ b/engine/api/sdk/index.md
@@ -100,6 +100,7 @@ func main() {
     if err != nil {
         panic(err)
     }
+    defer cli.Close()
 
     reader, err := cli.ImagePull(ctx, "docker.io/library/alpine", types.ImagePullOptions{})
     if err != nil {


### PR DESCRIPTION
calling, `defer cli.Close()`
to close the underline transport used by the client

<!--
  Thank you for contributing to Docker documentation!

  Here are a few things to keep in mind:

  - Links between pages should use a relative path
  - Remember to add an alt text for images

  ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
  ┃     Review our contribution guidelines:       ┃
  ┃                                               ┃
  ┃ https://docs.docker.com/contribute/overview/  ┃
  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
-->

### Proposed changes

A better practice is to close all the resources used.
So proposed change is to call Close() method for cli to close the underline transport.

<!-- Tell us what you did and why -->

### Related issues (optional)

<!--
  Refer to related PRs or issues:

  #1234
  Closes #1234
  Closes docker/cli#1234
-->
