### PR TITLE
build: removed toc link to multiple builders page

### DIFF
--- a/_data/toc.yaml
+++ b/_data/toc.yaml
@@ -1575,8 +1575,6 @@ manuals:
           title: Multi-platform images
         - path: /build/building/base-images/
           title: Create your own base image
-        - path: /build/building/multiple-builders/
-          title: Using multiple builders
     - sectiontitle: Drivers
       section:
         - path: /build/drivers/


### PR DESCRIPTION
Signed-off-by: David Karlsson <david.karlsson@docker.com>

<!--
  Thank you for contributing to Docker documentation!

  Here are a few things to keep in mind:

  - Links between pages should use a relative path
  - Remember to add an alt text for images

  ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
  ┃     Review our contribution guidelines:       ┃
  ┃                                               ┃
  ┃ https://docs.docker.com/contribute/overview/  ┃
  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
-->

### Proposed changes

<!-- Tell us what you did and why -->

### Related issues (optional)

Closes #16342
