### PR TITLE
Engdocs 1062

### DIFF
--- a/compose/extends.md
+++ b/compose/extends.md
@@ -443,11 +443,6 @@ services:
 ```
 
 
-## Compose documentation
+## Reference information 
 
-- [User guide](index.md)
-- [Installing Compose](install/index.md)
-- [Getting Started](gettingstarted.md)
-- [Command line reference](reference/index.md)
-- [Compose file reference](compose-file/index.md)
-- [Sample apps with Compose](samples-for-compose.md)
+- [`extends`](compose-file/index.md#extends)

--- a/compose/extends.md
+++ b/compose/extends.md
@@ -6,14 +6,14 @@ title: Share Compose configurations between files and projects
 
 Compose supports two methods of sharing common configuration:
 
-1. Extending an entire Compose file by
+1. Extend an entire Compose file by
    [using multiple Compose files](extends.md#multiple-compose-files)
-2. Extending individual services with [the `extends` field](extends.md#extending-services) (for Compose file versions up to 2.1)
+2. Extend individual services with [the `extends` field](extends.md#extending-services) (for Compose file versions up to 2.1)
 
 
 ## Multiple Compose files
 
-Using multiple Compose files enables you to customize a Compose application
+Using multiple Compose files lets you customize a Compose application
 for different environments or different workflows.
 
 ### Understanding multiple Compose files
@@ -170,17 +170,6 @@ $ docker compose -f docker-compose.yml -f docker-compose.admin.yml \
 ```
 
 ## Extending services
-
-> **Note**
->
-> The `extends` keyword is supported in earlier Compose file formats up to Compose
-> file version 2.1 (see [extends in v2](compose-file/compose-file-v2.md#extends)), but is
-> not supported in Compose version 3.x. See the [Version 3 summary](compose-file/compose-versioning.md#version-3)
-> of keys added and removed, along with information on [how to upgrade](compose-file/compose-versioning.md#upgrading).
-> See [moby/moby#31101](https://github.com/moby/moby/issues/31101) to follow the
-> discussion thread on the possibility of adding support for `extends` in some form in
-> future versions. The `extends` keyword has been included in docker-compose versions 1.27
-> and higher.
 
 Docker Compose's `extends` keyword enables the sharing of common configurations
 among different files, or even different projects entirely. Extending services

--- a/compose/production.md
+++ b/compose/production.md
@@ -14,15 +14,15 @@ up your application, you can run Compose apps on a Swarm cluster.
 
 ### Modify your Compose file for production
 
-You probably need to make changes to your app configuration to make it ready for
-production. These changes may include:
+you may need to make changes to your app configuration to make it ready for
+production. These changes could include:
 
 - Removing any volume bindings for application code, so that code stays inside
   the container and can't be changed from outside
 - Binding to different ports on the host
 - Setting environment variables differently, such as reducing the verbosity of
   logging, or to specify settings for external services such as an email server
-- Specifying a restart policy like `restart: always` to avoid downtime
+- Specifying a restart policy like [`restart: always`](compose-file/index.md#restart){: target="_blank" rel="noopener" class="_" } to avoid downtime
 - Adding extra services such as a log aggregator
 
 For this reason, consider defining an additional Compose file, say
@@ -52,24 +52,21 @@ $ docker compose build web
 $ docker compose up --no-deps -d web
 ```
 
-This first rebuilds the image for `web` and then stop, destroy, and recreate
-*just* the `web` service. The `--no-deps` flag prevents Compose from also
+This first rebuilds the image for `web` and then stops, destroys, and recreates
+just the `web` service. The `--no-deps` flag prevents Compose from also
 recreating any services which `web` depends on.
 
 ### Running Compose on a single server
 
 You can use Compose to deploy an app to a remote Docker host by setting the
 `DOCKER_HOST`, `DOCKER_TLS_VERIFY`, and `DOCKER_CERT_PATH` environment variables
-appropriately. See also [Compose CLI environment variables](../compose/reference/envvars.md).
+appropriately. See also [Compose CLI environment variables](reference/envvars.md).
 
 Once you've set up your environment variables, all the normal `docker compose`
 commands work with no further configuration.
 
-## Compose documentation
+## What's new?
 
-- [User guide](index.md)
-- [Installing Compose](install/index.md)
-- [Getting Started](gettingstarted.md)
 - [Command line reference](reference/index.md)
 - [Compose file reference](compose-file/index.md)
 - [Sample apps with Compose](samples-for-compose.md)

--- a/compose/production.md
+++ b/compose/production.md
@@ -14,8 +14,8 @@ up your application, you can run Compose apps on a Swarm cluster.
 
 ### Modify your Compose file for production
 
-you may need to make changes to your app configuration to make it ready for
-production. These changes could include:
+You may need to make changes to your app configuration to make it ready for
+production. These changes might include:
 
 - Removing any volume bindings for application code, so that code stays inside
   the container and can't be changed from outside
@@ -27,11 +27,10 @@ production. These changes could include:
 
 For this reason, consider defining an additional Compose file, say
 `production.yml`, which specifies production-appropriate
-configuration. This configuration file only needs to include the changes you'd
-like to make from the original Compose file. The additional Compose file
-can be applied over the original `docker-compose.yml` to create a new configuration.
+configuration. This configuration file only needs to include the changes you want to make from the original Compose file. The additional Compose file
+is then applied over the original `docker-compose.yml` to create a new configuration.
 
-Once you've got a second configuration file, tell Compose to use it with the
+Once you have a second configuration file, you can use it with the
 `-f` option:
 
 ```console
@@ -52,7 +51,7 @@ $ docker compose build web
 $ docker compose up --no-deps -d web
 ```
 
-This first rebuilds the image for `web` and then stops, destroys, and recreates
+This first command rebuilds the image for `web` and then stops, destroys, and recreates
 just the `web` service. The `--no-deps` flag prevents Compose from also
 recreating any services which `web` depends on.
 


### PR DESCRIPTION
PR aligns the 'Extend services' page in Compose with the Style guide, makes sure it is referring to the Compose spec

Addresses:
https://github.com/docker/docs/issues/16388
