### PR TITLE
Add some mention to show extension containers from other places in the doc

### DIFF
--- a/desktop/extensions-sdk/build/set-up/minimal-backend-extension.md
+++ b/desktop/extensions-sdk/build/set-up/minimal-backend-extension.md
@@ -92,6 +92,12 @@ COPY --from=client-builder /app/client/dist ui
 CMD [ "sleep", "infinity" ]
 ```
 
+> **Tip**
+>
+> Enable the "Show system containers" option in Docker Desktop to see the extension container running.
+> See [how to show extension containers](../test-debug.md#show-the-extension-containers) for more information.
+{: .tip }
+
 ## Configure the metadata file
 
 A `metadata.json` file is required at the root of the image filesystem.

--- a/desktop/extensions-sdk/quickstart.md
+++ b/desktop/extensions-sdk/quickstart.md
@@ -58,9 +58,11 @@ To install the extension in Docker Desktop, run:
 $ docker extension install <name-of-your-extension>
 ```
 
-To preview the extension in Docker Desktop, close and open Docker Dashboard once the installation is complete.
+To preview the extension in Docker Desktop, open Docker Dashboard once the installation is complete.
 
 During UI development, it’s helpful to use hot reloading to test your changes without rebuilding your entire extension. See [Preview whilst developing the UI](build/test-debug.md#hot-reloading-whilst-developing-the-ui) for more information.
+
+You may also want to inspect the containers that belongs to the extension. By default, extension containers are hidden from the Docker Dashboard. You can change that in the settings, see [how to show extension containers](build/test-debug.md#show-the-extension-containers) for more information.
 
 ## Step four: Submit and publish your extension to the Marketplace
 

--- a/desktop/extensions-sdk/quickstart.md
+++ b/desktop/extensions-sdk/quickstart.md
@@ -62,7 +62,7 @@ To preview the extension in Docker Desktop, open Docker Dashboard once the insta
 
 During UI development, it’s helpful to use hot reloading to test your changes without rebuilding your entire extension. See [Preview whilst developing the UI](build/test-debug.md#hot-reloading-whilst-developing-the-ui) for more information.
 
-You may also want to inspect the containers that belongs to the extension. By default, extension containers are hidden from the Docker Dashboard. You can change that in the settings, see [how to show extension containers](build/test-debug.md#show-the-extension-containers) for more information.
+You may also want to inspect the containers that belong to the extension. By default, extension containers are hidden from the Docker Dashboard. You can change this in **Settings**, see [how to show extension containers](build/test-debug.md#show-the-extension-containers) for more information.
 
 ## Step four: Submit and publish your extension to the Marketplace
 


### PR DESCRIPTION
<!--
  Thank you for contributing to Docker documentation!

  Here are a few things to keep in mind:

  - Links between pages should use a relative path
  - Remember to add an alt text for images

  ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
  ┃     Review our contribution guidelines:       ┃
  ┃                                               ┃
  ┃ https://docs.docker.com/contribute/overview/  ┃
  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
-->

### Proposed changes

<!-- Tell us what you did and why -->

During interview some developers complained that the containers of their extension was hidden by default.
Now the documentation will mention that on the pages that beginners will likely read first.

### Related issues (optional)

<!--
  Refer to related PRs or issues:

  #1234
  Closes #1234
  Closes docker/cli#1234
-->
