### PR TITLE
Note that `ENV` creates an intermediate image

### DIFF
--- a/develop/develop-images/dockerfile_best-practices.md
+++ b/develop/develop-images/dockerfile_best-practices.md
@@ -611,10 +611,10 @@ Similar to having constant variables in a program, as opposed to hard-coding
 values, this approach lets you change a single `ENV` instruction to
 automatically bump the version of the software in your container.
 
-Each `ENV` line creates a new intermediate layer, just like `RUN` commands. This
-means that even if you unset the environment variable in a future layer, it
-still persists in this layer and its value can be dumped. You can test this by
-creating a Dockerfile like the following, and then building it.
+Each `ENV` line creates a new intermediate image. This means that even if you
+unset the environment variable in a future layer, it still persists in this
+layer and its value can be dumped. You can test this by creating a Dockerfile
+like the following, and then building it.
 
 ```dockerfile
 # syntax=docker/dockerfile:1


### PR DESCRIPTION
<!--
  Thank you for contributing to Docker documentation!

  Here are a few things to keep in mind:

  - Links between pages should use a relative path
  - Remember to add an alt text for images

  ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
  ┃     Review our contribution guidelines:       ┃
  ┃                                               ┃
  ┃ https://docs.docker.com/contribute/overview/  ┃
  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
-->

### Proposed changes

Note that `ENV` creates an intermediate image
And not an intermediate layer. This is consistent with what's noted under `Minimize the number of layers` which states:

> Only the instructions `RUN`, `COPY`, `ADD` create layers. Other instructions
  create temporary intermediate images, and do not increase the size of the build.

This was updated with b8f99168b4f6674318dcc138457af56bd6e1bde9 (see also e7f9c01bce9a4e7cbeccbb3d68d7bb9776a55573). These mention Docker 1.10.0 but I couldn't find a note of a specific change like that in the changelog[1].

[1] https://github.com/docker/engine/blob/8955d8da8951695a98eb7e15bead19d402c6eb27/CHANGELOG.md?plain=1#L1486

### Related issues (optional)

* https://github.com/docker/docs/issues/10169
* https://github.com/docker/docs/issues/8655
