### PR TITLE
engine: use API definitions from default branch

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -171,7 +171,12 @@ fetch-remote:
 
   - repo: "https://github.com/docker/docker"
     default_branch: "master"
-    ref: "20.10"
+    # The default branch has separate files for each API version, so we can
+    # consume the swagger files from that branch (we only publish the ones
+    # that have been released through the stubs in the engine/api/ directory).
+    # Using the default (master) branch allows for API docs changes to be
+    # published without them being cherry-picked into the release branch.
+    ref: "master"
     paths:
       - dest: "engine/api"
         src:


### PR DESCRIPTION
- relates to https://github.com/docker/docs/pull/16416
- relates to https://github.com/moby/moby/issues/40342

The default branch has separate files for each API version, so we can consume the swagger files from that branch (we only publish the ones that have been released through the stubs in the engine/api/ directory). Using the default (master) branch allows for API docs changes to be published without them being cherry-picked into the release branch.
