### PR TITLE
Remove extension beta mentions - prepare for Desktop 4.16

### DIFF
--- a/_data/toc.yaml
+++ b/_data/toc.yaml
@@ -844,7 +844,7 @@ reference:
         path: /docker-hub/api/deprecated/
   - title: Registry API
     path: /registry/spec/api/
-  - sectiontitle: Docker Extension SDK API (Beta)
+  - sectiontitle: Docker Extension SDK API
     section:
       - path: /desktop/extensions-sdk/dev/api/reference/interfaces/DesktopUI/
         title: DesktopUI
@@ -1159,7 +1159,7 @@ manuals:
           title: Distribute your dev environment
         - path: /desktop/dev-environments/dev-cli/
           title: Use the docker dev CLI plugin
-    - sectiontitle: Extensions (Beta)
+    - sectiontitle: Extensions
       section:
       - path: /desktop/extensions/
         title: What are Docker Extensions?
@@ -1169,7 +1169,7 @@ manuals:
         title: Manage non-Marketplace extensions
       - path: /desktop/extensions/settings-feedback/
         title: Change Settings and give feedback
-    - sectiontitle: Extensions SDK (Beta)
+    - sectiontitle: Extensions SDK
       section:
         - path: /desktop/extensions-sdk/
           title: Overview

--- a/desktop/extensions-sdk/build/minimal-frontend-extension.md
+++ b/desktop/extensions-sdk/build/minimal-frontend-extension.md
@@ -51,7 +51,7 @@ FROM scratch
 LABEL org.opencontainers.image.title="Minimal frontend" \
     org.opencontainers.image.description="A sample extension to show how easy it's to get started with Desktop Extensions." \
     org.opencontainers.image.vendor="Awesome Inc." \
-    com.docker.desktop.extension.api.version="1.0.0-beta.1" \
+    com.docker.desktop.extension.api.version="0.3.0" \
     com.docker.desktop.extension.icon="https://www.docker.com/wp-content/uploads/2022/03/Moby-logo.png"
 
 COPY ui ./ui
@@ -85,8 +85,7 @@ install it.
 $ docker build --tag= awesome-inc/my-extension:latest .
 ```
 
-This built an image tagged `awesome-inc/my-extension:latest`, you can run `docker inspect
-awesome-inc/my-extension:latest` to see more details about it.
+This built an image tagged `awesome-inc/my-extension:latest`, you can run `docker inspect awesome-inc/my-extension:latest` to see more details about it.
 
 Finally, you can install the extension and see it appearing in the Docker Desktop Dashboard.
 

--- a/desktop/extensions-sdk/index.md
+++ b/desktop/extensions-sdk/index.md
@@ -3,15 +3,10 @@ title: Overview
 description: Overall index for Docker Extensions SDK documentation
 keywords: Docker, Extensions, sdk
 redirect_from:
- - /desktop/extensions-sdk/dev/overview/
+  - /desktop/extensions-sdk/dev/overview/
 ---
 
 Use the resources in this section to create your own Docker Extension.
-
-> Beta
->
-> The Docker Extensions SDK is currently in [Beta](../../release-lifecycle.md#beta).
-> Features and APIs detailed below are subject to change.
 
 Extensions are packaged as specially formatted Docker images, which our CLI tool helps to build. At the root of the image filesystem is a `metadata.json` file which describes the content of the extension. It is a fundamental element of a Docker extension.
 

--- a/desktop/extensions/index.md
+++ b/desktop/extensions/index.md
@@ -6,21 +6,17 @@ toc_min: 1
 toc_max: 2
 ---
 
-> **Beta**
->
-> This feature is currently in [Beta](../../release-lifecycle.md#beta). We recommend that you do not use Docker Extensions in production environments.
-
-Docker Extensions lets you use third-party tools within Docker Desktop to extend its functionality. 
+Docker Extensions lets you use third-party tools within Docker Desktop to extend its functionality.
 
 You can seamlessly connect your favorite development tools to your application development and deployment workflows. Augment Docker Desktop with debugging, testing, security, and networking functionalities, and build custom add-ons using the Extensions [SDK](../extensions-sdk/index.md).
 
-Anyone can use Docker Extensions and there is no limit to the number of extensions you can install. 
+Anyone can use Docker Extensions and there is no limit to the number of extensions you can install.
 
 ![extenstions](../images/extensions-marketplace.PNG){:width="750px"}
 
 ## What extensions are available?
 
-There is a mix of partner and community-built extensions and Docker-built extensions. 
+There is a mix of partner and community-built extensions and Docker-built extensions.
 You can explore the list of available extensions in [Docker Hub](https://hub.docker.com/search?q=&type=extension){:target="_blank" rel="noopener" class="_"} or in the Extensions Marketplace within Docker Desktop.
 
 To find out more about Docker Extensions, we recommend the video walkthrough from DockerCon 2022:


### PR DESCRIPTION
Signed-off-by: Guillaume Tardif <guillaume.tardif@gmail.com>

<!--
  Thank you for contributing to Docker documentation!

  Here are a few things to keep in mind:

  - Links between pages should use a relative path
  - Remember to add an alt text for images

  ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
  ┃     Review our contribution guidelines:       ┃
  ┃                                               ┃
  ┃ https://docs.docker.com/contribute/overview/  ┃
  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
-->

### Proposed changes

make extensions GA, remove "beta" next to extensions

This needs to be synced with Desktop 4.16

<!-- Tell us what you did and why -->

### Related issues (optional)

<!--
  Refer to related PRs or issues:

  #1234
  Closes #1234
  Closes docker/cli#1234
-->
