### PR TITLE
runtime: fixed linktitle for c8d image store page

### DIFF
--- a/_data/toc.yaml
+++ b/_data/toc.yaml
@@ -1242,7 +1242,7 @@ manuals:
                 - title: API Reference
                   path: /desktop/extensions-sdk/dev/api/reference/README/
     - path: /desktop/containerd/
-      title: Containerd Image Store (Beta)
+      title: containerd image store (Beta)
     - path: /desktop/wasm/
       title: Wasm (Beta)
     - sectiontitle: FAQs


### PR DESCRIPTION
<!--
  Thank you for contributing to Docker documentation!

  Here are a few things to keep in mind:

  - Links between pages should use a relative path
  - Remember to add an alt text for images

  ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
  ┃     Review our contribution guidelines:       ┃
  ┃                                               ┃
  ┃ https://docs.docker.com/contribute/overview/  ┃
  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
-->

### Proposed changes

<!-- Tell us what you did and why -->

### Related issues (optional)

<!--
  Refer to related PRs or issues:

  #1234
  Closes #1234
  Closes docker/cli#1234
-->
