### PR TITLE
Engdocs 1060

### DIFF
--- a/compose/gpu-support.md
+++ b/compose/gpu-support.md
@@ -4,11 +4,11 @@ keywords: documentation, docs, docker, compose, GPU access, NVIDIA, samples
 title: Enabling GPU access with Compose
 ---
 
-Compose services can define GPU device reservations if the Docker host contains such devices and the Docker Daemon is set accordingly. For this, make sure to install the [prerequisites](../config/containers/resource_constraints.md#gpu) if you have not already done so.
+Compose services can define GPU device reservations if the Docker host contains such devices and the Docker Daemon is set accordingly. For this, make sure you install the [prerequisites](../config/containers/resource_constraints.md#gpu){: target="_blank" rel="noopener" class="_" } if you have not already done so.
 
 The examples in the following sections focus specifically on providing service containers access to GPU devices with Docker Compose. 
 You can use either `docker-compose` or `docker compose` commands.  
-See also, [Compose command compatibility with docker-compose](cli-command-compatibility.md).
+See also, [Compose command compatibility with docker-compose](cli-command-compatibility.md){: target="_blank" rel="noopener" class="_" }.
 
 ### Use of service `runtime` property from Compose v2.3 format (legacy)
 
@@ -25,25 +25,28 @@ services:
 
 ### Enabling GPU access to service containers
 
-Docker Compose v1.28.0+ allows to define GPU reservations using the [device](https://github.com/compose-spec/compose-spec/blob/master/deploy.md#devices) structure defined in the Compose Specification. This provides more granular control over a GPU reservation as custom values can be set for the following device properties: 
+GPUs are referenced in a `docker-compose.yml` file using the [device](compose-file/deploy.md#devices){:target="_blank" rel="noopener" class="_"} structure, within your services that need them. 
 
-- [capabilities](https://github.com/compose-spec/compose-spec/blob/master/deploy.md#capabilities){:target="_blank" rel="noopener" class="_"} - value specifies as a list of strings (eg. `capabilities: [gpu]`). You must set this field in the Compose file. Otherwise, it returns an error on service deployment.
-- [count](https://github.com/compose-spec/compose-spec/blob/master/deploy.md#count){:target="_blank" rel="noopener" class="_"} - value specified as an int or the value `all` representing the number of GPU devices that should be reserved ( providing the host holds that number of GPUs).
-- [device_ids](https://github.com/compose-spec/compose-spec/blob/master/deploy.md#device_ids){:target="_blank" rel="noopener" class="_"} - value specified as a list of strings representing GPU device IDs from the host. You can find the device ID in the output of `nvidia-smi` on the host.
-- [driver](https://github.com/compose-spec/compose-spec/blob/master/deploy.md#driver){:target="_blank" rel="noopener" class="_"} - value specified as a string (eg. `driver: 'nvidia'`)
-- [options](https://github.com/compose-spec/compose-spec/blob/master/deploy.md#options){:target="_blank" rel="noopener" class="_"} - key-value pairs representing driver specific options.
+This provides more granular control over a GPU reservation as custom values can be set for the following device properties: 
+
+- `capabilities`. This value specifies as a list of strings (eg. `capabilities: [gpu]`). You must set this field in the Compose file. Otherwise, it returns an error on service deployment.
+- `count`. This value specified as an integer or the value `all` representing the number of GPU devices that should be reserved ( providing the host holds that number of GPUs). If no `count`is set, all GPUs available on the host are used by default.
+- `device_ids`. This value specified as a list of strings representing GPU device IDs from the host. You can find the device ID in the output of `nvidia-smi` on the host. If no `device_ids` are set, all GPUs available on the host used by default.
+- `driver`. This value is specified as a string, for example `driver: 'nvidia'`
+- `options`. Key-value pairs representing driver specific options.
 
 
-> **Note**
+> **Important**
 >
 > You must set the `capabilities` field. Otherwise, it returns an error on service deployment.
 >
 > `count` and `device_ids` are mutually exclusive. You must only define one field at a time.
+{: .important}
 
-For more information on these properties, see the `deploy` section in the [Compose Specification](https://github.com/compose-spec/compose-spec/blob/master/deploy.md#devices){:target="_blank" rel="noopener" class="_"}.
+For more information on these properties, see the `deploy` section in the [Compose Specification](compose-file/deploy.md#devices){:target="_blank" rel="noopener" class="_"}.
 
 
-Example of a Compose file for running a service with access to 1 GPU device:
+#### Example of a Compose file for running a service with access to 1 GPU device:
 
 ```yaml
 services:
@@ -89,34 +92,9 @@ gpu_test_1 exited with code 0
 
 ```
 
-If no `count` or `device_ids` are set, all GPUs available on the host are going to be used by default.
+On machines hosting multiple GPUs, `device_ids` field can be set to target specific GPU devices and `count` can be used to limit the number of GPU devices assigned to a service container. 
 
-```yaml
-services:
-  test:
-    image: tensorflow/tensorflow:latest-gpu
-    command: python -c "import tensorflow as tf;tf.test.gpu_device_name()"
-    deploy:
-      resources:
-        reservations:
-          devices:
-            - capabilities: [gpu]
-```
-
-```console
-$ docker compose up
-Creating network "gpu_default" with the default driver
-Creating gpu_test_1 ... done
-Attaching to gpu_test_1
-test_1  | I tensorflow/stream_executor/platform/default/dso_loader.cc:48] Successfully opened dynamic library libcudart.so.10.1
-.....
-test_1  | I tensorflow/core/common_runtime/gpu/gpu_device.cc:1402]
-Created TensorFlow device (/device:GPU:0 with 13970 MB memory) -> physical GPU (device: 0, name: Tesla T4, pci bus id: 0000:00:1e.0, compute capability: 7.5)
-test_1  | /device:GPU:0
-gpu_test_1 exited with code 0
-```
-
-On machines hosting multiple GPUs, `device_ids` field can be set to target specific GPU devices and `count` can be used to limit the number of GPU devices assigned to a service container. If `count` exceeds the number of available GPUs on the host, the deployment will error out.
+You can use `count` or `device_ids` in each of your service definitions. An error is returned if you try to combine both, specify an invalid device ID, or use a value of count that’s higher than the number of GPUs in your system.
 
 ```console
 $ nvidia-smi   
@@ -145,6 +123,8 @@ $ nvidia-smi
 +-------------------------------+----------------------+----------------------+
 ```
 
+### Access specific devices
+
 To enable access only to GPU-0 and GPU-3 devices:
 
 ```yaml
@@ -160,14 +140,4 @@ services:
             device_ids: ['0', '3']
             capabilities: [gpu]
 
-```
-
-```sh
-$ docker compose up
-...
-Created TensorFlow device (/device:GPU:0 with 13970 MB memory -> physical GPU (device: 0, name: Tesla T4, pci bus id: 0000:00:1b.0, compute capability: 7.5)
-...
-Created TensorFlow device (/device:GPU:1 with 13970 MB memory) -> physical GPU (device: 1, name: Tesla T4, pci bus id: 0000:00:1e.0, compute capability: 7.5)
-...
-gpu_test_1 exited with code 0
 ```

--- a/compose/profiles.md
+++ b/compose/profiles.md
@@ -4,20 +4,21 @@ desription: Using profiles with Compose
 keywords: cli, compose, profile, profiles reference
 ---
 
-Profiles allow adjusting the Compose application model for various usages and
+Profiles help you adjust your Compose application model for various uses and
 environments by selectively enabling services.
+
 This is achieved by assigning each service to zero or more profiles. If
-unassigned, the service is _always_ started but if assigned, it is only started
+unassigned, the service is always started but if assigned, it is only started
 if the profile is activated.
 
-This allows one to define additional services in a single `docker-compose.yml` file
-that should only be started in specific scenarios, e.g. for debugging or
+This allows you to define additional services in a single `docker-compose.yml` file
+that should only be started in specific scenarios, for example for debugging or
 development tasks.
 
 ## Assigning profiles to services
 
 Services are associated with profiles through the
-[`profiles` attribute](compose-file/compose-file-v3.md#profiles) which takes an
+[`profiles` attribute](compose-file/index.md#profiles) which takes an
 array of profile names:
 
 ```yaml
@@ -45,47 +46,54 @@ Here the services `frontend` and `phpmyadmin` are assigned to the profiles
 `frontend` and `debug` respectively and as such are only started when their
 respective profiles are enabled.
 
-Services without a `profiles` attribute will _always_ be enabled, i.e. in this
-case running `docker compose up` would only start `backend` and `db`.
+Services without a `profiles` attribute are always enabled. In this
+case running `docker compose up` only starts `backend` and `db`.
 
-Valid profile names follow the regex format of `[a-zA-Z0-9][a-zA-Z0-9_.-]+`.
+Valid profiles names follow the regex format of `[a-zA-Z0-9][a-zA-Z0-9_.-]+`.
 
-> **Note**
+> **Tip**
 >
-> The core services of your application should not be assigned `profiles` so
-> they will always be enabled and automatically started.
+> The core services of your application shouldn't be assigned `profiles` so
+> they are always enabled and automatically started.
+{: .tip}
 
-## Enabling profiles
+## Enable profiles
 
-To enable a profile supply the `--profile` [command-line option](reference/index.md) or
+To enable profiles, supply the `--profile` [command-line option](reference/index.md) or
 use the [`COMPOSE_PROFILES` environment variable](reference/envvars.md#compose_profiles):
 
-```sh
+```console
 $ docker compose --profile debug up
+```
+```console
 $ COMPOSE_PROFILES=debug docker compose up
 ```
 
-The above command would both start your application with the `debug` profile enabled.
-Using the `docker-compose.yml` file above, this would start the services `backend`,
+The above commands both start your application with the `debug` profile enabled.
+In the example `docker-compose.yml` file above, this starts the services `backend`,
 `db` and `phpmyadmin`.
+
+### Enable multiple profiles
 
 Multiple profiles can be specified by passing multiple `--profile` flags or
 a comma-separated list for the `COMPOSE_PROFILES` environment variable:
 
-```sh
+```console
 $ docker compose --profile frontend --profile debug up
+```
+
+```console
 $ COMPOSE_PROFILES=frontend,debug docker compose up
 ```
 
 ## Auto-enabling profiles and dependency resolution
 
 When a service with assigned `profiles` is explicitly targeted on the command
-line its profiles will be enabled automatically so you don't need to enable them
+line, its profiles are enabled automatically so you don't need to enable them
 manually. This can be used for one-off services and debugging tools.
-As an example consider this configuration:
+As an example consider the following configuration:
 
 ```yaml
-version: "{{ site.compose_file_v3 }}"
 services:
   backend:
     image: backend
@@ -103,22 +111,22 @@ services:
 ```
 
 ```sh
-# will only start backend and db
+# Only start backend and db
 $ docker compose up -d
 
-# this will run db-migrations (and - if necessary - start db)
-# by implicitly enabling profile `tools`
+# This runs db-migrations (and, if necessary, start db)
+# by implicitly enabling profiles `tools`
 $ docker compose run db-migrations
 ```
 
-But keep in mind that `docker compose` will only automatically enable the
-profiles of the services on the command line and not of any dependencies. This
-means that all services the targeted service `depends_on` must have a common
-profile with it, be always enabled (by omitting `profiles`) or have a matching
-profile enabled explicitly:
+Keep in mind that `docker compose` only automatically enables the
+profiles of the services on the command line and not of any dependencies. 
+
+This means that any other services the targeted service `depends_on` should either:
+- Share a common profile 
+- Always be enabled, by omitting `profiles` or having a matching profile enabled explicitly
 
 ```yaml
-version: "{{ site.compose_file_v3 }}"
 services:
   web:
     image: web
@@ -141,20 +149,20 @@ services:
 ```
 
 ```sh
-# will only start "web"
+# Only start "web"
 $ docker compose up -d
 
-# this will start mock-backend (and - if necessary - db)
-# by implicitly enabling profile `dev`
+# Start mock-backend (and - if necessary - db)
+# by implicitly enabling profiles `dev`
 $ docker compose up -d mock-backend
 
-# this will fail because profile "dev" is disabled
+# This fails because profiles "dev" is disabled
 $ docker compose up phpmyadmin
 ```
 
-Although targeting `phpmyadmin` will automatically enable its profiles - i.e.
-`debug` - it will not automatically enable the profile(s) required by `db` -
-i.e. `dev`. To fix this you either have to add the `debug` profile to the `db` service:
+Although targeting `phpmyadmin` automatically enables the profiles `debug`, it doesn't automatically enable the profiles required by `db` which is `dev`. 
+
+To fix this you either have to add the `debug` profiles to the `db` service:
 
 ```yaml
 db:
@@ -164,18 +172,13 @@ db:
 
 or enable a profile of `db` explicitly:
 
-```sh
-# profile "debug" is enabled automatically by targeting phpmyadmin
+```console
+# Profiles "debug" is enabled automatically by targeting phpmyadmin
 $ docker compose --profile dev up phpmyadmin
 $ COMPOSE_PROFILES=dev docker compose up phpmyadmin
 ```
 
 
-## Compose documentation
+## Reference information 
 
-- [User guide](index.md)
-- [Installing Compose](install/index.md)
-- [Getting Started](gettingstarted.md)
-- [Command line reference](reference/index.md)
-- [Compose file reference](compose-file/index.md)
-- [Sample apps with Compose](samples-for-compose.md)
+- [`profiles`](compose-file/index.md#profiles)


### PR DESCRIPTION
PR aligns the 'Using service profiles' page in Compose with the Style guide, makes sure it is referring to the Compose spec

To do

- [x] Check https://github.com/docker/docs/issues/15059
