### PR TITLE
ci(validate-upstream): use ref name

### DIFF
--- a/.github/workflows/validate-upstream.yml
+++ b/.github/workflows/validate-upstream.yml
@@ -47,7 +47,7 @@ jobs:
                 remote['repo'] = "${{ github.event.pull_request.head.repo.html_url }}";
                 remote['ref'] = "${{ github.event.pull_request.head.ref }}"
               } else {
-                remote['ref'] = "${{ github.ref }}";
+                remote['ref'] = "${{ github.ref_name }}";
               }
             }
 


### PR DESCRIPTION
Git clone does not work with fully-formed ref of the branch or tag that triggered the workflow: https://github.com/docker/buildx/actions/runs/3437270705/jobs/5731843158#step:8:584

```
#20 7.475   Repo https://github.com/docker/buildx
#20 7.476     Cloning repository into /tmp/docker-docs-clone/docker/buildx
#20 7.722                     ------------------------------------------------
#20 7.723       Jekyll 4.2.2   Please append `--trace` to the `build` command 
#20 7.724                      for any additional information or backtrace. 
#20 7.724                     ------------------------------------------------
#20 7.725 /usr/local/bundle/gems/git-1.12.0/lib/git/lib.rb:1125:in `command': git '-c' 'core.quotePath=true' '-c' 'color.ui=false' clone '--branch' 'refs/heads/master' '--depth' '1' '--' 'https://github.com/docker/buildx.git' '/tmp/docker-docs-clone/docker/buildx'  2>&1:Cloning into '/tmp/docker-docs-clone/docker/buildx'... (Git::GitExecuteError)
#20 7.727 warning: Could not find remote branch refs/heads/master to clone.
#20 7.727 fatal: Remote branch refs/heads/master not found in upstream origin
#20 7.728 	from /usr/local/bundle/gems/git-1.12.0/lib/git/lib.rb:116:in `clone'
#20 7.728 	from /usr/local/bundle/gems/git-1.12.0/lib/git/base.rb:21:in `clone'
#20 7.728 	from /usr/local/bundle/gems/git-1.12.0/lib/git.rb:176:in `clone'
```

Use the short ref name instead to fix this issue. In a follow-up, instead of cloning in `fetch_remote` plugin, we could init/fetch/checkout.

Signed-off-by: CrazyMax <crazy-max@users.noreply.github.com>