### PR TITLE
Fix error: PowerShell environment variable setting

### DIFF
--- a/engine/context/working-with-contexts.md
+++ b/engine/context/working-with-contexts.md
@@ -155,7 +155,7 @@ Use the appropriate command below to set the context to `docker-test` using an e
 Windows PowerShell:
 
 ```console
-> $Env:DOCKER_CONTEXT=docker-test
+> $env:DOCKER_CONTEXT='docker-test'
 ```
 
 Linux:


### PR DESCRIPTION
Required to be surrounded by `'` or `"`. If not so, PowerShell throws exception.

### Proposed changes

Adding `'` (or `"`).

### Related issues (optional)

#13427 original PR 1yr ago. The conflict cannot be solved and has been closed.

<!--
  Refer to related PRs or issues:

  #1234
  Closes #1234
  Closes docker/cli#1234
-->
