### PR TITLE
build: move bake under the build section

### DIFF
--- a/_data/toc.yaml
+++ b/_data/toc.yaml
@@ -1613,22 +1613,22 @@ manuals:
           title: Create your own base image
     - sectiontitle: Customizing builds
       section:
-        - sectiontitle: High-level builds with Bake
-          section:
-            - path: /build/customize/bake/
-              title: Overview
-            - path: /build/customize/bake/file-definition/
-              title: File definition
-            - path: /build/customize/bake/configuring-build/
-              title: Configuring builds
-            - path: /build/customize/bake/hcl-funcs/
-              title: User defined HCL functions
-            - path: /build/customize/bake/build-contexts/
-              title: Build contexts and linking targets
-            - path: /build/customize/bake/compose-file/
-              title: Building from Compose file
         - path: /build/customize/color-output-controls/
           title: Color output controls
+    - sectiontitle: Bake
+      section:
+        - path: /build/bake/
+          title: Overview
+        - path: /build/bake/file-definition/
+          title: File definition
+        - path: /build/bake/configuring-build/
+          title: Configuring builds
+        - path: /build/bake/hcl-funcs/
+          title: User defined HCL functions
+        - path: /build/bake/build-contexts/
+          title: Build contexts and linking targets
+        - path: /build/bake/compose-file/
+          title: Building from Compose file
     - sectiontitle: BuildKit
       section:
         - path: /build/buildkit/

--- a/build/bake/build-contexts.md
+++ b/build/bake/build-contexts.md
@@ -2,12 +2,12 @@
 title: "Defining additional build contexts and linking targets"
 keywords: build, buildx, bake, buildkit, hcl
 redirect_from:
-- /build/bake/build-contexts/
+- /build/customize/bake/build-contexts/
 ---
 
 In addition to the main `context` key that defines the build context each target
 can also define additional named contexts with a map defined with key `contexts`.
-These values map to the `--build-context` flag in the [build command](../../../engine/reference/commandline/buildx_build.md#build-context).
+These values map to the `--build-context` flag in the [build command](../../engine/reference/commandline/buildx_build.md#build-context).
 
 Inside the Dockerfile these contexts can be used with the `FROM` instruction or `--from` flag.
 

--- a/build/bake/compose-file.md
+++ b/build/bake/compose-file.md
@@ -2,12 +2,12 @@
 title: "Building from Compose file"
 keywords: build, buildx, bake, buildkit, compose
 redirect_from:
-- /build/bake/compose-file/
+- /build/customize/bake/compose-file/
 ---
 
 ## Specification
 
-Bake uses the [compose-spec](../../../compose/compose-file/index.md) to
+Bake uses the [compose-spec](../../compose/compose-file/index.md) to
 parse a compose file and translate each service to a [target](file-definition.md#target).
 
 ```yaml
@@ -153,7 +153,7 @@ $ docker buildx bake --print
 ## Extension field with `x-bake`
 
 Even if some fields are not (yet) available in the compose specification, you
-can use the [special extension](../../../compose/compose-file/index.md#extension)
+can use the [special extension](../../compose/compose-file/index.md#extension)
 field `x-bake` in your compose file to evaluate extra fields:
 
 ```yaml

--- a/build/bake/configuring-build.md
+++ b/build/bake/configuring-build.md
@@ -2,7 +2,7 @@
 title: "Configuring builds"
 keywords: build, buildx, bake, buildkit, hcl, json
 redirect_from:
-- /build/bake/configuring-build/
+- /build/customize/bake/configuring-build/
 ---
 
 Bake supports loading build definition from files, but sometimes you need even
@@ -96,7 +96,7 @@ $ docker buildx bake -f docker-bake.hcl -f env.hcl --print app
 ## From command line
 
 You can also override target configurations from the command line with the
-[`--set` flag](../../../engine/reference/commandline/buildx_bake.md#set):
+[`--set` flag](../../engine/reference/commandline/buildx_bake.md#set):
 
 ```hcl
 # docker-bake.hcl

--- a/build/bake/file-definition.md
+++ b/build/bake/file-definition.md
@@ -2,7 +2,7 @@
 title: "Bake file definition"
 keywords: build, buildx, bake, buildkit, hcl, json, compose
 redirect_from:
-- /build/bake/file-definition/
+- /build/customize/bake/file-definition/
 ---
 
 `buildx bake` supports HCL, JSON and Compose file format for defining build
@@ -46,26 +46,26 @@ $ docker buildx bake webapp-dev
 Complete list of valid target fields available for [HCL](#hcl-definition) and
 [JSON](#json-definition) definitions:
 
-| Name                | Type   | Description                                                                                                                        |
-|---------------------|--------|------------------------------------------------------------------------------------------------------------------------------------|
-| `inherits`          | List   | [Inherit build options](#merging-and-inheritance) from other targets                                                               |
-| `args`              | Map    | Set build-time variables (same as [`--build-arg` flag](../../../engine/reference/commandline/buildx_build.md))                     |
-| `cache-from`        | List   | External cache sources (same as [`--cache-from` flag](../../../engine/reference/commandline/buildx_build.md))                      |
-| `cache-to`          | List   | Cache export destinations (same as [`--cache-to` flag](../../../engine/reference/commandline/buildx_build.md))                     |
-| `context`           | String | Set of files located in the specified path or URL                                                                                  |
-| `contexts`          | Map    | Additional build contexts (same as [`--build-context` flag](../../../engine/reference/commandline/buildx_build.md))                |
-| `dockerfile`        | String | Name of the Dockerfile (same as [`--file` flag](../../../engine/reference/commandline/buildx_build.md))                            |
-| `dockerfile-inline` | String | Inline Dockerfile content                                                                                                          |
-| `labels`            | Map    | Set metadata for an image (same as [`--label` flag](../../../engine/reference/commandline/buildx_build.md))                        |
-| `no-cache`          | Bool   | Do not use cache when building the image (same as [`--no-cache` flag](../../../engine/reference/commandline/buildx_build.md))      |
-| `no-cache-filter`   | List   | Do not cache specified stages (same as [`--no-cache-filter` flag](../../../engine/reference/commandline/buildx_build.md))          |
-| `output`            | List   | Output destination (same as [`--output` flag](../../../engine/reference/commandline/buildx_build.md))                              |
-| `platforms`         | List   | Set target platforms for build (same as [`--platform` flag](../../../engine/reference/commandline/buildx_build.md))                |
-| `pull`              | Bool   | Always attempt to pull all referenced images (same as [`--pull` flag](../../../engine/reference/commandline/buildx_build.md))      |
-| `secret`            | List   | Secret to expose to the build (same as [`--secret` flag](../../../engine/reference/commandline/buildx_build.md))                   |
-| `ssh`               | List   | SSH agent socket or keys to expose to the build (same as [`--ssh` flag](../../../engine/reference/commandline/buildx_build.md))    |
-| `tags`              | List   | Name and optionally a tag in the format `name:tag` (same as [`--tag` flag](../../../engine/reference/commandline/buildx_build.md)) |
-| `target`            | String | Set the target build stage to build (same as [`--target` flag](../../../engine/reference/commandline/buildx_build.md))             |
+| Name                | Type   | Description                                                                                                                     |
+|---------------------|--------|---------------------------------------------------------------------------------------------------------------------------------|
+| `inherits`          | List   | [Inherit build options](#merging-and-inheritance) from other targets                                                            |
+| `args`              | Map    | Set build-time variables (same as [`--build-arg` flag](../../engine/reference/commandline/buildx_build.md))                     |
+| `cache-from`        | List   | External cache sources (same as [`--cache-from` flag](../../engine/reference/commandline/buildx_build.md))                      |
+| `cache-to`          | List   | Cache export destinations (same as [`--cache-to` flag](../../engine/reference/commandline/buildx_build.md))                     |
+| `context`           | String | Set of files located in the specified path or URL                                                                               |
+| `contexts`          | Map    | Additional build contexts (same as [`--build-context` flag](../../engine/reference/commandline/buildx_build.md))                |
+| `dockerfile`        | String | Name of the Dockerfile (same as [`--file` flag](../../engine/reference/commandline/buildx_build.md))                            |
+| `dockerfile-inline` | String | Inline Dockerfile content                                                                                                       |
+| `labels`            | Map    | Set metadata for an image (same as [`--label` flag](../../engine/reference/commandline/buildx_build.md))                        |
+| `no-cache`          | Bool   | Do not use cache when building the image (same as [`--no-cache` flag](../../engine/reference/commandline/buildx_build.md))      |
+| `no-cache-filter`   | List   | Do not cache specified stages (same as [`--no-cache-filter` flag](../../engine/reference/commandline/buildx_build.md))          |
+| `output`            | List   | Output destination (same as [`--output` flag](../../engine/reference/commandline/buildx_build.md))                              |
+| `platforms`         | List   | Set target platforms for build (same as [`--platform` flag](../../engine/reference/commandline/buildx_build.md))                |
+| `pull`              | Bool   | Always attempt to pull all referenced images (same as [`--pull` flag](../../engine/reference/commandline/buildx_build.md))      |
+| `secret`            | List   | Secret to expose to the build (same as [`--secret` flag](../../engine/reference/commandline/buildx_build.md))                   |
+| `ssh`               | List   | SSH agent socket or keys to expose to the build (same as [`--ssh` flag](../../engine/reference/commandline/buildx_build.md))    |
+| `tags`              | List   | Name and optionally a tag in the format `name:tag` (same as [`--tag` flag](../../engine/reference/commandline/buildx_build.md)) |
+| `target`            | String | Set the target build stage to build (same as [`--target` flag](../../engine/reference/commandline/buildx_build.md))             |
 
 ### Group
 

--- a/build/bake/hcl-funcs.md
+++ b/build/bake/hcl-funcs.md
@@ -2,7 +2,7 @@
 title: "User defined HCL functions"
 keywords: build, buildx, bake, buildkit, hcl
 redirect_from:
-- /build/bake/hcl-funcs/
+- /build/customize/bake/hcl-funcs/
 ---
 
 ## Using interpolation to tag an image with the git sha

--- a/build/bake/index.md
+++ b/build/bake/index.md
@@ -2,7 +2,7 @@
 title: High-level builds with Bake
 keywords: build, buildx, bake, buildkit, hcl, json, compose
 redirect_from:
-- /build/bake/
+- /build/customize/bake/
 ---
 
 > This command is experimental.
@@ -21,10 +21,10 @@ The build commands can be combined with general-purpose command runners
 (for example, `make`). However, these tools generally invoke builds in sequence
 and therefore cannot leverage the full potential of BuildKit parallelization,
 or combine BuildKit's output for the user. For this use case, we have added a
-command called [`docker buildx bake`](../../../engine/reference/commandline/buildx_bake.md).
+command called [`docker buildx bake`](../../engine/reference/commandline/buildx_bake.md).
 
 The `bake` command supports building images from HCL, JSON and Compose files.
-This is similar to [`docker compose build`](../../../compose/compose-file/build.md),
+This is similar to [`docker compose build`](../../compose/compose-file/build.md),
 but allowing all the services to be built concurrently as part of a single
 request. If multiple files are specified they are all read and configurations are
 combined.

--- a/build/ci/github-actions/index.md
+++ b/build/ci/github-actions/index.md
@@ -26,7 +26,7 @@ The following GitHub Actions are available:
   installs [QEMU](https://github.com/qemu/qemu) static binaries for multi-arch
   builds.
 - [Docker Buildx Bake](https://github.com/marketplace/actions/docker-buildx-bake){: target="_blank" rel="noopener" class="_" }:
-  enables using high-level builds with [Bake](../../customize/bake/index.md).
+  enables using high-level builds with [Bake](../../bake/index.md).
 
 Using Docker's actions provides an easy-to-use interface, while still allowing
 flexibility for customizing build parameters.

--- a/build/index.md
+++ b/build/index.md
@@ -144,11 +144,11 @@ advanced scenarios.
     <div class="col-xs-12 col-sm-12 col-md-12 col-lg-4 block">
       <div class="component">
         <div class="component-icon">
-          <a href="/build/customize/bake/">
+          <a href="/build/bake/">
            <img src="/assets/images/build-bake.svg" alt="Cake silhouette" width="70px" height="70px">
           </a>
         </div>
-        <h2><a href="/build/customize/bake/">Bake</a></h2>
+        <h2><a href="/build/bake/">Bake</a></h2>
         <p>
           Orchestrate your builds with Bake.
         </p>

--- a/build/release-notes.md
+++ b/build/release-notes.md
@@ -147,7 +147,7 @@ For more details, see the complete release notes in the [Buildx GitHub repositor
 
 * Build command now accepts `--build-context` flag to [define additional named build contexts](/engine/reference/commandline/buildx_build/#build-context)
   for your builds {% include github_issue.md repo="docker/buildx" number="904" %}
-* Bake definitions now support [defining dependencies between targets](customize/bake/build-contexts.md)
+* Bake definitions now support [defining dependencies between targets](bake/build-contexts.md)
   and using the result of one target in another build {% include github_issue.md repo="docker/buildx" number="928" %}
   {% include github_issue.md repo="docker/buildx" number="965" %} {% include github_issue.md repo="docker/buildx" number="963" %}
   {% include github_issue.md repo="docker/buildx" number="962" %} {% include github_issue.md repo="docker/buildx" number="981" %}

--- a/compose/compose-file/build.md
+++ b/compose/compose-file/build.md
@@ -432,4 +432,4 @@ services:
 ## Implementations
 
 * [docker-compose](../../compose/index.md)
-* [buildx bake](../../build/customize/bake/index.md)
+* [buildx bake](../../build/bake/index.md)


### PR DESCRIPTION
As discussed, we want to move some sections directly under "Docker Build" section. This PR moves the Bake one to start with.

Signed-off-by: CrazyMax <crazy-max@users.noreply.github.com>