### PR TITLE
build: buildkit resource limiting

### DIFF
--- a/build/buildkit/configure.md
+++ b/build/buildkit/configure.md
@@ -178,3 +178,37 @@ $ docker buildx create --use --bootstrap \
   --driver-opt "image=buildkit-cni:local" \
   --buildkitd-flags "--oci-worker-net=cni"
 ```
+
+## Resource limiting
+
+### Max parallelism
+
+You can limit the parallelism of the BuildKit solver, which is particularly useful
+for low-powered machines, using a [BuildKit configuration](toml-configuration.md)
+while creating a builder with the [`--config` flags](../../engine/reference/commandline/buildx_create.md#config).
+
+```toml
+# /etc/buildkitd.toml
+[worker.oci]
+  max-parallelism = 4
+```
+
+Now you can [create a `docker-container` builder](../drivers/docker-container.md)
+that will use this BuildKit configuration to limit parallelism.
+
+```console
+$ docker buildx create --use \
+  --name mybuilder \
+  --driver docker-container \
+  --config /etc/buildkitd.toml
+```
+
+### TCP connection limit
+
+TCP connections are limited to 4 simultaneous connections per registry for
+pulling and pushing images, plus one additional connection dedicated to metadata
+requests. This connection limit prevents your build from getting stuck while
+pulling images. The dedicated metadata connection helps reduce the overall build
+time.
+
+More information: [moby/buildkit#2259](https://github.com/moby/buildkit/pull/2259){:target="blank" rel="noopener" class=""}


### PR DESCRIPTION
moved from https://github.com/docker/buildx/blob/master/docs/guides/resource-limiting.md

Signed-off-by: CrazyMax <crazy-max@users.noreply.github.com>