### PR TITLE
Fix directory for Dockerfile in C# docker tutorial

### DIFF
--- a/language/dotnet/build-images.md
+++ b/language/dotnet/build-images.md
@@ -101,7 +101,7 @@ Press Ctrl+C in the terminal window to stop the application.
 
 ## Create a Dockerfile
 
-In the `dotnet-docker\src` directory, create a file named `Dockerfile`.
+In the `dotnet-docker` directory, create a file named `Dockerfile`.
 
 Next, we need to add a line in our Dockerfile that tells Docker what image
 we would like to use to build our application. Open the `Dockerfile` in an IDE or a text editor, and add the following instructions.


### PR DESCRIPTION
File: [language/dotnet/build-images.md](https://docs.docker.com/language/dotnet/build-images/)

### Problem description

[Create a Docker File](https://docs.docker.com/language/dotnet/build-images/#create-a-dockerfile) section directs to create the file in the  `dotnet-docker\src` directory.

The following instructions in the tutorial suppose that the Dockerfile is actually located at the same level as the `src` folder:
```
├── dotnet-docker
│ ├── src/
│ ├── Dockerfile
│ ├── .dockerignore
```

If you would create the file in the `dotnet-docker\src` it is not going to work.

<!--
  Thank you for contributing to Docker documentation!

  Here are a few things to keep in mind:

  - Links between pages should use a relative path
  - Remember to add an alt text for images

  ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
  ┃     Review our contribution guidelines:       ┃
  ┃                                               ┃
  ┃ https://docs.docker.com/contribute/overview/  ┃
  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
-->

### Proposed changes

<!-- Tell us what you did and why -->
Suggest to change the first sentence to 

In the `dotnet-docker` directory, create a file named `Dockerfile`.

### Related issues (optional)

<!--
  Refer to related PRs or issues:

  #1234
  Closes #16273
  Closes docker/cli#1234
-->
Closes #16273
