### PR TITLE
Use the correct error message when trying to inspect a nonexisting service

### DIFF
--- a/engine/swarm/swarm-tutorial/delete-service.md
+++ b/engine/swarm/swarm-tutorial/delete-service.md
@@ -27,7 +27,7 @@ you can delete the service from the swarm.
     ```console
     $ docker service inspect helloworld
     []
-    Error: no such service: helloworld
+    Status: Error: no such service: helloworld, Code: 1
     ```
 
 4.  Even though the service no longer exists, the task containers take a few


### PR DESCRIPTION
<!--
  Thank you for contributing to Docker documentation!

  Here are a few things to keep in mind:

  - Links between pages should use a relative path
  - Remember to add an alt text for images

  ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
  ┃     Review our contribution guidelines:       ┃
  ┃                                               ┃
  ┃ https://docs.docker.com/contribute/overview/  ┃
  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
-->

### Proposed changes

Uses the correct error message when inspecting a non exiting service