### PR TITLE
fix [WORKDIR /app] docker file content

### DIFF
--- a/get-started/02_our_app.md
+++ b/get-started/02_our_app.md
@@ -80,7 +80,7 @@ In order to build the [container image](../get-started/overview.md/#docker-objec
    # syntax=docker/dockerfile:1
    FROM node:12-alpine
    RUN apk add --no-cache python2 g++ make
-   WORKDIR /app
+   WORKDIR /
    COPY . .
    RUN yarn install --production
    CMD ["node", "src/index.js"]


### PR DESCRIPTION
when run app from docker. Nodejs throw error not found /app/src/index.js because toturial step 2 cd to folder  app.

<!--
  Thank you for contributing to Docker documentation!

  Here are a few things to keep in mind:

  - Links between pages should use a relative path
  - Remember to add an alt text for images

  ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
  ┃     Review our contribution guidelines:       ┃
  ┃                                               ┃
  ┃ https://docs.docker.com/contribute/overview/  ┃
  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
-->

### Proposed changes

<!-- Tell us what you did and why -->

### Related issues (optional)

<!--
  Refer to related PRs or issues:

  #1234
  Closes #1234
  Closes docker/cli#1234
-->
