### PR TITLE
doc: add documentation for `READY` state

### DIFF
--- a/engine/swarm/how-swarm-mode-works/swarm-task-states.md
+++ b/engine/swarm/how-swarm-mode-works/swarm-task-states.md
@@ -32,6 +32,7 @@ Tasks go through the states in the following order:
 | `PENDING`   | Resources for the task were allocated.                                                                      |
 | `ASSIGNED`  | Docker assigned the task to nodes.                                                                          |
 | `ACCEPTED`  | The task was accepted by a worker node. If a worker node rejects the task, the state changes to `REJECTED`. |
+| `READY`     | The worker node is ready to start the task                                                                  |
 | `PREPARING` | Docker is preparing the task.                                                                               |
 | `STARTING`  | Docker is starting the task.                                                                                |
 | `RUNNING`   | The task is executing.                                                                                      |


### PR DESCRIPTION
<!--
  Thank you for contributing to Docker documentation!

  Here are a few things to keep in mind:

  - Links between pages should use a relative path
  - Remember to add an alt text for images

  ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
  ┃     Review our contribution guidelines:       ┃
  ┃                                               ┃
  ┃ https://docs.docker.com/contribute/overview/  ┃
  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
-->

### Proposed changes

<!-- Tell us what you did and why -->

The `READY` state for worker nodes was omitted from the documentation

https://github.com/moby/swarmkit/blob/48dd89375d0a3e8a333c52bce1e6297e0b192d06/api/types.proto#L509