### PR TITLE
fix: update log path on Windows

### DIFF
--- a/config/daemon/index.md
+++ b/config/daemon/index.md
@@ -229,8 +229,8 @@ subsystem used:
 | Linux                               | Use the command `journalctl -xu docker.service` (or read `/var/log/syslog` or `/var/log/messages`, depending on your Linux Distribution) |
 | macOS (`dockerd` logs)              | `~/Library/Containers/com.docker.docker/Data/log/vm/dockerd.log`                                                                         |
 | macOS (`containerd` logs)           | `~/Library/Containers/com.docker.docker/Data/log/vm/containerd.log`                                                                      |
-| Windows (WSL2) (`dockerd` logs)     | `AppData\Roaming\Docker\log\vm\dockerd.log`                                                                                              |
-| Windows (WSL2) (`containerd` logs)  | `AppData\Roaming\Docker\log\vm\containerd.log`                                                                                           |
+| Windows (WSL2) (`dockerd` logs)     | `AppData\Local\Docker\log\vm\dockerd.log`                                                                                              |
+| Windows (WSL2) (`containerd` logs)  | `AppData\Local\Docker\log\vm\containerd.log`                                                                                           |
 | Windows (Windows containers)        | Logs are in the Windows Event Log                                                                                                        |
 
 To view the `dockerd` logs on macOS, open a terminal Window, and use the `tail`


### PR DESCRIPTION
<!--
  Thank you for contributing to Docker documentation!

  Here are a few things to keep in mind:

  - Links between pages should use a relative path
  - Remember to add an alt text for images

  ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
  ┃     Review our contribution guidelines:       ┃
  ┃                                               ┃
  ┃ https://docs.docker.com/contribute/overview/  ┃
  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
-->

### Proposed changes

Updated log path from `Roaming` to `Local` (changed sometime in June).

### Related issues (optional)

<!--
  Refer to related PRs or issues:

  #1234
  Closes #1234
  Closes docker/cli#1234
-->
