### PR TITLE
add Compose v1 deprecation notice to Compose documentation

### DIFF
--- a/_includes/compose/compose-v1-eol.md
+++ b/_includes/compose/compose-v1-eol.md
@@ -1,0 +1,7 @@
+> Important
+> 
+> The Python version of Docker Compose is reaching end-of-life.  
+> From April 2023 Compose v1 won't be supported anymore and will be removed from all Docker Desktop versions.  
+> You can already use the Compose v2 with the `docker compose` CLI plugin or by activating the `Use Docker Compose V2` preference in Docker Desktop.   
+>
+{: .important}

--- a/compose/cli-command-compatibility.md
+++ b/compose/cli-command-compatibility.md
@@ -3,6 +3,8 @@ description: Compose command compatibility with docker-compose
 keywords: documentation, docs, docker, compose, containers
 title: Compose command compatibility with docker-compose
 ---
+{%- include compose/compose-v1-eol.md -%}
+
 
 The `compose` command in the Docker CLI supports most of the `docker-compose` commands and flags. It is expected to be a drop-in replacement for `docker-compose`. 
 

--- a/compose/compose-file/build.md
+++ b/compose/compose-file/build.md
@@ -5,6 +5,7 @@ title: Compose file build reference
 toc_max: 4
 toc_min: 2
 ---
+{%- include compose/compose-v1-eol.md -%}
 
 Compose specification is a platform-neutral way to define multi-container applications. A Compose implementation
 focusing on development use-case to run application on local machine will obviously also support (re)building

--- a/compose/compose-file/compose-file-v2.md
+++ b/compose/compose-file/compose-file-v2.md
@@ -5,6 +5,8 @@ title: Compose file version 2 reference
 toc_max: 4
 toc_min: 1
 ---
+{%- include compose/compose-v1-eol.md -%}
+
 
 ## Reference and guidelines
 

--- a/compose/compose-file/compose-file-v3.md
+++ b/compose/compose-file/compose-file-v3.md
@@ -5,6 +5,8 @@ title: Compose file version 3 reference
 toc_max: 4
 toc_min: 1
 ---
+{%- include compose/compose-v1-eol.md -%}
+
 
 ## Reference and guidelines
 

--- a/compose/compose-file/compose-versioning.md
+++ b/compose/compose-file/compose-versioning.md
@@ -3,6 +3,8 @@ description: Compose file reference
 keywords: fig, composition, compose, versions, upgrading, docker
 title: Compose file versions and upgrading
 ---
+{%- include compose/compose-v1-eol.md -%}
+
 
 The Compose file is a [YAML](https://yaml.org) file defining services,
 networks, and volumes for a Docker application.

--- a/compose/compose-file/deploy.md
+++ b/compose/compose-file/deploy.md
@@ -5,6 +5,8 @@ title: Compose file deploy reference
 toc_max: 4
 toc_min: 2
 ---
+{%- include compose/compose-v1-eol.md -%}
+
 
 Compose specification is a platform-neutral way to define multi-container applications. A Compose implementation supporting
 deployment of application model MAY require some additional metadata as the Compose application model is way too abstract

--- a/compose/compose-file/index.md
+++ b/compose/compose-file/index.md
@@ -8,6 +8,8 @@ title: Compose specification
 toc_max: 4
 toc_min: 1
 ---
+{%- include compose/compose-v1-eol.md -%}
+
 
 The Compose file is a [YAML](https://yaml.org){: target="_blank" rel="noopener" class="_"} file defining services,
 networks, and volumes for a Docker application. The latest and recommended

--- a/compose/compose-v2/index.md
+++ b/compose/compose-v2/index.md
@@ -3,6 +3,8 @@ description: Key features and use cases of Docker Compose
 keywords: documentation, docs, docker, compose, orchestration, containers, uses, features
 title: Compose V2 Overview
 ---
+{%- include compose/compose-v1-eol.md -%}
+
 
 ## Compose V2 and the new `docker compose` command
 

--- a/compose/env-file.md
+++ b/compose/env-file.md
@@ -3,6 +3,8 @@ description: Declare default environment variables in a file
 keywords: fig, composition, compose, docker, orchestration, environment, env file
 title: Declare default environment variables in file
 ---
+{%- include compose/compose-v1-eol.md -%}
+
 
 Compose supports declaring environment variables in an environment file.
 

--- a/compose/environment-variables.md
+++ b/compose/environment-variables.md
@@ -6,6 +6,8 @@ redirect_from:
 - /compose/env/
 - /compose/link-env-deprecated/
 ---
+{%- include compose/compose-v1-eol.md -%}
+
 
 There are multiple parts of Compose that deal with environment variables in one
 sense or another. This page should help you find the information you need.

--- a/compose/envvars-precedence.md
+++ b/compose/envvars-precedence.md
@@ -3,6 +3,8 @@ title: Environment variables precedence
 description: Scenario Overview illustrating how environment variables are resolved in Compose
 keywords: compose, environment, env file
 ---
+{%- include compose/compose-v1-eol.md -%}
+
 
 This page contains information on how interpolation works when using environment variables in Compose.
 

--- a/compose/extends.md
+++ b/compose/extends.md
@@ -3,6 +3,8 @@ description: How to use Docker Compose's extends keyword to share configuration 
 keywords: fig, composition, compose, docker, orchestration, documentation, docs
 title: Share Compose configurations between files and projects
 ---
+{%- include compose/compose-v1-eol.md -%}
+
 
 Compose supports two methods of sharing common configuration:
 

--- a/compose/faq.md
+++ b/compose/faq.md
@@ -3,6 +3,8 @@ description: Docker Compose FAQ
 keywords: documentation, docs,  docker, compose, faq
 title: Frequently asked questions
 ---
+{%- include compose/compose-v1-eol.md -%}
+
 
 If you don’t see your question here, feel free to drop by
 [#docker-compose](https://dockercommunity.slack.com/archives/C2X82D9PA) on the

--- a/compose/features-uses.md
+++ b/compose/features-uses.md
@@ -3,6 +3,8 @@ description: Key features and use cases of Docker Compose
 keywords: documentation, docs, docker, compose, orchestration, containers, uses, features
 title: Key features and use cases
 ---
+{%- include compose/compose-v1-eol.md -%}
+
 
 Using Compose is essentially a three-step process:
 

--- a/compose/gettingstarted.md
+++ b/compose/gettingstarted.md
@@ -3,6 +3,8 @@ description: Get started with Docker Compose
 keywords: documentation, docs, docker, compose, orchestration, containers
 title: Try Docker Compose
 ---
+{%- include compose/compose-v1-eol.md -%}
+
 
 This tutorial is designed to introduce the key concepts of Docker Compose whilst building a simple Python web application. The application uses the Flask framework and maintains a hit counter in
 Redis. 

--- a/compose/gpu-support.md
+++ b/compose/gpu-support.md
@@ -3,6 +3,8 @@ description: GPU support in Compose
 keywords: documentation, docs, docker, compose, GPU access, NVIDIA, samples
 title: Enabling GPU access with Compose
 ---
+{%- include compose/compose-v1-eol.md -%}
+
 
 Compose services can define GPU device reservations if the Docker host contains such devices and the Docker Daemon is set accordingly. For this, make sure to install the [prerequisites](../config/containers/resource_constraints.md#gpu) if you have not already done so.
 

--- a/compose/index.md
+++ b/compose/index.md
@@ -9,6 +9,8 @@ redirect_from:
  - /compose/swarm/
  - /compose/completion/
 ---
+{%- include compose/compose-v1-eol.md -%}
+
 
 Compose is a tool for defining and running multi-container Docker applications.
 With Compose, you use a YAML file to configure your application's services.

--- a/compose/install/index.md
+++ b/compose/install/index.md
@@ -6,6 +6,8 @@ toc_max: 3
 redirect_from:
 - /compose/compose-desktop/
 ---
+{%- include compose/compose-v1-eol.md -%}
+
 
 This page contains summary information about the available options for getting Docker Compose.
 

--- a/compose/install/linux.md
+++ b/compose/install/linux.md
@@ -7,6 +7,8 @@ redirect_from:
 - /compose/compose-plugin/
 - /compose/compose-linux/
 ---
+{%- include compose/compose-v1-eol.md -%}
+
 
 On this page you can find instructions on how to install the Compose plugin on Linux from the command line.
 

--- a/compose/install/other.md
+++ b/compose/install/other.md
@@ -4,6 +4,8 @@ keywords: compose, orchestration, install, installation, docker, documentation
 toc_max: 3
 title: Install the Compose standalone
 ---
+{%- include compose/compose-v1-eol.md -%}
+
 
 On this page you can find instructions on how to install the Compose standalone on Linux or Windows Server, from the command line.
 

--- a/compose/install/uninstall.md
+++ b/compose/install/uninstall.md
@@ -4,6 +4,8 @@ keywords: compose, orchestration, uninstall, uninstallation, docker, documentati
 
 title: Uninstall Docker Compose
 ---
+{%- include compose/compose-v1-eol.md -%}
+
 
 Uninstalling Docker Compose depends on the method you have used to install Docker Compose. On this page you can find specific instructions to uninstall Docker Compose.
 

--- a/compose/networking.md
+++ b/compose/networking.md
@@ -3,6 +3,8 @@ description: How Compose sets up networking between containers
 keywords: documentation, docs, docker, compose, orchestration, containers, networking
 title: Networking in Compose
 ---
+{%- include compose/compose-v1-eol.md -%}
+
 
 > This page applies to Compose file formats [version 2](compose-file/compose-file-v2.md) and [higher](compose-file/index.md). Networking features are not supported for Compose file version 1 (deprecated).
 

--- a/compose/production.md
+++ b/compose/production.md
@@ -3,6 +3,8 @@ description: Guide to using Docker Compose in production
 keywords: compose, orchestration, containers, production
 title: Use Compose in production
 ---
+{%- include compose/compose-v1-eol.md -%}
+
 
 When you define your app with Compose in development, you can use this
 definition to run your application in different environments such as CI,

--- a/compose/profiles.md
+++ b/compose/profiles.md
@@ -3,6 +3,8 @@ title: Using profiles with Compose
 desription: Using profiles with Compose
 keywords: cli, compose, profile, profiles reference
 ---
+{%- include compose/compose-v1-eol.md -%}
+
 
 Profiles allow adjusting the Compose application model for various usages and
 environments by selectively enabling services.

--- a/compose/reference/envvars.md
+++ b/compose/reference/envvars.md
@@ -3,6 +3,8 @@ description: Compose CLI environment variables
 keywords: fig, composition, compose, docker, orchestration, cli, reference
 title: Compose CLI environment variables
 ---
+{%- include compose/compose-v1-eol.md -%}
+
 
 In this section you can find the list of pre-defined environment variables you can use to configure the Docker Compose command-line behavior.  
 **See also** [Declare default environment variables in file](../env-file.md) to check how to declare default environment variables in an environment file named `.env` placed in the project directory.

--- a/compose/reference/index.md
+++ b/compose/reference/index.md
@@ -5,6 +5,8 @@ redirect_from:
 - /compose/reference/overview/
 title: Overview of docker compose CLI
 ---
+{%- include compose/compose-v1-eol.md -%}
+
 
 This page provides the usage information for the `docker compose` Command.
 

--- a/compose/release-notes.md
+++ b/compose/release-notes.md
@@ -6,6 +6,9 @@ toc_max: 2
 redirect_from:
   - /release-notes/docker-compose/
 ---
+{%- include compose/compose-v1-eol.md -%}
+
+
 ## 2.14.0
 {% include release-date.html date="2022-12-02" %}
 

--- a/compose/samples-for-compose.md
+++ b/compose/samples-for-compose.md
@@ -3,6 +3,8 @@ description: Summary of samples related to Compose
 keywords: documentation, docs, docker, compose, samples
 title: Sample apps with Compose
 ---
+{%- include compose/compose-v1-eol.md -%}
+
 
 The following samples show the various aspects of how to work with Docker
 Compose. As a prerequisite, be sure to [install Docker Compose](install/index.md)

--- a/compose/startup-order.md
+++ b/compose/startup-order.md
@@ -4,6 +4,8 @@ keywords: documentation, docs, docker, compose, startup, shutdown, order
 title: Control startup and shutdown order in Compose
 notoc: true
 ---
+{%- include compose/compose-v1-eol.md -%}
+
 
 You can control the order of service startup and shutdown with the
 [depends_on](compose-file/compose-file-v3.md#depends_on) option. Compose always starts and stops


### PR DESCRIPTION
Signed-off-by: Guillaume Lours <705411+glours@users.noreply.github.com>

<!--
  Thank you for contributing to Docker documentation!

  Here are a few things to keep in mind:

  - Links between pages should use a relative path
  - Remember to add an alt text for images

  ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
  ┃     Review our contribution guidelines:       ┃
  ┃                                               ┃
  ┃ https://docs.docker.com/contribute/overview/  ┃
  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
-->

### Proposed changes
Add deprecation notice of Compose v1 to all Compose documentation pages
<!-- Tell us what you did and why -->

### Related issues (optional)
https://docker.atlassian.net/browse/EN-364
<!--
  Refer to related PRs or issues:

  #1234
  Closes #1234
  Closes docker/cli#1234
-->
