### PR TITLE
rootless: consider user namespace limitations and using ipc host

### DIFF
--- a/engine/security/rootless.md
+++ b/engine/security/rootless.md
@@ -136,6 +136,7 @@ testuser:231072:65536
   This means the IP address is not reachable from the host without `nsenter`-ing into the network namespace.
 - Host network (`docker run --net=host`) is also namespaced inside RootlessKit.
 - NFS mounts as the docker "data-root" is not supported. This limitation is not specific to rootless mode.
+- Rootless Docker relies on userns-remap mode so you should also see the [user namespace known limitations](userns-remap.md#user-namespace-known-limitations).
 
 ## Install
 > **Note**

--- a/engine/security/userns-remap.md
+++ b/engine/security/userns-remap.md
@@ -254,7 +254,7 @@ What this means is that the whole container filesystem will belong to the user s
 The following standard Docker features are incompatible with running a Docker
 daemon with user namespaces enabled:
 
-- sharing PID or NET namespaces with the host (`--pid=host` or `--network=host`).
+- sharing PID, IPC, or NET namespaces with the host (`--pid=host`, `--ipc=host`, or `--network=host`) in any combination.
 - external (volume or storage) drivers which are unaware or incapable of using
   daemon user mappings.
 - Using the `--privileged` mode flag on `docker run` without also specifying


### PR DESCRIPTION
### Proposed changes
Sharing the IPC namespace with the host currently fails for both the usernamespace remapping feature and if rootless docker is used. This PR documents this limitation.

### Related issues (optional)
- https://github.com/moby/moby/issues/44294