### PR TITLE
add docker-ce-rootless-extras to uninstall command

### DIFF
--- a/engine/install/centos.md
+++ b/engine/install/centos.md
@@ -215,7 +215,7 @@ instead of `yum -y install`, and point to the new file.
 1.  Uninstall the Docker Engine, CLI, Containerd, and Docker Compose packages:
 
     ```console
-    $ sudo yum remove docker-ce docker-ce-cli containerd.io docker-compose-plugin
+    $ sudo yum remove docker-ce docker-ce-cli containerd.io docker-compose-plugin docker-ce-rootless-extras
     ```
 
 2.  Images, containers, volumes, or customized configuration files on your host

--- a/engine/install/fedora.md
+++ b/engine/install/fedora.md
@@ -210,7 +210,7 @@ instead of `dnf -y install`, and point to the new file.
 1.  Uninstall the Docker Engine, CLI, Containerd, and Docker Compose packages:
 
     ```console
-    $ sudo dnf remove docker-ce docker-ce-cli containerd.io docker-compose-plugin
+    $ sudo dnf remove docker-ce docker-ce-cli containerd.io docker-compose-plugin docker-ce-rootless-extras
     ```
 
 2.  Images, containers, volumes, or customized configuration files on your host

--- a/engine/install/rhel.md
+++ b/engine/install/rhel.md
@@ -219,7 +219,7 @@ instead of `yum -y install`, and point to the new file.
 1.  Uninstall the Docker Engine, CLI, Containerd, and Docker Compose packages:
 
     ```console
-    $ sudo yum remove docker-ce docker-ce-cli containerd.io docker-compose-plugin
+    $ sudo yum remove docker-ce docker-ce-cli containerd.io docker-compose-plugin docker-ce-rootless-extras
     ```
 
 2.  Images, containers, volumes, or customized configuration files on your host

--- a/engine/install/sles.md
+++ b/engine/install/sles.md
@@ -237,7 +237,7 @@ instead of `zypper -y install`, and point to the new file.
 1.  Uninstall the Docker Engine, CLI, Containerd, and Docker Compose packages:
 
     ```console
-    $ sudo zypper remove docker-ce docker-ce-cli containerd.io docker-compose-plugin
+    $ sudo zypper remove docker-ce docker-ce-cli containerd.io docker-compose-plugin docker-ce-rootless-extras
     ```
 
 2.  Images, containers, volumes, or customized configuration files on your host

--- a/engine/install/ubuntu.md
+++ b/engine/install/ubuntu.md
@@ -254,7 +254,7 @@ To upgrade Docker Engine, download the newer package file and repeat the
 1.  Uninstall the Docker Engine, CLI, containerd, and Docker Compose packages:
 
     ```console
-    $ sudo apt-get purge docker-ce docker-ce-cli containerd.io docker-compose-plugin
+    $ sudo apt-get purge docker-ce docker-ce-cli containerd.io docker-compose-plugin docker-ce-rootless-extras
     ```
 
 2.  Images, containers, volumes, or custom configuration files on your host


### PR DESCRIPTION
<!--
  Thank you for contributing to Docker documentation!

  Here are a few things to keep in mind:

  - Links between pages should use a relative path
  - Remember to add an alt text for images

  ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
  ┃     Review our contribution guidelines:       ┃
  ┃                                               ┃
  ┃ https://docs.docker.com/contribute/overview/  ┃
  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
-->

### Proposed changes

Adds `docker-ce-rootless-extras` to the engine uninstall command

### Related issues (optional)

#16148
