### PR TITLE
Updated dotnet template name language/dotnet/build-images.md

### DIFF
--- a/language/dotnet/build-images.md
+++ b/language/dotnet/build-images.md
@@ -27,7 +27,7 @@ For our sample application, let’s create a simple application from a template 
 ```console
 $ mkdir dotnet-docker
 $ cd dotnet-docker
-$ dotnet new webApp -n myWebApp -o src --no-https
+$ dotnet new webapp -n myWebApp -o src --no-https
 ```
 
 Output similar to the following appears.


### PR DESCRIPTION
### Proposed changes

Updated the template name for the `dotnet new` command from ~~`webApp`~~ to `webapp`.
Template name verified from [https://learn.microsoft.com/en-us/dotnet/core/tools/dotnet-new-sdk-templates](https://learn.microsoft.com/en-us/dotnet/core/tools/dotnet-new-sdk-templates#web-options)

File Updated: [/language/dotnet/build-images.md](https://github.com/docker/docs/blob/main/language/dotnet/build-images.md)

<!-- Tell us what you did and why -->

### Related issues (optional)
  Closes #16256

(This is my first Open Source PR 🙂)

