### PR TITLE
Adjust instructions for Docker Desktop on Mac uninstall from command line

### DIFF
--- a/desktop/uninstall.md
+++ b/desktop/uninstall.md
@@ -39,13 +39,13 @@ To uninstall Docker Desktop from your Mac:
 
 > Uninstall Docker Desktop from the command line
 >
-> To uninstall Docker Desktop from a terminal, run: `<DockerforMacPath>
-> --uninstall`. If your instance is installed in the default location, this
+> To uninstall Docker Desktop from a terminal, run: `<path to Docker app>/Contents/MacOS/uninstall`.
+> If your instance is installed in the default location, this
 > command provides a clean uninstall:
 >
 > ```console
-> $ /Applications/Docker.app/Contents/MacOS/Docker --uninstall
-> Docker is running, exiting...
+> $ /Applications/Docker.app/Contents/MacOS/uninstall
+> Uninstalling Docker Desktop...
 > Docker uninstalled successfully. You can move the Docker application to the trash.
 > ```
 >


### PR DESCRIPTION
<!--
  Thank you for contributing to Docker documentation!

  Here are a few things to keep in mind:

  - Links between pages should use a relative path
  - Remember to add an alt text for images

  ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
  ┃     Review our contribution guidelines:       ┃
  ┃                                               ┃
  ┃ https://docs.docker.com/contribute/overview/  ┃
  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
-->

### Proposed changes

Adjusted the instructions for Docker Desktop on Mac uninstall from the command line.
The `--uninstall` flag was removed from the Docker Desktop application with 4.4.2, but we’ve never replaced it with anything else as of yet. The new command will be available in Docker Desktop 4.16.

### Related issues (optional)

<!--
  Refer to related PRs or issues:

  #1234
  Closes #1234
  Closes docker/cli#1234
-->
