### PR TITLE
fix variable name typo

### DIFF
--- a/compose/gettingstarted.md
+++ b/compose/gettingstarted.md
@@ -236,7 +236,7 @@ services:
 The new `volumes` key mounts the project directory (current directory) on the
 host to `/code` inside the container, allowing you to modify the code on the
 fly, without having to rebuild the image. The `environment` key sets the
-`FLASK_ENV` environment variable, which tells `flask run` to run in development
+`FLASK_DEBUG` environment variable, which tells `flask run` to run in development
 mode and reload the code on change. This mode should only be used in development.
 
 ## Step 6: Re-build and run the app with Compose


### PR DESCRIPTION
<!--
  Thank you for contributing to Docker documentation!

  Here are a few things to keep in mind:

  - Links between pages should use a relative path
  - Remember to add an alt text for images

  ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
  ┃     Review our contribution guidelines:       ┃
  ┃                                               ┃
  ┃ https://docs.docker.com/contribute/overview/  ┃
  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
-->

### Proposed changes

<!-- Tell us what you did and why -->

Fix minor env var name typo
### Related issues (optional)

<!--
  Refer to related PRs or issues:

  #1234
  Closes #1234
  Closes docker/cli#1234
-->
