### PR TITLE
Add syntax directive to get started Dockerfile

### DIFF
--- a/get-started/02_our_app.md
+++ b/get-started/02_our_app.md
@@ -76,7 +76,7 @@ In order to build the [container image](../get-started/overview.md/#docker-objec
 
 2. Using a text editor or code editor, add the following contents to the Dockerfile:
 
-   ```dockerfile'
+   ```dockerfile
    # syntax=docker/dockerfile:1
    FROM node:18-alpine
    WORKDIR /app

--- a/get-started/02_our_app.md
+++ b/get-started/02_our_app.md
@@ -76,7 +76,8 @@ In order to build the [container image](../get-started/overview.md/#docker-objec
 
 2. Using a text editor or code editor, add the following contents to the Dockerfile:
 
-   ```dockerfile
+   ```dockerfile'
+   # syntax=docker/dockerfile:1
    FROM node:18-alpine
    WORKDIR /app
    COPY . .


### PR DESCRIPTION
### Proposed changes

The syntax directive was recently removed from the Dockerfile when copying some updates from the get-started repo.
Added it back based on https://github.com/docker/docs/commit/e22984f7d4f5b604c09b972a932fea0e99c2ff17
