### PR TITLE
Desktop: update with latest HTTP proxy info

### DIFF
--- a/desktop/settings/linux.md
+++ b/desktop/settings/linux.md
@@ -99,23 +99,15 @@ File share settings are:
 ### Proxies
 
 To configure HTTP proxies, switch on the **Manual proxy configuration** setting.
+This setting is used for logging into Docker, for pulling and pushing images, and for
+container Internet access. If the proxy requires authorization then Docker Desktop will dynamically ask
+the developer for a username and password. All passwords are stored securely in the OS credential store.
+Note that only the `Basic` proxy authentication method is supported so we recommend using an `https://`
+URL for your HTTP/HTTPS proxies to protect passwords while in transit on the network. Docker Desktop
+supports TLS 1.3 when communicating with proxies.
 
-Your proxy settings, however, are not propagated into the containers you start.
-If you wish to set the proxy settings for your containers, you need to define
-environment variables for them, just like you would do on Linux, for example:
-
-```console
-$ docker run -e HTTP_PROXY=http://proxy.example.com:3128 alpine env
-
-PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-HOSTNAME=b7edf988b2b5
-TERM=xterm
-HOME=/root
-HTTP_PROXY=http://proxy.example.com:3128
-```
-
-For more information on configuring the Docker CLI to automatically set proxy variables for both `docker run` and `docker build`
-see [Configure the Docker client](../../network/proxy.md#configure-the-docker-client).
+To prevent developers from accidentally changing the proxy settings, see
+[settings management](../hardened-desktop/settings-management/#what-features-can-i-configure-with-settings-management).
 
 ### Network
 

--- a/desktop/settings/linux.md
+++ b/desktop/settings/linux.md
@@ -107,7 +107,7 @@ URL for your HTTP/HTTPS proxies to protect passwords while in transit on the net
 supports TLS 1.3 when communicating with proxies.
 
 To prevent developers from accidentally changing the proxy settings, see
-[settings management](../hardened-desktop/settings-management/#what-features-can-i-configure-with-settings-management).
+[Settings Management](../hardened-desktop/settings-management/index.md#what-features-can-i-configure-with-settings-management).
 
 ### Network
 

--- a/desktop/settings/linux.md
+++ b/desktop/settings/linux.md
@@ -100,7 +100,7 @@ File share settings are:
 
 To configure HTTP proxies, switch on the **Manual proxy configuration** setting.
 This setting is used for logging into Docker, for pulling and pushing images, and for
-container Internet access. If the proxy requires authorization then Docker Desktop will dynamically ask
+container Internet access. If the proxy requires authorization then Docker Desktop dynamically asks
 the developer for a username and password. All passwords are stored securely in the OS credential store.
 Note that only the `Basic` proxy authentication method is supported so we recommend using an `https://`
 URL for your HTTP/HTTPS proxies to protect passwords while in transit on the network. Docker Desktop

--- a/desktop/settings/mac.md
+++ b/desktop/settings/mac.md
@@ -134,16 +134,20 @@ HTTP/HTTPS proxies can be used when:
 - Containers interact with the external network
 - Scanning images
 
-If the host uses a static HTTP/HTTPS proxy configuration, Docker Desktop reads this configuration
-and automatically uses these settings for logging into Docker and for pulling and pushing images.
+If the host uses a HTTP/HTTPS proxy configuration (static or via Proxy Auto-Configuration), Docker Desktop reads
+this configuration
+and automatically uses these settings for logging into Docker, for pulling and pushing images, and for
+container Internet access. If the proxy requires authorization then Docker Desktop will dynamically ask
+the developer for a username and password. All passwords are stored securely in the OS credential store.
+Note that only the `Basic` proxy authentication method is supported so we recommend using an `https://`
+URL for your HTTP/HTTPS proxies to protect passwords while in transit on the network. Docker Desktop
+supports TLS 1.3 when communicating with proxies.
 
-If the host uses a more sophisticated HTTP/HTTPS configuration, enable **Manual proxy configuration** and enter a single upstream proxy URL
-of the form `http://username:password@proxy:port`.
+To set a different proxy for Docker Desktop, enable **Manual proxy configuration** and enter a single
+upstream proxy URL of the form `http://proxy:port` or `https://proxy:port`.
 
-HTTP/HTTPS traffic from image builds and running containers is forwarded transparently to the same
-upstream proxy used for logging in and image pulls.
-If you want to override this behaviour and use different HTTP/HTTPS proxies for image builds and
-running containers, see [Configure the Docker client](../../network/proxy.md#configure-the-docker-client).
+To prevent developers from accidentally changing the proxy settings, see
+[settings management](../hardened-desktop/settings-management/#what-features-can-i-configure-with-settings-management).
 
 The HTTPS proxy settings used for scanning images are set using the `HTTPS_PROXY` environment variable.
 

--- a/desktop/settings/mac.md
+++ b/desktop/settings/mac.md
@@ -137,7 +137,7 @@ HTTP/HTTPS proxies can be used when:
 If the host uses a HTTP/HTTPS proxy configuration (static or via Proxy Auto-Configuration), Docker Desktop reads
 this configuration
 and automatically uses these settings for logging into Docker, for pulling and pushing images, and for
-container Internet access. If the proxy requires authorization then Docker Desktop will dynamically ask
+container Internet access. If the proxy requires authorization then Docker Desktop dynamically asks
 the developer for a username and password. All passwords are stored securely in the OS credential store.
 Note that only the `Basic` proxy authentication method is supported so we recommend using an `https://`
 URL for your HTTP/HTTPS proxies to protect passwords while in transit on the network. Docker Desktop

--- a/desktop/settings/mac.md
+++ b/desktop/settings/mac.md
@@ -147,7 +147,7 @@ To set a different proxy for Docker Desktop, enable **Manual proxy configuration
 upstream proxy URL of the form `http://proxy:port` or `https://proxy:port`.
 
 To prevent developers from accidentally changing the proxy settings, see
-[settings management](../hardened-desktop/settings-management/#what-features-can-i-configure-with-settings-management).
+[Settings Management](../hardened-desktop/settings-management/index.md#what-features-can-i-configure-with-settings-management).
 
 The HTTPS proxy settings used for scanning images are set using the `HTTPS_PROXY` environment variable.
 

--- a/desktop/settings/mac.md
+++ b/desktop/settings/mac.md
@@ -134,8 +134,6 @@ HTTP/HTTPS proxies can be used when:
 - Containers interact with the external network
 - Scanning images
 
-Each use case above is configured slightly differently.
-
 If the host uses a static HTTP/HTTPS proxy configuration, Docker Desktop reads this configuration
 and automatically uses these settings for logging into Docker and for pulling and pushing images.
 

--- a/desktop/settings/windows.md
+++ b/desktop/settings/windows.md
@@ -161,7 +161,7 @@ HTTP/HTTPS proxies can be used when:
 If the host uses a HTTP/HTTPS proxy configuration (static or via Proxy Auto-Configuration), Docker Desktop reads
 this configuration
 and automatically uses these settings for logging into Docker, for pulling and pushing images, and for
-container Internet access. If the proxy requires authorization then Docker Desktop will dynamically ask
+container Internet access. If the proxy requires authorization then Docker Desktop dynamically asks
 the developer for a username and password. All passwords are stored securely in the OS credential store.
 Note that only the `Basic` proxy authentication method is supported so we recommend using an `https://`
 URL for your HTTP/HTTPS proxies to protect passwords while in transit on the network. Docker Desktop

--- a/desktop/settings/windows.md
+++ b/desktop/settings/windows.md
@@ -171,7 +171,7 @@ To set a different proxy for Docker Desktop, enable **Manual proxy configuration
 upstream proxy URL of the form `http://proxy:port` or `https://proxy:port`.
 
 To prevent developers from accidentally changing the proxy settings, see
-[settings management](../hardened-desktop/settings-management/#what-features-can-i-configure-with-settings-management).
+[Settings Management](../hardened-desktop/settings-management/index.md#what-features-can-i-configure-with-settings-management).
 
 The HTTPS proxy settings used for scanning images are set using the `HTTPS_PROXY` environment variable.
 

--- a/desktop/settings/windows.md
+++ b/desktop/settings/windows.md
@@ -158,14 +158,20 @@ HTTP/HTTPS proxies can be used when:
 - Containers interact with the external network
 - Scanning images
 
-If the host uses a static HTTP/HTTPS proxy configuration, Docker Desktop reads this configuration
-and automatically uses these settings for logging into Docker and for pulling and pushing images.
+If the host uses a HTTP/HTTPS proxy configuration (static or via Proxy Auto-Configuration), Docker Desktop reads
+this configuration
+and automatically uses these settings for logging into Docker, for pulling and pushing images, and for
+container Internet access. If the proxy requires authorization then Docker Desktop will dynamically ask
+the developer for a username and password. All passwords are stored securely in the OS credential store.
+Note that only the `Basic` proxy authentication method is supported so we recommend using an `https://`
+URL for your HTTP/HTTPS proxies to protect passwords while in transit on the network. Docker Desktop
+supports TLS 1.3 when communicating with proxies.
 
-If the host uses a more sophisticated HTTP/HTTPS configuration, enable **Manual proxy configuration** and enter a single upstream proxy URL
-of the form `http://username:password@proxy:port`.
+To set a different proxy for Docker Desktop, enable **Manual proxy configuration** and enter a single
+upstream proxy URL of the form `http://proxy:port` or `https://proxy:port`.
 
-The HTTP/HTTPS proxy settings used for fetching artifacts during builds and for running containers
-are set via the `.docker/config.json` file, see [Configure the Docker client](../../network/proxy.md#configure-the-docker-client).
+To prevent developers from accidentally changing the proxy settings, see
+[settings management](../hardened-desktop/settings-management/#what-features-can-i-configure-with-settings-management).
 
 The HTTPS proxy settings used for scanning images are set using the `HTTPS_PROXY` environment variable.
 

--- a/desktop/settings/windows.md
+++ b/desktop/settings/windows.md
@@ -158,8 +158,6 @@ HTTP/HTTPS proxies can be used when:
 - Containers interact with the external network
 - Scanning images
 
-Each use case above is configured slightly differently.
-
 If the host uses a static HTTP/HTTPS proxy configuration, Docker Desktop reads this configuration
 and automatically uses these settings for logging into Docker and for pulling and pushing images.
 


### PR DESCRIPTION
<!--
  Thank you for contributing to Docker documentation!

  Here are a few things to keep in mind:

  - Links between pages should use a relative path
  - Remember to add an alt text for images

  ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
  ┃     Review our contribution guidelines:       ┃
  ┃                                               ┃
  ┃ https://docs.docker.com/contribute/overview/  ┃
  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
-->

### Proposed changes

<!-- Tell us what you did and why -->

In 4.15 there are a bunch of improvements to HTTP proxy support in Desktop:

- support for Proxy Auto-Configuration
- dynamically ask the developer for username and password, if the proxy requires auth
- support TLS 1.3 for talking to the proxy
- be controllable with settings management

It should be much more consistent now, so you shouldn't have to configure every component separately (with the exception of `docker scan`)

### Related issues (optional)

<!--
  Refer to related PRs or issues:

  #1234
  Closes #1234
  Closes docker/cli#1234
-->
