### PR TITLE
 fixes "Command 'docker-compose' not found" error.

### DIFF
--- a/language/nodejs/develop.md
+++ b/language/nodejs/develop.md
@@ -177,7 +177,7 @@ $ npm install nodemon
 Let’s start our application and confirm that it is running properly.
 
 ```console
-$ docker-compose -f docker-compose.dev.yml up --build
+$ docker compose -f docker-compose.dev.yml up --build
 ```
 
 We pass the `--build` flag so Docker compiles our image and then starts it.


### PR DESCRIPTION
This commit fixes the error thrown due to a typo in the command `docker-compose -f docker-compose.dev.yml up --build`. The correct command is `docker compose -f docker-compose.dev.yml up --build` without the hyphen between 'docker' and 'compose' in the command sequence