### PR TITLE
Refresh pull limit docs

### DIFF
--- a/docker-hub/download-rate-limit.md
+++ b/docker-hub/download-rate-limit.md
@@ -84,9 +84,9 @@ This means my limit is 100 pulls per 21600 seconds (6 hours), and I have 76 pull
 
 ### I don't see any RateLimit headers
 
-If you do not see these headers, that means pulling that image would not count towards pull limits. This could be because you are authenticated with a Docker Hub account associated with a Pro, Team, or a Business subscription, or because the image or your IP is unlimited in partnership with a publisher, provider, or an open-source organization.
+If you do not see these headers, that means pulling that image would not count towards pull limits. This could be because the image or your IP is unlimited in partnership with a publisher, provider, or an open-source organization.
 
-## I'm being limited even though I have a paid Docker subscription
+## I'm being limited to a lower rate even though I have a paid Docker subscription
 
 To take advantage of the higher limits included in a paid Docker subscription, you must [authenticate pulls](#how-do-i-authenticate-pull-requests) with your user account.
 

--- a/docker-hub/service-accounts.md
+++ b/docker-hub/service-accounts.md
@@ -4,11 +4,11 @@ keywords: Docker, service, accounts, Docker Hub
 title: Service accounts
 ---
 
-A service account is a Docker ID used for automated management of container images or containerized applications. Service accounts are typically used in automated workflows, and do not share Docker IDs with the members in the Team plan. Common use cases for service accounts include mirroring content on Docker Hub, or tying in image pulls from your CI/CD process.
+A service account is a Docker ID used for automated management of container images or containerized applications. Service accounts are typically used in automated workflows, and do not share Docker IDs with the members in the organization. Common use cases for service accounts include mirroring content on Docker Hub, or tying in image pulls from your CI/CD process.
 
 > **Note**
 >
-> Service accounts included with the Team plan are limited to 5,000 pulls per day. If you require a higher number of pulls, you can purchase an Enhanced Service Account add-on.
+> All paid Docker subscriptions are limited to 5000 pulls per day. If you require a higher number of pulls, you can purchase an Enhanced Service Account add-on. 
 
 ## Enhanced Service Account add-on pricing
 
@@ -22,7 +22,7 @@ Refer to the following table for details on the Enhanced Service Account add-on 
 | 4 | 50,000-100,000 | $58,950/yr |
 | 5 | 100,000+ | [Contact Sales](https://www.docker.com/pricing/questions){:target="_blank" rel="noopener" class="_"} |
 
-<sub>*Once the initial Tier is established, that is the minimum fee for the year.  Annual commitment required.  The service account may exceed Pulls by up to 25% for up to 20 days during the year without incurring additional fees.  Reports on consumption will be provided upon request.  At the end of the initial 1-year term, the appropriate Tier will be established for the following year.<sub>
+<sub>*Once the initial Tier is established, that is the minimum fee for the year. Annual commitment required. The service account may exceed Pulls by up to 25% for up to 20 days during the year without incurring additional fees. Reports on consumption will be provided upon request. At the end of the initial 1-year term, the appropriate Tier will be established for the following year.<sub>
 
 ## How a pull is defined
 

--- a/registry/recipes/mirror.md
+++ b/registry/recipes/mirror.md
@@ -78,7 +78,7 @@ but this property does not hold true for a registry cache cluster.
 
 > **Note**
 >
-> All paid Docker subscriptions are limited to 5000 pulls per day. If you require a higher number of pulls, you can purchase an Enhanced Service Account add-on. See [Service Accounts](/docker-hub/service-accounts/) for more details.
+> When using Docker Hub, all paid Docker subscriptions are limited to 5000 pulls per day. If you require a higher number of pulls, you can purchase an Enhanced Service Account add-on. See [Service Accounts](/docker-hub/service-accounts/) for more details.
 
 ### Configure the cache
 

--- a/registry/recipes/mirror.md
+++ b/registry/recipes/mirror.md
@@ -78,7 +78,7 @@ but this property does not hold true for a registry cache cluster.
 
 > **Note**
 >
-> Service accounts included in the Team plan are limited to 5,000 pulls per day. See [Service Accounts](/docker-hub/service-accounts/) for more details.
+> All paid Docker subscriptions are limited to 5000 pulls per day. If you require a higher number of pulls, you can purchase an Enhanced Service Account add-on. See [Service Accounts](/docker-hub/service-accounts/) for more details.
 
 ### Configure the cache
 


### PR DESCRIPTION
### Proposed changes
Update wording to reflect that all paid accounts are limited to 5k pulls per day, not just service accounts.



### Related issues (optional)
ENGDOCS-1035