### PR TITLE
compose-file: prevent pulling old docs/docstage image

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,5 +14,6 @@ services:
         - DOCS_ENFORCE_GIT_LOG_HISTORY
       context: .
     image: docs/docstage
+    pull_policy: never
     ports:
      - "4000:4000"


### PR DESCRIPTION
Before this, docker compose would always first pull the `docs/docstage` image from docker hub, then build the local docs:

Before this:

```
docker compose up
[+] Running 1/12
 ⠿ docs Pulled                                                          11.1s
   ⠧ 706c320525cd Download complete                                      8.7s
   ⠴ 4f98bba63633 Download complete                                      7.5s
   ⠇ 4f4fb700ef54 Exists                                                 4.8s
   ⠇ a47abff02990 Download complete                                      4.8s
   ⠧ ab1af07f990a Download complete                                      4.7s
   ⠧ bd5777bb8f79 Download complete                                      4.7s
   ⠧ 8b79b42c3524 Download complete                                      4.7s
   ⠧ d4b8ebd00804 Download complete                                      4.7s
   ⠧ f1398ae18173 Download complete                                      4.7s
   ⠧ 9981e73032c8 Download complete                                      4.7s
   ⠧ e5f90f35b4bc Download complete                                      4.7s
[+] Building 69.1s (15/20)
 => [internal] load .dockerignore                                        0.0s
 => => transferring context: 196B                                        0.0s
 => [internal] load build definition from Dockerfile                     0.0s
 => => transferring dockerfile: 3.85kB                                   0.0s
 => resolve image config for docker.io/docker/dockerfile:1               2.2s
 ...
```

With this patch, the `docs pulled` step is skipped, and we start building immediately:

```
docker compose up
[+] Building 6.7s (11/20)
 => [internal] load .dockerignore                                       0.0s
 => => transferring context: 196B                                       0.0s
 => [internal] load build definition from Dockerfile                    0.0s
...
```

Perhaps compose does this as it was to help with caching when building with the legacy builder, but BuildKit does not use local images for caching, so we don't need to do so (I'm planning to open a ticket in compose to discuss this).

As we're using this compose-file to build the docs (not to view some older version), let's disable pulling, so that we're always building.

