### PR TITLE
night-mode: don't override search background color

### DIFF
--- a/_scss/_night-mode.scss
+++ b/_scss/_night-mode.scss
@@ -64,15 +64,6 @@ a {
     }
     .nav-secondary {
         background-color: $bg-header-night;
-
-        .search-form input[type=search] {
-          background-color: rgba(76, 76, 76, 0.47);
-          color: $white;
-
-          & :focus {
-            background-color: rgba(255, 255, 255, 0.17);
-          }
-        }
     }
     .breadcrumb {
         background-color: $dark-grey-100;


### PR DESCRIPTION
The color of the top-navigation for "light" and "night" mode is the same, so we don't need to override the color (for now). The old override used a hue that was slightly out of tone with the rest of the theme.

Before:

<img width="428" alt="Screenshot 2022-12-07 at 12 34 54" src="https://user-images.githubusercontent.com/1804568/206169781-15ab6f04-f6dc-46bd-95e0-84b9d0b65cec.png">


After:

<img width="413" alt="Screenshot 2022-12-07 at 12 37 33" src="https://user-images.githubusercontent.com/1804568/206169801-6363d805-9df4-45da-a0c0-d064bf1e8b93.png">



