### PR TITLE
jekyll: enforce ruby platform to compile gems with native extensions from source

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,7 @@ ARG BUNDLER_VERSION
 COPY Gemfile* .
 RUN gem uninstall -aIx bundler \
   && gem install bundler -v ${BUNDLER_VERSION} \
+  && bundle config set force_ruby_platform true \
   && bundle install --jobs 4 --retry 3
 
 # Vendor Gemfile for Jekyll


### PR DESCRIPTION
`htmlproofer` cannot load `nokogiri` on M1 machine:

```
 > [htmlproofer 1/1] RUN <<EOF (cat /results...):                                                                                                                                                                                                     
#0 0.028 /usr/local/lib/ruby/2.7.0/rubygems/core_ext/kernel_require.rb:83:in `require': cannot load such file -- nokogiri/nokogiri (LoadError)                                                                                                        
#0 0.028        from /usr/local/lib/ruby/2.7.0/rubygems/core_ext/kernel_require.rb:83:in `require'                                                                                                                                                    
#0 0.028        from /usr/local/bundle/gems/nokogiri-1.13.9-aarch64-linux/lib/nokogiri/extension.rb:30:in `rescue in <top (required)>'
#0 0.028        from /usr/local/bundle/gems/nokogiri-1.13.9-aarch64-linux/lib/nokogiri/extension.rb:4:in `<top (required)>'
#0 0.028        from /usr/local/bundle/gems/nokogiri-1.13.9-aarch64-linux/lib/nokogiri.rb:10:in `require_relative'
#0 0.028        from /usr/local/bundle/gems/nokogiri-1.13.9-aarch64-linux/lib/nokogiri.rb:10:in `<top (required)>'
#0 0.028        from /usr/local/lib/ruby/2.7.0/rubygems/core_ext/kernel_require.rb:158:in `require'
#0 0.028        from /usr/local/lib/ruby/2.7.0/rubygems/core_ext/kernel_require.rb:158:in `rescue in require'
#0 0.028        from /usr/local/lib/ruby/2.7.0/rubygems/core_ext/kernel_require.rb:147:in `require'
#0 0.028        from /usr/local/bundle/gems/html-proofer-3.19.4/lib/html-proofer/utils.rb:3:in `<top (required)>'
#0 0.028        from /usr/local/bundle/gems/html-proofer-3.19.4/lib/html-proofer.rb:11:in `require_relative'
#0 0.028        from /usr/local/bundle/gems/html-proofer-3.19.4/lib/html-proofer.rb:11:in `<top (required)>'
#0 0.028        from /usr/local/lib/ruby/2.7.0/rubygems/core_ext/kernel_require.rb:83:in `require'
#0 0.028        from /usr/local/lib/ruby/2.7.0/rubygems/core_ext/kernel_require.rb:83:in `require'
#0 0.028        from /usr/local/bundle/gems/html-proofer-3.19.4/bin/htmlproofer:8:in `<top (required)>'
#0 0.028        from /usr/local/bundle/bin/htmlproofer:23:in `load'
#0 0.028        from /usr/local/bundle/bin/htmlproofer:23:in `<main>'
#0 0.028 /usr/local/bundle/gems/nokogiri-1.13.9-aarch64-linux/lib/nokogiri/extension.rb:7:in `require_relative': Error loading shared library ld-linux-aarch64.so.1: No such file or directory (needed by /usr/local/bundle/gems/nokogiri-1.13.9-aarch64-linux/lib/nokogiri/2.7/nokogiri.so) - /usr/local/bundle/gems/nokogiri-1.13.9-aarch64-linux/lib/nokogiri/2.7/nokogiri.so (LoadError)
#0 0.028        from /usr/local/bundle/gems/nokogiri-1.13.9-aarch64-linux/lib/nokogiri/extension.rb:7:in `<top (required)>'
#0 0.028        from /usr/local/bundle/gems/nokogiri-1.13.9-aarch64-linux/lib/nokogiri.rb:10:in `require_relative'
#0 0.028        from /usr/local/bundle/gems/nokogiri-1.13.9-aarch64-linux/lib/nokogiri.rb:10:in `<top (required)>'
#0 0.028        from /usr/local/lib/ruby/2.7.0/rubygems/core_ext/kernel_require.rb:158:in `require'
#0 0.028        from /usr/local/lib/ruby/2.7.0/rubygems/core_ext/kernel_require.rb:158:in `rescue in require'
#0 0.028        from /usr/local/lib/ruby/2.7.0/rubygems/core_ext/kernel_require.rb:147:in `require'
#0 0.028        from /usr/local/bundle/gems/html-proofer-3.19.4/lib/html-proofer/utils.rb:3:in `<top (required)>'
#0 0.028        from /usr/local/bundle/gems/html-proofer-3.19.4/lib/html-proofer.rb:11:in `require_relative'
#0 0.028        from /usr/local/bundle/gems/html-proofer-3.19.4/lib/html-proofer.rb:11:in `<top (required)>'
#0 0.028        from /usr/local/lib/ruby/2.7.0/rubygems/core_ext/kernel_require.rb:83:in `require'
#0 0.028        from /usr/local/lib/ruby/2.7.0/rubygems/core_ext/kernel_require.rb:83:in `require'
#0 0.028        from /usr/local/bundle/gems/html-proofer-3.19.4/bin/htmlproofer:8:in `<top (required)>'
#0 0.028        from /usr/local/bundle/bin/htmlproofer:23:in `load'
#0 0.028        from /usr/local/bundle/bin/htmlproofer:23:in `<main>'
#0 0.028 /usr/local/lib/ruby/2.7.0/rubygems/core_ext/kernel_require.rb:83:in `require': cannot load such file -- nokogiri/nokogiri (LoadError)
#0 0.028        from /usr/local/lib/ruby/2.7.0/rubygems/core_ext/kernel_require.rb:83:in `require'
#0 0.028        from /usr/local/bundle/gems/nokogiri-1.13.9-aarch64-linux/lib/nokogiri/extension.rb:30:in `rescue in <top (required)>'
#0 0.028        from /usr/local/bundle/gems/nokogiri-1.13.9-aarch64-linux/lib/nokogiri/extension.rb:4:in `<top (required)>'
#0 0.028        from /usr/local/bundle/gems/nokogiri-1.13.9-aarch64-linux/lib/nokogiri.rb:10:in `require_relative'
#0 0.028        from /usr/local/bundle/gems/nokogiri-1.13.9-aarch64-linux/lib/nokogiri.rb:10:in `<top (required)>'
#0 0.028        from /usr/local/lib/ruby/2.7.0/rubygems/core_ext/kernel_require.rb:83:in `require'
#0 0.028        from /usr/local/lib/ruby/2.7.0/rubygems/core_ext/kernel_require.rb:83:in `require'
#0 0.028        from /usr/local/bundle/gems/html-proofer-3.19.4/lib/html-proofer/utils.rb:3:in `<top (required)>'
#0 0.028        from /usr/local/bundle/gems/html-proofer-3.19.4/lib/html-proofer.rb:11:in `require_relative'
#0 0.028        from /usr/local/bundle/gems/html-proofer-3.19.4/lib/html-proofer.rb:11:in `<top (required)>'
#0 0.028        from /usr/local/lib/ruby/2.7.0/rubygems/core_ext/kernel_require.rb:83:in `require'
#0 0.028        from /usr/local/lib/ruby/2.7.0/rubygems/core_ext/kernel_require.rb:83:in `require'
#0 0.028        from /usr/local/bundle/gems/html-proofer-3.19.4/bin/htmlproofer:8:in `<top (required)>'
#0 0.028        from /usr/local/bundle/bin/htmlproofer:23:in `load'
#0 0.028        from /usr/local/bundle/bin/htmlproofer:23:in `<main>'
#0 0.028 /usr/local/bundle/gems/nokogiri-1.13.9-aarch64-linux/lib/nokogiri/extension.rb:7:in `require_relative': Error loading shared library ld-linux-aarch64.so.1: No such file or directory (needed by /usr/local/bundle/gems/nokogiri-1.13.9-aarch64-linux/lib/nokogiri/2.7/nokogiri.so) - /usr/local/bundle/gems/nokogiri-1.13.9-aarch64-linux/lib/nokogiri/2.7/nokogiri.so (LoadError)
#0 0.028        from /usr/local/bundle/gems/nokogiri-1.13.9-aarch64-linux/lib/nokogiri/extension.rb:7:in `<top (required)>'
#0 0.028        from /usr/local/bundle/gems/nokogiri-1.13.9-aarch64-linux/lib/nokogiri.rb:10:in `require_relative'
#0 0.028        from /usr/local/bundle/gems/nokogiri-1.13.9-aarch64-linux/lib/nokogiri.rb:10:in `<top (required)>'
#0 0.028        from /usr/local/lib/ruby/2.7.0/rubygems/core_ext/kernel_require.rb:83:in `require'
#0 0.028        from /usr/local/lib/ruby/2.7.0/rubygems/core_ext/kernel_require.rb:83:in `require'
#0 0.028        from /usr/local/bundle/gems/html-proofer-3.19.4/lib/html-proofer/utils.rb:3:in `<top (required)>'
#0 0.028        from /usr/local/bundle/gems/html-proofer-3.19.4/lib/html-proofer.rb:11:in `require_relative'
#0 0.028        from /usr/local/bundle/gems/html-proofer-3.19.4/lib/html-proofer.rb:11:in `<top (required)>'
#0 0.028        from /usr/local/lib/ruby/2.7.0/rubygems/core_ext/kernel_require.rb:83:in `require'
#0 0.028        from /usr/local/lib/ruby/2.7.0/rubygems/core_ext/kernel_require.rb:83:in `require'
#0 0.028        from /usr/local/bundle/gems/html-proofer-3.19.4/bin/htmlproofer:8:in `<top (required)>'
#0 0.028        from /usr/local/bundle/bin/htmlproofer:23:in `load'
#0 0.028        from /usr/local/bundle/bin/htmlproofer:23:in `<main>'
```

As a workaround, sets `force_ruby_platform` to `true` to ignore the current machine's platform and install only ruby platform gems. As a result, gems with native extensions will be compiled from source.

Signed-off-by: CrazyMax <crazy-max@users.noreply.github.com>