### PR TITLE
Remove Fedora 34, 35 as they're EOL

### DIFF
--- a/desktop/install/fedora.md
+++ b/desktop/install/fedora.md
@@ -16,7 +16,7 @@ This page contains information on how to install, launch and upgrade Docker Desk
 To install Docker Desktop successfully, you must:
 
 - Meet the [system requirements](linux-install.md#system-requirements).
-- Have a 64-bit version of either Fedora 35 or Fedora 36.
+- Have a 64-bit version of either Fedora 36 or Fedora 37.
 
 Additionally, for a Gnome Desktop environment you must install AppIndicator and KStatusNotifierItem [Gnome extensions](https://extensions.gnome.org/extension/615/appindicator-support/){:target="_blank" rel="noopener" class="_"}.
 

--- a/engine/install/fedora.md
+++ b/engine/install/fedora.md
@@ -20,9 +20,8 @@ To get started with Docker Engine on Fedora, make sure you
 
 To install Docker Engine, you need the 64-bit version of one of these Fedora versions:
 
-- Fedora 34
-- Fedora 35
 - Fedora 36
+- Fedora 37
 
 ### Uninstall old versions
 


### PR DESCRIPTION
Fedora 24 reached EOL on June 6, Fedora 36 reached EOL on December 13; https://docs.fedoraproject.org/en-US/releases/eol/

