### PR TITLE
remove deprecated version property

### DIFF
--- a/_includes/content/compose-extfields-sub.md
+++ b/_includes/content/compose-extfields-sub.md
@@ -9,7 +9,6 @@ your Compose file and their name start with the `x-` character sequence.
 > of service, volume, network, config and secret definitions.
 
 ```yaml
-version: "{{ site.compose_file_v3 }}"
 x-custom:
   items:
     - a
@@ -35,7 +34,6 @@ logging:
 You may write your Compose file as follows:
 
 ```yaml
-version: "{{ site.compose_file_v3 }}"
 x-logging:
   &default-logging
   options:
@@ -56,7 +54,6 @@ It is also possible to partially override values in extension fields using
 the [YAML merge type](https://yaml.org/type/merge.html). For example:
 
 ```yaml
-version: "{{ site.compose_file_v3 }}"
 x-volumes:
   &default-volume
   driver: foobar-storage

--- a/compose/compose-file/compose-file-v3.md
+++ b/compose/compose-file/compose-file-v3.md
@@ -31,7 +31,7 @@ topic on [Deploying an app to a Swarm](https://github.com/docker/labs/blob/maste
     <i class="chevron fa fa-fw"></i></div>
     <div class="collapse block" id="collapseSample1">
 <pre><code>
-version: "{{ site.compose_file_v3 }}"
+version: "{{ site.compose_file_v3 }}" # optional since v1.27.0
 services:
 
   redis:
@@ -173,7 +173,6 @@ Configuration options that are applied at build time.
 context:
 
 ```yaml
-version: "{{ site.compose_file_v3 }}"
 services:
   webapp:
     build: ./dir
@@ -183,7 +182,6 @@ Or, as an object with the path specified under [context](#context) and
 optionally [Dockerfile](#dockerfile) and [args](#args):
 
 ```yaml
-version: "{{ site.compose_file_v3 }}"
 services:
   webapp:
     build:
@@ -482,7 +480,6 @@ the stack deployment fails with a `config not found` error.
 > compose file format.
 
 ```yaml
-version: "{{ site.compose_file_v3 }}"
 services:
   redis:
     image: redis:latest
@@ -524,7 +521,6 @@ to `103`. The `redis` service does not have access to the `my_other_config`
 config.
 
 ```yaml
-version: "{{ site.compose_file_v3 }}"
 services:
   redis:
     image: redis:latest
@@ -604,7 +600,6 @@ When configuring a gMSA credential spec for a service, you only need
 to specify a credential spec with `config`, as shown in the following example:
 
 ```yaml
-version: "{{ site.compose_file_v3 }}"
 services:
   myservice:
     image: myimage:latest
@@ -632,7 +627,6 @@ behaviors:
 Simple example:
 
 ```yaml
-version: "{{ site.compose_file_v3 }}"
 services:
   web:
     build: .
@@ -665,7 +659,6 @@ sub-options only takes effect when deploying to a [swarm](../../engine/swarm/ind
 ignored by `docker-compose up` and `docker-compose run`, except for `resources`.
 
 ```yaml
-version: "{{ site.compose_file_v3 }}"
 services:
   redis:
     image: redis:alpine
@@ -703,8 +696,6 @@ in cases where you want to use your own load balancer, or for Hybrid
 Windows and Linux applications.
 
 ```yaml
-version: "{{ site.compose_file_v3 }}"
-
 services:
   wordpress:
     image: wordpress
@@ -751,7 +742,6 @@ Specify labels for the service. These labels are *only* set on the service,
 and *not* on any containers for the service.
 
 ```yaml
-version: "{{ site.compose_file_v3 }}"
 services:
   web:
     image: web
@@ -763,7 +753,6 @@ services:
 To set labels on containers instead, use the `labels` key outside of `deploy`:
 
 ```yaml
-version: "{{ site.compose_file_v3 }}"
 services:
   web:
     image: web
@@ -780,7 +769,6 @@ in the [swarm](../../engine/swarm/index.md) topics.)
 
 
 ```yaml
-version: "{{ site.compose_file_v3 }}"
 services:
   worker:
     image: dockersamples/examplevotingapp_worker
@@ -797,7 +785,6 @@ documentation for a full description of the syntax and available types of
 and [specifying the maximum replicas per node](../../engine/reference/commandline/service_create.md#specify-maximum-replicas-per-node---replicas-max-per-node)
 
 ```yaml
-version: "{{ site.compose_file_v3 }}"
 services:
   db:
     image: postgres
@@ -821,7 +808,6 @@ When there are more tasks requested than running nodes, an error
 `no suitable node (max replicas per node limit exceed)` is raised.
 
 ```yaml
-version: "{{ site.compose_file_v3 }}"
 services:
   worker:
     image: dockersamples/examplevotingapp_worker
@@ -841,7 +827,6 @@ If the service is `replicated` (which is the default), specify the number of
 containers that should be running at any given time.
 
 ```yaml
-version: "{{ site.compose_file_v3 }}"
 services:
   worker:
     image: dockersamples/examplevotingapp_worker
@@ -873,7 +858,6 @@ In this general example, the `redis` service is constrained to use no more than
 and has `20M` of memory and `0.25` CPU time reserved (as always available to it).
 
 ```yaml
-version: "{{ site.compose_file_v3 }}"
 services:
   redis:
     image: redis:alpine
@@ -927,7 +911,6 @@ Configures if and how to restart containers when they exit. Replaces
   decide immediately).
 
 ```yaml
-version: "{{ site.compose_file_v3 }}"
 services:
   redis:
     image: redis:alpine
@@ -972,7 +955,6 @@ updates.
 > file format.
 
 ```yaml
-version: "{{ site.compose_file_v3 }}"
 services:
   vote:
     image: dockersamples/examplevotingapp_vote:before
@@ -1326,7 +1308,6 @@ Run an init inside the container that forwards signals and reaps processes.
 Set this option to `true` to enable this feature for the service.
 
 ```yaml
-version: "{{ site.compose_file_v3 }}"
 services:
   web:
     image: alpine:latest
@@ -1473,7 +1454,6 @@ files are removed to allow storage of new logs.
 Here is an example `docker-compose.yml` file that limits logging storage:
 
 ```yaml
-version: "{{ site.compose_file_v3 }}"
 services:
   some-service:
     image: some-service
@@ -1566,8 +1546,6 @@ the hostname `db` or `database` on the `new` network, and at `db` or `mysql` on
 the `legacy` network.
 
 ```yaml
-version: "{{ site.compose_file_v3 }}"
-
 services:
   web:
     image: "nginx:alpine"
@@ -1619,8 +1597,6 @@ Then, reload the docker daemon and edit docker-compose.yml to contain the follow
 An example:
 
 ```yaml
-version: "{{ site.compose_file_v3 }}"
-
 services:
   app:
     image: nginx:alpine
@@ -1779,7 +1755,6 @@ command or by another stack deployment. If the external secret does not exist,
 the stack deployment fails with a `secret not found` error.
 
 ```yaml
-version: "{{ site.compose_file_v3 }}"
 services:
   redis:
     image: redis:latest
@@ -1822,7 +1797,6 @@ to `103`. The `redis` service does not have access to the `my_other_secret`
 secret.
 
 ```yaml
-version: "{{ site.compose_file_v3 }}"
 services:
   redis:
     image: redis:latest
@@ -2002,7 +1976,6 @@ for mounting a named volume. Named volumes must be listed under the top-level
 `volumes` key, as shown.
 
 ```yaml
-version: "{{ site.compose_file_v3 }}"
 services:
   web:
     image: nginx:alpine
@@ -2084,7 +2057,6 @@ expressed in the short form.
   - `size`: the size for the tmpfs mount in bytes
 
 ```yaml
-version: "{{ site.compose_file_v3 }}"
 services:
   web:
     image: nginx:alpine
@@ -2139,7 +2111,6 @@ as a named volume to persist the data on the swarm, _and_ is constrained to run
 only on `manager` nodes. Here is the relevant snip-it from that file:
 
 ```yaml
-version: "{{ site.compose_file_v3 }}"
 services:
   db:
     image: postgres:9.4
@@ -2221,8 +2192,6 @@ shared with another service as a volume so that it can be periodically backed
 up:
 
 ```yaml
-version: "{{ site.compose_file_v3 }}"
-
 services:
   db:
     image: db
@@ -2283,8 +2252,6 @@ In the example below, instead of attempting to create a volume called
 called `data` and mount it into the `db` service's containers.
 
 ```yaml
-version: "{{ site.compose_file_v3 }}"
-
 services:
   db:
     image: postgres
@@ -2353,7 +2320,6 @@ volumes that contain special characters. The name is used as is
 and will **not** be scoped with the stack name.
 
 ```yaml
-version: "{{ site.compose_file_v3 }}"
 volumes:
   data:
     name: my-app-data
@@ -2362,7 +2328,6 @@ volumes:
 It can also be used in conjunction with the `external` property:
 
 ```yaml
-version: "{{ site.compose_file_v3 }}"
 volumes:
   data:
     external: true
@@ -2428,7 +2393,6 @@ Docker has already created automatically) and an alias that Compose can use
 network using the alias.
 
 ```yaml
-version: "{{ site.compose_file_v3 }}"
 services:
   web:
     networks:
@@ -2572,8 +2536,6 @@ looks for an existing network simply called `outside` and connect the `proxy`
 service's containers to it.
 
 ```yaml
-version: "{{ site.compose_file_v3 }}"
-
 services:
   proxy:
     build: ./proxy
@@ -2599,7 +2561,6 @@ You can also specify the name of the network separately from the name used to
 refer to it within the Compose file:
 
 ```yaml
-version: "{{ site.compose_file_v3 }}"
 networks:
   outside:
     external:
@@ -2615,7 +2576,6 @@ networks which contain special characters. The name is used as is
 and will **not** be scoped with the stack name.
 
 ```yaml
-version: "{{ site.compose_file_v3 }}"
 networks:
   network1:
     name: my-app-net
@@ -2624,7 +2584,6 @@ networks:
 It can also be used in conjunction with the `external` property:
 
 ```yaml
-version: "{{ site.compose_file_v3 }}"
 networks:
   network1:
     external: true

--- a/compose/compose-file/compose-versioning.md
+++ b/compose/compose-file/compose-versioning.md
@@ -406,7 +406,7 @@ several options have been removed:
     [top-level `volumes` option](compose-file-v3.md#volume-configuration-reference)
     and specify the driver there.
 
-        version: "{{ site.compose_file_v3 }}"
+        version: "{{ site.compose_file_v3 }}"  # optional since v1.27.0
         services:
           db:
             image: postgres

--- a/compose/gettingstarted.md
+++ b/compose/gettingstarted.md
@@ -124,7 +124,6 @@ Create a file called `docker-compose.yml` in your project directory and paste
 the following:
 
 ```yaml
-version: "{{ site.compose_file_v3 }}"
 services:
   web:
     build: .
@@ -219,7 +218,6 @@ Edit `docker-compose.yml` in your project directory to add a
 [bind mount](../storage/bind-mounts.md) for the `web` service:
 
 ```yaml
-version: "{{ site.compose_file_v3 }}"
 services:
   web:
     build: .

--- a/compose/networking.md
+++ b/compose/networking.md
@@ -22,7 +22,6 @@ identical to the container name.
 For example, suppose your app is in a directory called `myapp`, and your `docker-compose.yml` looks like this:
 
 ```yaml
-version: "{{ site.compose_file_v3 }}"
 services:
   web:
     build: .
@@ -77,7 +76,6 @@ If any containers have connections open to the old container, they are closed. I
 Links allow you to define extra aliases by which a service is reachable from another service. They are not required to enable services to communicate - by default, any service can reach any other service at that service's name. In the following example, `db` is reachable from `web` at the hostnames `db` and `database`:
 
 ```yaml
-version: "{{ site.compose_file_v3 }}"
 services:
 
   web:
@@ -108,8 +106,6 @@ Each service can specify what networks to connect to with the *service-level* `n
 Here's an example Compose file defining two custom networks. The `proxy` service is isolated from the `db` service, because they do not share a network in common - only `app` can talk to both.
 
 ```yaml
-version: "{{ site.compose_file_v3 }}"
-
 services:
   proxy:
     build: ./proxy
@@ -142,7 +138,6 @@ Networks can be configured with static IP addresses by setting the [ipv4_address
 Networks can also be given a [custom name](compose-file/compose-file-v3.md#network-configuration-reference) (since version 3.5):
 
 ```yaml
-version: "{{ site.compose_file_v3 }}"
 services:
   # ...
 networks:
@@ -161,7 +156,6 @@ For full details of the network configuration options available, see the followi
 Instead of (or as well as) specifying your own networks, you can also change the settings of the app-wide default network by defining an entry under `networks` named `default`:
 
 ```yaml
-version: "{{ site.compose_file_v3 }}"
 services:
   web:
     build: .

--- a/compose/profiles.md
+++ b/compose/profiles.md
@@ -21,7 +21,6 @@ Services are associated with profiles through the
 array of profile names:
 
 ```yaml
-version: "{{ site.compose_file_v3 }}"
 services:
   frontend:
     image: frontend
@@ -85,7 +84,6 @@ manually. This can be used for one-off services and debugging tools.
 As an example consider this configuration:
 
 ```yaml
-version: "{{ site.compose_file_v3 }}"
 services:
   backend:
     image: backend
@@ -118,7 +116,6 @@ profile with it, be always enabled (by omitting `profiles`) or have a matching
 profile enabled explicitly:
 
 ```yaml
-version: "{{ site.compose_file_v3 }}"
 services:
   web:
     image: web

--- a/engine/swarm/secrets.md
+++ b/engine/swarm/secrets.md
@@ -969,8 +969,6 @@ the information from a Docker-managed secret instead of being passed directly.
 ## Use Secrets in Compose
 
 ```yaml
-version: "{{ site.compose_file_v3 }}"
-
 services:
    db:
      image: mysql:latest

--- a/engine/swarm/stack-deploy.md
+++ b/engine/swarm/stack-deploy.md
@@ -115,9 +115,7 @@ counter whenever you visit it.
 
 5.  Create a file called `docker-compose.yml` and paste this in:
 
-    ```none
-    version: "{{ site.compose_file_v3 }}"
-
+    ```yaml
     services:
       web:
         image: 127.0.0.1:5000/stackdemo
@@ -144,7 +142,7 @@ counter whenever you visit it.
     Compose doesn't take advantage of swarm mode, and deploys everything to a
     single node. You can safely ignore this.
 
-    ```none
+    ```console
     $ docker-compose up -d
 
     WARNING: The Docker Engine you're using is running in swarm mode.

--- a/storage/bind-mounts.md
+++ b/storage/bind-mounts.md
@@ -389,7 +389,6 @@ $ docker run -d \
 A single Docker Compose service with a bind mount looks like this:
 
 ```yaml
-version: "{{ site.compose_file_v3 }}"
 services:
   frontend:
     image: node:lts


### PR DESCRIPTION
<!--
  Thank you for contributing to Docker documentation!

  Here are a few things to keep in mind:

  - Links between pages should use a relative path
  - Remember to add an alt text for images

  ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
  ┃     Review our contribution guidelines:       ┃
  ┃                                               ┃
  ┃ https://docs.docker.com/contribute/overview/  ┃
  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
-->

### Proposed changes

According to the compose-spec the `version` property is marked as deprecated.
https://github.com/compose-spec/compose-spec/blob/master/spec.md#compose-file

It is just available backward compatibility but is only informative. 
https://github.com/compose-spec/compose-spec/blob/master/spec.md#version-top-level-element

Since it does not add any functionality it should be removed from the examples.

### Related issues (optional)

<!--
  Refer to related PRs or issues:

  #1234
  Closes #1234
  Closes docker/cli#1234
-->
