### PR TITLE
Docs: Update Dockerfile base image and python version

### DIFF
--- a/get-started/02_our_app.md
+++ b/get-started/02_our_app.md
@@ -78,8 +78,8 @@ In order to build the [container image](../get-started/overview.md/#docker-objec
 
    ```dockerfile
    # syntax=docker/dockerfile:1
-   FROM node:12-alpine
-   RUN apk add --no-cache python2 g++ make
+   FROM node:19-alpine
+   RUN apk add --no-cache python3 g++ make
    WORKDIR /app
    COPY . .
    RUN yarn install --production


### PR DESCRIPTION
changed base image from node:12-alpine to node:19-alpine as new version of Jest requires node 18 or above.

<!--
  Thank you for contributing to Docker documentation!

  Here are a few things to keep in mind:

  - Links between pages should use a relative path
  - Remember to add an alt text for images

  ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
  ┃     Review our contribution guidelines:       ┃
  ┃                                               ┃
  ┃ https://docs.docker.com/contribute/overview/  ┃
  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
-->

### Proposed changes

<!-- Tell us what you did and why -->
Updated the base image in the Docker file from node:12-alpine to node:19-alpine because Jest expected a newer version.
Also updated python to python3, as python2 package was not found.

### Related issues (optional)

<!--
  Refer to related PRs or issues:

  #1234
  Closes #1234
  Closes docker/cli#1234
-->
