### PR TITLE
jekyll(last_modified_at): fallback to mtime on rescue

### DIFF
--- a/_plugins/last_modified_at.rb
+++ b/_plugins/last_modified_at.rb
@@ -46,7 +46,13 @@ module Jekyll
               set_mode = "git"
             end
           rescue => e
-            # Ignored
+            begin
+              page.data['last_modified_at'] = File.mtime(page_relative_path).strftime(DATE_FORMAT)
+              set_mode = "mtime"
+            rescue => e
+              page.data['last_modified_at'] = Time.now.strftime(DATE_FORMAT)
+              set_mode = "rescue"
+            end
           end
         end
         puts"  #{page.relative_path}#{path_override}\n    last_modified_at(#{set_mode}): #{page.data['last_modified_at']}"


### PR DESCRIPTION
fallback to mtime on rescue and if it doesn't work (like for pageless redirections introduced in https://github.com/docker/docs/pull/16101), use current time as best effort.

Signed-off-by: CrazyMax <crazy-max@users.noreply.github.com>