### PR TITLE
_includes/cli.md: do not escape flag descriptions

### DIFF
--- a/_includes/cli.md
+++ b/_includes/cli.md
@@ -138,7 +138,7 @@ For example uses of this command, refer to the [examples section](#examples) bel
     <td markdown="span">`--{{ option.option }}`{% if option.shorthand %} , `-{{ option.shorthand }}`{% endif %}</td>
     {%- endif %}
     <td markdown="span">{{ option-default }}</td>
-    <td markdown="span">{% if all-badges != '' %}{{ all-badges | strip }}<br />{% endif %}{{ option.description | strip | escape }}</td>
+    <td markdown="span">{% if all-badges != '' %}{{ all-badges | strip }}<br />{% endif %}{{ option.description | strip }}</td>
   </tr>
 {% endfor %} <!-- end for option -->
 </tbody>


### PR DESCRIPTION
revert changes https://github.com/docker/docs/pull/12083

`--ssh` flag with buildx is now properly escaped upstream but with #12083 it now also escapes inline code: https://docs.docker.com/engine/reference/commandline/buildx_build/

![image](https://user-images.githubusercontent.com/1951866/200110672-034e86f2-76bf-4f6b-b435-e5014816a94e.png)

Signed-off-by: CrazyMax <crazy-max@users.noreply.github.com>