### PR TITLE
restructure engine docs

### DIFF
--- a/_data/toc.yaml
+++ b/_data/toc.yaml
@@ -167,92 +167,6 @@ guides:
       path: /get-started/kube-deploy/
     - title: "Deploy to Swarm"
       path: /get-started/swarm-deploy/
-  - sectiontitle: Configure all objects
-    section:
-    - path: /config/labels-custom-metadata/
-      title: Apply custom metadata to objects
-    - path: /config/pruning/
-      title: Prune unused objects
-    - path: /config/formatting/
-      title: Format command and log output
-  - sectiontitle: Configure the daemon
-    section:
-    - path: /config/daemon/
-      title: Configure and run Docker
-    - path: /config/daemon/systemd/
-      title: Control Docker with systemd
-    - path: /config/daemon/ipv6/
-      title: Configure the daemon for IPv6
-    - path: /network/iptables/
-      title: Docker and iptables
-    - sectiontitle: Store data within containers
-      section:
-      - path: /storage/storagedriver/
-        title: About storage drivers
-      - path: /storage/storagedriver/select-storage-driver/
-        title: Select a storage driver
-      - path: /storage/storagedriver/aufs-driver/
-        title: Use the AUFS storage driver
-      - path: /storage/storagedriver/btrfs-driver/
-        title: Use the Btrfs storage driver
-      - path: /storage/storagedriver/device-mapper-driver/
-        title: Use the Device mapper storage driver
-      - path: /storage/storagedriver/overlayfs-driver/
-        title: Use the OverlayFS storage driver
-      - path: /storage/storagedriver/zfs-driver/
-        title: Use the ZFS storage driver
-      - path: /storage/storagedriver/vfs-driver/
-        title: Use the VFS storage driver
-  - path: /config/daemon/prometheus/
-    title: Collect metrics with Prometheus
-  - sectiontitle: Configure containers
-    section:
-    - path: /config/containers/start-containers-automatically/
-      title: Start containers automatically
-    - path: /config/containers/live-restore/
-      title: Keep containers alive during daemon downtime
-    - path: /config/containers/multi-service_container/
-      title: Run multiple services in a container
-    - path: /config/containers/runmetrics/
-      title: Container runtime metrics
-    - path: /config/containers/resource_constraints/
-      title: Runtime options with Memory, CPUs, and GPUs
-    - sectiontitle: Logging
-      section:
-      - path: /config/containers/logging/
-        title: View a container's logs
-      - path: /config/containers/logging/configure/
-        title: Configure logging drivers
-      - path: /config/containers/logging/dual-logging/
-        title: Use docker logs with a logging driver
-      - path: /config/containers/logging/plugins/
-        title: Use a logging driver plugin
-      - path: /config/containers/logging/log_tags/
-        title: Customize log driver output
-      - sectiontitle: Logging driver details
-        section:
-        - path: /config/containers/logging/local/
-          title: Local file logging driver
-        - path: /config/containers/logging/logentries/
-          title: Logentries logging driver
-        - path: /config/containers/logging/json-file/
-          title: JSON File logging driver
-        - path: /config/containers/logging/gelf/
-          title: Graylog Extended Format (GELF) logging driver
-        - path: /config/containers/logging/syslog/
-          title: Syslog logging driver
-        - path: /config/containers/logging/awslogs/
-          title: Amazon CloudWatch logs logging driver
-        - path: /config/containers/logging/etwlogs/
-          title: ETW logging driver
-        - path: /config/containers/logging/fluentd/
-          title: Fluentd logging driver
-        - path: /config/containers/logging/gcplogs/
-          title: Google Cloud logging driver
-        - path: /config/containers/logging/journald/
-          title: Journald logging driver
-        - path: /config/containers/logging/splunk/
-          title: Splunk logging driver
     - sectiontitle: Scale your app
       section:
       - path: /engine/swarm/
@@ -311,68 +225,6 @@ guides:
         title: Swarm administration guide
       - path: /engine/swarm/raft/
         title: Raft consensus in swarm mode
-    - sectiontitle: Extend Docker
-      section:
-      - path: /engine/extend/
-        title: Managed plugin system
-      - path: /engine/extend/plugins_authorization/
-        title: Access authorization plugin
-      - path: /engine/extend/legacy_plugins/
-        title: Extending Docker with plugins
-      - path: /engine/extend/plugins_network/
-        title: Docker network driver plugins
-      - path: /engine/extend/plugins_volume/
-        title: Volume plugins
-      - title: Plugin configuration
-        path: /engine/extend/config/
-      - path: /engine/extend/plugin_api/
-        title: Plugins
-  - sectiontitle: Configure networking
-    section:
-    - path: /network/
-      title: Networking overview
-    - path: /config/containers/container-networking/
-      title: Container networking
-    - path: /network/proxy/
-      title: Configure Docker to use a proxy server
-    - path: /network/bridge/
-      title: Use bridge networks
-    - path: /network/overlay/
-      title: Use overlay networks
-    - path: /network/host/
-      title: Use host networking
-    - path: /network/ipvlan/
-      title: Use IPvlan networks
-    - path: /network/macvlan/
-      title: Use Macvlan networks
-    - path: /network/none/
-      title: Disable networking for a container
-    - sectiontitle: Networking tutorials
-      section:
-      - path: /network/network-tutorial-standalone/
-        title: Bridge network tutorial
-      - path: /network/network-tutorial-host/
-        title: Host networking tutorial
-      - path: /network/network-tutorial-overlay/
-        title: Overlay networking tutorial
-      - path: /network/network-tutorial-macvlan/
-        title: Macvlan network tutorial
-    - sectiontitle: Legacy networking content
-      section:
-      - path: /network/links/
-        title: (Legacy) Container links
-  - sectiontitle: Configure storage
-    section:
-    - path: /storage/
-      title: Overview
-    - path: /storage/volumes/
-      title: Volumes
-    - path: /storage/bind-mounts/
-      title: Bind mounts
-    - path: /storage/tmpfs/
-      title: tmpfs mounts
-    - path: /storage/troubleshooting_volume_errors/
-      title: Troubleshoot
 - path: /get-started/resources/
   title: "Educational resources"
 
@@ -1426,71 +1278,269 @@ manuals:
   - sectiontitle: Install
     section:
     - path: /engine/install/
-      title: Installation Overview
+      title: Overview
     - path: /engine/install/centos/
-      title: Install on CentOS
+      title: CentOS
     - path: /engine/install/debian/
-      title: Install on Debian
+      title: Debian
     - path: /engine/install/fedora/
-      title: Install on Fedora
+      title: Fedora
     - path: /engine/install/rhel/
-      title: Install on RHEL
+      title: RHEL
     - path: /engine/install/sles/
-      title: Install on SLES
+      title: SLES
     - path: /engine/install/ubuntu/
-      title: Install on Ubuntu
+      title: Ubuntu
     - path: /engine/install/binaries/
-      title: Install binaries
+      title: Binaries
     - path: /engine/install/linux-postinstall/
       title: Post-installation steps
     - path: /engine/install/troubleshoot/
       title: Troubleshoot installation
+  - sectiontitle: Storage
+    section:
+    - path: /storage/
+      title: Overview
+    - path: /storage/volumes/
+      title: Volumes
+    - path: /storage/bind-mounts/
+      title: Bind mounts
+    - path: /storage/tmpfs/
+      title: tmpfs mounts
+    - path: /storage/troubleshooting_volume_errors/
+      title: Troubleshoot
+    - sectiontitle: Storage drivers
+      section:
+      - path: /storage/storagedriver/
+        title: Overview
+      - path: /storage/storagedriver/select-storage-driver/
+        title: Select a storage driver
+      - path: /storage/storagedriver/aufs-driver/
+        title: Use the AUFS storage driver
+      - path: /storage/storagedriver/btrfs-driver/
+        title: Use the Btrfs storage driver
+      - path: /storage/storagedriver/device-mapper-driver/
+        title: Use the Device mapper storage driver
+      - path: /storage/storagedriver/overlayfs-driver/
+        title: Use the OverlayFS storage driver
+      - path: /storage/storagedriver/zfs-driver/
+        title: Use the ZFS storage driver
+      - path: /storage/storagedriver/vfs-driver/
+        title: Use the VFS storage driver
+  - sectiontitle: Networking
+    section:
+    - path: /network/
+      title: Overview
+    - path: /config/containers/container-networking/
+      title: Container networking
+    - path: /network/proxy/
+      title: Configure Docker to use a proxy server
+    - path: /network/bridge/
+      title: Bridge networks
+    - path: /network/overlay/
+      title: Overlay networks
+    - path: /network/host/
+      title: Host networking
+    - path: /network/ipvlan/
+      title: IPvlan networks
+    - path: /network/macvlan/
+      title: Macvlan networks
+    - path: /network/none/
+      title: Disable networking for a container
+    - sectiontitle: Networking tutorials
+      section:
+      - path: /network/network-tutorial-standalone/
+        title: Bridge network tutorial
+      - path: /network/network-tutorial-host/
+        title: Host networking tutorial
+      - path: /network/network-tutorial-overlay/
+        title: Overlay networking tutorial
+      - path: /network/network-tutorial-macvlan/
+        title: Macvlan network tutorial
+    - sectiontitle: Legacy networking content
+      section:
+      - path: /network/links/
+        title: (Legacy) Container links
+  - sectiontitle: Working with Docker Engine
+    section:
+    - path: /config/daemon/start/
+      title: Start the daemon
+    - path: /config/pruning/
+      title: Prune unused objects
+    - path: /config/formatting/
+      title: Format command and log output
+    - path: /config/containers/start-containers-automatically/
+      title: Start containers automatically
+    - path: /config/labels-custom-metadata/
+      title: Labels
+    - path: /engine/scan/
+      title: Docker Scan
+    - path: /engine/sbom/
+      title: Docker SBOM (Experimental)
+  - sectiontitle: Logging
+    section:
+    - sectiontitle: Container logs
+      section:
+      - path: /config/containers/logging/
+        title: View container logs
+      - sectiontitle: Manage container logs
+        section:
+        - path: /config/containers/logging/configure/
+          title: Configure logging drivers
+        - path: /config/containers/logging/dual-logging/
+          title: Use a remote logging driver
+        - path: /config/containers/logging/plugins/
+          title: Use a logging driver plugin
+        - path: /config/containers/logging/log_tags/
+          title: Customize log driver output
+        - sectiontitle: Logging drivers
+          section:
+          - path: /config/containers/logging/local/
+            title: Local file logging driver
+          - path: /config/containers/logging/logentries/
+            title: Logentries logging driver
+          - path: /config/containers/logging/json-file/
+            title: JSON File logging driver
+          - path: /config/containers/logging/gelf/
+            title: Graylog Extended Format (GELF) logging driver
+          - path: /config/containers/logging/syslog/
+            title: Syslog logging driver
+          - path: /config/containers/logging/awslogs/
+            title: Amazon CloudWatch logs logging driver
+          - path: /config/containers/logging/etwlogs/
+            title: ETW logging driver
+          - path: /config/containers/logging/fluentd/
+            title: Fluentd logging driver
+          - path: /config/containers/logging/gcplogs/
+            title: Google Cloud logging driver
+          - path: /config/containers/logging/journald/
+            title: Journald logging driver
+          - path: /config/containers/logging/splunk/
+            title: Splunk logging driver
+    - path: /config/daemon/logs/
+      title: Daemon logs
+  - sectiontitle: Security
+    section:
+      - path: /engine/security/
+        title: Overview
+      - path: /engine/security/rootless/
+        title: Rootless mode
+      - path: /engine/security/non-events/
+        title: Docker security non-events
+      - path: /engine/security/protect-access/
+        title: Protect the Docker daemon socket
+      - path: /engine/security/certificates/
+        title: Using certificates for repository client verification
+      - sectiontitle: Use trusted images
+        section:
+        - path: /engine/security/trust/
+          title: Overview
+        - path: /engine/security/trust/trust_automation/
+          title: Automation
+        - path: /engine/security/trust/trust_delegation/
+          title: Delegations
+        - path: /engine/security/trust/deploying_notary/
+          title: Deploy Notary
+        - path: /engine/security/trust/trust_key_mng/
+          title: Manage content trust keys
+        - path: /engine/security/trust/trust_sandbox/
+          title: Play in a content trust sandbox
+      - path: /engine/security/antivirus/
+        title: Antivirus software
+      - path: /engine/security/apparmor/
+        title: AppArmor security profiles
+      - path: /engine/security/seccomp/
+        title: Seccomp security profiles
+      - path: /engine/security/userns-remap/
+        title: Isolate containers with a user namespace
+  - sectiontitle: Advanced concepts
+    section:
+    - sectiontitle: Container runtime
+      section:
+      - path: /config/containers/resource_constraints/
+        title: Configure runtime resource constraints
+      - path: /config/containers/runmetrics/
+        title: Collect runtime metrics
+      - path: /config/containers/multi-service_container/
+        title: Run multiple services in a container
+      - path: /config/daemon/prometheus/
+        title: Collect metrics with Prometheus
+    - sectiontitle: Daemon configuration
+      section:
+      - path: /config/daemon/
+        title: Configuration overview
+      - path: /config/daemon/systemd/
+        title: Configure with systemd
+      - path: /config/daemon/ipv6/
+        title: Use IPv6
+      - path: /config/containers/live-restore/
+        title: Keep containers alive during daemon downtime
+      - path: /config/daemon/troubleshoot/
+        title: Troubleshoot
+      - path: /network/iptables/
+        title: Docker and iptables
+      - path: /config/daemon/remote-access/
+        title: Remote access
+      - path: /engine/context/working-with-contexts/
+        title: Contexts
+    - sectiontitle: Engine plugins
+      section:
+      - path: /engine/extend/
+        title: Managed plugin system
+      - path: /engine/extend/plugins_authorization/
+        title: Access authorization plugin
+      - path: /engine/extend/legacy_plugins/
+        title: Extending Docker with plugins
+      - path: /engine/extend/plugins_network/
+        title: Docker network driver plugins
+      - path: /engine/extend/plugins_volume/
+        title: Volume plugins
+      - title: Plugin configuration
+        path: /engine/extend/config/
+      - path: /engine/extend/plugin_api/
+        title: Plugins
   - path: /engine/deprecated/
     title: Deprecated features
-  - path: /engine/context/working-with-contexts/
-    title: Docker Context
-  - path: /engine/scan/
-    title: Docker Scan
-  - path: /engine/sbom/
-    title: Docker SBOM (Experimental)
-  - path: /engine/release-notes/
-    title: Release notes
-  - sectiontitle: Previous versions
+  - sectiontitle: Release notes
     section:
+    - path: /engine/release-notes/
+      title: Engine 20.10
+    - sectiontitle: Previous versions
+      section:
       - path: /engine/release-notes/19.03/
-        title: Engine 19.03 release notes
+        title: Engine 19.03
       - path: /engine/release-notes/18.09/
-        title: Engine 18.09 release notes
+        title: Engine 18.09
       - path: /engine/release-notes/18.06/
-        title: Engine 18.06 release notes
+        title: Engine 18.06
       - path: /engine/release-notes/18.05/
-        title: Engine 18.05 release notes
+        title: Engine 18.05
       - path: /engine/release-notes/18.04/
-        title: Engine 18.04 release notes
+        title: Engine 18.04
       - path: /engine/release-notes/18.03/
-        title: Engine 18.03 release notes
+        title: Engine 18.03
       - path: /engine/release-notes/18.02/
-        title: Engine 18.02 release notes
+        title: Engine 18.02
       - path: /engine/release-notes/18.01/
-        title: Engine 18.01 release notes
+        title: Engine 18.01
       - path: /engine/release-notes/17.12/
-        title: Engine 17.12 release notes
+        title: Engine 17.12
       - path: /engine/release-notes/17.11/
-        title: Engine 17.11 release notes
+        title: Engine 17.11
       - path: /engine/release-notes/17.10/
-        title: Engine 17.10 release notes
+        title: Engine 17.10
       - path: /engine/release-notes/17.09/
-        title: Engine 17.09 release notes
+        title: Engine 17.09
       - path: /engine/release-notes/17.07/
-        title: Engine 17.07 release notes
+        title: Engine 17.07
       - path: /engine/release-notes/17.06/
-        title: Engine 17.06 release notes
+        title: Engine 17.06
       - path: /engine/release-notes/17.05/
-        title: Engine 17.05 release notes
+        title: Engine 17.05
       - path: /engine/release-notes/17.04/
-        title: Engine 17.04 release notes
+        title: Engine 17.04
       - path: /engine/release-notes/17.03/
-        title: Engine 17.03 release notes
+        title: Engine 17.03
       - path: /engine/release-notes/prior-releases/
         title: Engine 1.13 and earlier
 - sectiontitle: Docker Build
@@ -1766,44 +1816,8 @@ manuals:
     title: Image Access Management
 
 
-- sectiontitle: Security
-  section:
-  - path: /security/
-    title: Announcements
-  - sectiontitle: Docker Engine security
-    section:
-      - path: /engine/security/
-        title: Overview
-      - path: /engine/security/non-events/
-        title: Docker security non-events
-      - path: /engine/security/protect-access/
-        title: Protect the Docker daemon socket
-      - path: /engine/security/certificates/
-        title: Using certificates for repository client verification
-      - sectiontitle: Use trusted images
-        section:
-        - path: /engine/security/trust/
-          title: Overview
-        - path: /engine/security/trust/trust_automation/
-          title: Automation
-        - path: /engine/security/trust/trust_delegation/
-          title: Delegations
-        - path: /engine/security/trust/deploying_notary/
-          title: Deploy Notary
-        - path: /engine/security/trust/trust_key_mng/
-          title: Manage content trust keys
-        - path: /engine/security/trust/trust_sandbox/
-          title: Play in a content trust sandbox
-      - path: /engine/security/antivirus/
-        title: Antivirus software
-      - path: /engine/security/apparmor/
-        title: AppArmor security profiles
-      - path: /engine/security/seccomp/
-        title: Seccomp security profiles
-      - path: /engine/security/userns-remap/
-        title: Isolate containers with a user namespace
-      - path: /engine/security/rootless/
-        title: Rootless mode
+- title: Security announcements
+  path: /security/
 
 - sectiontitle: Atomist
   section:

--- a/assets/images/engine-configure-daemon.svg
+++ b/assets/images/engine-configure-daemon.svg
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   height="48"
+   width="48"
+   version="1.1"
+   id="svg58"
+   sodipodi:docname="engine-configure-daemon.svg"
+   inkscape:version="1.2.1 (9c6d41e, 2022-07-14)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs62" />
+  <sodipodi:namedview
+     id="namedview60"
+     pagecolor="#505050"
+     bordercolor="#eeeeee"
+     borderopacity="1"
+     inkscape:showpageshadow="0"
+     inkscape:pageopacity="0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#505050"
+     showgrid="false"
+     inkscape:zoom="12.91943"
+     inkscape:cx="23.298241"
+     inkscape:cy="25.19461"
+     inkscape:window-width="1189"
+     inkscape:window-height="1025"
+     inkscape:window-x="526"
+     inkscape:window-y="51"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg58" />
+  <path
+     d="M37.65 16.8q-.2 0-.4-.1t-.3-.35l-1.5-3.25-3.25-1.5q-.25-.1-.35-.3-.1-.2-.1-.4t.1-.4q.1-.2.35-.3l3.25-1.5 1.5-3.25q.1-.25.3-.35.2-.1.4-.1t.4.1q.2.1.3.35l1.5 3.25 3.25 1.5q.25.1.35.3.1.2.1.4t-.1.4q-.1.2-.35.3l-3.25 1.5-1.5 3.25q-.1.25-.3.35-.2.1-.4.1Zm4.2 14.45q-.2 0-.4-.1t-.3-.3l-.8-1.75-1.75-.8q-.1-.05-.4-.7 0-.2.1-.4t.3-.3l1.75-.8.8-1.75q.05-.1.7-.4.2 0 .4.1t.3.3l.8 1.75 1.75.8q.1.05.4.7 0 .2-.1.4t-.3.3l-1.75.8-.8 1.75q-.05.1-.7.4ZM17.05 44q-.55 0-.975-.4-.425-.4-.525-.95l-.35-3.25q-.7-.1-1.45-.45t-1.3-.85l-2.7 1.15q-.55.25-1.05.05t-.8-.65l-3-4.85q-.3-.55-.175-1.125t.625-.925l2.6-1.7q-.25-.85-.25-1.5t.25-1.5l-2.6-1.7q-.5-.35-.625-.925Q4.6 23.85 4.9 23.3l3-4.85q.3-.45.8-.65t1.05.05l2.7 1.15q.55-.5 1.3-.85t1.45-.45l.35-3.25q.1-.55.525-.95.425-.4.975-.4h5.7q.55 0 .975.4.425.4.525.95l.35 3.25q.7.1 1.45.45t1.3.85l2.7-1.15q.55-.25 1.05-.05t.8.65l3 4.85q.3.55.175 1.125t-.625.925l-2.6 1.7q.25.85.25 1.5t-.25 1.5l2.6 1.7q.5.35.625.925.125.575-.175 1.125l-3 4.85q-.3.45-.8.65t-1.05-.05l-2.7-1.15q-.55.5-1.3.85t-1.45.45l-.35 3.25q-.1.55-.525.95-.425.4-.975.4Zm2.85-9.7q2.5 0 4.125-1.625t1.625-4.125q0-2.5-1.625-4.125T19.9 22.8q-2.5 0-4.125 1.625T14.15 28.55q0 2.5 1.625 4.125T19.9 34.3Zm0-5.75Z"
+     id="path56"
+     style="fill:#677285;fill-opacity:1" />
+</svg>

--- a/assets/images/engine-deprecated.svg
+++ b/assets/images/engine-deprecated.svg
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   height="48"
+   width="48"
+   version="1.1"
+   id="svg2826"
+   sodipodi:docname="engine-deprecated.svg"
+   inkscape:version="1.2.1 (9c6d41e, 2022-07-14)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs2830" />
+  <sodipodi:namedview
+     id="namedview2828"
+     pagecolor="#505050"
+     bordercolor="#eeeeee"
+     borderopacity="1"
+     inkscape:showpageshadow="0"
+     inkscape:pageopacity="0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#505050"
+     showgrid="false"
+     inkscape:zoom="6.6041667"
+     inkscape:cx="24.07571"
+     inkscape:cy="24.15142"
+     inkscape:window-width="1189"
+     inkscape:window-height="1025"
+     inkscape:window-x="526"
+     inkscape:window-y="51"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg2826" />
+  <path
+     d="M24 26.6q.65 0 1.075-.425.425-.425.425-1.075v-7.6q0-.65-.425-1.075Q24.65 16 24 16q-.65 0-1.075.425-.425.425-.425 1.075v7.6q0 .65.425 1.075.425.425 1.075.425Zm0 5.4q.7 0 1.175-.475.475-.475.475-1.175 0-.7-.475-1.175Q24.7 28.7 24 28.7q-.7 0-1.175.475-.475.475-.475 1.175 0 .7.475 1.175Q23.3 32 24 32ZM9.5 38q-.65 0-1.075-.425Q8 37.15 8 36.5q0-.65.425-1.075Q8.85 35 9.5 35h2.7V19.7q0-4.1 2.475-7.425T21.2 8.1V6.65q0-1.15.825-1.9T24 4q1.15 0 1.975.75.825.75.825 1.9V8.1q4.05.85 6.55 4.175 2.5 3.325 2.5 7.425V35h2.65q.65 0 1.075.425Q40 35.85 40 36.5q0 .65-.425 1.075Q39.15 38 38.5 38ZM24 44q-1.6 0-2.8-1.175Q20 41.65 20 40h8q0 1.65-1.175 2.825Q25.65 44 24 44Z"
+     id="path2824"
+     style="fill:#677285;fill-opacity:1" />
+</svg>

--- a/assets/images/engine-logging.svg
+++ b/assets/images/engine-logging.svg
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   height="48"
+   width="48"
+   version="1.1"
+   id="svg3648"
+   sodipodi:docname="engine-logging.svg"
+   inkscape:version="1.2.1 (9c6d41e, 2022-07-14)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs3652" />
+  <sodipodi:namedview
+     id="namedview3650"
+     pagecolor="#505050"
+     bordercolor="#eeeeee"
+     borderopacity="1"
+     inkscape:showpageshadow="0"
+     inkscape:pageopacity="0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#505050"
+     showgrid="false"
+     inkscape:zoom="6.6041667"
+     inkscape:cx="24.07571"
+     inkscape:cy="24.15142"
+     inkscape:window-width="1189"
+     inkscape:window-height="1025"
+     inkscape:window-x="526"
+     inkscape:window-y="51"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg3648" />
+  <path
+     d="M9 42q-1.2 0-2.1-.9Q6 40.2 6 39V9q0-1.2.9-2.1Q7.8 6 9 6h23.1l9.9 9.9V39q0 1.2-.9 2.1-.9.9-2.1.9Zm6.45-8.55h17.1q.65 0 1.075-.425.425-.425.425-1.075 0-.65-.425-1.075-.425-.425-1.075-.425h-17.1q-.65 0-1.075.425-.425.425-.425 1.075 0 .65.425 1.075.425.425 1.075.425Zm0-15.9h7.05q.65 0 1.075-.425Q24 16.7 24 16.05q0-.65-.425-1.075-.425-.425-1.075-.425h-7.05q-.65 0-1.075.425-.425.425-.425 1.075 0 .65.425 1.075.425.425 1.075.425Zm0 7.95h17.1q.65 0 1.075-.425.425-.425.425-1.075 0-.65-.425-1.075-.425-.425-1.075-.425h-17.1q-.65 0-1.075.425-.425.425-.425 1.075 0 .65.425 1.075.425.425 1.075.425Zm16.5-7.95H39L30.45 9v7.05q0 .65.425 1.075.425.425 1.075.425Z"
+     id="path3646"
+     style="fill:#677285;fill-opacity:1" />
+</svg>

--- a/assets/images/engine-networking.svg
+++ b/assets/images/engine-networking.svg
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   height="48"
+   width="48"
+   version="1.1"
+   id="svg4421"
+   sodipodi:docname="engine-networking.svg"
+   inkscape:version="1.2.1 (9c6d41e, 2022-07-14)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs4425" />
+  <sodipodi:namedview
+     id="namedview4423"
+     pagecolor="#505050"
+     bordercolor="#eeeeee"
+     borderopacity="1"
+     inkscape:showpageshadow="0"
+     inkscape:pageopacity="0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#505050"
+     showgrid="false"
+     inkscape:zoom="6.6041667"
+     inkscape:cx="24.07571"
+     inkscape:cy="24.15142"
+     inkscape:window-width="1189"
+     inkscape:window-height="1025"
+     inkscape:window-x="526"
+     inkscape:window-y="51"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg4421" />
+  <path
+     d="M9 44q-1.25 0-2.125-.875T6 41v-7.5q0-1.25.875-2.125T9 30.5h3v-5q0-1.25.875-2.125T15 22.5h7.5v-5h-3q-1.25 0-2.125-.875T16.5 14.5V7q0-1.25.875-2.125T19.5 4h9q1.25 0 2.125.875T31.5 7v7.5q0 1.25-.875 2.125T28.5 17.5h-3v5H33q1.25 0 2.125.875T36 25.5v5h3q1.25 0 2.125.875T42 33.5V41q0 1.25-.875 2.125T39 44h-9q-1.25 0-2.125-.875T27 41v-7.5q0-1.25.875-2.125T30 30.5h3v-5H15v5h3q1.25 0 2.125.875T21 33.5V41q0 1.25-.875 2.125T18 44Z"
+     id="path4419"
+     style="fill:#677285;fill-opacity:1" />
+</svg>

--- a/assets/images/engine-pruning.svg
+++ b/assets/images/engine-pruning.svg
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   height="48"
+   width="48"
+   version="1.1"
+   id="svg5194"
+   sodipodi:docname="engine-pruning.svg"
+   inkscape:version="1.2.1 (9c6d41e, 2022-07-14)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs5198" />
+  <sodipodi:namedview
+     id="namedview5196"
+     pagecolor="#505050"
+     bordercolor="#eeeeee"
+     borderopacity="1"
+     inkscape:showpageshadow="0"
+     inkscape:pageopacity="0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#505050"
+     showgrid="false"
+     inkscape:zoom="6.6041667"
+     inkscape:cx="24.07571"
+     inkscape:cy="24.15142"
+     inkscape:window-width="1189"
+     inkscape:window-height="1025"
+     inkscape:window-x="526"
+     inkscape:window-y="51"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg5194" />
+  <path
+     d="M39.1 42.3 24.05 27.25 18.2 33.1q.55.85.675 1.65.125.8.125 1.75 0 3.2-2.15 5.35Q14.7 44 11.5 44q-3.2 0-5.35-2.15Q4 39.7 4 36.5q0-3.2 2.15-5.35Q8.3 29 11.5 29q.9 0 1.775.25.875.25 1.825.75l5.8-5.8-5.9-5.9q-.85.4-1.725.55Q12.4 19 11.5 19q-3.2 0-5.35-2.15Q4 14.7 4 11.5q0-3.2 2.15-5.35Q8.3 4 11.5 4q3.2 0 5.35 2.15Q19 8.3 19 11.5q0 .95-.125 1.8-.125.85-.525 1.6l25.7 25.7v1.7Zm-9.15-20.65-3.3-3.3L39.1 5.9h4.95v1.65ZM11.5 16q1.9 0 3.2-1.3 1.3-1.3 1.3-3.2 0-1.9-1.3-3.2Q13.4 7 11.5 7 9.6 7 8.3 8.3 7 9.6 7 11.5q0 1.9 1.3 3.2Q9.6 16 11.5 16Zm12.65 9.15q.4 0 .675-.275t.275-.675q0-.4-.275-.675t-.675-.275q-.4 0-.675.275t-.275.675q0 .4.275.675t.675.275ZM11.5 41q1.9 0 3.2-1.3 1.3-1.3 1.3-3.2 0-1.9-1.3-3.2-1.3-1.3-3.2-1.3-1.9 0-3.2 1.3Q7 34.6 7 36.5q0 1.9 1.3 3.2Q9.6 41 11.5 41Z"
+     id="path5192"
+     style="fill:#677285;fill-opacity:1" />
+</svg>

--- a/assets/images/engine-rootless.svg
+++ b/assets/images/engine-rootless.svg
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   height="48"
+   width="48"
+   version="1.1"
+   id="svg5971"
+   sodipodi:docname="engine-rootless.svg"
+   inkscape:version="1.2.1 (9c6d41e, 2022-07-14)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs5975" />
+  <sodipodi:namedview
+     id="namedview5973"
+     pagecolor="#505050"
+     bordercolor="#eeeeee"
+     borderopacity="1"
+     inkscape:showpageshadow="0"
+     inkscape:pageopacity="0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#505050"
+     showgrid="false"
+     inkscape:zoom="6.6041667"
+     inkscape:cx="24.07571"
+     inkscape:cy="24.15142"
+     inkscape:window-width="1189"
+     inkscape:window-height="1025"
+     inkscape:window-x="526"
+     inkscape:window-y="51"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg5971" />
+  <path
+     d="M24 43.8q-.3 0-.6-.025t-.55-.125q-6.55-2.15-10.7-8.3Q8 29.2 8 21.9v-9.8q0-.95.55-1.725.55-.775 1.4-1.125l13-4.85q.55-.2 1.05-.2t1.05.2l13 4.85q.85.35 1.4 1.125.55.775.55 1.725v9.8q0 7.3-4.15 13.45-4.15 6.15-10.7 8.3-.25.1-.55.125-.3.025-.6.025Zm0-2.9q5.3-1.75 8.775-6.425Q36.25 29.8 36.85 24H24V7.25L11 12.1v9.8q0 .6.025 1.025.025.425.125 1.075H24Z"
+     id="path5969"
+     style="fill:#677285;fill-opacity:1" />
+</svg>

--- a/assets/images/engine-storage.svg
+++ b/assets/images/engine-storage.svg
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   height="48"
+   width="48"
+   version="1.1"
+   id="svg6744"
+   sodipodi:docname="engine-storage.svg"
+   inkscape:version="1.2.1 (9c6d41e, 2022-07-14)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs6748" />
+  <sodipodi:namedview
+     id="namedview6746"
+     pagecolor="#505050"
+     bordercolor="#eeeeee"
+     borderopacity="1"
+     inkscape:showpageshadow="0"
+     inkscape:pageopacity="0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#505050"
+     showgrid="false"
+     inkscape:zoom="6.6041667"
+     inkscape:cx="24.07571"
+     inkscape:cy="24.15142"
+     inkscape:window-width="1189"
+     inkscape:window-height="1025"
+     inkscape:window-x="526"
+     inkscape:window-y="51"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg6744" />
+  <path
+     d="M24 22q-8.05 0-13.025-2.45T6 14q0-3.15 4.975-5.575Q15.95 6 24 6t13.025 2.425Q42 10.85 42 14q0 3.1-4.975 5.55Q32.05 22 24 22Zm0 10q-7.3 0-12.65-2.2Q6 27.6 6 24.5v-5q0 1.95 1.875 3.375t4.65 2.35q2.775.925 5.9 1.35Q21.55 27 24 27q2.5 0 5.6-.425 3.1-.425 5.875-1.325 2.775-.9 4.65-2.325Q42 21.5 42 19.5v5q0 3.1-5.35 5.3Q31.3 32 24 32Zm0 10q-7.3 0-12.65-2.2Q6 37.6 6 34.5v-5q0 1.95 1.875 3.375t4.65 2.35q2.775.925 5.9 1.35Q21.55 37 24 37q2.5 0 5.6-.425 3.1-.425 5.875-1.325 2.775-.9 4.65-2.325Q42 31.5 42 29.5v5q0 3.1-5.35 5.3Q31.3 42 24 42Z"
+     id="path6742"
+     style="fill:#677285;fill-opacity:1" />
+</svg>

--- a/config/containers/logging/index.md
+++ b/config/containers/logging/index.md
@@ -1,7 +1,7 @@
 ---
 description: How to write to and view a container's logs
 keywords: docker, logging
-title: View logs for a container or service
+title: View container logs
 redirect_from:
 - /engine/admin/logging/
 - /engine/admin/logging/view_container_logs/

--- a/config/daemon/index.md
+++ b/config/daemon/index.md
@@ -2,82 +2,49 @@
 description: Configuring and troubleshooting the Docker daemon
 keywords: docker, daemon, configuration, troubleshooting
 redirect_from:
-- /articles/chef/
-- /articles/configuring/
-- /articles/dsc/
-- /articles/puppet/
-- /config/thirdparty/
-- /config/thirdparty/ansible/
-- /config/thirdparty/chef/
-- /config/thirdparty/dsc/
-- /config/thirdparty/puppet/
-- /engine/admin/
-- /engine/admin/ansible/
-- /engine/admin/chef/
-- /engine/admin/configuring/
-- /engine/admin/dsc/
-- /engine/admin/puppet/
-- /engine/articles/chef/
-- /engine/articles/configuring/
-- /engine/articles/dsc/
-- /engine/articles/puppet/
-- /engine/userguide/
-
-title: Configure and troubleshoot the Docker daemon
+  - /articles/chef/
+  - /articles/configuring/
+  - /articles/dsc/
+  - /articles/puppet/
+  - /config/thirdparty/
+  - /config/thirdparty/ansible/
+  - /config/thirdparty/chef/
+  - /config/thirdparty/dsc/
+  - /config/thirdparty/puppet/
+  - /engine/admin/
+  - /engine/admin/ansible/
+  - /engine/admin/chef/
+  - /engine/admin/configuring/
+  - /engine/admin/dsc/
+  - /engine/admin/puppet/
+  - /engine/articles/chef/
+  - /engine/articles/configuring/
+  - /engine/articles/dsc/
+  - /engine/articles/puppet/
+  - /engine/userguide/
+title: Docker daemon configuration overview
 ---
 
-After successfully installing and starting Docker, the `dockerd` daemon
-runs with its default configuration. This topic shows how to customize
-the configuration, start the daemon manually, and troubleshoot and debug the
-daemon if you run into issues.
-
-## Start the daemon using operating system utilities
-
-On a typical installation the Docker daemon is started by a system utility,
-not manually by a user. This makes it easier to automatically start Docker when
-the machine reboots.
-
-The command to start Docker depends on your operating system. Check the correct
-page under [Install Docker](../../engine/install/index.md). To configure Docker
-to start automatically at system boot, see
-[Configure Docker to start on boot](../../engine/install/linux-postinstall.md#configure-docker-to-start-on-boot-with-systemd).
-
-## Start the daemon manually
-
-If you don't want to use a system utility to manage the Docker daemon, or
-just want to test things out, you can manually run it using the `dockerd`
-command. You may need to use `sudo`, depending on your operating system
+After successfully installing and starting Docker, the `dockerd` daemon runs
+with its default configuration. This page shows how to customize the daemon
 configuration.
-
-When you start Docker this way, it runs in the foreground and sends its logs
-directly to your terminal.
-
-```console
-$ dockerd
-
-INFO[0000] +job init_networkdriver()
-INFO[0000] +job serveapi(unix:///var/run/docker.sock)
-INFO[0000] Listening for HTTP on unix (/var/run/docker.sock)
-```
-
-To stop Docker when you have started it manually, issue a `Ctrl+C` in your
-terminal.
 
 ## Configure the Docker daemon
 
 There are two ways to configure the Docker daemon:
 
-* Use a JSON configuration file. This is the preferred option, since it keeps
-all configurations in a single place.
-* Use flags when starting `dockerd`.
+- Use a JSON configuration file. This is the preferred option, since it keeps
+  all configurations in a single place.
+- Use flags when starting `dockerd`.
 
-You can use both of these options together as long as you don't specify the
-same option both as a flag and in the JSON file. If that happens, the Docker
-daemon won't start and prints an error message.
+You can use both of these options together as long as you don't specify the same
+option both as a flag and in the JSON file. If that happens, the Docker daemon
+won't start and prints an error message.
 
 To configure the Docker daemon using a JSON file, create a file at
-`/etc/docker/daemon.json` on Linux systems, or `C:\ProgramData\docker\config\daemon.json`
-on Windows. On MacOS go to the whale in the taskbar > Preferences > Daemon > Advanced.
+`/etc/docker/daemon.json` on Linux systems, or
+`C:\ProgramData\docker\config\daemon.json` on Windows. On macOS go to the whale
+in the taskbar and select **Preferences** > **Daemon** > **Advanced**.
 
 Here's what the configuration file looks like:
 
@@ -92,15 +59,15 @@ Here's what the configuration file looks like:
 ```
 
 With this configuration the Docker daemon runs in debug mode, uses TLS, and
-listens for traffic routed to `192.168.59.3` on port `2376`.
-You can learn what configuration options are available in the
+listens for traffic routed to `192.168.59.3` on port `2376`. You can learn what
+configuration options are available in the
 [dockerd reference docs](../../engine/reference/commandline/dockerd.md#daemon-configuration-file)
 
-You can also start the Docker daemon manually and configure it using flags.
-This can be useful for troubleshooting problems.
+You can also start the Docker daemon manually and configure it using flags. This
+can be useful for troubleshooting problems.
 
 Here's an example of how to manually start the Docker daemon, using the same
-configurations as above:
+configurations as shown in the previous JSON configuration:
 
 ```console
 $ dockerd --debug \
@@ -111,7 +78,8 @@ $ dockerd --debug \
 ```
 
 You can learn what configuration options are available in the
-[dockerd reference docs](../../engine/reference/commandline/dockerd.md), or by running:
+[dockerd reference docs](../../engine/reference/commandline/dockerd.md), or by
+running:
 
 ```console
 $ dockerd --help
@@ -125,234 +93,32 @@ documentation. Some places to go next include:
 - [Configure storage drivers](../../storage/storagedriver/select-storage-driver.md)
 - [Container security](../../engine/security/index.md)
 
-## Docker daemon directory
+You can configure most daemon options using the `daemon.json` file. One thing
+you can't configure using daemon.json mechanism is an HTTP proxy. For
+instructions on using a proxy, see
+[Configure Docker to use a proxy server](../../network/proxy.md).
 
-The Docker daemon persists all data in a single directory. This tracks everything
-related to Docker, including containers, images, volumes, service definition,
-and secrets.
+## Daemon data directory
+
+The Docker daemon persists all data in a single directory. This tracks
+everything related to Docker, including containers, images, volumes, service
+definition, and secrets.
 
 By default this directory is:
 
-* `/var/lib/docker` on Linux.
-* `C:\ProgramData\docker` on Windows.
+- `/var/lib/docker` on Linux.
+- `C:\ProgramData\docker` on Windows.
 
 You can configure the Docker daemon to use a different directory, using the
-`data-root` configuration option.
+`data-root` configuration option. For example:
 
-Since the state of a Docker daemon is kept on this directory, make sure
-you use a dedicated directory for each daemon. If two daemons share the same
-directory, for example, an NFS share, you are going to experience errors that
-are difficult to troubleshoot.
-
-## Troubleshoot the daemon
-
-You can enable debugging on the daemon to learn about the runtime activity of
-the daemon and to aid in troubleshooting. If the daemon is completely
-non-responsive, you can also
-[force a full stack trace](#force-a-stack-trace-to-be-logged) of all
-threads to be added to the daemon log by sending the `SIGUSR` signal to the
-Docker daemon.
-
-### Troubleshoot conflicts between the `daemon.json` and startup scripts
-
-If you use a `daemon.json` file and also pass options to the `dockerd`
-command manually or using start-up scripts, and these options conflict,
-Docker fails to start with an error such as:
-
-```none
-unable to configure the Docker daemon with file /etc/docker/daemon.json:
-the following directives are specified both as a flag and in the configuration
-file: hosts: (from flag: [unix:///var/run/docker.sock], from file: [tcp://127.0.0.1:2376])
+```json
+{
+  "data-root": "/mnt/docker-data"
+}
 ```
 
-If you see an error similar to this one and you are starting the daemon manually with flags,
-you may need to adjust your flags or the `daemon.json` to remove the conflict.
-
-> **Note**: If you see this specific error, continue to the
-> [next section](#use-the-hosts-key-in-daemonjson-with-systemd) for a workaround.
-
-If you are starting Docker using your operating system's init scripts, you may
-need to override the defaults in these scripts in ways that are specific to the
-operating system.
-
-#### Use the hosts key in daemon.json with systemd
-
-One notable example of a configuration conflict that is difficult to troubleshoot
-is when you want to specify a different daemon address from
-the default. Docker listens on a socket by default. On Debian and Ubuntu systems using `systemd`,
-this means that a host flag `-H` is always used when starting `dockerd`. If you specify a
-`hosts` entry in the `daemon.json`, this causes a configuration conflict (as in the above message)
-and Docker fails to start.
-
-To work around this problem, create a new file `/etc/systemd/system/docker.service.d/docker.conf` with
-the following contents, to remove the `-H` argument that is used when starting the daemon by default.
-
-```none
-[Service]
-ExecStart=
-ExecStart=/usr/bin/dockerd
-```
-
-There are other times when you might need to configure `systemd` with Docker, such as
-[configuring a HTTP or HTTPS proxy](systemd.md#httphttps-proxy).
-
-> **Note**: If you override this option and then do not specify a `hosts` entry in the `daemon.json`
-> or a `-H` flag when starting Docker manually, Docker fails to start.
-
-Run `sudo systemctl daemon-reload` before attempting to start Docker. If Docker starts
-successfully, it is now listening on the IP address specified in the `hosts` key of the
-`daemon.json` instead of a socket.
-
-> **Important**: Setting `hosts` in the `daemon.json` is not supported on Docker Desktop for Windows
-> or Docker Desktop for Mac.
-{:.important}
-
-
-
-### Out Of Memory Exceptions (OOME)
-
-If your containers attempt to use more memory than the system has available,
-you may experience an Out Of Memory Exception (OOME) and a container, or the
-Docker daemon, might be killed by the kernel OOM killer. To prevent this from
-happening, ensure that your application runs on hosts with adequate memory and
-see
-[Understand the risks of running out of memory](../containers/resource_constraints.md#understand-the-risks-of-running-out-of-memory).
-
-### Read the logs
-
-The daemon logs may help you diagnose problems. The logs may be saved in one of
-a few locations, depending on the operating system configuration and the logging
-subsystem used:
-
-| Operating system                    | Location                                                                                                                                 |
-|:------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------|
-| Linux                               | Use the command `journalctl -xu docker.service` (or read `/var/log/syslog` or `/var/log/messages`, depending on your Linux Distribution) |
-| macOS (`dockerd` logs)              | `~/Library/Containers/com.docker.docker/Data/log/vm/dockerd.log`                                                                         |
-| macOS (`containerd` logs)           | `~/Library/Containers/com.docker.docker/Data/log/vm/containerd.log`                                                                      |
-| Windows (WSL2) (`dockerd` logs)     | `AppData\Local\Docker\log\vm\dockerd.log`                                                                                              |
-| Windows (WSL2) (`containerd` logs)  | `AppData\Local\Docker\log\vm\containerd.log`                                                                                           |
-| Windows (Windows containers)        | Logs are in the Windows Event Log                                                                                                        |
-
-To view the `dockerd` logs on macOS, open a terminal Window, and use the `tail`
-command with the `-f` flag to "follow" the logs. Logs will be printed until you
-terminate the command using `CTRL+c`:
-
-```console
-$ tail -f ~/Library/Containers/com.docker.docker/Data/log/vm/dockerd.log
-2021-07-28T10:21:21Z dockerd time="2021-07-28T10:21:21.497642089Z" level=debug msg="attach: stdout: begin"
-2021-07-28T10:21:21Z dockerd time="2021-07-28T10:21:21.497714291Z" level=debug msg="attach: stderr: begin"
-2021-07-28T10:21:21Z dockerd time="2021-07-28T10:21:21.499798390Z" level=debug msg="Calling POST /v1.41/containers/35fc5ec0ffe1ad492d0a4fbf51fd6286a087b89d4dd66367fa3b7aec70b46a40/wait?condition=removed"
-2021-07-28T10:21:21Z dockerd time="2021-07-28T10:21:21.518403686Z" level=debug msg="Calling GET /v1.41/containers/35fc5ec0ffe1ad492d0a4fbf51fd6286a087b89d4dd66367fa3b7aec70b46a40/json"
-2021-07-28T10:21:21Z dockerd time="2021-07-28T10:21:21.527074928Z" level=debug msg="Calling POST /v1.41/containers/35fc5ec0ffe1ad492d0a4fbf51fd6286a087b89d4dd66367fa3b7aec70b46a40/start"
-2021-07-28T10:21:21Z dockerd time="2021-07-28T10:21:21.528203579Z" level=debug msg="container mounted via layerStore: &{/var/lib/docker/overlay2/6e76ffecede030507fcaa576404e141e5f87fc4d7e1760e9ce5b52acb24
-...
-^C
-```
-
-
-### Enable debugging
-
-There are two ways to enable debugging. The recommended approach is to set the
-`debug` key to `true` in the `daemon.json` file. This method works for every
-Docker platform.
-
-1.  Edit the `daemon.json` file, which is usually located in `/etc/docker/`.
-    You may need to create this file, if it does not yet exist. On macOS or
-    Windows, do not edit the file directly. Instead, go to
-    **Preferences** / **Daemon** / **Advanced**.
-
-2.  If the file is empty, add the following:
-
-    ```json
-    {
-      "debug": true
-    }
-    ```
-
-    If the file already contains JSON, just add the key `"debug": true`, being
-    careful to add a comma to the end of the line if it is not the last line
-    before the closing bracket. Also verify that if the `log-level` key is set,
-    it is set to either `info` or `debug`. `info` is the default, and possible
-    values are `debug`, `info`, `warn`, `error`, `fatal`.
-
-3.  Send a `HUP` signal to the daemon to cause it to reload its configuration.
-    On Linux hosts, use the following command.
-
-    ```console
-    $ sudo kill -SIGHUP $(pidof dockerd)
-    ```
-
-    On Windows hosts, restart Docker.
-
-Instead of following this procedure, you can also stop the Docker daemon and
-restart it manually with the debug flag `-D`. However, this may result in Docker
-restarting with a different environment than the one the hosts' startup scripts
-create, and this may make debugging more difficult.
-
-### Force a stack trace to be logged
-
-If the daemon is unresponsive, you can force a full stack trace to be logged
-by sending a `SIGUSR1` signal to the daemon.
-
-- **Linux**:
-
-  ```console
-  $ sudo kill -SIGUSR1 $(pidof dockerd)
-  ```
-
-- **Windows Server**:
-
-  Download [docker-signal](https://github.com/moby/docker-signal).
-  
-  Get the process ID of dockerd `Get-Process dockerd`.
-
-  Run the executable with the flag `--pid=<PID of daemon>`.
-
-This forces a stack trace to be logged but does not stop the daemon.
-Daemon logs show the stack trace or the path to a file containing the
-stack trace if it was logged to a file.
-
-The daemon continues operating after handling the `SIGUSR1` signal and
-dumping the stack traces to the log. The stack traces can be used to determine
-the state of all goroutines and threads within the daemon.
-
-### View stack traces
-
-The Docker daemon log can be viewed by using one of the following methods:
-
-- By running `journalctl -u docker.service` on Linux systems using `systemctl`
-- `/var/log/messages`, `/var/log/daemon.log`, or `/var/log/docker.log` on older
-  Linux systems
-
-> **Note**
-> 
-> It is not possible to manually generate a stack trace on Docker Desktop for
-> Mac or Docker Desktop for Windows. However, you can click the Docker taskbar
-> icon and choose **Troubleshoot** to send information to Docker if you
-> run into issues.
-
-Look in the Docker logs for a message like the following:
-
-```none
-...goroutine stacks written to /var/run/docker/goroutine-stacks-2017-06-02T193336z.log
-...daemon datastructure dump written to /var/run/docker/daemon-data-2017-06-02T193336z.log
-```
-
-The locations where Docker saves these stack traces and dumps depends on your
-operating system and configuration. You can sometimes get useful diagnostic
-information straight from the stack traces and dumps. Otherwise, you can provide
-this information to Docker for help diagnosing the problem.
-
-
-## Check whether Docker is running
-
-The operating-system independent way to check whether Docker is running is to
-ask Docker, using the `docker info` command.
-
-You can also use operating system utilities, such as
-`sudo systemctl is-active docker` or `sudo status docker` or
-`sudo service docker status`, or checking the service status using Windows
-utilities.
-
-Finally, you can check in the process list for the `dockerd` process, using
-commands like `ps` or `top`.
+Since the state of a Docker daemon is kept on this directory, make sure you use
+a dedicated directory for each daemon. If two daemons share the same directory,
+for example, an NFS share, you are going to experience errors that are difficult
+to troubleshoot.

--- a/config/daemon/logs.md
+++ b/config/daemon/logs.md
@@ -1,0 +1,127 @@
+---
+title: Read the daemon logs
+description: How to read the container logs for the Docker daemon.
+keywords: docker, daemon, configuration, troubleshooting, logging
+---
+
+The daemon logs may help you diagnose problems. The logs may be saved in one of
+a few locations, depending on the operating system configuration and the logging
+subsystem used:
+
+| Operating system                   | Location                                                                                                                                 |
+| :--------------------------------- | :--------------------------------------------------------------------------------------------------------------------------------------- |
+| Linux                              | Use the command `journalctl -xu docker.service` (or read `/var/log/syslog` or `/var/log/messages`, depending on your Linux Distribution) |
+| macOS (`dockerd` logs)             | `~/Library/Containers/com.docker.docker/Data/log/vm/dockerd.log`                                                                         |
+| macOS (`containerd` logs)          | `~/Library/Containers/com.docker.docker/Data/log/vm/containerd.log`                                                                      |
+| Windows (WSL2) (`dockerd` logs)    | `AppData\Local\Docker\log\vm\dockerd.log`                                                                                                |
+| Windows (WSL2) (`containerd` logs) | `AppData\Local\Docker\log\vm\containerd.log`                                                                                             |
+| Windows (Windows containers)       | Logs are in the Windows Event Log                                                                                                        |
+
+To view the `dockerd` logs on macOS, open a terminal Window, and use the `tail`
+command with the `-f` flag to "follow" the logs. Logs will be printed until you
+terminate the command using `CTRL+c`:
+
+```console
+$ tail -f ~/Library/Containers/com.docker.docker/Data/log/vm/dockerd.log
+2021-07-28T10:21:21Z dockerd time="2021-07-28T10:21:21.497642089Z" level=debug msg="attach: stdout: begin"
+2021-07-28T10:21:21Z dockerd time="2021-07-28T10:21:21.497714291Z" level=debug msg="attach: stderr: begin"
+2021-07-28T10:21:21Z dockerd time="2021-07-28T10:21:21.499798390Z" level=debug msg="Calling POST /v1.41/containers/35fc5ec0ffe1ad492d0a4fbf51fd6286a087b89d4dd66367fa3b7aec70b46a40/wait?condition=removed"
+2021-07-28T10:21:21Z dockerd time="2021-07-28T10:21:21.518403686Z" level=debug msg="Calling GET /v1.41/containers/35fc5ec0ffe1ad492d0a4fbf51fd6286a087b89d4dd66367fa3b7aec70b46a40/json"
+2021-07-28T10:21:21Z dockerd time="2021-07-28T10:21:21.527074928Z" level=debug msg="Calling POST /v1.41/containers/35fc5ec0ffe1ad492d0a4fbf51fd6286a087b89d4dd66367fa3b7aec70b46a40/start"
+2021-07-28T10:21:21Z dockerd time="2021-07-28T10:21:21.528203579Z" level=debug msg="container mounted via layerStore: &{/var/lib/docker/overlay2/6e76ffecede030507fcaa576404e141e5f87fc4d7e1760e9ce5b52acb24
+...
+^C
+```
+
+## Enable debugging
+
+There are two ways to enable debugging. The recommended approach is to set the
+`debug` key to `true` in the `daemon.json` file. This method works for every
+Docker platform.
+
+1.  Edit the `daemon.json` file, which is usually located in `/etc/docker/`. You
+    may need to create this file, if it does not yet exist. On macOS or Windows,
+    do not edit the file directly. Instead, go to **Preferences** / **Daemon** /
+    **Advanced**.
+
+2.  If the file is empty, add the following:
+
+    ```json
+    {
+      "debug": true
+    }
+    ```
+
+    If the file already contains JSON, just add the key `"debug": true`, being
+    careful to add a comma to the end of the line if it is not the last line
+    before the closing bracket. Also verify that if the `log-level` key is set,
+    it is set to either `info` or `debug`. `info` is the default, and possible
+    values are `debug`, `info`, `warn`, `error`, `fatal`.
+
+3.  Send a `HUP` signal to the daemon to cause it to reload its configuration.
+    On Linux hosts, use the following command.
+
+    ```console
+    $ sudo kill -SIGHUP $(pidof dockerd)
+    ```
+
+    On Windows hosts, restart Docker.
+
+Instead of following this procedure, you can also stop the Docker daemon and
+restart it manually with the debug flag `-D`. However, this may result in Docker
+restarting with a different environment than the one the hosts' startup scripts
+create, and this may make debugging more difficult.
+
+## Force a stack trace to be logged
+
+If the daemon is unresponsive, you can force a full stack trace to be logged by
+sending a `SIGUSR1` signal to the daemon.
+
+- **Linux**:
+
+  ```console
+  $ sudo kill -SIGUSR1 $(pidof dockerd)
+  ```
+
+- **Windows Server**:
+
+  Download [docker-signal](https://github.com/moby/docker-signal).
+
+  Get the process ID of dockerd `Get-Process dockerd`.
+
+  Run the executable with the flag `--pid=<PID of daemon>`.
+
+This forces a stack trace to be logged but does not stop the daemon. Daemon logs
+show the stack trace or the path to a file containing the stack trace if it was
+logged to a file.
+
+The daemon continues operating after handling the `SIGUSR1` signal and dumping
+the stack traces to the log. The stack traces can be used to determine the state
+of all goroutines and threads within the daemon.
+
+## View stack traces
+
+The Docker daemon log can be viewed by using one of the following methods:
+
+- By running `journalctl -u docker.service` on Linux systems using `systemctl`
+- `/var/log/messages`, `/var/log/daemon.log`, or `/var/log/docker.log` on older
+  Linux systems
+
+> **Note**
+>
+> It is not possible to manually generate a stack trace on Docker Desktop for
+> Mac or Docker Desktop for Windows. However, you can click the Docker taskbar
+> icon and choose **Troubleshoot** to send information to Docker if you run into
+> issues.
+
+Look in the Docker logs for a message like the following:
+
+```none
+...goroutine stacks written to /var/run/docker/goroutine-stacks-2017-06-02T193336z.log
+...daemon datastructure dump written to /var/run/docker/daemon-data-2017-06-02T193336z.log
+```
+
+The locations where Docker saves these stack traces and dumps depends on your
+operating system and configuration. You can sometimes get useful diagnostic
+information straight from the stack traces and dumps. Otherwise, you can provide
+this information to Docker for help diagnosing the problem.

--- a/config/daemon/remote-access.md
+++ b/config/daemon/remote-access.md
@@ -1,0 +1,91 @@
+---
+description: >
+  Configuring remote access allows Docker to accept requests from remote hosts
+  by configuring it to listen on an IP address and port as well as the Unix
+  socket
+keywords: configuration, daemon, remote access, engine
+title: Configure remote access for Docker daemon
+---
+
+By default, the Docker daemon listens for connections on a Unix socket to accept
+requests from local clients. It's possible to allow Docker to accept requests
+from remote hosts by configuring it to listen on an IP address and port as well
+as the Unix socket. For more detailed information on this configuration option,
+refer to the
+[dockerd CLI reference](/engine/reference/commandline/dockerd/#bind-docker-to-another-hostport-or-a-unix-socket).
+
+<!-- prettier-ignore -->
+> Secure your connection
+>
+> Before configuring Docker to accept connections from remote hosts it's
+> critically important that you understand the security implications of opening
+> Docker to the network. If steps aren't taken to secure the connection, it's
+> possible for remote non-root users to gain root access on the host. For more
+> information on how to use TLS certificates to secure this connection, check
+> [Protect the Docker daemon socket](../../engine/security/protect-access.md).
+{: .warning}
+
+You can configure Docker to accept remote connections. This can be done using
+the `docker.service` systemd unit file for Linux distributions using systemd. Or
+you can use the `daemon.json` file, if your distribution doesn't use systemd.
+
+> systemd vs `daemon.json`
+>
+> Configuring Docker to listen for connections using both the systemd unit file
+> and the `daemon.json` file causes a conflict that prevents Docker from
+> starting.
+
+### Configuring remote access with systemd unit file
+
+1. Use the command `sudo systemctl edit docker.service` to open an override file
+   for `docker.service` in a text editor.
+
+2. Add or modify the following lines, substituting your own values.
+
+   ```systemd
+   [Service]
+   ExecStart=
+   ExecStart=/usr/bin/dockerd -H fd:// -H tcp://127.0.0.1:2375
+   ```
+
+3. Save the file.
+
+4. Reload the `systemctl` configuration.
+
+   ```console
+    $ sudo systemctl daemon-reload
+   ```
+
+5. Restart Docker.
+
+   ```console
+   $ sudo systemctl restart docker.service
+   ```
+
+6. Verify that the change has gone through.
+
+   ```console
+   $ sudo netstat -lntp | grep dockerd
+   tcp        0      0 127.0.0.1:2375          0.0.0.0:*               LISTEN      3758/dockerd
+   ```
+
+### Configuring remote access with `daemon.json`
+
+1. Set the `hosts` array in the `/etc/docker/daemon.json` to connect to the Unix
+   socket and an IP address, as follows:
+
+   ```json
+   {
+     "hosts": ["unix:///var/run/docker.sock", "tcp://127.0.0.1:2375"]
+   }
+   ```
+
+2. Restart Docker.
+
+3. Verify that the change has gone through.
+
+   ```console
+   $ sudo netstat -lntp | grep dockerd
+   tcp        0      0 127.0.0.1:2375          0.0.0.0:*               LISTEN      3758/dockerd
+   ```
+

--- a/config/daemon/start.md
+++ b/config/daemon/start.md
@@ -1,0 +1,48 @@
+---
+title: Start the daemon
+description: Starting the Docker daemon manually
+keywords: docker, daemon, configuration, troubleshooting
+---
+
+This page shows how to start the daemon, either manually or using OS utilities.
+
+## Start the daemon using operating system utilities
+
+On a typical installation the Docker daemon is started by a system utility, not
+manually by a user. This makes it easier to automatically start Docker when the
+machine reboots.
+
+The command to start Docker depends on your operating system. Check the correct
+page under [Install Docker](../../engine/install/index.md).
+
+### Start with systemd
+
+On some operating systems, like Ubuntu and Debian, the Docker daemon service
+starts automatically. Use the following command to start it manually:
+
+```console
+$ sudo systemctl start docker
+```
+
+If you want Docker to start at boot, see
+[Configure Docker to start on boot](../../engine/install/linux-postinstall.md#configure-docker-to-start-on-boot-with-systemd).
+
+## Start the daemon manually
+
+If you don't want to use a system utility to manage the Docker daemon, or just
+want to test things out, you can manually run it using the `dockerd` command.
+You may need to use `sudo`, depending on your operating system configuration.
+
+When you start Docker this way, it runs in the foreground and sends its logs
+directly to your terminal.
+
+```console
+$ dockerd
+
+INFO[0000] +job init_networkdriver()
+INFO[0000] +job serveapi(unix:///var/run/docker.sock)
+INFO[0000] Listening for HTTP on unix (/var/run/docker.sock)
+```
+
+To stop Docker when you have started it manually, issue a `Ctrl+C` in your
+terminal.

--- a/config/daemon/systemd.md
+++ b/config/daemon/systemd.md
@@ -2,77 +2,50 @@
 description: Controlling and configuring Docker using systemd
 keywords: docker, daemon, systemd, configuration
 redirect_from:
-- /articles/host_integration/
-- /articles/systemd/
-- /engine/admin/systemd/
-- /engine/articles/systemd/
-title: Control Docker with systemd
+  - /articles/host_integration/
+  - /articles/systemd/
+  - /engine/admin/systemd/
+  - /engine/articles/systemd/
+title: Configure the daemon with systemd
 ---
 
-Many Linux distributions use systemd to start the Docker daemon. This document
-shows a few examples of how to customize Docker's settings.
-
-## Start the Docker daemon
-
-### Start manually
-
-Once Docker is installed, you need to start the Docker daemon.
-Most Linux distributions use `systemctl` to start services.
-
-```console
-$ sudo systemctl start docker
-```
-
-### Start automatically at system boot
-
-If you want Docker to start at boot, see
-[Configure Docker to start on boot](../../engine/install/linux-postinstall.md#configure-docker-to-start-on-boot-with-systemd).
+This page describes how to customize daemon settings when using systemd.
 
 ## Custom Docker daemon options
 
-There are a number of ways to configure the daemon flags and environment variables
-for your Docker daemon. The recommended way is to use the platform-independent
-`daemon.json` file, which is located in `/etc/docker/` on Linux by default. See
-[Daemon configuration file](../../engine/reference/commandline/dockerd.md#daemon-configuration-file).
+Most configuration options for the Docker daemon are set using the `daemon.json`
+configuration file. See [Docker daemon configuration overview](./index.md) for
+more information.
 
-You can configure nearly all daemon configuration options using `daemon.json`. The following
-example configures two options. One thing you cannot configure using `daemon.json` mechanism is
-a [HTTP proxy](#httphttps-proxy).
+## Manually create the systemd unit files
 
-### Runtime directory and storage driver
+When installing the binary without a package manager, you may want to integrate
+Docker with systemd. For this, install the two unit files (`service` and
+`socket`) from
+[the github repository](https://github.com/moby/moby/tree/master/contrib/init/systemd)
+to `/etc/systemd/system`.
 
-You may want to control the disk space used for Docker images, containers,
-and volumes by moving it to a separate partition.
+## HTTP/HTTPS proxy
 
-To accomplish this, set the following flags in the `daemon.json` file:
-
-```json
-{
-    "data-root": "/mnt/docker-data",
-    "storage-driver": "overlay2"
-}
-```
-
-### HTTP/HTTPS proxy
-
-The Docker daemon uses the `HTTP_PROXY`, `HTTPS_PROXY`, and `NO_PROXY` environmental variables in
-its start-up environment to configure HTTP or HTTPS proxy behavior. You cannot configure
-these environment variables using the `daemon.json` file.
+The Docker daemon uses the `HTTP_PROXY`, `HTTPS_PROXY`, and `NO_PROXY`
+environmental variables in its start-up environment to configure HTTP or HTTPS
+proxy behavior. You can't configure these environment variables using the
+`daemon.json` file.
 
 This example overrides the default `docker.service` file.
 
-If you are behind an HTTP or HTTPS proxy server, for example in corporate settings,
-you need to add this configuration in the Docker systemd service file.
+If you are behind an HTTP or HTTPS proxy server, for example in corporate
+settings, you need to add this configuration in the Docker systemd service file.
 
 > **Note for rootless mode**
 >
 > The location of systemd configuration files are different when running Docker
-> in [rootless mode](../../engine/security/rootless.md). When running in rootless
-> mode, Docker is started as a user-mode systemd service, and uses files stored
-> in each users' home directory in `~/.config/systemd/user/docker.service.d/`.
-> In addition, `systemctl` must be executed without `sudo` and with the `--user`
-> flag. Select the _"rootless mode"_ tab below if you are running Docker in rootless mode.
-
+> in [rootless mode](../../engine/security/rootless.md). When running in
+> rootless mode, Docker is started as a user-mode systemd service, and uses
+> files stored in each users' home directory in
+> `~/.config/systemd/user/docker.service.d/`. In addition, `systemctl` must be
+> executed without `sudo` and with the `--user` flag. Select the _"rootless
+> mode"_ tab below if you are running Docker in rootless mode.
 
 <ul class="nav nav-tabs">
   <li class="active"><a data-toggle="tab" data-target="#rootful">regular install</a></li>
@@ -81,187 +54,176 @@ you need to add this configuration in the Docker systemd service file.
 <div class="tab-content">
 <div id="rootful" class="tab-pane fade in active" markdown="1">
 
-1.  Create a systemd drop-in directory for the docker service:
+1. Create a systemd drop-in directory for the `docker` service:
 
-    ```console
-    $ sudo mkdir -p /etc/systemd/system/docker.service.d
-    ```
+   ```console
+   $ sudo mkdir -p /etc/systemd/system/docker.service.d
+   ```
 
-2.  Create a file named `/etc/systemd/system/docker.service.d/http-proxy.conf`
-    that adds the `HTTP_PROXY` environment variable:
+2. Create a file named `/etc/systemd/system/docker.service.d/http-proxy.conf`
+   that adds the `HTTP_PROXY` environment variable:
 
-    ```systemd
-    [Service]
-    Environment="HTTP_PROXY=http://proxy.example.com:80"
-    ```
+   ```systemd
+   [Service]
+   Environment="HTTP_PROXY=http://proxy.example.com:80"
+   ```
 
-    If you are behind an HTTPS proxy server, set the `HTTPS_PROXY` environment
-    variable:
+   If you are behind an HTTPS proxy server, set the `HTTPS_PROXY` environment
+   variable:
 
-    ```systemd
-    [Service]
-    Environment="HTTPS_PROXY=https://proxy.example.com:443"
-    ```
-    
-    Multiple environment variables can be set; to set both a non-HTTPS and
-    a HTTPs proxy;
+   ```systemd
+   [Service]
+   Environment="HTTPS_PROXY=https://proxy.example.com:443"
+   ```
 
-    ```systemd
-    [Service]
-    Environment="HTTP_PROXY=http://proxy.example.com:80"
-    Environment="HTTPS_PROXY=https://proxy.example.com:443"
-    ```
-        
-    > **Note**
-    >
-    > Special characters in the proxy value, such as `#?!()[]{}`, must be double
-    > escaped using `%%`. For example:
-    > 
-    > ```
-    > [Service]
-    > Environment="HTTP_PROXY=http://domain%%5Cuser:complex%%23pass@proxy.example.com:8080/"
-    > ```
-     
-3.  If you have internal Docker registries that you need to contact without
-    proxying you can specify them via the `NO_PROXY` environment variable.
+   Multiple environment variables can be set; to set both a non-HTTPS and a
+   HTTPs proxy;
 
-    The `NO_PROXY` variable specifies a string that contains comma-separated
-    values for hosts that should be excluded from proxying. These are the
-    options you can specify to exclude hosts: 
-    * IP address prefix (`1.2.3.4`)   
-    * Domain name, or a special DNS label (`*`)
-    * A domain name matches that name and all subdomains. A domain name with
-      a leading "." matches subdomains only. For example, given the domains
-      `foo.example.com` and `example.com`:
-      * `example.com` matches `example.com` and `foo.example.com`, and
-      * `.example.com` matches only `foo.example.com`
-    * A single asterisk (`*`) indicates that no proxying should be done
-    * Literal port numbers are accepted by IP address prefixes (`1.2.3.4:80`)
-      and domain names (`foo.example.com:80`)
-    
-    Config example:
+   ```systemd
+   [Service]
+   Environment="HTTP_PROXY=http://proxy.example.com:80"
+   Environment="HTTPS_PROXY=https://proxy.example.com:443"
+   ```
 
-    ```systemd
-    [Service]
-    Environment="HTTP_PROXY=http://proxy.example.com:80"
-    Environment="HTTPS_PROXY=https://proxy.example.com:443"
-    Environment="NO_PROXY=localhost,127.0.0.1,docker-registry.example.com,.corp"
-    ```
+   > **Note**
+   >
+   > Special characters in the proxy value, such as `#?!()[]{}`, must be double
+   > escaped using `%%`. For example:
+   >
+   > ```
+   > [Service]
+   > Environment="HTTP_PROXY=http://domain%%5Cuser:complex%%23pass@proxy.example.com:8080/"
+   > ```
 
-4.  Flush changes and restart Docker
+3. If you have internal Docker registries that you need to contact without
+   proxying, you can specify them via the `NO_PROXY` environment variable.
 
-    ```console
-    $ sudo systemctl daemon-reload
-    $ sudo systemctl restart docker
-    ```
+   The `NO_PROXY` variable specifies a string that contains comma-separated
+   values for hosts that should be excluded from proxying. These are the options
+   you can specify to exclude hosts:
 
-5.  Verify that the configuration has been loaded and matches the changes you
-    made, for example:
+   - IP address prefix (`1.2.3.4`)
+   - Domain name, or a special DNS label (`*`)
+   - A domain name matches that name and all subdomains. A domain name with a
+     leading "." matches subdomains only. For example, given the domains
+     `foo.example.com` and `example.com`:
+     - `example.com` matches `example.com` and `foo.example.com`, and
+     - `.example.com` matches only `foo.example.com`
+   - A single asterisk (`*`) indicates that no proxying should be done
+   - Literal port numbers are accepted by IP address prefixes (`1.2.3.4:80`) and
+     domain names (`foo.example.com:80`)
 
-    ```console
-    $ sudo systemctl show --property=Environment docker
-    
-    Environment=HTTP_PROXY=http://proxy.example.com:80 HTTPS_PROXY=https://proxy.example.com:443 NO_PROXY=localhost,127.0.0.1,docker-registry.example.com,.corp
-    ```
+   Config example:
+
+   ```systemd
+   [Service]
+   Environment="HTTP_PROXY=http://proxy.example.com:80"
+   Environment="HTTPS_PROXY=https://proxy.example.com:443"
+   Environment="NO_PROXY=localhost,127.0.0.1,docker-registry.example.com,.corp"
+   ```
+
+4. Flush changes and restart Docker
+
+   ```console
+   $ sudo systemctl daemon-reload
+   $ sudo systemctl restart docker
+   ```
+
+5. Verify that the configuration has been loaded and matches the changes you
+   made, for example:
+
+   ```console
+   $ sudo systemctl show --property=Environment docker
+
+   Environment=HTTP_PROXY=http://proxy.example.com:80 HTTPS_PROXY=https://proxy.example.com:443 NO_PROXY=localhost,127.0.0.1,docker-registry.example.com,.corp
+   ```
 
 </div>
 <div id="rootless" class="tab-pane fade in" markdown="1">
 
-1.  Create a systemd drop-in directory for the docker service:
+1. Create a systemd drop-in directory for the `docker` service:
 
-    ```console
-    $ mkdir -p ~/.config/systemd/user/docker.service.d
-    ```
+   ```console
+   $ mkdir -p ~/.config/systemd/user/docker.service.d
+   ```
 
-2.  Create a file named `~/.config/systemd/user/docker.service.d/http-proxy.conf`
-    that adds the `HTTP_PROXY` environment variable:
+2. Create a file named `~/.config/systemd/user/docker.service.d/http-proxy.conf`
+   that adds the `HTTP_PROXY` environment variable:
 
-    ```systemd
-    [Service]
-    Environment="HTTP_PROXY=http://proxy.example.com:80"
-    ```
+   ```systemd
+   [Service]
+   Environment="HTTP_PROXY=http://proxy.example.com:80"
+   ```
 
-    If you are behind an HTTPS proxy server, set the `HTTPS_PROXY` environment
-    variable:
+   If you are behind an HTTPS proxy server, set the `HTTPS_PROXY` environment
+   variable:
 
-    ```systemd
-    [Service]
-    Environment="HTTPS_PROXY=https://proxy.example.com:443"
-    ```
-    
-    Multiple environment variables can be set; to set both a non-HTTPS and
-    a HTTPs proxy;
+   ```systemd
+   [Service]
+   Environment="HTTPS_PROXY=https://proxy.example.com:443"
+   ```
 
-    ```systemd
-    [Service]
-    Environment="HTTP_PROXY=http://proxy.example.com:80"
-    Environment="HTTPS_PROXY=https://proxy.example.com:443"
-    ```
-    
-    > **Note**
-    >
-    > Special characters in the proxy value, such as `#?!()[]{}`, must be double
-    > escaped using `%%`. For example:
-    > 
-    > ```
-    > [Service]
-    > Environment="HTTP_PROXY=http://domain%%5Cuser:complex%%23pass@proxy.example.com:8080/"
-    > ```
-     
-3.  If you have internal Docker registries that you need to contact without
-    proxying, you can specify them via the `NO_PROXY` environment variable.
+   Multiple environment variables can be set; to set both a non-HTTPS and a
+   HTTPs proxy;
 
-    The `NO_PROXY` variable specifies a string that contains comma-separated
-    values for hosts that should be excluded from proxying. These are the
-    options you can specify to exclude hosts: 
-    * IP address prefix (`1.2.3.4`)   
-    * Domain name, or a special DNS label (`*`)
-    * A domain name matches that name and all subdomains. A domain name with
-      a leading "." matches subdomains only. For example, given the domains
-      `foo.example.com` and `example.com`:
-      * `example.com` matches `example.com` and `foo.example.com`, and
-      * `.example.com` matches only `foo.example.com`
-    * A single asterisk (`*`) indicates that no proxying should be done
-    * Literal port numbers are accepted by IP address prefixes (`1.2.3.4:80`)
-      and domain names (`foo.example.com:80`)
-    
-    Config example:
+   ```systemd
+   [Service]
+   Environment="HTTP_PROXY=http://proxy.example.com:80"
+   Environment="HTTPS_PROXY=https://proxy.example.com:443"
+   ```
 
-    ```systemd
-    [Service]
-    Environment="HTTP_PROXY=http://proxy.example.com:80"
-    Environment="HTTPS_PROXY=https://proxy.example.com:443"
-    Environment="NO_PROXY=localhost,127.0.0.1,docker-registry.example.com,.corp"
-    ```
+   > **Note**
+   >
+   > Special characters in the proxy value, such as `#?!()[]{}`, must be double
+   > escaped using `%%`. For example:
+   >
+   > ```
+   > [Service]
+   > Environment="HTTP_PROXY=http://domain%%5Cuser:complex%%23pass@proxy.example.com:8080/"
+   > ```
 
-4.  Flush changes and restart Docker
+3. If you have internal Docker registries that you need to contact without
+   proxying, you can specify them via the `NO_PROXY` environment variable.
 
-    ```console
-    $ systemctl --user daemon-reload
-    $ systemctl --user restart docker
-    ```
+   The `NO_PROXY` variable specifies a string that contains comma-separated
+   values for hosts that should be excluded from proxying. These are the options
+   you can specify to exclude hosts:
 
-5.  Verify that the configuration has been loaded and matches the changes you
-    made, for example:
+   - IP address prefix (`1.2.3.4`)
+   - Domain name, or a special DNS label (`*`)
+   - A domain name matches that name and all subdomains. A domain name with a
+     leading "." matches subdomains only. For example, given the domains
+     `foo.example.com` and `example.com`:
+     - `example.com` matches `example.com` and `foo.example.com`, and
+     - `.example.com` matches only `foo.example.com`
+   - A single asterisk (`*`) indicates that no proxying should be done
+   - Literal port numbers are accepted by IP address prefixes (`1.2.3.4:80`) and
+     domain names (`foo.example.com:80`)
 
-    ```console
-    $ systemctl --user show --property=Environment docker
+   Config example:
 
-    Environment=HTTP_PROXY=http://proxy.example.com:80 HTTPS_PROXY=https://proxy.example.com:443 NO_PROXY=localhost,127.0.0.1,docker-registry.example.com,.corp
-    ```
+   ```systemd
+   [Service]
+   Environment="HTTP_PROXY=http://proxy.example.com:80"
+   Environment="HTTPS_PROXY=https://proxy.example.com:443"
+   Environment="NO_PROXY=localhost,127.0.0.1,docker-registry.example.com,.corp"
+   ```
+
+4. Flush changes and restart Docker
+
+   ```console
+   $ systemctl --user daemon-reload
+   $ systemctl --user restart docker
+   ```
+
+5. Verify that the configuration has been loaded and matches the changes you
+   made, for example:
+
+   ```console
+   $ systemctl --user show --property=Environment docker
+
+   Environment=HTTP_PROXY=http://proxy.example.com:80 HTTPS_PROXY=https://proxy.example.com:443 NO_PROXY=localhost,127.0.0.1,docker-registry.example.com,.corp
+   ```
 
 </div>
 </div> <!-- tab-content -->
-
-
-## Configure where the Docker daemon listens for connections
-
-See
-[Configure where the Docker daemon listens for connections](../../engine/install/linux-postinstall.md#configure-where-the-docker-daemon-listens-for-connections).
-
-## Manually create the systemd unit files
-
-When installing the binary without a package, you may want
-to integrate Docker with systemd. For this, install the two unit files
-(`service` and `socket`) from [the github repository](https://github.com/moby/moby/tree/master/contrib/init/systemd)
-to `/etc/systemd/system`.

--- a/config/daemon/troubleshoot.md
+++ b/config/daemon/troubleshoot.md
@@ -1,0 +1,97 @@
+---
+title: Troubleshoot the Docker daemon
+description: Configuring and troubleshooting the Docker daemon
+keywords: docker, daemon, configuration, troubleshooting
+---
+
+This page describes how to troubleshoot and debug the daemon if you run into
+issues.
+
+You can turn on debugging on the daemon to learn about the runtime activity of
+the daemon and to aid in troubleshooting. If the daemon is unresponsive, you can
+also [force a full stack trace](logs.md#force-a-stack-trace-to-be-logged) of all
+threads to be added to the daemon log by sending the `SIGUSR` signal to the
+Docker daemon.
+
+## Troubleshoot conflicts between the `daemon.json` and startup scripts
+
+If you use a `daemon.json` file and also pass options to the `dockerd` command
+manually or using start-up scripts, and these options conflict, Docker fails to
+start with an error such as:
+
+```none
+unable to configure the Docker daemon with file /etc/docker/daemon.json:
+the following directives are specified both as a flag and in the configuration
+file: hosts: (from flag: [unix:///var/run/docker.sock], from file: [tcp://127.0.0.1:2376])
+```
+
+If you see an error similar to this one and you are starting the daemon manually
+with flags, you may need to adjust your flags or the `daemon.json` to remove the
+conflict.
+
+> **Note**: If you see this specific error, continue to the
+> [next section](#use-the-hosts-key-in-daemonjson-with-systemd) for a
+> workaround.
+
+If you are starting Docker using your operating system's init scripts, you may
+need to override the defaults in these scripts in ways that are specific to the
+operating system.
+
+### Use the hosts key in daemon.json with systemd
+
+One notable example of a configuration conflict that is difficult to
+troubleshoot is when you want to specify a different daemon address from the
+default. Docker listens on a socket by default. On Debian and Ubuntu systems
+using `systemd`, this means that a host flag `-H` is always used when starting
+`dockerd`. If you specify a `hosts` entry in the `daemon.json`, this causes a
+configuration conflict (as in the above message) and Docker fails to start.
+
+To work around this problem, create a new file
+`/etc/systemd/system/docker.service.d/docker.conf` with the following contents,
+to remove the `-H` argument that is used when starting the daemon by default.
+
+```none
+[Service]
+ExecStart=
+ExecStart=/usr/bin/dockerd
+```
+
+There are other times when you might need to configure `systemd` with Docker,
+such as [configuring a HTTP or HTTPS proxy](systemd.md#httphttps-proxy).
+
+> **Note**: If you override this option and then do not specify a `hosts` entry
+> in the `daemon.json` or a `-H` flag when starting Docker manually, Docker
+> fails to start.
+
+Run `sudo systemctl daemon-reload` before attempting to start Docker. If Docker
+starts successfully, it is now listening on the IP address specified in the
+`hosts` key of the `daemon.json` instead of a socket.
+
+<!-- prettier-ignore -->
+> **Important**
+> 
+> Setting `hosts` in the `daemon.json` is not supported on Docker
+> Desktop for Windows or Docker Desktop for Mac.
+{:.important}
+
+## Out of memory issues
+
+If your containers attempt to use more memory than the system has available, you
+may experience an Out of Memory (OOM) exception, and a container, or the Docker
+daemon, might be stopped by the kernel OOM killer. To prevent this from
+happening, ensure that your application runs on hosts with adequate memory and
+see
+[Understand the risks of running out of memory](../containers/resource_constraints.md#understand-the-risks-of-running-out-of-memory).
+
+## Check whether Docker is running
+
+The operating-system independent way to check whether Docker is running is to
+ask Docker, using the `docker info` command.
+
+You can also use operating system utilities, such as
+`sudo systemctl is-active docker` or `sudo status docker` or
+`sudo service docker status`, or checking the service status using Windows
+utilities.
+
+Finally, you can check in the process list for the `dockerd` process, using
+commands like `ps` or `top`.

--- a/desktop/release-notes.md
+++ b/desktop/release-notes.md
@@ -900,8 +900,8 @@ For frequently asked questions about Docker Desktop releases, see [FAQs](faqs/ge
 ### New
 
 - IT Administrators can now install Docker Desktop remotely using the command line.
-- Add the Docker Software Bill of Materials (SBOM) CLI plugin. The new CLI plugin enables users to generate SBOMs for Docker images. For more information, see [Docker SBOM](../engine/sbom/index.md).
-- Use [cri-dockerd](https://github.com/Mirantis/cri-dockerd){: target="_blank" rel="noopener" class="_"} for new Kubernetes clusters instead of `dockershim`. The change is transparent from the user's point of view and Kubernetes containers run on the Docker Engine as before. `cri-dockerd` allows Kubernetes to manage Docker containers using the standard [Container Runtime Interface](https://github.com/kubernetes/cri-api#readme){: target="_blank" rel="noopener" class="_"}, the same interface used to control other container runtimes. For more information, see [The Future of Dockershim is cri-dockerd](https://www.mirantis.com/blog/the-future-of-dockershim-is-cri-dockerd/){: target="_blank" rel="noopener" class="_"}.
+- Add  the Docker Software Bill of Materials (SBOM) CLI plugin. The new CLI plugin enables users to generate SBOMs for Docker images. For more information, see [Docker SBOM](../engine/sbom/index.md).
+- Use [cri-dockerd](https://github.com/Mirantis/cri-dockerd){: target="_blank" rel="noopener" class="_"}  for new Kubernetes clusters instead of `dockershim`. The change is transparent from the user's point of view and Kubernetes containers run on the Docker Engine as before. `cri-dockerd` allows Kubernetes to manage Docker containers using the standard [Container Runtime Interface](https://github.com/kubernetes/cri-api#readme){: target="_blank" rel="noopener" class="_"}, the same interface used to control other container runtimes. For more information, see [The Future of Dockershim is cri-dockerd](https://www.mirantis.com/blog/the-future-of-dockershim-is-cri-dockerd/){: target="_blank" rel="noopener" class="_"}.
 
 ### Updates
 

--- a/desktop/troubleshoot/overview.md
+++ b/desktop/troubleshoot/overview.md
@@ -228,9 +228,9 @@ To read the Docker app log messages, type `docker` in the Console window search 
 You can use the Console Log Query to search logs, filter the results in various
 ways, and create reports.
 
-### View the Docker Daemon logs
+### View the Docker daemon logs
 
-Refer to the [read the logs](../../config/daemon/index.md#read-the-logs) section
+Refer to the [Read the daemon logs](../../config/daemon/logs.md) section
 to learn how to view the Docker Daemon logs.
 
 </div>
@@ -247,9 +247,9 @@ $ journalctl --user --unit=docker-desktop
 You can also find the logs for the internal components included in Docker
 Desktop at `$HOME/.docker/desktop/log/`.
 
-### View the Docker Daemon logs
+### View the Docker daemon logs
 
-Refer to the [read the logs](../../config/daemon/index.md#read-the-logs) section
+Refer to the [Read the daemon logs](../../config/daemon/logs.md) section
 to learn how to view the Docker Daemon logs.
 
 </div>

--- a/engine/index.md
+++ b/engine/index.md
@@ -2,11 +2,11 @@
 description: Engine
 keywords: Engine
 redirect_from:
-- /edge/
-- /engine/ce-ee-node-activate/
-- /engine/misc/
-- /linux/
-- /manuals/ # TODO remove this redirect after we've created a landing page for the product manuals section
+  - /edge/
+  - /engine/ce-ee-node-activate/
+  - /engine/misc/
+  - /linux/
+  - /manuals/ # TODO remove this redirect after we've created a landing page for the product manuals section
 title: Docker Engine overview
 ---
 
@@ -14,50 +14,117 @@ Docker Engine is an open source containerization technology for building and
 containerizing your applications. Docker Engine acts as a client-server
 application with:
 
-* A server with a long-running daemon process [`dockerd`](/engine/reference/commandline/dockerd).
-* APIs which specify interfaces that programs can use to talk to and
-  instruct the Docker daemon.
-* A command line interface (CLI) client [`docker`](/engine/reference/commandline/cli/).
+- A server with a long-running daemon process
+  [`dockerd`](/engine/reference/commandline/dockerd).
+- APIs which specify interfaces that programs can use to talk to and instruct
+  the Docker daemon.
+- A command line interface (CLI) client
+  [`docker`](/engine/reference/commandline/cli/).
 
 The CLI uses [Docker APIs](api/index.md) to control or interact with the Docker
 daemon through scripting or direct CLI commands. Many other Docker applications
 use the underlying API and CLI. The daemon creates and manage Docker objects,
 such as images, containers, networks, and volumes.
 
-For more details, see [Docker Architecture](../get-started/overview.md#docker-architecture).
+For more details, see
+[Docker Architecture](../get-started/overview.md#docker-architecture).
 
-## Docker user guide
-
-To learn about Docker in more detail and to answer questions about usage and
-implementation, check out the [overview page in "get started"](../get-started/overview.md).
-
-## Installation guides
-
-The [installation section](install/index.md) shows you how to install Docker
-on a variety of platforms.
-
-## Release notes
-
-A summary of the changes in each release in the current series can now be found
-on the separate [Release Notes page](release-notes/index.md)
-
-## Feature Deprecation Policy
-
-As changes are made to Docker there may be times when existing features
-need to be removed or replaced with newer features. Before an existing
-feature is removed it is labeled as "deprecated" within the documentation
-and remains in Docker for at least 3 stable releases unless specified
-explicitly otherwise. After that time it may be removed.
-
-Users are expected to take note of the list of deprecated features each
-release and plan their migration away from those features, and (if applicable)
-towards the replacement features as soon as possible.
-
-The complete list of deprecated features can be found on the
-[Deprecated Features page](deprecated.md).
+<div class="component-container">
+  <!--start row-->
+  <div class="row">
+    <div class="col-xs-12 col-sm-12 col-md-12 col-lg-4 block">
+      <div class="component">
+        <div class="component-icon">
+          <a href="/engine/install/"><img src="/assets/images/download.svg" alt="Arrow pointing downwards" width="70px" height="70px"></a>
+        </div>
+        <h2><a href="/engine/install/">Install Docker Engine</a></h2>
+        <p>Learn how to install the open source Docker Engine for your distribution.</p>
+      </div>
+    </div>
+    <div class="col-xs-12 col-sm-12 col-md-12 col-lg-4 block">
+      <div class="component">
+        <div class="component-icon">
+          <a href="/storage/"><img src="/assets/images/engine-storage.svg" alt="Data disks" width="70px" height="70px"></a>
+        </div>
+        <h2><a href="/storage/">Storage</a></h2>
+        <p>Use persistent data with Docker containers.</p>
+      </div>
+    </div>
+    <div class="col-xs-12 col-sm-12 col-md-12 col-lg-4 block">
+      <div class="component">
+        <div class="component-icon">
+          <a href="/network/"><img src="/assets/images/engine-networking.svg" alt="Computers on a local area network" width="70px" height="70px"></a>
+        </div>
+        <h2><a href="/network/">Networking</a></h2>
+        <p>Manage network connections between containers.</p>
+      </div>
+    </div>
+  </div>
+  <!--start row-->
+  <div class="row">
+    <div class="col-xs-12 col-sm-12 col-md-12 col-lg-4 block">
+      <div class="component">
+        <div class="component-icon">
+          <a href="/config/containers/logging/"><img src="/assets/images/engine-logging.svg" alt="Document with a text outline" width="70px" height="70px"></a>
+        </div>
+        <h2><a href="/config/containers/logging/">Container logs</a></h2>
+        <p>Learn how to view and read container logs.</p>
+      </div>
+    </div>
+    <div class="col-xs-12 col-sm-12 col-md-12 col-lg-4 block">
+      <div class="component">
+        <div class="component-icon">
+          <a href="/config/pruning/"><img src="/assets/images/engine-pruning.svg" alt="A pair of scissors" width="70px" height="70px"></a>
+        </div>
+        <h2><a href="/config/pruning/">Prune</a></h2>
+        <p>Tidy up unused resources.</p>
+      </div>
+    </div>
+    <div class="col-xs-12 col-sm-12 col-md-12 col-lg-4 block">
+      <div class="component">
+        <div class="component-icon">
+          <a href="/config/daemon/"><img src="/assets/images/engine-configure-daemon.svg" alt="Settings cogwheel with stars" width="70px" height="70px"></a>
+        </div>
+        <h2><a href="/config/daemon/">Configure the daemon</a></h2>
+        <p>Delve into the configuration options of the Docker daemon.</p>
+      </div>
+    </div>
+  </div>
+  <!--start row-->
+  <div class="row">
+    <div class="col-xs-12 col-sm-12 col-md-12 col-lg-4 block">
+      <div class="component">
+        <div class="component-icon">
+          <a href="/engine/security/rootless/"><img src="/assets/images/engine-rootless.svg" alt="Checkered shield" width="70px" height="70px"></a>
+        </div>
+        <h2><a href="/engine/security/rootless/">Rootless mode</a></h2>
+        <p>Run Docker without root privileges.</p>
+      </div>
+    </div>
+    <div class="col-xs-12 col-sm-12 col-md-12 col-lg-4 block">
+      <div class="component">
+        <div class="component-icon">
+          <a href="/engine/deprecated/"><img src="/assets/images/engine-deprecated.svg" alt="Alarm bell with an exclamation mark" width="70px" height="70px"></a>
+        </div>
+        <h2><a href="/engine/deprecated/">Deprecated features</a></h2>
+        <p>Find out what features of Docker Engine you should stop using.</p>
+      </div>
+    </div>
+    <div class="col-xs-12 col-sm-12 col-md-12 col-lg-4 block">
+      <div class="component">
+        <div class="component-icon">
+          <a href="/engine/release-notes/"><img src="/assets/images/note-add.svg" alt="Document with an overlaying plus sign" width="70px" height="70px"></a>
+        </div>
+        <h2><a href="/engine/release-notes/">Release notes</a></h2>
+        <p>Read the release notes for the latest version.</p>
+      </div>
+    </div>
+  </div>
+</div>
 
 ## Licensing
 
-Docker is licensed under the Apache License, Version 2.0. See
-[LICENSE](https://github.com/moby/moby/blob/master/LICENSE) for the full
-license text.
+The Docker Engine is licensed under the Apache License, Version 2.0. See
+[LICENSE](https://github.com/moby/moby/blob/master/LICENSE) for the full license
+text.
+

--- a/engine/install/centos.md
+++ b/engine/install/centos.md
@@ -1,5 +1,5 @@
 ---
-description: Instructions for installing Docker Engine on CentOS
+description: Install Docker Engine on CentOS
 keywords: requirements, apt, installation, centos, rpm, install, uninstall, upgrade, update
 redirect_from:
 - /ee/docker-ee/centos/

--- a/engine/install/linux-postinstall.md
+++ b/engine/install/linux-postinstall.md
@@ -3,7 +3,7 @@ description: Optional post-installation steps for Linux
 keywords: >
   Docker, Docker documentation, requirements, apt, installation, ubuntu,
   install, uninstall, upgrade, update
-title: Post-installation steps for Linux
+title: Docker Engine post-installation steps
 redirect_from:
   - /engine/installation/linux/docker-ee/linux-postinstall/
   - /engine/installation/linux/linux-postinstall/
@@ -135,95 +135,6 @@ options:
   such as the ["local" logging driver](../../config/containers/logging/local.md)
   that performs log rotation by default
 - Use a logging driver that sends logs to a remote logging aggregator.
-
-## Configure where the Docker daemon listens for connections
-
-By default, the Docker daemon listens for connections on a Unix socket to accept
-requests from local clients. It's possible to allow Docker to accept requests
-from remote hosts by configuring it to listen on an IP address and port as well
-as the Unix socket. For more detailed information on this configuration option,
-refer to the
-[dockerd CLI reference](/engine/reference/commandline/dockerd/#bind-docker-to-another-hostport-or-a-unix-socket).
-
-<!-- prettier-ignore -->
-> Secure your connection
->
-> Before configuring Docker to accept connections from remote hosts it's
-> critically important that you understand the security implications of opening
-> Docker to the network. If steps aren't taken to secure the connection, it's
-> possible for remote non-root users to gain root access on the host. For more
-> information on how to use TLS certificates to secure this connection, check
-> [Protect the Docker daemon socket](../security/protect-access.md).
-{: .warning}
-
-You can configure Docker to accept remote connections. This can be done using
-the `docker.service` systemd unit file for Linux distributions using systemd. Or
-you can use the `daemon.json` file, if your distribution doesn't use systemd.
-
-> systemd vs `daemon.json`
->
-> Configuring Docker to listen for connections using both the systemd unit file
-> and the `daemon.json` file causes a conflict that prevents Docker from
-> starting.
-
-### Configuring remote access with systemd unit file
-
-1. Use the command `sudo systemctl edit docker.service` to open an override file
-   for `docker.service` in a text editor.
-
-2. Add or modify the following lines, substituting your own values.
-
-   ```systemd
-   [Service]
-   ExecStart=
-   ExecStart=/usr/bin/dockerd -H fd:// -H tcp://127.0.0.1:2375
-   ```
-
-3. Save the file.
-
-4. Reload the `systemctl` configuration.
-
-   ```console
-    $ sudo systemctl daemon-reload
-   ```
-
-5. Restart Docker.
-
-   ```console
-   $ sudo systemctl restart docker.service
-   ```
-
-6. Verify that the change has gone through.
-
-   ```console
-   $ sudo netstat -lntp | grep dockerd
-   tcp        0      0 127.0.0.1:2375          0.0.0.0:*               LISTEN      3758/dockerd
-   ```
-
-### Configuring remote access with `daemon.json`
-
-1. Set the `hosts` array in the `/etc/docker/daemon.json` to connect to the UNIX
-   socket and an IP address, as follows:
-
-   ```json
-   {
-     "hosts": ["unix:///var/run/docker.sock", "tcp://127.0.0.1:2375"]
-   }
-   ```
-
-2. Restart Docker.
-
-3. Verify that the change has gone through.
-
-   ```console
-   $ sudo netstat -lntp | grep dockerd
-   tcp        0      0 127.0.0.1:2375          0.0.0.0:*               LISTEN      3758/dockerd
-   ```
-
-## Enable IPv6 on the Docker daemon
-
-To enable IPv6 on the Docker daemon, see
-[Enable IPv6 support](../../config/daemon/ipv6.md).
 
 ## Next steps
 

--- a/engine/install/troubleshoot.md
+++ b/engine/install/troubleshoot.md
@@ -1,5 +1,5 @@
 ---
-title: Troubleshoot Docker Engine
+title: Troubleshoot Docker Engine installation
 description:
   Diagnose and resolve error messages related to the Docker Engine installation
 keywords: Docker Engine, troubleshooting, error, Linux

--- a/storage/bind-mounts.md
+++ b/storage/bind-mounts.md
@@ -1,6 +1,6 @@
 ---
 description: Using bind mounts
-title: Use bind mounts
+title: Bind mounts
 keywords: storage, persistence, data persistence, mounts, bind mounts
 redirect_from:
 - /engine/admin/volumes/bind-mounts/

--- a/storage/tmpfs.md
+++ b/storage/tmpfs.md
@@ -1,6 +1,6 @@
 ---
 description: Using tmpfs mounts
-title: Use tmpfs mounts
+title: tmpfs mounts
 keywords: storage, persistence, data persistence, tmpfs
 redirect_from:
 - /engine/admin/volumes/tmpfs/

--- a/storage/volumes.md
+++ b/storage/volumes.md
@@ -1,6 +1,6 @@
 ---
 description: Using volumes
-title: Use volumes
+title: Volumes
 keywords: storage, persistence, data persistence, volumes
 redirect_from:
 - /userguide/dockervolumes/


### PR DESCRIPTION
<!--
  Thank you for contributing to Docker documentation!

  Here are a few things to keep in mind:

  - Links between pages should use a relative path
  - Remember to add an alt text for images

  ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
  ┃     Review our contribution guidelines:       ┃
  ┃                                               ┃
  ┃ https://docs.docker.com/contribute/overview/  ┃
  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
-->

### Proposed changes

This PR ~moves docs related to Docker Engine to the `/engine` subdirectory, and~ updates the TOC so that Engine pages are found under **Manuals** > **Docker Engine**.

ENGDOCS-1080