### PR TITLE
remove containerd release note repetition

### DIFF
--- a/desktop/containerd/index.md
+++ b/desktop/containerd/index.md
@@ -203,31 +203,13 @@ View Tags on DockerHub to see multi-platform result:
 
 ![containerd_feature_tags](../images/containerd_feature_tags.png){:width="750px"}
 
-## Containerd Image Store Release Notes
+## Known issues
 
-### 2022-10-19 
-New commands and multiple bug fixes included with Docker Desktop 4.13.0.
+### Docker Desktop 4.13.0 release
 
-#### New
-* Added `docker diff` and `docker run --platform` support.
-
-#### Bug fixes
-* Fixed a bug which caused Kubernetes not starting.
-* Fixed a bug which caused Kubernetes IN Docker (kind) not starting.
-* Fixed a bug which caused Dev Environments not working.
-* Fixed a bug which caused Insecure Registries not working.
-
-#### Known issues
 * Listing images with `docker images` returns the error `content digest not found` on ARM machines after running or pulling an image with the `--platform` parameter.
 
-### 2022-09-01  
-The Containerd Image Store is shipped as a [Beta](../../release-lifecycle.md/#beta) feature on Docker Desktop 4.12.0.
-
-#### New
-
-Initial implementation of the Docker commands: `run`, `commit`, `build`, `push`, `load`, `search` and `save`.
-
-#### Known issues
+### Docker Desktop 4.12.0 release
 
 * The Containerd Image Store feature requires Buildx version 0.9.0 or newer.
     + On Docker Desktop for Linux (DD4L), validate if your locally installed version meets this requirement.  


### PR DESCRIPTION
This PR removes the release note repetition in the containerd page. 

Closes https://github.com/docker/docs/pull/16238