### PR TITLE
chore: prevent publish job from running on forks

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,6 +16,7 @@ permissions:
 jobs:
   publish:
     runs-on: ubuntu-20.04
+    if: github.repository_owner == 'docker'
     steps:
       -
         name: Prepare


### PR DESCRIPTION
<!--
  Thank you for contributing to Docker documentation!

  Here are a few things to keep in mind:

  - Links between pages should use a relative path
  - Remember to add an alt text for images

  ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
  ┃     Review our contribution guidelines:       ┃
  ┃                                               ┃
  ┃ https://docs.docker.com/contribute/overview/  ┃
  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
-->

### Proposed changes

This update prevents the `publish` job from running in people's forks of the docker/docs repository.

Currently, the `publish` job will be attempted whenever a person synchronizes the `main` branch of their fork.

It doesn't actually publish, but it fails because it's unable to read the AWS credential.

This update should prevent the `publish` job from being attempted at all.
