### PR TITLE
engine: update reference docs to use new anchor tags

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -66,12 +66,11 @@ EOT
 # htmlproofer checks for broken links
 FROM gem AS htmlproofer-base
 # FIXME(thaJeztah): remove temporary exclusion rule for buildx_build once anchor links are updated.
-# FIXME(thaJeztah): remove temporary exclusion rule for commandline/cli once https://github.com/docker/cli/pull/3525 is merged.
 RUN --mount=type=bind,from=generate,source=/out,target=_site <<EOF
   htmlproofer ./_site \
     --disable-external \
     --internal-domains="docs.docker.com,docs-stage.docker.com,localhost:4000" \
-    --file-ignore="/^./_site/engine/api/.*$/,./_site/registry/configuration/index.html,./_site/engine/reference/commandline/buildx_build/index.html,./_site/engine/reference/commandline/cli/index.html" \
+    --file-ignore="/^./_site/engine/api/.*$/,./_site/registry/configuration/index.html,./_site/engine/reference/commandline/buildx_build/index.html" \
     --url-ignore="/^/docker-hub/api/latest/.*$/,/^/engine/api/v.+/#.*$/,/^/glossary/.*$/" > /results 2>&1
   rc=$?
   if [[ $rc -eq 0 ]]; then

--- a/_data/engine-cli/docker_attach.yaml
+++ b/_data/engine-cli/docker_attach.yaml
@@ -26,12 +26,12 @@ long: |-
   > so.
 
   It is forbidden to redirect the standard input of a `docker attach` command
-  while attaching to a tty-enabled container (i.e.: launched with `-t`).
+  while attaching to a TTY-enabled container (using the `-i` and `-t` options).
 
-  While a client is connected to container's stdio using `docker attach`, Docker
-  uses a ~1MB memory buffer to maximize the throughput of the application. If
-  this buffer is filled, the speed of the API connection will start to have an
-  effect on the process output writing speed. This is similar to other
+  While a client is connected to container's `stdio` using `docker attach`, Docker
+  uses a ~1MB memory buffer to maximize the throughput of the application.
+  Once this buffer is full, the speed of the API connection is affected, and so
+  this impacts the output process' writing speed. This is similar to other
   applications like SSH. Because of this, it is not recommended to run
   performance critical applications that generate a lot of output in the
   foreground over a slow client connection. Instead, users should use the
@@ -93,45 +93,68 @@ options:
 examples: |-
   ### Attach to and detach from a running container
 
+  The following example starts an ubuntu container running `top` in detached mode,
+  then attaches to the container;
+
   ```console
-  $ docker run -d --name topdemo ubuntu /usr/bin/top -b
+  $ docker run -d --name topdemo ubuntu:22.04 /usr/bin/top -b
 
   $ docker attach topdemo
 
-  top - 02:05:52 up  3:05,  0 users,  load average: 0.01, 0.02, 0.05
+  top - 12:27:44 up 3 days, 21:54,  0 users,  load average: 0.00, 0.00, 0.00
   Tasks:   1 total,   1 running,   0 sleeping,   0 stopped,   0 zombie
-  Cpu(s):  0.1%us,  0.2%sy,  0.0%ni, 99.7%id,  0.0%wa,  0.0%hi,  0.0%si,  0.0%st
-  Mem:    373572k total,   355560k used,    18012k free,    27872k buffers
-  Swap:   786428k total,        0k used,   786428k free,   221740k cached
+  %Cpu(s):  0.1 us,  0.1 sy,  0.0 ni, 99.8 id,  0.0 wa,  0.0 hi,  0.0 si,  0.0 st
+  MiB Mem :   3934.3 total,    770.1 free,    674.2 used,   2490.1 buff/cache
+  MiB Swap:   1024.0 total,    839.3 free,    184.7 used.   2814.0 avail Mem
 
-  PID USER      PR  NI  VIRT  RES  SHR S %CPU %MEM    TIME+  COMMAND
-   1 root      20   0 17200 1116  912 R    0  0.3   0:00.03 top
+    PID USER      PR  NI    VIRT    RES    SHR S  %CPU  %MEM     TIME+ COMMAND
+      1 root      20   0    7180   2896   2568 R   0.0   0.1   0:00.02 top
+  ```
 
-   top - 02:05:55 up  3:05,  0 users,  load average: 0.01, 0.02, 0.05
-   Tasks:   1 total,   1 running,   0 sleeping,   0 stopped,   0 zombie
-   Cpu(s):  0.0%us,  0.2%sy,  0.0%ni, 99.8%id,  0.0%wa,  0.0%hi,  0.0%si,  0.0%st
-   Mem:    373572k total,   355244k used,    18328k free,    27872k buffers
-   Swap:   786428k total,        0k used,   786428k free,   221776k cached
+  As the container was started without the `-i`, and `-t` options, signals are
+  forwarded to the attached process, which means that the default `CTRL-p CTRL-q`
+  detach key sequence produces no effect, but pressing `CTRL-c` terminates the
+  container:
 
-     PID USER      PR  NI  VIRT  RES  SHR S %CPU %MEM    TIME+  COMMAND
-         1 root      20   0 17208 1144  932 R    0  0.3   0:00.03 top
+  ```console
+  <...>
+    PID USER      PR  NI    VIRT    RES    SHR S  %CPU  %MEM     TIME+ COMMAND
+      1 root      20   0    7180   2896   2568 R   0.0   0.1   0:00.02 top^P^Q
+  ^C
 
+  $ docker ps -a --filter name=topdemo
 
-   top - 02:05:58 up  3:06,  0 users,  load average: 0.01, 0.02, 0.05
-   Tasks:   1 total,   1 running,   0 sleeping,   0 stopped,   0 zombie
-   Cpu(s):  0.2%us,  0.3%sy,  0.0%ni, 99.5%id,  0.0%wa,  0.0%hi,  0.0%si,  0.0%st
-   Mem:    373572k total,   355780k used,    17792k free,    27880k buffers
-   Swap:   786428k total,        0k used,   786428k free,   221776k cached
+  CONTAINER ID   IMAGE          COMMAND             CREATED              STATUS                          PORTS     NAMES
+  4cf0d0ebb079   ubuntu:22.04   "/usr/bin/top -b"   About a minute ago   Exited (0) About a minute ago             topdemo
+  ```
 
-   PID USER      PR  NI  VIRT  RES  SHR S %CPU %MEM    TIME+  COMMAND
-        1 root      20   0 17208 1144  932 R    0  0.3   0:00.03 top
-  ^C$
+  Repeating the example above, but this time with the `-i` and `-t` options set;
 
-  $ echo $?
-  0
-  $ docker ps -a | grep topdemo
+  ```console
+  $ docker run -dit --name topdemo2 ubuntu:22.04 /usr/bin/top -b
+  ```
 
-  7998ac8581f9        ubuntu:14.04        "/usr/bin/top -b"   38 seconds ago      Exited (0) 21 seconds ago                          topdemo
+  Now, when attaching to the container, and pressing the `CTRL-p CTRL-q` ("read
+  escape sequence"), the Docker CLI is handling the detach sequence, and the
+  `attach` command is detached from the container. Checking the container's status
+  with `docker ps` shows that the container is still running in the background:
+
+  ```console
+  $ docker attach topdemo2
+
+  top - 12:44:32 up 3 days, 22:11,  0 users,  load average: 0.00, 0.00, 0.00
+  Tasks:   1 total,   1 running,   0 sleeping,   0 stopped,   0 zombie
+  %Cpu(s): 50.0 us,  0.0 sy,  0.0 ni, 50.0 id,  0.0 wa,  0.0 hi,  0.0 si,  0.0 st
+  MiB Mem :   3934.3 total,    770.6 free,    672.4 used,   2491.4 buff/cache
+  MiB Swap:   1024.0 total,    839.3 free,    184.7 used.   2815.8 avail Mem
+
+    PID USER      PR  NI    VIRT    RES    SHR S  %CPU  %MEM     TIME+ COMMAND
+      1 root      20   0    7180   2776   2452 R   0.0   0.1   0:00.02 topread escape sequence
+
+  $ docker ps -a --filter name=topdemo2
+
+  CONTAINER ID   IMAGE          COMMAND             CREATED         STATUS         PORTS     NAMES
+  b1661dce0fc2   ubuntu:22.04   "/usr/bin/top -b"   2 minutes ago   Up 2 minutes             topdemo2
   ```
 
   ### Get the exit code of the container's command
@@ -140,20 +163,19 @@ examples: |-
   process is returned by the `docker attach` command to its caller too:
 
   ```console
-  $ docker run --name test -d -it debian
+  $ docker run --name test -dit alpine
   275c44472aebd77c926d4527885bb09f2f6db21d878c75f0a1c212c03d3bcfab
 
   $ docker attach test
-  root@f38c87f2a42d:/# exit 13
-
-  exit
+  /# exit 13
 
   $ echo $?
   13
 
-  $ docker ps -a | grep test
+  $ docker ps -a --filter name=test
 
-  275c44472aeb        debian:7            "/bin/bash"         26 seconds ago      Exited (13) 17 seconds ago                         test
+  CONTAINER ID   IMAGE     COMMAND     CREATED              STATUS                       PORTS     NAMES
+  a2fe3fd886db   alpine    "/bin/sh"   About a minute ago   Exited (13) 40 seconds ago             test
   ```
 deprecated: false
 experimental: false

--- a/_data/engine-cli/docker_build.yaml
+++ b/_data/engine-cli/docker_build.yaml
@@ -570,7 +570,7 @@ examples: |-
   expect to ignore different sets of files.
 
 
-  ### Tag an image (-t)
+  ### <a name="tag"></a> Tag an image (-t, --tag)
 
   ```console
   $ docker build -t vieux/apache:2.0 .
@@ -590,7 +590,7 @@ examples: |-
   $ docker build -t whenry/fedora-jboss:latest -t whenry/fedora-jboss:v2.1 .
   ```
 
-  ### Specify a Dockerfile (-f)
+  ### <a name="file"></a> Specify a Dockerfile (-f, --file)
 
   ```console
   $ docker build -f Dockerfile.debug .
@@ -637,17 +637,17 @@ examples: |-
   > repeatable builds on remote Docker hosts. This is also the reason why
   > `ADD ../file` does not work.
 
-  ### Use a custom parent cgroup (--cgroup-parent)
+  ### <a name="cgroup-parent"></a> Use a custom parent cgroup (--cgroup-parent)
 
   When `docker build` is run with the `--cgroup-parent` option the containers
   used in the build will be run with the [corresponding `docker run` flag](../run.md#specify-custom-cgroups).
 
-  ### Set ulimits in container (--ulimit)
+  ### <a name="ulimit"></a> Set ulimits in container (--ulimit)
 
   Using the `--ulimit` option with `docker build` will cause each build step's
-  container to be started using those [`--ulimit` flag values](run.md#set-ulimits-in-container---ulimit).
+  container to be started using those [`--ulimit` flag values](run.md#ulimit).
 
-  ### Set build-time variables (--build-arg)
+  ### <a name="build-arg"></a> Set build-time variables (--build-arg)
 
   You can use `ENV` instructions in a Dockerfile to define variable
   values. These values persist in the built image. However, often
@@ -682,16 +682,16 @@ examples: |-
   $ docker build --build-arg HTTP_PROXY .
   ```
 
-  This is similar to how `docker run -e` works. Refer to the [`docker run` documentation](https://docs.docker.com/engine/reference/commandline/run/#set-environment-variables--e---env---env-file)
+  This is similar to how `docker run -e` works. Refer to the [`docker run` documentation](run.md#env)
   for more information.
 
-  ### Optional security options (--security-opt)
+  ### <a name="security-opt"></a> Optional security options (--security-opt)
 
   This flag is only supported on a daemon running on Windows, and only supports
   the `credentialspec` option. The `credentialspec` must be in the format
   `file://spec.txt` or `registry://keyname`.
 
-  ### Specify isolation technology for container (--isolation)
+  ### <a name="isolation"></a> Specify isolation technology for container (--isolation)
 
   This option is useful in situations where you are running Docker containers on
   Windows. The `--isolation=<value>` option sets a container's isolation
@@ -707,7 +707,7 @@ examples: |-
 
   Specifying the `--isolation` flag without a value is the same as setting `--isolation="default"`.
 
-  ### Add entries to container hosts file (--add-host)
+  ### <a name="add-host"></a> Add entries to container hosts file (--add-host)
 
   You can add other hosts into a container's `/etc/hosts` file by using one or
   more `--add-host` flags. This example adds a static address for a host named
@@ -715,7 +715,7 @@ examples: |-
 
       $ docker build --add-host=docker:10.180.0.1 .
 
-  ### Specifying target build stage (--target)
+  ### <a name="target"></a> Specifying target build stage (--target)
 
   When building a Dockerfile with multiple build stages, `--target` can be used to
   specify an intermediate build stage by name as a final stage for the resulting
@@ -733,7 +733,14 @@ examples: |-
   $ docker build -t mybuildimage --target build-env .
   ```
 
-  ### Custom build outputs
+  ### <a name="output"></a> Custom build outputs (--output)
+
+  > **Note**
+  >
+  > This feature requires the BuildKit backend. You can either
+  > [enable BuildKit](https://docs.docker.com/build/buildkit/#getting-started) or
+  > use the [buildx](https://github.com/docker/buildx) plugin which provides more
+  > output type options.
 
   By default, a local container image is created from the build result. The
   `--output` (or `-o`) flag allows you to override this behavior, and a specify a
@@ -820,14 +827,14 @@ examples: |-
   vndr
   ```
 
+  ### <a name="cache-from"></a> Specifying external cache sources (--cache-from)
+
   > **Note**
   >
   > This feature requires the BuildKit backend. You can either
   > [enable BuildKit](https://docs.docker.com/build/buildkit/#getting-started) or
-  > use the [buildx](https://github.com/docker/buildx) plugin which provides more
-  > output type options.
-
-  ### Specifying external cache sources
+  > use the [buildx](https://github.com/docker/buildx) plugin. The previous
+  > builder has limited support for reusing cache from pre-pulled images.
 
   In addition to local build cache, the builder can reuse the cache generated from
   previous builds with the `--cache-from` flag pointing to an image in the registry.
@@ -863,14 +870,7 @@ examples: |-
   $ docker build --cache-from myname/myapp .
   ```
 
-  > **Note**
-  >
-  > This feature requires the BuildKit backend. You can either
-  > [enable BuildKit](https://docs.docker.com/build/buildkit/#getting-started) or
-  > use the [buildx](https://github.com/docker/buildx) plugin. The previous
-  > builder has limited support for reusing cache from pre-pulled images.
-
-  ### Squash an image's layers (--squash) (experimental)
+  ### <a name="squash"></a> Squash an image's layers (--squash) (experimental)
 
   #### Overview
 

--- a/_data/engine-cli/docker_commit.yaml
+++ b/_data/engine-cli/docker_commit.yaml
@@ -66,8 +66,8 @@ examples: |-
   $ docker ps
 
   CONTAINER ID        IMAGE               COMMAND             CREATED             STATUS              PORTS              NAMES
-  c3f279d17e0a        ubuntu:12.04        /bin/bash           7 days ago          Up 25 hours                            desperate_dubinsky
-  197387f1b436        ubuntu:12.04        /bin/bash           7 days ago          Up 25 hours                            focused_hamilton
+  c3f279d17e0a        ubuntu:22.04        /bin/bash           7 days ago          Up 25 hours                            desperate_dubinsky
+  197387f1b436        ubuntu:22.04        /bin/bash           7 days ago          Up 25 hours                            focused_hamilton
 
   $ docker commit c3f279d17e0a  svendowideit/testimage:version3
 
@@ -79,14 +79,14 @@ examples: |-
   svendowideit/testimage            version3            f5283438590d        16 seconds ago      335.7 MB
   ```
 
-  ### Commit a container with new configurations
+  ### <a name="change"></a> Commit a container with new configurations (--change)
 
   ```console
   $ docker ps
 
   CONTAINER ID       IMAGE               COMMAND             CREATED             STATUS              PORTS              NAMES
-  c3f279d17e0a        ubuntu:12.04        /bin/bash           7 days ago          Up 25 hours                            desperate_dubinsky
-  197387f1b436        ubuntu:12.04        /bin/bash           7 days ago          Up 25 hours                            focused_hamilton
+  c3f279d17e0a       ubuntu:22.04        /bin/bash           7 days ago          Up 25 hours                            desperate_dubinsky
+  197387f1b436       ubuntu:22.04        /bin/bash           7 days ago          Up 25 hours                            focused_hamilton
 
   $ docker inspect -f "{{ .Config.Env }}" c3f279d17e0a
 
@@ -107,8 +107,8 @@ examples: |-
   $ docker ps
 
   CONTAINER ID        IMAGE               COMMAND             CREATED             STATUS              PORTS              NAMES
-  c3f279d17e0a        ubuntu:12.04        /bin/bash           7 days ago          Up 25 hours                            desperate_dubinsky
-  197387f1b436        ubuntu:12.04        /bin/bash           7 days ago          Up 25 hours                            focused_hamilton
+  c3f279d17e0a        ubuntu:22.04        /bin/bash           7 days ago          Up 25 hours                            desperate_dubinsky
+  197387f1b436        ubuntu:22.04        /bin/bash           7 days ago          Up 25 hours                            focused_hamilton
 
   $ docker commit --change='CMD ["apachectl", "-DFOREGROUND"]' -c "EXPOSE 80" c3f279d17e0a  svendowideit/testimage:version4
 
@@ -122,8 +122,8 @@ examples: |-
 
   CONTAINER ID        IMAGE               COMMAND                 CREATED             STATUS              PORTS              NAMES
   89373736e2e7        testimage:version4  "apachectl -DFOREGROU"  3 seconds ago       Up 2 seconds        80/tcp             distracted_fermat
-  c3f279d17e0a        ubuntu:12.04        /bin/bash               7 days ago          Up 25 hours                            desperate_dubinsky
-  197387f1b436        ubuntu:12.04        /bin/bash               7 days ago          Up 25 hours                            focused_hamilton
+  c3f279d17e0a        ubuntu:22.04        /bin/bash               7 days ago          Up 25 hours                            desperate_dubinsky
+  197387f1b436        ubuntu:22.04        /bin/bash               7 days ago          Up 25 hours                            focused_hamilton
   ```
 deprecated: false
 experimental: false

--- a/_data/engine-cli/docker_config_create.yaml
+++ b/_data/engine-cli/docker_config_create.yaml
@@ -60,7 +60,7 @@ examples: |-
   dg426haahpi5ezmkkj5kyl3sn   my_config           7 seconds ago       7 seconds ago
   ```
 
-  ### Create a config with labels
+  ### <a name="label"></a> Create a config with labels (-l, --label)
 
   ```console
   $ docker config create \

--- a/_data/engine-cli/docker_config_inspect.yaml
+++ b/_data/engine-cli/docker_config_inspect.yaml
@@ -80,7 +80,7 @@ examples: |-
   ]
   ```
 
-  ### Formatting
+  ### <a name="format"></a> Format the output (--format)
 
   You can use the --format option to obtain specific information about a
   config. The following example command outputs the creation time of the

--- a/_data/engine-cli/docker_config_ls.yaml
+++ b/_data/engine-cli/docker_config_ls.yaml
@@ -53,7 +53,7 @@ examples: |-
   mem02h8n73mybpgqjf0kfi1n0   test_config                 3 seconds ago       3 seconds ago
   ```
 
-  ### Filtering
+  ### <a name="filter"></a> Filtering (-f, --filter)
 
   The filtering flag (`-f` or `--filter`) format is a `key=value` pair. If there is more
   than one filter, then pass multiple flags (e.g., `--filter "foo=bar" --filter "bif=baz"`)
@@ -113,7 +113,7 @@ examples: |-
   mem02h8n73mybpgqjf0kfi1n0   test_config                 About an hour ago   About an hour ago
   ```
 
-  ### Format the output
+  ### <a name="format"></a> Format the output (--format)
 
   The formatting option (`--format`) pretty prints configs output
   using a Go template.

--- a/_data/engine-cli/docker_container_prune.yaml
+++ b/_data/engine-cli/docker_container_prune.yaml
@@ -37,7 +37,7 @@ examples: |-
   Total reclaimed space: 212 B
   ```
 
-  ### Filtering
+  ### <a name="filter"></a> Filtering (--filter)
 
   The filtering flag (`--filter`) format is of "key=value". If there is more
   than one filter, then pass multiple flags (e.g., `--filter "foo=bar" --filter "bif=baz"`)

--- a/_data/engine-cli/docker_context_create.yaml
+++ b/_data/engine-cli/docker_context_create.yaml
@@ -65,7 +65,7 @@ examples: |-
       my-context
   ```
 
-  ### Create a context based on an existing context
+  ### <a name="from"></a> Create a context based on an existing context (--from)
 
   Use the `--from=<context-name>` option to create a new context from
   an existing context. The example below creates a new context named `my-context`

--- a/_data/engine-cli/docker_cp.yaml
+++ b/_data/engine-cli/docker_cp.yaml
@@ -111,7 +111,7 @@ examples: |-
   ### Corner cases
 
   It is not possible to copy certain system files such as resources under
-  `/proc`, `/sys`, `/dev`, [tmpfs](run.md#mount-tmpfs---tmpfs), and mounts created by
+  `/proc`, `/sys`, `/dev`, [tmpfs](run.md#tmpfs), and mounts created by
   the user in the container. However, you can still copy such files by manually
   running `tar` in `docker exec`. Both of the following examples do the same thing
   in different ways (consider `SRC_PATH` and `DEST_PATH` are directories):

--- a/_data/engine-cli/docker_events.yaml
+++ b/_data/engine-cli/docker_events.yaml
@@ -121,7 +121,7 @@ long: |-
 
   ### Limiting, filtering, and formatting the output
 
-  #### Limit events by time
+  #### <a name="since"></a> Limit events by time (--since, --until)
 
   The `--since` and `--until` parameters can be Unix timestamps, date formatted
   timestamps, or Go duration strings (e.g. `10m`, `1h30m`) computed
@@ -139,7 +139,7 @@ long: |-
   Only the last 1000 log events are returned. You can use filters to further limit
   the number of events returned.
 
-  #### Filtering
+  #### <a name="filter"></a> Filtering (--filter)
 
   The filtering flag (`-f` or `--filter`) format is of "key=value". If you would
   like to use multiple filters, pass multiple flags (e.g.,
@@ -170,7 +170,7 @@ long: |-
   * type (`type=<container or image or volume or network or daemon or plugin or service or node or secret or config>`)
   * volume (`volume=<name>`)
 
-  #### Format
+  #### <a name="format"></a> Format the output (--format)
 
   If a format (`--format`) is specified, the given template will be executed
   instead of the default
@@ -355,8 +355,8 @@ examples: |-
 
   $ docker events --filter 'container=container_1' --filter 'container=container_2'
 
-  2014-09-03T15:49:29.999999999Z07:00 container die 4386fb97867d (image=ubuntu-1:14.04)
-  2014-05-10T17:42:14.999999999Z07:00 container stop 4386fb97867d (image=ubuntu-1:14.04)
+  2014-09-03T15:49:29.999999999Z07:00 container die 4386fb97867d (image=ubuntu:22.04)
+  2014-05-10T17:42:14.999999999Z07:00 container stop 4386fb97867d (image=ubuntu:22.04)
   2014-05-10T17:42:14.999999999Z07:00 container die 7805c1d35632 (imager=redis:2.8)
   2014-09-03T15:49:29.999999999Z07:00 container stop 7805c1d35632 (image=redis:2.8)
 

--- a/_data/engine-cli/docker_exec.yaml
+++ b/_data/engine-cli/docker_exec.yaml
@@ -7,13 +7,13 @@ long: |-
   process (`PID 1`) is running, and it is not restarted if the container is
   restarted.
 
-  COMMAND will run in the default directory of the container. If the
-  underlying image has a custom directory specified with the WORKDIR directive
-  in its Dockerfile, this will be used instead.
+  COMMAND runs in the default directory of the container. If the underlying image
+  has a custom directory specified with the WORKDIR directive in its Dockerfile,
+  this directory is used instead.
 
-  COMMAND should be an executable, a chained or a quoted command
-  will not work. Example: `docker exec -ti my_container "echo a && echo b"` will
-  not work, but `docker exec -ti my_container sh -c "echo a && echo b"` will.
+  COMMAND must be an executable. A chained or a quoted command does not work.
+  For example, `docker exec -it my_container sh -c "echo a && echo b"` works,
+  work, but `docker exec -it my_container "echo a && echo b"` does not.
 usage: docker exec [OPTIONS] CONTAINER COMMAND [ARG...]
 pname: docker
 plink: docker.yaml
@@ -103,80 +103,40 @@ options:
   experimentalcli: false
   kubernetes: false
   swarm: false
-examples: |-
-  ### Run `docker exec` on a running container
-
-  First, start a container.
-
-  ```console
-  $ docker run --name ubuntu_bash --rm -i -t ubuntu bash
-  ```
-
-  This will create a container named `ubuntu_bash` and start a Bash session.
-
-  Next, execute a command on the container.
-
-  ```console
-  $ docker exec -d ubuntu_bash touch /tmp/execWorks
-  ```
-
-  This will create a new file `/tmp/execWorks` inside the running container
-  `ubuntu_bash`, in the background.
-
-  Next, execute an interactive `bash` shell on the container.
-
-  ```console
-  $ docker exec -it ubuntu_bash bash
-  ```
-
-  This will create a new Bash session in the container `ubuntu_bash`.
-
-  Next, set an environment variable in the current bash session.
-
-  ```console
-  $ docker exec -it -e VAR=1 ubuntu_bash bash
-  ```
-
-  This will create a new Bash session in the container `ubuntu_bash` with environment
-  variable `$VAR` set to "1". Note that this environment variable will only be valid
-  on the current Bash session.
-
-  By default `docker exec` command runs in the same working directory set when container was created.
-
-  ```console
-  $ docker exec -it ubuntu_bash pwd
-  /
-  ```
-
-  You can select working directory for the command to execute into
-
-  ```console
-  $ docker exec -it -w /root ubuntu_bash pwd
-  /root
-  ```
-
-
-  ### Try to run `docker exec` on a paused container
-
-  If the container is paused, then the `docker exec` command will fail with an error:
-
-  ```console
-  $ docker pause test
-
-  test
-
-  $ docker ps
-
-  CONTAINER ID        IMAGE               COMMAND             CREATED             STATUS                   PORTS               NAMES
-  1ae3b36715d2        ubuntu:latest       "bash"              17 seconds ago      Up 16 seconds (Paused)                       test
-
-  $ docker exec test ls
-
-  FATA[0000] Error response from daemon: Container test is paused, unpause the container before exec
-
-  $ echo $?
-  1
-  ```
+examples: "### Run `docker exec` on a running container\n\nFirst, start a container.\n\n```console\n$
+  docker run --name mycontainer -d -i -t alpine /bin/sh\n```\n\nThis creates and starts
+  a container named `mycontainer` from an `alpine` image\nwith an `sh` shell as its
+  main process. The `-d` option (shorthand for `--detach`)\nsets the container to
+  run in the background, in detached mode, with a pseudo-TTY\nattached (`-t`). The
+  `-i` option is set to keep `STDIN` attached (`-i`), which\nprevents the `sh` process
+  from exiting immediately.\n\nNext, execute a command on the container.\n\n```console\n$
+  docker exec -d mycontainer touch /tmp/execWorks\n```\n\nThis creates a new file
+  `/tmp/execWorks` inside the running container\n`mycontainer`, in the background.\n\nNext,
+  execute an interactive `sh` shell on the container.\n\n```console\n$ docker exec
+  -it mycontainer sh\n```\n\nThis starts a new shell session in the container `mycontainer`.\n\n###
+  <a name=\"env\"></a> Set environment variables for the exec process (--env, -e)\n\nNext,
+  set environment variables in the current bash session.\n\nBy default, the `docker
+  exec` command, inherits the environment variables that\nare set at the time the
+  container is created. Use the `--env` (or the `-e` shorthand)\nto override global
+  environment variables, or to set additional environment variables\nfor the process
+  started by `docker exec`.\n\nThe example below creates a new shell session in the
+  container `mycontainer` with\nenvironment variables `$VAR_A` and `$VAR_B` set to
+  \"1\" and \"2\" respectively.\nThese environment variables are only valid for the
+  `sh` process started by that\n`docker exec` command, and are not available to other
+  processes running inside\nthe container.\n\n```console\n$ docker exec -e VAR_A=1
+  -e VAR_B=2 mycontainer env\nPATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin\nHOSTNAME=f64a4851eb71\nVAR_A=1\nVAR_B=2\nHOME=/root\n```\n\n###
+  <a name=\"workdir\"></a> Set the working directory for the exec process (--workdir,
+  -w)\n\nBy default `docker exec` command runs in the same working directory set when
+  \nthe container was created.\n\n```console\n$ docker exec -it mycontainer pwd\n/\n```\n\nYou
+  can specify an alternative working directory for the command to execute \nusing
+  the `--workdir` option (or the `-w` shorthand):\n\n```console\n$ docker exec -it
+  -w /root mycontainer pwd\n/root\n```\n\n\n### Try to run `docker exec` on a paused
+  container\n\nIf the container is paused, then the `docker exec` command fails with
+  an error:\n\n```console\n$ docker pause mycontainer\nmycontainer\n\n$ docker ps\n\nCONTAINER
+  ID   IMAGE     COMMAND     CREATED          STATUS                   PORTS     NAMES\n482efdf39fac
+  \  alpine    \"/bin/sh\"   17 seconds ago   Up 16 seconds (Paused)             mycontainer\n\n$
+  docker exec mycontainer sh\n\nError response from daemon: Container mycontainer
+  is paused, unpause the container before exec\n\n$ echo $?\n1\n```"
 deprecated: false
 experimental: false
 experimentalcli: false

--- a/_data/engine-cli/docker_export.yaml
+++ b/_data/engine-cli/docker_export.yaml
@@ -6,7 +6,7 @@ long: |-
   the container, `docker export` will export the contents of the *underlying*
   directory, not the contents of the volume.
 
-  Refer to [Back up, restore, or migrate data volumes](https://docs.docker.com/storage/volumes/#back-up-restore-or-migrate-data-volumes)
+  Refer to [Backup, restore, or migrate data volumes](https://docs.docker.com/storage/volumes/#back-up-restore-or-migrate-data-volumes)
   in the user guide for examples on exporting data in a volume.
 usage: docker export [OPTIONS] CONTAINER
 pname: docker

--- a/_data/engine-cli/docker_history.yaml
+++ b/_data/engine-cli/docker_history.yaml
@@ -68,7 +68,7 @@ examples: |-
   511136ea3c5a        19 months ago                                                       0 B                 Imported from -
   ```
 
-  ### Format the output
+  ### <a name="format"></a> Format the output (--format)
 
   The formatting option (`--format`) will pretty-prints history output
   using a Go template.

--- a/_data/engine-cli/docker_image_prune.yaml
+++ b/_data/engine-cli/docker_image_prune.yaml
@@ -70,7 +70,7 @@ examples: |-
   Total reclaimed space: 16.43 MB
   ```
 
-  ### Filtering
+  ### <a name="filter"></a> Filtering (--filter)
 
   The filtering flag (`--filter`) format is of "key=value". If there is more
   than one filter, then pass multiple flags (e.g., `--filter "foo=bar" --filter "bif=baz"`)

--- a/_data/engine-cli/docker_images.yaml
+++ b/_data/engine-cli/docker_images.yaml
@@ -133,7 +133,7 @@ examples: |-
   REPOSITORY          TAG                 IMAGE ID            CREATED             SIZE
   ```
 
-  ### List the full length image IDs
+  ### <a name="no-trunc"></a> List the full length image IDs (--no-trunc)
 
   ```console
   $ docker images --no-trunc
@@ -150,7 +150,7 @@ examples: |-
   <none>                        <none>              sha256:5ed6274db6ceb2397844896966ea239290555e74ef307030ebb01ff91b1914df   24 hours ago        1.089 GB
   ```
 
-  ### List image digests
+  ### <a name="digests"></a> List image digests (--digests)
 
   Images that use the v2 or later format have a content-addressable identifier
   called a `digest`. As long as the input used to generate the image is
@@ -168,7 +168,7 @@ examples: |-
   also reference by digest in `create`, `run`, and `rmi` commands, as well as the
   `FROM` image reference in a Dockerfile.
 
-  ### Filtering
+  ### <a name="filter"></a> Filtering (--filter)
 
   The filtering flag (`-f` or `--filter`) format is of "key=value". If there is more
   than one filter, then pass multiple flags (e.g., `--filter "foo=bar" --filter "bif=baz"`)
@@ -316,7 +316,7 @@ examples: |-
   busybox             glibc               21c16b6787c6        5 weeks ago         4.19 MB
   ```
 
-  ### Format the output
+  ### <a name="format"></a> Format the output (--format)
 
   The formatting option (`--format`) will pretty print container output
   using a Go template.

--- a/_data/engine-cli/docker_info.yaml
+++ b/_data/engine-cli/docker_info.yaml
@@ -34,9 +34,9 @@ options:
 examples: |-
   ### Show output
 
-  The example below shows the output for a daemon running on Red Hat Enterprise Linux,
-  using the `devicemapper` storage driver. As can be seen in the output, additional
-  information about the `devicemapper` storage driver is shown:
+  The example below shows the output for a daemon running on Ubuntu Linux,
+  using the `overlay2` storage driver. As can be seen in the output, additional
+  information about the `overlay2` storage driver is shown:
 
   ```console
   $ docker info
@@ -44,6 +44,16 @@ examples: |-
   Client:
    Context:    default
    Debug Mode: false
+   Plugins:
+    buildx: Docker Buildx (Docker Inc.)
+      Version:  v0.8.2
+      Path:     /usr/libexec/docker/cli-plugins/docker-buildx
+    compose: Docker Compose (Docker Inc.)
+      Version:  v2.6.0
+      Path:     /usr/libexec/docker/cli-plugins/docker-compose
+    scan: Docker Scan (Docker Inc.)
+      Version:  v0.17.0
+      Path:     /usr/libexec/docker/cli-plugins/docker-scan
 
   Server:
    Containers: 14
@@ -51,142 +61,52 @@ examples: |-
     Paused: 1
     Stopped: 10
    Images: 52
-   Server Version: 1.10.3
-   Storage Driver: devicemapper
-    Pool Name: docker-202:2-25583803-pool
-    Pool Blocksize: 65.54 kB
-    Base Device Size: 10.74 GB
-    Backing Filesystem: xfs
-    Data file: /dev/loop0
-    Metadata file: /dev/loop1
-    Data Space Used: 1.68 GB
-    Data Space Total: 107.4 GB
-    Data Space Available: 7.548 GB
-    Metadata Space Used: 2.322 MB
-    Metadata Space Total: 2.147 GB
-    Metadata Space Available: 2.145 GB
-    Udev Sync Supported: true
-    Deferred Removal Enabled: false
-    Deferred Deletion Enabled: false
-    Deferred Deleted Device Count: 0
-    Data loop file: /var/lib/docker/devicemapper/devicemapper/data
-    Metadata loop file: /var/lib/docker/devicemapper/devicemapper/metadata
-    Library Version: 1.02.107-RHEL7 (2015-12-01)
-   Execution Driver: native-0.2
+   Server Version: 22.06.0
+   Storage Driver: overlay2
+    Backing Filesystem: extfs
+    Supports d_type: true
+    Using metacopy: false
+    Native Overlay Diff: true
+    userxattr: false
    Logging Driver: json-file
+   Cgroup Driver: systemd
+   Cgroup Version: 2
    Plugins:
     Volume: local
-    Network: null host bridge
-   Kernel Version: 3.10.0-327.el7.x86_64
-   Operating System: Red Hat Enterprise Linux Server 7.2 (Maipo)
+    Network: bridge host ipvlan macvlan null overlay
+    Log: awslogs fluentd gcplogs gelf journald json-file local logentries splunk syslog
+   Swarm: inactive
+   Runtimes: io.containerd.runc.v2 io.containerd.runtime.v1.linux runc
+   Default Runtime: runc
+   Init Binary: docker-init
+   containerd version: 212e8b6fa2f44b9c21b2798135fc6fb7c53efc16
+   runc version: v1.1.1-0-g52de29d
+   init version: de40ad0
+   Security Options:
+    apparmor
+    seccomp
+     Profile: builtin
+    cgroupns
+   Kernel Version: 5.15.0-25-generic
+   Operating System: Ubuntu 22.04 LTS
    OSType: linux
    Architecture: x86_64
    CPUs: 1
    Total Memory: 991.7 MiB
    Name: ip-172-30-0-91.ec2.internal
-   ID: I54V:OLXT:HVMM:TPKO:JPHQ:CQCD:JNLC:O3BZ:4ZVJ:43XJ:PFHZ:6N2S
+   ID: 4cee4408-10d2-4e17-891c-a41736ac4536
    Docker Root Dir: /var/lib/docker
    Debug Mode: false
    Username: gordontheturtle
    Registry: https://index.docker.io/v1/
+   Experimental: false
    Insecure registries:
     myinsecurehost:5000
     127.0.0.0/8
-  ```
-
-  ### Show debugging output
-
-  Here is a sample output for a daemon running on Ubuntu, using the overlay2
-  storage driver and a node that is part of a 2-node swarm:
-
-  ```console
-  $ docker --debug info
-
-  Client:
-   Context:    default
-   Debug Mode: true
-
-  Server:
-   Containers: 14
-    Running: 3
-    Paused: 1
-    Stopped: 10
-   Images: 52
-   Server Version: 1.13.0
-   Storage Driver: overlay2
-    Backing Filesystem: extfs
-    Supports d_type: true
-    Native Overlay Diff: false
-   Logging Driver: json-file
-   Cgroup Driver: cgroupfs
-   Plugins:
-    Volume: local
-    Network: bridge host macvlan null overlay
-   Swarm: active
-    NodeID: rdjq45w1op418waxlairloqbm
-    Is Manager: true
-    ClusterID: te8kdyw33n36fqiz74bfjeixd
-    Managers: 1
-    Nodes: 2
-    Orchestration:
-     Task History Retention Limit: 5
-    Raft:
-     Snapshot Interval: 10000
-     Number of Old Snapshots to Retain: 0
-     Heartbeat Tick: 1
-     Election Tick: 3
-    Dispatcher:
-     Heartbeat Period: 5 seconds
-    CA Configuration:
-     Expiry Duration: 3 months
-    Root Rotation In Progress: false
-    Node Address: 172.16.66.128 172.16.66.129
-    Manager Addresses:
-     172.16.66.128:2477
-   Runtimes: runc
-   Default Runtime: runc
-   Init Binary: docker-init
-   containerd version: 8517738ba4b82aff5662c97ca4627e7e4d03b531
-   runc version: ac031b5bf1cc92239461125f4c1ffb760522bbf2
-   init version: N/A (expected: v0.13.0)
-   Security Options:
-    apparmor
-    seccomp
-     Profile: default
-   Kernel Version: 4.4.0-31-generic
-   Operating System: Ubuntu 16.04.1 LTS
-   OSType: linux
-   Architecture: x86_64
-   CPUs: 2
-   Total Memory: 1.937 GiB
-   Name: ubuntu
-   ID: H52R:7ZR6:EIIA:76JG:ORIY:BVKF:GSFU:HNPG:B5MK:APSC:SZ3Q:N326
-   Docker Root Dir: /var/lib/docker
-   Debug Mode: true
-    File Descriptors: 30
-    Goroutines: 123
-    System Time: 2016-11-12T17:24:37.955404361-08:00
-    EventsListeners: 0
-   Http Proxy: http://test:test@proxy.example.com:8080
-   Https Proxy: https://test:test@proxy.example.com:8080
-   No Proxy: localhost,127.0.0.1,docker-registry.somecorporation.com
-   Registry: https://index.docker.io/v1/
-   WARNING: No swap limit support
-   Labels:
-    storage=ssd
-    staging=true
-   Experimental: false
-   Insecure Registries:
-    127.0.0.0/8
-   Registry Mirrors:
-     http://192.168.1.2/
-     http://registry-mirror.example.com:5000/
    Live Restore Enabled: false
   ```
 
-  The global `-D` option causes all `docker` commands to output debug information.
-
-  ### Format the output
+  ### <a name="format"></a> Format the output (--format)
 
   You can also specify the output format:
 
@@ -198,13 +118,18 @@ examples: |-
 
   ### Run `docker info` on Windows
 
-  Here is a sample output for a daemon running on Windows Server 2016:
+  Here is a sample output for a daemon running on Windows Server:
 
   ```console
-  E:\docker>docker info
+  C:\> docker info
+
   Client:
    Context:    default
    Debug Mode: false
+   Plugins:
+    buildx: Docker Buildx (Docker Inc., v0.8.2-docker)
+    compose: Docker Compose (Docker Inc., v2.6.0)
+    scan: Docker Scan (Docker Inc., v0.17.0)
 
   Server:
    Containers: 1
@@ -212,27 +137,29 @@ examples: |-
     Paused: 0
     Stopped: 1
    Images: 17
-   Server Version: 1.13.0
+   Server Version: 20.10.16
    Storage Driver: windowsfilter
-    Windows:
    Logging Driver: json-file
    Plugins:
     Volume: local
-    Network: nat null overlay
+    Network: ics internal l2bridge l2tunnel nat null overlay private transparent
+    Log: awslogs etwlogs fluentd gcplogs gelf json-file local logentries splunk syslog
    Swarm: inactive
    Default Isolation: process
-   Kernel Version: 10.0 14393 (14393.206.amd64fre.rs1_release.160912-1937)
-   Operating System: Windows Server 2016 Datacenter
+   Kernel Version: 10.0 20348 (20348.1.amd64fre.fe_release.210507-1500)
+   Operating System: Microsoft Windows Server Version 21H2 (OS Build 20348.707)
    OSType: windows
    Architecture: x86_64
    CPUs: 8
    Total Memory: 3.999 GiB
    Name: WIN-V0V70C0LU5P
-   ID: NYMS:B5VK:UMSL:FVDZ:EWB5:FKVK:LPFL:FJMQ:H6FT:BZJ6:L2TD:XH62
-   Docker Root Dir: C:\control
+   ID: 2880d38d-464e-4d01-91bd-c76f33ba3981
+   Docker Root Dir: C:\ProgramData\docker
    Debug Mode: false
    Registry: https://index.docker.io/v1/
+   Experimental: true
    Insecure Registries:
+    myregistry:5000
     127.0.0.0/8
    Registry Mirrors:
      http://192.168.1.2/

--- a/_data/engine-cli/docker_inspect.yaml
+++ b/_data/engine-cli/docker_inspect.yaml
@@ -4,6 +4,59 @@ long: |-
   Docker inspect provides detailed information on constructs controlled by Docker.
 
   By default, `docker inspect` will render results in a JSON array.
+
+  ### <a name="format"></a> Format the output (--format)
+
+  If a format is specified, the given template will be executed for each result.
+
+  Go's [text/template](https://golang.org/pkg/text/template/) package describes
+  all the details of the format.
+
+  ### <a name="type"></a> Specify target type (--type)
+
+  `--type container|image|node|network|secret|service|volume|task|plugin`
+
+  The `docker inspect` command matches any type of object by either ID or name. In
+  some cases multiple type of objects (for example, a container and a volume)
+  exist with the same name, making the result ambiguous.
+
+  To restrict `docker inspect` to a specific type of object, use the `--type`
+  option.
+
+  The following example inspects a _volume_ named "myvolume"
+
+  ```console
+  $ docker inspect --type=volume myvolume
+  ```
+
+  ### <a name="size"></a> Inspect the size of a container (-s, --size)
+
+  The `--size`, or short-form `-s`, option adds two additional fields to the
+  `docker inspect` output. This option only works for containers. The container
+  doesn't have to be running, it also works for stopped containers.
+
+  ```console
+  $ docker inspect --size mycontainer
+  ```
+
+  The output includes the full output of a regular `docker inspect` command, with
+  the following additional fields:
+
+  - `SizeRootFs`: the total size of all the files in the container, in bytes.
+  - `SizeRw`: the size of the files that have been created or changed in the
+    container, compared to it's image, in bytes.
+
+  ```console
+  $ docker run --name database -d redis
+  3b2cbf074c99db4a0cad35966a9e24d7bc277f5565c17233386589029b7db273
+  $ docker inspect --size database -f '{{ .SizeRootFs }}'
+  123125760
+  $ docker inspect --size database -f '{{ .SizeRw }}'
+  8192
+  $ docker exec database fallocate -l 1000 /newfile
+  $ docker inspect --size database -f '{{ .SizeRw }}'
+  12288
+  ```
 usage: docker inspect [OPTIONS] NAME|ID [NAME|ID...]
 pname: docker
 plink: docker.yaml
@@ -65,8 +118,7 @@ examples: |-
 
   ### List all port bindings
 
-  You can loop over arrays and maps in the results to produce simple text
-  output:
+  You can loop over arrays and maps in the results to produce simple text output:
 
   ```console
   $ docker inspect --format='{{range $p, $conf := .NetworkSettings.Ports}} {{$p}} -> {{(index $conf 0).HostPort}} {{end}}' $INSTANCE_ID
@@ -74,13 +126,12 @@ examples: |-
 
   ### Find a specific port mapping
 
-  The `.Field` syntax doesn't work when the field name begins with a
-  number, but the template language's `index` function does. The
-  `.NetworkSettings.Ports` section contains a map of the internal port
-  mappings to a list of external address/port objects. To grab just the
-  numeric public port, you use `index` to find the specific port map, and
-  then `index` 0 contains the first object inside of that. Then we ask for
-  the `HostPort` field to get the public address.
+  The `.Field` syntax doesn't work when the field name begins with a number, but
+  the template language's `index` function does. The `.NetworkSettings.Ports`
+  section contains a map of the internal port mappings to a list of external
+  address/port objects. To grab just the numeric public port, you use `index` to
+  find the specific port map, and then `index` 0 contains the first object inside
+  of that. Then we ask for the `HostPort` field to get the public address.
 
   ```console
   $ docker inspect --format='{{(index (index .NetworkSettings.Ports "8787/tcp") 0).HostPort}}' $INSTANCE_ID
@@ -88,10 +139,9 @@ examples: |-
 
   ### Get a subsection in JSON format
 
-  If you request a field which is itself a structure containing other
-  fields, by default you get a Go-style dump of the inner values.
-  Docker adds a template function, `json`, which can be applied to get
-  results in JSON format.
+  If you request a field which is itself a structure containing other fields, by
+  default you get a Go-style dump of the inner values. Docker adds a template
+  function, `json`, which can be applied to get results in JSON format.
 
   ```console
   $ docker inspect --format='{{json .Config}}' $INSTANCE_ID

--- a/_data/engine-cli/docker_kill.yaml
+++ b/_data/engine-cli/docker_kill.yaml
@@ -45,7 +45,7 @@ examples: |-
   $ docker kill my_container
   ```
 
-  ### Send a custom signal to a container
+  ### <a name="signal"></a> Send a custom signal to a container (--signal)
 
   The following example sends a `SIGHUP` signal to the container named
   `my_container`:

--- a/_data/engine-cli/docker_load.yaml
+++ b/_data/engine-cli/docker_load.yaml
@@ -31,18 +31,25 @@ examples: |-
   $ docker image ls
 
   REPOSITORY          TAG                 IMAGE ID            CREATED             SIZE
+  ```
 
+  ### Load images from STDIN
+
+  ```console
   $ docker load < busybox.tar.gz
 
   Loaded image: busybox:latest
   $ docker images
   REPOSITORY          TAG                 IMAGE ID            CREATED             SIZE
   busybox             latest              769b9341d937        7 weeks ago         2.489 MB
+  ```
 
+  ### <a name="input"></a> Load images from a file (--input)
+
+  ```console
   $ docker load --input fedora.tar
 
   Loaded image: fedora:rawhide
-
   Loaded image: fedora:20
 
   $ docker images

--- a/_data/engine-cli/docker_login.yaml
+++ b/_data/engine-cli/docker_login.yaml
@@ -42,7 +42,7 @@ examples: |-
   $ docker login localhost:8080
   ```
 
-  ### Provide a password using STDIN
+  ### <a name="password-stdin"></a> Provide a password using STDIN (--password-stdin)
 
   To run the `docker login` command non-interactively, you can set the
   `--password-stdin` flag to provide a password through `STDIN`. Using

--- a/_data/engine-cli/docker_logs.yaml
+++ b/_data/engine-cli/docker_logs.yaml
@@ -3,11 +3,6 @@ short: Fetch the logs of a container
 long: |-
   The `docker logs` command batch-retrieves logs present at the time of execution.
 
-  > **Note**
-  >
-  > This command is only functional for containers that are started with the
-  > `json-file` or `journald` logging driver.
-
   For more information about selecting and configuring logging drivers, refer to
   [Configure logging drivers](https://docs.docker.com/config/containers/logging/configure/).
 
@@ -101,7 +96,7 @@ options:
   kubernetes: false
   swarm: false
 examples: |-
-  ### Retrieve logs until a specific point in time
+  ### <a name="until"></a> Retrieve logs until a specific point in time (--until)
 
   In order to retrieve logs before a specific point in time, run:
 

--- a/_data/engine-cli/docker_network_connect.yaml
+++ b/_data/engine-cli/docker_network_connect.yaml
@@ -75,7 +75,7 @@ examples: |-
   $ docker run -itd --network=multi-host-network busybox
   ```
 
-  ### Specify the IP address a container will use on a given network
+  ### <a name="ip"></a> Specify the IP address a container will use on a given network (--ip)
 
   You can specify the IP address you want to be assigned to the container's interface.
 
@@ -83,7 +83,7 @@ examples: |-
   $ docker network connect --ip 10.10.36.122 multi-host-network container2
   ```
 
-  ### Use the legacy `--link` option
+  ### <a name="link"></a> Use the legacy `--link` option (--link)
 
   You can use `--link` option to link another container with a preferred alias
 
@@ -91,7 +91,7 @@ examples: |-
   $ docker network connect --link container1:c1 multi-host-network container2
   ```
 
-  ### Create a network alias for a container
+  ### <a name="alias"></a> Create a network alias for a container (--alias)
 
   `--alias` option can be used to resolve the container by another name in the network
   being connected to.

--- a/_data/engine-cli/docker_network_create.yaml
+++ b/_data/engine-cli/docker_network_create.yaml
@@ -313,14 +313,14 @@ examples: |-
       simple-network
   ```
 
-  ### Network internal mode
+  ### <a name="internal"></a> Network internal mode (--internal)
 
   By default, when you connect a container to an `overlay` network, Docker also
   connects a bridge network to it to provide external connectivity. If you want
   to create an externally isolated `overlay` network, you can specify the
   `--internal` option.
 
-  ### Network ingress mode
+  ### <a name="ingress"></a> Network ingress mode (--ingress)
 
   You can create the network which will be used to provide the routing-mesh in the
   swarm cluster. You do so by specifying `--ingress` when creating the network. Only

--- a/_data/engine-cli/docker_network_ls.yaml
+++ b/_data/engine-cli/docker_network_ls.yaml
@@ -68,7 +68,7 @@ examples: |-
   63d1ff1f77b07ca51070a8c227e962238358bd310bde1529cf62e6c307ade161   dev                 bridge           local
   ```
 
-  ### Filtering
+  ### <a name="filter"></a> Filtering (--filter)
 
   The filtering flag (`-f` or `--filter`) format is a `key=value` pair. If there
   is more than one filter, then pass multiple flags (e.g. `--filter "foo=bar" --filter "bif=baz"`).
@@ -213,7 +213,7 @@ examples: |-
   A warning will be issued when trying to remove a network that has containers
   attached.
 
-  ### Formatting
+  ### <a name="format"></a> Format the output (--format)
 
   The formatting options (`--format`) pretty-prints networks output
   using a Go template.

--- a/_data/engine-cli/docker_network_prune.yaml
+++ b/_data/engine-cli/docker_network_prune.yaml
@@ -36,7 +36,7 @@ examples: |-
   n2
   ```
 
-  ### Filtering
+  ### <a name="filter"></a> Filtering (--filter)
 
   The filtering flag (`--filter`) format is of "key=value". If there is more
   than one filter, then pass multiple flags (e.g., `--filter "foo=bar" --filter "bif=baz"`)

--- a/_data/engine-cli/docker_node_inspect.yaml
+++ b/_data/engine-cli/docker_node_inspect.yaml
@@ -113,7 +113,7 @@ examples: |-
   ]
   ```
 
-  ### Specify an output format
+  ### <a name="format"></a> Format the output (--format)
 
   ```console
   $ docker node inspect --format '{{ .ManagerStatus.Leader }}' self

--- a/_data/engine-cli/docker_node_ls.yaml
+++ b/_data/engine-cli/docker_node_ls.yaml
@@ -3,7 +3,7 @@ aliases: list
 short: List nodes in the swarm
 long: |-
   Lists all the nodes that the Docker Swarm manager knows about. You can filter
-  using the `-f` or `--filter` flag. Refer to the [filtering](#filtering) section
+  using the `-f` or `--filter` flag. Refer to the [filtering](#filter) section
   for more information about available filter options.
 
   > **Note**
@@ -60,7 +60,7 @@ examples: |-
   > `e216jshn25ckzbvmwlnh5jr3g *`) means this node is the current docker daemon.
 
 
-  ### Filtering
+  ### <a name="filter"></a> Filtering (--filter)
 
   The filtering flag (`-f` or `--filter`) format is of "key=value". If there is more
   than one filter, then pass multiple flags (e.g., `--filter "foo=bar" --filter "bif=baz"`)
@@ -178,7 +178,7 @@ examples: |-
   e216jshn25ckzbvmwlnh5jr3g *  swarm-manager1  Ready   Active        Leader
   ```
 
-  ### Formatting
+  ### <a name="format"></a> Format the output (--format)
 
   The formatting options (`--format`) pretty-prints nodes output
   using a Go template.

--- a/_data/engine-cli/docker_node_ps.yaml
+++ b/_data/engine-cli/docker_node_ps.yaml
@@ -2,7 +2,7 @@ command: docker node ps
 short: List tasks running on one or more nodes, defaults to current node
 long: |-
   Lists all the tasks on a Node that Docker knows about. You can filter using the
-  `-f` or `--filter` flag. Refer to the [filtering](#filtering) section for more
+  `-f` or `--filter` flag. Refer to the [filtering](#filter) section for more
   information about available filter options.
 
   > **Note**
@@ -72,7 +72,7 @@ examples: |-
   redis.10.0tgctg8h8cech4w0k0gwrmr23  redis:3.0.6  swarm-manager1  Running        Running 5 seconds
   ```
 
-  ### Filtering
+  ### <a name="filter"></a> Filtering (--filter)
 
   The filtering flag (`-f` or `--filter`) format is of "key=value". If there is more
   than one filter, then pass multiple flags (e.g., `--filter "foo=bar" --filter "bif=baz"`)
@@ -133,7 +133,7 @@ examples: |-
   The `desired-state` filter can take the values `running`, `shutdown`, or `accepted`.
 
 
-  ### Formatting
+  ### <a name="format"></a> Format the output (--format)
 
   The formatting options (`--format`) pretty-prints tasks output
   using a Go template.

--- a/_data/engine-cli/docker_node_rm.yaml
+++ b/_data/engine-cli/docker_node_rm.yaml
@@ -45,7 +45,7 @@ examples: |-
   down and can't be removed
   ```
 
-  ### Forcibly remove an inaccessible node from a swarm
+  ### <a name="force"></a> Forcibly remove an inaccessible node from a swarm (--force)
 
   If you lose access to a worker node or need to shut it down because it has been
   compromised or is not behaving as expected, you can use the `--force` option.

--- a/_data/engine-cli/docker_node_update.yaml
+++ b/_data/engine-cli/docker_node_update.yaml
@@ -46,7 +46,7 @@ options:
   kubernetes: false
   swarm: false
 examples: |-
-  ### Add label metadata to a node
+  ### <a name="label-add"></a> Add label metadata to a node (--label-add)
 
   Add metadata to a swarm node using node labels. You can specify a node label as
   a key with an empty value:

--- a/_data/engine-cli/docker_plugin_inspect.yaml
+++ b/_data/engine-cli/docker_plugin_inspect.yaml
@@ -136,7 +136,7 @@ examples: |-
   ```
 
 
-  ### Formatting the output
+  ### <a name="format"></a> Format the output (--format)
 
   ```console
   $ docker plugin inspect -f '{{.Id}}' tiborvass/sample-volume-plugin:latest

--- a/_data/engine-cli/docker_plugin_ls.yaml
+++ b/_data/engine-cli/docker_plugin_ls.yaml
@@ -5,7 +5,7 @@ long: |-
   Lists all the plugins that are currently installed. You can install plugins
   using the [`docker plugin install`](plugin_install.md) command.
   You can also filter using the `-f` or `--filter` flag.
-  Refer to the [filtering](#filtering) section for more information about available filter options.
+  Refer to the [filtering](#filter) section for more information about available filter options.
 usage: docker plugin ls [OPTIONS]
 pname: docker plugin
 plink: docker_plugin.yaml
@@ -54,7 +54,7 @@ examples: |-
   69553ca1d123  tiborvass/sample-volume-plugin:latest   A test plugin for Docker   true
   ```
 
-  ### Filtering
+  ### <a name="format"></a> Filtering (--filter)
 
   The filtering flag (`-f` or `--filter`) format is of "key=value". If there is more
   than one filter, then pass multiple flags (e.g., `--filter "foo=bar" --filter "bif=baz"`)
@@ -84,7 +84,7 @@ examples: |-
   ID                  NAME                DESCRIPTION         ENABLED
   ```
 
-  ### Formatting
+  ### <a name="format"></a> Format the output (--format)
 
   The formatting options (`--format`) pretty-prints plugins output
   using a Go template.

--- a/_data/engine-cli/docker_ps.yaml
+++ b/_data/engine-cli/docker_ps.yaml
@@ -82,7 +82,7 @@ options:
   kubernetes: false
   swarm: false
 examples: |-
-  ### Prevent truncating output
+  ### <a name="no-trunc"></a> Do not truncate output (--no-trunc)
 
   Running `docker ps --no-trunc` showing 2 linked containers.
 
@@ -90,14 +90,14 @@ examples: |-
   $ docker ps
 
   CONTAINER ID        IMAGE                        COMMAND                CREATED              STATUS              PORTS               NAMES
-  4c01db0b339c        ubuntu:12.04                 bash                   17 seconds ago       Up 16 seconds       3300-3310/tcp       webapp
+  4c01db0b339c        ubuntu:22.04                 bash                   17 seconds ago       Up 16 seconds       3300-3310/tcp       webapp
   d7886598dbe2        crosbymichael/redis:latest   /redis-server --dir    33 minutes ago       Up 33 minutes       6379/tcp            redis,webapp/db
   ```
 
-  ### Show both running and stopped containers
+  ### <a name="all"></a> Show both running and stopped containers (-a, --all)
 
   The `docker ps` command only shows running containers by default. To see all
-  containers, use the `-a` (or `--all`) flag:
+  containers, use the `--all` (or `-a`) flag:
 
   ```console
   $ docker ps -a
@@ -107,12 +107,12 @@ examples: |-
   container that exposes TCP ports `100, 101, 102` displays `100-102/tcp` in
   the `PORTS` column.
 
-  ### Show disk usage by container
+  ### <a name="size"></a> Show disk usage by container (--size)
 
-  The `docker ps -s` command displays two different on-disk-sizes for each container:
+  The `docker ps --size` (or `-s`) command displays two different on-disk-sizes for each container:
 
   ```console
-  $ docker ps -s
+  $ docker ps --size
 
   CONTAINER ID   IMAGE          COMMAND                  CREATED        STATUS       PORTS   NAMES        SIZE                                                                                      SIZE
   e90b8831a4b8   nginx          "/bin/bash -c 'mkdir "   11 weeks ago   Up 4 hours           my_nginx     35.58 kB (virtual 109.2 MB)
@@ -124,9 +124,9 @@ examples: |-
   For more information, refer to the [container size on disk](https://docs.docker.com/storage/storagedriver/#container-size-on-disk) section.
 
 
-  ### Filtering
+  ### <a name="filter"></a> Filtering (--filter)
 
-  The filtering flag (`-f` or `--filter`) format is a `key=value` pair. If there is more
+  The `--filter` (or `-f`) flag format is a `key=value` pair. If there is more
   than one filter, then pass multiple flags (e.g. `--filter "foo=bar" --filter "bif=baz"`)
 
   The currently supported filters are:
@@ -287,13 +287,13 @@ examples: |-
   919e1179bdb8        ubuntu-c1           "top"               About a minute ago   Up About a minute                       admiring_lovelace
   ```
 
-  Match containers based on the `ubuntu` version `12.04.5` image:
+  Match containers based on the `ubuntu` version `22.04` image:
 
   ```console
-  $ docker ps --filter ancestor=ubuntu:12.04.5
+  $ docker ps --filter ancestor=ubuntu:22.04
 
   CONTAINER ID        IMAGE               COMMAND             CREATED              STATUS              PORTS               NAMES
-  82a598284012        ubuntu:12.04.5      "top"               3 minutes ago        Up 3 minutes                            sleepy_bose
+  82a598284012        ubuntu:22.04        "top"               3 minutes ago        Up 3 minutes                            sleepy_bose
   ```
 
   The following matches containers based on the layer `d0e008c6cf02` or an image
@@ -303,7 +303,7 @@ examples: |-
   $ docker ps --filter ancestor=d0e008c6cf02
 
   CONTAINER ID        IMAGE               COMMAND             CREATED              STATUS              PORTS               NAMES
-  82a598284012        ubuntu:12.04.5      "top"               3 minutes ago        Up 3 minutes                            sleepy_bose
+  82a598284012        ubuntu:22.04        "top"               3 minutes ago        Up 3 minutes                            sleepy_bose
   ```
 
   #### Create time
@@ -435,7 +435,7 @@ examples: |-
   CONTAINER ID        IMAGE               COMMAND             CREATED             STATUS              PORTS               NAMES
   ```
 
-  ### Formatting
+  ### <a name="format"></a> Format the output (--format)
 
   The formatting option (`--format`) pretty-prints container output using a Go
   template.

--- a/_data/engine-cli/docker_pull.yaml
+++ b/_data/engine-cli/docker_pull.yaml
@@ -71,36 +71,36 @@ examples: |-
   ### Pull an image from Docker Hub
 
   To download a particular image, or set of images (i.e., a repository), use
-  `docker pull`. If no tag is provided, Docker Engine uses the `:latest` tag as a
-  default. This command pulls the `debian:latest` image:
+  `docker image pull` (or the `docker pull` shorthand). If no tag is provided,
+  Docker Engine uses the `:latest` tag as a default. This example pulls the
+  `debian:latest` image:
 
   ```console
-  $ docker pull debian
+  $ docker image pull debian
 
   Using default tag: latest
   latest: Pulling from library/debian
-  fdd5d7827f33: Pull complete
-  a3ed95caeb02: Pull complete
-  Digest: sha256:e7d38b3517548a1c71e41bffe9c8ae6d6d29546ce46bf62159837aad072c90aa
+  e756f3fdd6a3: Pull complete
+  Digest: sha256:3f1d6c17773a45c97bd8f158d665c9709d7b29ed7917ac934086ad96f92e4510
   Status: Downloaded newer image for debian:latest
+  docker.io/library/debian:latest
   ```
 
   Docker images can consist of multiple layers. In the example above, the image
-  consists of two layers; `fdd5d7827f33` and `a3ed95caeb02`.
+  consists of a single layer; `e756f3fdd6a3`.
 
-  Layers can be reused by images. For example, the `debian:jessie` image shares
-  both layers with `debian:latest`. Pulling the `debian:jessie` image therefore
-  only pulls its metadata, but not its layers, because all layers are already
-  present locally:
+  Layers can be reused by images. For example, the `debian:bullseye` image shares
+  its layer with the `debian:latest`. Pulling the `debian:bullseye` image therefore
+  only pulls its metadata, but not its layers, because the layer is already present
+  locally:
 
   ```console
-  $ docker pull debian:jessie
+  $ docker image pull debian:bullseye
 
-  jessie: Pulling from library/debian
-  fdd5d7827f33: Already exists
-  a3ed95caeb02: Already exists
-  Digest: sha256:a9c958be96d7d40df920e7041608f2f017af81800ca5ad23e327bc402626b58e
-  Status: Downloaded newer image for debian:jessie
+  bullseye: Pulling from library/debian
+  Digest: sha256:3f1d6c17773a45c97bd8f158d665c9709d7b29ed7917ac934086ad96f92e4510
+  Status: Downloaded newer image for debian:bullseye
+  docker.io/library/debian:bullseye
   ```
 
   To see which images are present locally, use the [`docker images`](images.md)
@@ -109,17 +109,16 @@ examples: |-
   ```console
   $ docker images
 
-  REPOSITORY   TAG      IMAGE ID        CREATED      SIZE
-  debian       jessie   f50f9524513f    5 days ago   125.1 MB
-  debian       latest   f50f9524513f    5 days ago   125.1 MB
+  REPOSITORY   TAG        IMAGE ID       CREATED        SIZE
+  debian       bullseye   4eacea30377a   8 days ago     124MB
+  debian       latest     4eacea30377a   8 days ago     124MB
   ```
 
   Docker uses a content-addressable image store, and the image ID is a SHA256
   digest covering the image's configuration and layers. In the example above,
-  `debian:jessie` and `debian:latest` have the same image ID because they are
-  actually the *same* image tagged with different names. Because they are the
-  same image, their layers are stored only once and do not consume extra disk
-  space.
+  `debian:bullseye` and `debian:latest` have the same image ID because they are
+  the *same* image tagged with different names. Because they are the same image,
+  their layers are stored only once and do not consume extra disk space.
 
   For more information about images, layers, and the content-addressable store,
   refer to [understand images, containers, and storage drivers](https://docs.docker.com/storage/storagedriver/).
@@ -130,8 +129,8 @@ examples: |-
   So far, you've pulled images by their name (and "tag"). Using names and tags is
   a convenient way to work with images. When using tags, you can `docker pull` an
   image again to make sure you have the most up-to-date version of that image.
-  For example, `docker pull ubuntu:20.04` pulls the latest version of the Ubuntu
-  20.04 image.
+  For example, `docker pull ubuntu:22.04` pulls the latest version of the Ubuntu
+  22.04 image.
 
   In some cases you don't want images to be updated to newer versions, but prefer
   to use a fixed version of an image. Docker enables you to pull an image by its
@@ -140,23 +139,23 @@ examples: |-
   and guarantee that the image you're using is always the same.
 
   To know the digest of an image, pull the image first. Let's pull the latest
-  `ubuntu:20.04` image from Docker Hub:
+  `ubuntu:22.04` image from Docker Hub:
 
   ```console
-  $ docker pull ubuntu:20.04
+  $ docker pull ubuntu:22.04
 
-  20.04: Pulling from library/ubuntu
-  16ec32c2132b: Pull complete
-  Digest: sha256:82becede498899ec668628e7cb0ad87b6e1c371cb8a1e597d83a47fac21d6af3
-  Status: Downloaded newer image for ubuntu:20.04
-  docker.io/library/ubuntu:20.04
+  22.04: Pulling from library/ubuntu
+  125a6e411906: Pull complete
+  Digest: sha256:26c68657ccce2cb0a31b330cb0be2b5e108d467f641c62e13ab40cbec258c68d
+  Status: Downloaded newer image for ubuntu:22.04
+  docker.io/library/ubuntu:22.04
   ```
 
   Docker prints the digest of the image after the pull has finished. In the example
   above, the digest of the image is:
 
   ```console
-  sha256:82becede498899ec668628e7cb0ad87b6e1c371cb8a1e597d83a47fac21d6af3
+  sha256:26c68657ccce2cb0a31b330cb0be2b5e108d467f641c62e13ab40cbec258c68d
   ```
 
   Docker also prints the digest of an image when *pushing* to a registry. This
@@ -166,25 +165,25 @@ examples: |-
   pull the above image by digest, run the following command:
 
   ```console
-  $ docker pull ubuntu@sha256:82becede498899ec668628e7cb0ad87b6e1c371cb8a1e597d83a47fac21d6af3
+  $ docker pull ubuntu@sha256:26c68657ccce2cb0a31b330cb0be2b5e108d467f641c62e13ab40cbec258c68d
 
-  docker.io/library/ubuntu@sha256:82becede498899ec668628e7cb0ad87b6e1c371cb8a1e597d83a47fac21d6af3: Pulling from library/ubuntu
-  Digest: sha256:82becede498899ec668628e7cb0ad87b6e1c371cb8a1e597d83a47fac21d6af3
-  Status: Image is up to date for ubuntu@sha256:82becede498899ec668628e7cb0ad87b6e1c371cb8a1e597d83a47fac21d6af3
-  docker.io/library/ubuntu@sha256:82becede498899ec668628e7cb0ad87b6e1c371cb8a1e597d83a47fac21d6af3
+  docker.io/library/ubuntu@sha256:26c68657ccce2cb0a31b330cb0be2b5e108d467f641c62e13ab40cbec258c68d: Pulling from library/ubuntu
+  Digest: sha256:26c68657ccce2cb0a31b330cb0be2b5e108d467f641c62e13ab40cbec258c68d
+  Status: Image is up to date for ubuntu@sha256:26c68657ccce2cb0a31b330cb0be2b5e108d467f641c62e13ab40cbec258c68d
+  docker.io/library/ubuntu@sha256:26c68657ccce2cb0a31b330cb0be2b5e108d467f641c62e13ab40cbec258c68d
   ```
 
   Digest can also be used in the `FROM` of a Dockerfile, for example:
 
   ```dockerfile
-  FROM ubuntu@sha256:82becede498899ec668628e7cb0ad87b6e1c371cb8a1e597d83a47fac21d6af3
+  FROM ubuntu@sha256:26c68657ccce2cb0a31b330cb0be2b5e108d467f641c62e13ab40cbec258c68d
   LABEL org.opencontainers.image.authors="some maintainer <maintainer@example.com>"
   ```
 
   > **Note**
   >
   > Using this feature "pins" an image to a specific version in time.
-  > Docker will therefore not pull updated versions of an image, which may include
+  > Docker does therefore not pull updated versions of an image, which may include
   > security updates. If you want to pull an updated image, you need to change the
   > digest accordingly.
 
@@ -200,7 +199,7 @@ examples: |-
   listening on port 5000 (`myregistry.local:5000`):
 
   ```console
-  $ docker pull myregistry.local:5000/testing/test-image
+  $ docker image pull myregistry.local:5000/testing/test-image
   ```
 
   Registry credentials are managed by [docker login](login.md).
@@ -210,39 +209,41 @@ examples: |-
   [insecure registries](dockerd.md#insecure-registries) section for more information.
 
 
-  ### Pull a repository with multiple images
+  ### <a name="all-tags"></a> Pull a repository with multiple images (-a, --all-tags)
 
   By default, `docker pull` pulls a *single* image from the registry. A repository
   can contain multiple images. To pull all images from a repository, provide the
   `-a` (or `--all-tags`) option when using `docker pull`.
 
-  This command pulls all images from the `fedora` repository:
+  This command pulls all images from the `ubuntu` repository:
 
   ```console
-  $ docker pull --all-tags fedora
+  $ docker image pull --all-tags ubuntu
 
-  Pulling repository fedora
+  Pulling repository ubuntu
   ad57ef8d78d7: Download complete
   105182bb5e8b: Download complete
   511136ea3c5a: Download complete
   73bd853d2ea5: Download complete
   ....
 
-  Status: Downloaded newer image for fedora
+  Status: Downloaded newer image for ubuntu
   ```
 
-  After the pull has completed use the `docker images` command to see the
-  images that were pulled. The example below shows all the `fedora` images
-  that are present locally:
+  After the pull has completed use the `docker image ls` command (or the `docker images`
+  shorthand) to see the images that were pulled. The example below shows all the
+  `ubuntu` images that are present locally:
 
   ```console
-  $ docker images fedora
-
-  REPOSITORY   TAG         IMAGE ID        CREATED      SIZE
-  fedora       rawhide     ad57ef8d78d7    5 days ago   359.3 MB
-  fedora       20          105182bb5e8b    5 days ago   372.7 MB
-  fedora       heisenbug   105182bb5e8b    5 days ago   372.7 MB
-  fedora       latest      105182bb5e8b    5 days ago   372.7 MB
+  $ docker image ls --filter reference=ubuntu
+  REPOSITORY   TAG       IMAGE ID       CREATED        SIZE
+  ubuntu       18.04     c6ad7e71ba7d   5 weeks ago    63.2MB
+  ubuntu       bionic    c6ad7e71ba7d   5 weeks ago    63.2MB
+  ubuntu       22.04     5ccefbfc0416   2 months ago   78MB
+  ubuntu       focal     ff0fea8310f3   2 months ago   72.8MB
+  ubuntu       latest    ff0fea8310f3   2 months ago   72.8MB
+  ubuntu       jammy     41ba606c8ab9   3 months ago   79MB
+  ubuntu       20.04     ba6acccedd29   7 months ago   72.8MB
   ```
 
   ### Cancel a pull
@@ -251,21 +252,18 @@ examples: |-
   running in a terminal, will terminate the pull operation.
 
   ```console
-  $ docker pull fedora
+  $ docker pull ubuntu
 
   Using default tag: latest
-  latest: Pulling from library/fedora
+  latest: Pulling from library/ubuntu
   a3ed95caeb02: Pulling fs layer
   236608c7b546: Pulling fs layer
   ^C
   ```
 
-  > **Note**
-  >
-  > The Engine terminates a pull operation when the connection between the Docker
-  > Engine daemon and the Docker Engine client initiating the pull is lost. If the
-  > connection with the Engine daemon is lost for other reasons than a manual
-  > interaction, the pull is also aborted.
+  The Engine terminates a pull operation when the connection between the daemon
+  and the client (initiating the pull) is cut or lost for any reason or the
+  command is manually terminated.
 deprecated: false
 experimental: false
 experimentalcli: false

--- a/_data/engine-cli/docker_push.yaml
+++ b/_data/engine-cli/docker_push.yaml
@@ -86,7 +86,7 @@ examples: |-
   You should see both `rhel-httpd` and `registry-host:5000/myadmin/rhel-httpd`
   listed.
 
-  ### Push all tags of an image
+  ### <a name="all-tags"></a> Push all tags of an image (-a, --all-tags)
 
   Use the `-a` (or `--all-tags`) option to push all tags of a local image.
 

--- a/_data/engine-cli/docker_rm.yaml
+++ b/_data/engine-cli/docker_rm.yaml
@@ -46,7 +46,7 @@ examples: |-
   /redis
   ```
 
-  ### Remove a link specified with `--link` on the default bridge network
+  ### <a name="link"></a> Remove a link specified with `--link` on the default bridge network (--link)
 
   This removes the underlying link between `/webapp` and the `/redis`
   containers on the default bridge network, removing all network communication
@@ -59,7 +59,7 @@ examples: |-
   /webapp/redis
   ```
 
-  ### Force-remove a running container
+  ### <a name="force"></a> Force-remove a running container (--force)
 
   This command force-removes a running container.
 
@@ -102,10 +102,10 @@ examples: |-
   $ docker ps --filter status=exited -q | xargs docker rm
   ```
 
-  ### Remove a container and its volumes
+  ### <a name="volumes"></a> Remove a container and its volumes (-v, --volumes)
 
   ```console
-  $ docker rm -v redis
+  $ docker rm --volumes redis
   redis
   ```
 

--- a/_data/engine-cli/docker_run.yaml
+++ b/_data/engine-cli/docker_run.yaml
@@ -8,9 +8,6 @@ long: |-
   previous changes intact using `docker start`. See `docker ps -a` to view a list
   of all containers.
 
-  The `docker run` command can be used in combination with `docker commit` to
-  [*change the command that a container runs*](commit.md). There is additional detailed information about `docker run` in the [Docker run reference](../run.md).
-
   For information on connecting a container to a network, see the ["*Docker network overview*"](https://docs.docker.com/network/).
 usage: docker run [OPTIONS] IMAGE [COMMAND] [ARG...]
 pname: docker
@@ -925,7 +922,7 @@ options:
   kubernetes: false
   swarm: false
 examples: |-
-  ### Assign name and allocate pseudo-TTY (--name, -it)
+  ### <a name="name"></a> Assign name and allocate pseudo-TTY (--name, -it)
 
   ```console
   $ docker run --name test -it debian
@@ -944,7 +941,7 @@ examples: |-
   `exit 13`. This exit code is passed on to the caller of
   `docker run`, and is recorded in the `test` container's metadata.
 
-  ### Capture container ID (--cidfile)
+  ### <a name="cidfile"></a> Capture container ID (--cidfile)
 
   ```console
   $ docker run --cidfile /tmp/docker_test.cid ubuntu echo "test"
@@ -955,7 +952,7 @@ examples: |-
   If the file exists already, Docker will return an error. Docker will close this
   file when `docker run` exits.
 
-  ### Full container capabilities (--privileged)
+  ### <a name="privileged"></a> Full container capabilities (--privileged)
 
   ```console
   $ docker run -t -i --rm ubuntu bash
@@ -980,7 +977,7 @@ examples: |-
   words, the container can then do almost everything that the host can do. This
   flag exists to allow special use-cases, like running Docker within Docker.
 
-  ### Set working directory (-w)
+  ### <a name="workdir"></a> Set working directory (-w, --workdir)
 
   ```console
   $ docker  run -w /path/to/dir/ -i -t  ubuntu pwd
@@ -989,22 +986,22 @@ examples: |-
   The `-w` lets the command being executed inside directory given, here
   `/path/to/dir/`. If the path does not exist it is created inside the container.
 
-  ### Set storage driver options per container
+  ### <a name="storage-opt"></a> Set storage driver options per container (--storage-opt)
 
   ```console
   $ docker run -it --storage-opt size=120G fedora /bin/bash
   ```
 
-  This (size) will allow to set the container rootfs size to 120G at creation time.
+  This (size) will allow to set the container filesystem size to 120G at creation time.
   This option is only available for the `devicemapper`, `btrfs`, `overlay2`,
   `windowsfilter` and `zfs` graph drivers.
   For the `devicemapper`, `btrfs`, `windowsfilter` and `zfs` graph drivers,
   user cannot pass a size less than the Default BaseFS Size.
   For the `overlay2` storage driver, the size option is only available if the
-  backing fs is `xfs` and mounted with the `pquota` mount option.
-  Under these conditions, user can pass any size less than the backing fs size.
+  backing filesystem is `xfs` and mounted with the `pquota` mount option.
+  Under these conditions, user can pass any size less than the backing filesystem size.
 
-  ### Mount tmpfs (--tmpfs)
+  ### <a name="tmpfs"></a> Mount tmpfs (--tmpfs)
 
   ```console
   $ docker run -d --tmpfs /run:rw,noexec,nosuid,size=65536k my_image
@@ -1013,7 +1010,7 @@ examples: |-
   The `--tmpfs` flag mounts an empty tmpfs into the container with the `rw`,
   `noexec`, `nosuid`, `size=65536k` options.
 
-  ### Mount volume (-v, --read-only)
+  ### <a name="volume"></a> Mount volume (-v, --read-only)
 
   ```console
   $ docker  run  -v `pwd`:`pwd` -w `pwd` -i -t  ubuntu pwd
@@ -1047,8 +1044,8 @@ examples: |-
   $ docker run -t -i -v /var/run/docker.sock:/var/run/docker.sock -v /path/to/static-docker-binary:/usr/bin/docker busybox sh
   ```
 
-  By bind-mounting the docker unix socket and statically linked docker
-  binary (refer to [get the linux binary](https://docs.docker.com/engine/install/binaries/#install-static-binaries)),
+  By bind-mounting the Docker Unix socket and statically linked Docker
+  binary (refer to [get the Linux binary](https://docs.docker.com/engine/install/binaries/#install-static-binaries)),
   you give the container the full access to create and manipulate the host's
   Docker daemon.
 
@@ -1079,7 +1076,7 @@ examples: |-
   For in-depth information about volumes, refer to [manage data in containers](https://docs.docker.com/storage/volumes/)
 
 
-  ### Add bind mounts or volumes using the --mount flag
+  ### <a name="mount"></a> Add bind mounts or volumes using the --mount flag
 
   The `--mount` flag allows you to mount volumes, host-directories and `tmpfs`
   mounts in a container.
@@ -1087,7 +1084,7 @@ examples: |-
   The `--mount` flag supports most options that are supported by the `-v` or the
   `--volume` flag, but uses a different syntax. For in-depth information on the
   `--mount` flag, and a comparison between `--volume` and `--mount`, refer to
-  the [service create command reference](service_create.md#add-bind-mounts-volumes-or-memory-filesystems).
+  [Bind mounts](https://docs.docker.com/storage/bind-mounts/).
 
   Even though there is no plan to deprecate `--volume`, usage of `--mount` is recommended.
 
@@ -1101,7 +1098,7 @@ examples: |-
   $ docker run -t -i --mount type=bind,src=/data,dst=/data busybox sh
   ```
 
-  ### Publish or expose port (-p, --expose)
+  ### <a name="publish"></a> Publish or expose port (-p, --expose)
 
   ```console
   $ docker run -p 127.0.0.1:80:8080/tcp ubuntu bash
@@ -1139,7 +1136,7 @@ examples: |-
 
   When creating (and running) a container from an image, the daemon checks if the
   image exists in the local image cache. If the image is missing, an error is
-  returned to the cli, allowing it to initiate a pull.
+  returned to the CLI, allowing it to initiate a pull.
 
   The default (`missing`) is to only pull the image if it is not present in the
   daemon's image cache. This default allows you to run images that only exist
@@ -1166,7 +1163,7 @@ examples: |-
   docker: Error response from daemon: No such image: hello-world:latest.
   ```
 
-  ### Set environment variables (-e, --env, --env-file)
+  ### <a name="env"></a> Set environment variables (-e, --env, --env-file)
 
   ```console
   $ docker run -e MYVAR1 --env MYVAR2=foo --env-file ./env.list ubuntu bash
@@ -1217,7 +1214,7 @@ examples: |-
   USER=jonzeolla
   ```
 
-  ### Set metadata on container (-l, --label, --label-file)
+  ### <a name="label"></a> Set metadata on container (-l, --label, --label-file)
 
   A label is a `key=value` pair that applies metadata to a container. To label a container with two labels:
 
@@ -1259,12 +1256,14 @@ examples: |-
   metadata in Docker*](https://docs.docker.com/config/labels-custom-metadata/) in
   the Docker User Guide.
 
-  ### Connect a container to a network (--network)
+  ### <a name="network"></a> Connect a container to a network (--network)
 
   When you start a container use the `--network` flag to connect it to a network.
-  This adds the `busybox` container to the `my-net` network.
+  The following commands create a network named `my-net`, and adds a `busybox` container
+  to the `my-net` network.
 
   ```console
+  $ docker network create my-net
   $ docker run -itd --network=my-net busybox
   ```
 
@@ -1285,14 +1284,14 @@ examples: |-
 
   > **Note**
   >
-  > Service discovery is unavailable on the default bridge network. Containers can
-  > communicate via their IP addresses by default. To communicate by name, they
-  > must be linked.
+  > The default bridge network only allow containers to communicate with each other using
+  > internal IP addresses. User-created bridge networks provide DNS resolution between
+  > containers using container names.
 
   You can disconnect a container from a network using the `docker network
   disconnect` command.
 
-  ### Mount volumes from container (--volumes-from)
+  ### <a name="volumes-from"></a> Mount volumes from container (--volumes-from)
 
   ```console
   $ docker run --volumes-from 777f7dc92da7 --volumes-from ba8c0c54f0f2:ro -i -t ubuntu pwd
@@ -1318,11 +1317,11 @@ examples: |-
   The `Z` option tells Docker to label the content with a private unshared label.
   Only the current container can use a private volume.
 
-  ### Attach to STDIN/STDOUT/STDERR (-a)
+  ### <a name="attach"></a> Attach to STDIN/STDOUT/STDERR (-a, --attach)
 
-  The `-a` flag tells `docker run` to bind to the container's `STDIN`, `STDOUT`
-  or `STDERR`. This makes it possible to manipulate the output and input as
-  needed.
+  The `--attach` (or `-a`) flag tells `docker run` to bind to the container's
+  `STDIN`, `STDOUT` or `STDERR`. This makes it possible to manipulate the output
+  and input as needed.
 
   ```console
   $ echo "test" | docker run -i -a stdin ubuntu cat -
@@ -1343,13 +1342,15 @@ examples: |-
   $ cat somefile | docker run -i -a stdin mybuilder dobuild
   ```
 
-  This is how piping a file into a container could be done for a build.
+  This is a way of using `--attach` to pipe a build file into a container.
   The container's ID will be printed after the build is done and the build
   logs could be retrieved using `docker logs`. This is
   useful if you need to pipe a file or something else into a container and
   retrieve the container's ID once the container has finished running.
 
-  ### Add host device to container (--device)
+  See also [the `docker cp` command](cp.md).
+
+  ### <a name="device"></a> Add host device to container (--device)
 
   ```console
   $ docker run -it --rm \
@@ -1442,14 +1443,14 @@ examples: |-
   > **Note**: initially present devices still need to be explicitly added to the
   > `docker run` / `docker create` command.
 
-  ### Access an NVIDIA GPU
+  ### <a name="gpus"></a> Access an NVIDIA GPU
 
   The `--gpus` flag allows you to access NVIDIA GPU resources. First you need to
   install [nvidia-container-runtime](https://nvidia.github.io/nvidia-container-runtime/).
   Visit [Specify a container's resources](https://docs.docker.com/config/containers/resource_constraints/)
   for more information.
 
-  To use `--gpus`, specify which GPUs (or all) to use. If no value is provied, all
+  To use `--gpus`, specify which GPUs (or all) to use. If no value is provided, all
   available GPUs are used. The example below exposes all available GPUs.
 
   ```console
@@ -1469,7 +1470,7 @@ examples: |-
   $ docker run -it --rm --gpus '"device=0,2"' nvidia-smi
   ```
 
-  ### Restart policies (--restart)
+  ### <a name="restart"></a> Restart policies (--restart)
 
   Use Docker's `--restart` to specify a container's *restart policy*. A restart
   policy controls whether the Docker daemon restarts a container after exit.
@@ -1493,7 +1494,7 @@ examples: |-
   [Restart Policies (--restart)](../run.md#restart-policies---restart)
   section of the Docker run reference page.
 
-  ### Add entries to container hosts file (--add-host)
+  ### <a name="add-host"></a> Add entries to container hosts file (--add-host)
 
   You can add other hosts into a container's `/etc/hosts` file by using one or
   more `--add-host` flags. This example adds a static address for a host named
@@ -1531,7 +1532,7 @@ examples: |-
   devices, replace `eth0` with the correct device name (for example `docker0`
   for the bridge device).
 
-  ### Set ulimits in container (--ulimit)
+  ### <a name="ulimit"></a> Set ulimits in container (--ulimit)
 
   Since setting `ulimit` settings in a container requires extra privileges not
   available in the default container, you can set these using the `--ulimit` flag.
@@ -1560,7 +1561,7 @@ examples: |-
   #### For `nproc` usage
 
   Be careful setting `nproc` with the `ulimit` flag as `nproc` is designed by Linux to set the
-  maximum number of processes available to a user, not to a container.  For example, start four
+  maximum number of processes available to a user, not to a container. For example, start four
   containers with `daemon` user:
 
   ```console
@@ -1577,7 +1578,7 @@ examples: |-
   This fails because the caller set `nproc=3` resulting in the first three containers using up
   the three processes quota set for the `daemon` user.
 
-  ### Stop container with signal (--stop-signal)
+  ### <a name="stop-signal"></a> Stop container with signal (--stop-signal)
 
   The `--stop-signal` flag sets the system call signal that will be sent to the
   container to exit. This signal can be a signal name in the format `SIG<NAME>`,
@@ -1586,12 +1587,12 @@ examples: |-
 
   The default is `SIGTERM` if not specified.
 
-  ### Optional security options (--security-opt)
+  ### <a name="security-opt"></a> Optional security options (--security-opt)
 
   On Windows, this flag can be used to specify the `credentialspec` option.
   The `credentialspec` must be in the format `file://spec.txt` or `registry://keyname`.
 
-  ### Stop container with timeout (--stop-timeout)
+  ### <a name="stop-timeout"></a> Stop container with timeout (--stop-timeout)
 
   The `--stop-timeout` flag sets the number of seconds to wait for the container
   to stop after sending the pre-defined (see `--stop-signal`) system call signal.
@@ -1604,7 +1605,7 @@ examples: |-
   The default is determined by the daemon, and is 10 seconds for Linux containers,
   and 30 seconds for Windows containers.
 
-  ### Specify isolation technology for container (--isolation)
+  ### <a name="isolation"></a> Specify isolation technology for container (--isolation)
 
   This option is useful in situations where you are running Docker containers on
   Windows. The `--isolation=<value>` option sets a container's isolation technology.
@@ -1625,8 +1626,8 @@ examples: |-
   | `hyperv`  | Hyper-V hypervisor partition-based isolation.                                              |
 
   The default isolation on Windows server operating systems is `process`, and `hyperv`
-  on Windows client operating systems, such as Windows 10. Process isolation is more
-  performant, but requires the image to
+  on Windows client operating systems, such as Windows 10. Process isolation has better
+  performance, but requires that the image and host use the same kernel version.
 
   On Windows server, assuming the default configuration, these commands are equivalent
   and result in `process` isolation:
@@ -1647,7 +1648,7 @@ examples: |-
   PS C:\> docker run -d --isolation hyperv microsoft/nanoserver powershell echo hyperv
   ```
 
-  ### Specify hard limits on memory available to containers (-m, --memory)
+  ### <a name="memory"></a> Specify hard limits on memory available to containers (-m, --memory)
 
   These parameters always set an upper limit on the memory available to the container. On Linux, this
   is set on the cgroup and applications in a container can query it at `/sys/fs/cgroup/memory/memory.limit_in_bytes`.
@@ -1685,7 +1686,7 @@ examples: |-
       ```
 
 
-  ### Configure namespaced kernel parameters (sysctls) at runtime
+  ### <a name="sysctl"></a> Configure namespaced kernel parameters (sysctls) at runtime (--sysctl)
 
   The `--sysctl` sets namespaced kernel parameters (sysctls) in the
   container. For example, to turn on IP forwarding in the containers

--- a/_data/engine-cli/docker_search.yaml
+++ b/_data/engine-cli/docker_search.yaml
@@ -76,7 +76,7 @@ examples: |-
   marclop/busybox-solr
   ```
 
-  ### Display non-truncated description (--no-trunc)
+  ### <a name="no-trunc"></a> Display non-truncated description (--no-trunc)
 
   This example displays images with a name containing 'busybox',
   at least 3 stars and the description isn't truncated in the output:
@@ -90,12 +90,12 @@ examples: |-
   radial/busyboxplus   Full-chain, Internet enabled, busybox made from scratch. Comes in git and cURL flavors.   8                    [OK]
   ```
 
-  ### Limit search results (--limit)
+  ### <a name="limit"></a> Limit search results (--limit)
 
   The flag `--limit` is the maximum number of results returned by a search. This value could
   be in the range between 1 and 100. The default value of `--limit` is 25.
 
-  ### Filtering
+  ### <a name="filter"></a> Filtering (--filter)
 
   The filtering flag (`-f` or `--filter`) format is a `key=value` pair. If there is more
   than one filter, then pass multiple flags (e.g. `--filter is-automated=true --filter stars=3`)
@@ -145,7 +145,7 @@ examples: |-
   busybox   Busybox base image.   325       [OK]
   ```
 
-  ### Format the output
+  ### <a name="format"></a> Format the output (--format)
 
   The formatting option (`--format`) pretty-prints search output
   using a Go template.

--- a/_data/engine-cli/docker_secret_create.yaml
+++ b/_data/engine-cli/docker_secret_create.yaml
@@ -70,7 +70,7 @@ examples: |-
   dg426haahpi5ezmkkj5kyl3sn   my_secret           7 seconds ago       7 seconds ago
   ```
 
-  ### Create a secret with labels
+  ### <a name="label"></a> Create a secret with labels (--label)
 
   ```console
   $ docker secret create \

--- a/_data/engine-cli/docker_secret_inspect.yaml
+++ b/_data/engine-cli/docker_secret_inspect.yaml
@@ -79,7 +79,7 @@ examples: |-
   ]
   ```
 
-  ### Formatting
+  ### <a name="format"></a> Format the output (--format)
 
   You can use the --format option to obtain specific information about a
   secret. The following example command outputs the creation time of the

--- a/_data/engine-cli/docker_secret_ls.yaml
+++ b/_data/engine-cli/docker_secret_ls.yaml
@@ -53,7 +53,7 @@ examples: |-
   mem02h8n73mybpgqjf0kfi1n0   test_secret                 3 seconds ago       3 seconds ago
   ```
 
-  ### Filtering
+  ### <a name="filter"></a> Filtering (--filter)
 
   The filtering flag (`-f` or `--filter`) format is a `key=value` pair. If there is more
   than one filter, then pass multiple flags (e.g., `--filter "foo=bar" --filter "bif=baz"`)
@@ -113,7 +113,7 @@ examples: |-
   mem02h8n73mybpgqjf0kfi1n0   test_secret                 About an hour ago   About an hour ago
   ```
 
-  ### Format the output
+  ### <a name="format"></a> Format the output (--format)
 
   The formatting option (`--format`) pretty prints secrets output
   using a Go template.

--- a/_data/engine-cli/docker_service_create.yaml
+++ b/_data/engine-cli/docker_service_create.yaml
@@ -687,7 +687,7 @@ examples: |-
   a8q9dasaafud  redis2  global      1/1       redis:3.0.6
   ```
 
-  #### Create a service using an image on a private registry
+  #### <a name="with-registry-auth"></a> Create a service using an image on a private registry (--with-registry-auth)
 
   If your image is available on a private registry which requires login, use the
   `--with-registry-auth` flag with `docker service create`, after logging in. If
@@ -707,7 +707,7 @@ examples: |-
   service is deployed, using the encrypted WAL logs. With this information, the
   nodes are able to log into the registry and pull the image.
 
-  ### Create a service with 5 replica tasks (--replicas)
+  ### <a name="replicas"></a> Create a service with 5 replica tasks (--replicas)
 
   Use the `--replicas` flag to set the number of replica tasks for a replicated
   service. The following command creates a `redis` service with `5` replica tasks:
@@ -743,7 +743,7 @@ examples: |-
   4cdgfyky7ozw  redis  replicated  5/5       redis:3.0.7
   ```
 
-  ### Create a service with secrets
+  ### <a name="secret"></a> Create a service with secrets (--secret)
 
   Use the `--secret` flag to give a container access to a
   [secret](secret_create.md).
@@ -775,7 +775,7 @@ examples: |-
   example above, two files are created: `/run/secrets/ssh` and
   `/run/secrets/app` for each of the secret targets specified.
 
-  ### Create a service with configs
+  ### <a name="config"></a> Create a service with configs (--config)
 
   Use the `--config` flag to give a container access to a
   [config](config_create.md).
@@ -804,7 +804,7 @@ examples: |-
   target is specified, the name of the config is used as the name of the file in
   the container. If a target is specified, that is used as the filename.
 
-  ### Create a service with a rolling update policy
+  ### <a name="update-delay"></a> Create a service with a rolling update policy
 
   ```console
   $ docker service create \
@@ -820,7 +820,7 @@ examples: |-
   refer to the [rolling updates
   tutorial](https://docs.docker.com/engine/swarm/swarm-tutorial/rolling-update/).
 
-  ### Set environment variables (-e, --env)
+  ### <a name="env"></a> Set environment variables (-e, --env)
 
   This sets an environment variable for all tasks in a service. For example:
 
@@ -844,7 +844,7 @@ examples: |-
     redis:3.0.6
   ```
 
-  ### Create a service with specific hostname (--hostname)
+  ### <a name="hostname"></a> Create a service with specific hostname (--hostname)
 
   This option sets the docker service containers hostname to a specific string.
   For example:
@@ -853,7 +853,7 @@ examples: |-
   $ docker service create --name redis --hostname myredis redis:3.0.6
   ```
 
-  ### Set metadata on a service (-l, --label)
+  ### <a name="label"></a> Set metadata on a service (-l, --label)
 
   A label is a `key=value` pair that applies metadata to a service. To label a
   service with two labels:
@@ -861,7 +861,7 @@ examples: |-
   ```console
   $ docker service create \
     --name redis_2 \
-    --label com.example.foo="bar"
+    --label com.example.foo="bar" \
     --label bar=baz \
     redis:3.0.6
   ```
@@ -869,7 +869,7 @@ examples: |-
   For more information about labels, refer to [apply custom
   metadata](https://docs.docker.com/config/labels-custom-metadata/).
 
-  ### Add bind mounts, volumes or memory filesystems
+  ### <a name="mount"></a> Add bind mounts, volumes or memory filesystems (--mount)
 
   Docker supports three different kinds of mounts, which allow containers to read
   from or write to files or directories, either on the host operating system, or
@@ -1232,7 +1232,7 @@ examples: |-
    redis:3.0.6
   ```
 
-  ### Specify service constraints (--constraint)
+  ### <a name="constraint"></a> Specify service constraints (--constraint)
 
   You can limit the set of nodes where a task can be scheduled by defining
   constraint expressions. Constraint expressions can either use a _match_ (`==`)
@@ -1248,7 +1248,7 @@ examples: |-
   | `node.platform.os`   | Node operating system          | `node.platform.os==windows`                   |
   | `node.platform.arch` | Node architecture              | `node.platform.arch==x86_64`                  |
   | `node.labels`        | User-defined node labels       | `node.labels.security==high`                  |
-  | `engine.labels`      | Docker Engine's labels         | `engine.labels.operatingsystem==ubuntu-14.04` |
+  | `engine.labels`      | Docker Engine's labels         | `engine.labels.operatingsystem==ubuntu-22.04` |
 
   `engine.labels` apply to Docker Engine labels like operating system, drivers,
   etc. Swarm administrators add `node.labels` for operational purposes by using
@@ -1299,7 +1299,7 @@ examples: |-
   b6lww17hrr4e        web      replicated   1/1        nginx:alpine
   ```
 
-  ### Specify service placement preferences (--placement-pref)
+  ### <a name="placement-pref"></a> Specify service placement preferences (--placement-pref)
 
   You can set up the service to divide tasks evenly over different categories of
   nodes. One example of where this can be useful is to balance tasks over a set
@@ -1370,7 +1370,7 @@ examples: |-
   `--placement-pref-rm` removes an existing placement preference that matches the
   argument.
 
-  ### Specify memory requirements and constraints for a service (--reserve-memory and --limit-memory)
+  ### <a name="reserve-memory"></a> Specify memory requirements and constraints for a service (--reserve-memory and --limit-memory)
 
   If your service needs a minimum amount of memory in order to run correctly,
   you can use `--reserve-memory` to specify that the service should only be
@@ -1438,7 +1438,7 @@ examples: |-
   host at the level of the host operating system, using `cgroups` or other
   relevant operating system tools.
 
-  ### Specify maximum replicas per node (--replicas-max-per-node)
+  ### <a name="replicas-max-per-node"></a> Specify maximum replicas per node (--replicas-max-per-node)
 
   Use the `--replicas-max-per-node` flag to set the maximum number of replica tasks that can run on a node.
   The following command creates a nginx service with 2 replica tasks but only one replica task per node.
@@ -1458,7 +1458,7 @@ examples: |-
     nginx
   ```
 
-  ### Attach a service to an existing network (--network)
+  ### <a name="network"></a> Attach a service to an existing network (--network)
 
   You can use overlay networks to connect one or more services within the swarm.
 
@@ -1495,7 +1495,7 @@ examples: |-
   Long form syntax of `--network` allows to specify list of aliases and driver options:
   `--network name=my-network,alias=web1,driver-opt=field1=value1`
 
-  ### Publish service ports externally to the swarm (-p, --publish)
+  ### <a name="publish"></a> Publish service ports externally to the swarm (-p, --publish)
 
   You can publish service ports to make them available externally to the swarm
   using the `--publish` flag. The `--publish` flag can take two different styles
@@ -1566,7 +1566,7 @@ examples: |-
   the long syntax. For more information refer to
   [Use swarm mode routing mesh](https://docs.docker.com/engine/swarm/ingress/).
 
-  ### Provide credential specs for managed service accounts (Windows only)
+  ### <a name="credentials-spec"></a> Provide credential specs for managed service accounts (--credentials-spec)
 
   This option is only used for services using Windows containers. The
   `--credential-spec` must be in the format `file://<filename>` or
@@ -1661,7 +1661,7 @@ examples: |-
   x3ti0erg11rjpg64m75kej2mz-hosttempl
   ```
 
-  ### Specify isolation mode (Windows)
+  ### <a name="isolation"></a> Specify isolation mode on Windows (--isolation)
 
   By default, tasks scheduled on Windows nodes are run using the default isolation mode
   configured for this particular node. To force a specific isolation mode, you can use
@@ -1676,7 +1676,7 @@ examples: |-
   - `process`: use process isolation (Windows server only)
   - `hyperv`: use Hyper-V isolation
 
-  ### Create services requesting Generic Resources
+  ### <a name="generic-resources"></a> Create services requesting Generic Resources (--generic-resources)
 
   You can narrow the kind of nodes your task can land on through the using the
   `--generic-resource` flag (if the nodes advertise these resources):

--- a/_data/engine-cli/docker_service_inspect.yaml
+++ b/_data/engine-cli/docker_service_inspect.yaml
@@ -115,7 +115,7 @@ examples: |-
   ]
   ```
 
-  ### Formatting
+  ### <a name="pretty"></a> Formatting (--pretty)
 
   You can print the inspect output in a human-readable format instead of the default
   JSON output, by using the `--pretty` option:
@@ -148,9 +148,9 @@ examples: |-
 
   You can also use `--format pretty` for the same effect.
 
+  ### <a name="format"></a> Format the output (--format)
 
-  #### Find the number of tasks running as part of a service
-
+  You can use the --format option to obtain specific information about a
   The `--format` option can be used to obtain specific information about a
   service. For example, the following command outputs the number of replicas
   of the "redis" service.

--- a/_data/engine-cli/docker_service_ls.yaml
+++ b/_data/engine-cli/docker_service_ls.yaml
@@ -59,7 +59,7 @@ examples: |-
   additionally show the completion status of the job as completed tasks over
   total tasks the job will execute.
 
-  ### Filtering
+  ### <a name="filter"></a> Filtering (--filter)
 
   The filtering flag (`-f` or `--filter`) format is of "key=value". If there is more
   than one filter, then pass multiple flags (e.g., `--filter "foo=bar" --filter "bif=baz"`)
@@ -131,7 +131,7 @@ examples: |-
   0bcjwfh8ychr  redis  replicated  1/1       redis:3.0.6
   ```
 
-  ### Formatting
+  ### <a name="format"></a> Format the output (--format)
 
   The formatting options (`--format`) pretty-prints services output
   using a Go template.

--- a/_data/engine-cli/docker_service_ps.yaml
+++ b/_data/engine-cli/docker_service_ps.yaml
@@ -118,7 +118,7 @@ examples: |-
   nvjljf7rmor4htv7l8rwcx7i7   \_ redis.2   redis:3.0.6@sha256:6a692a76c2081888b589e26e6ec835743119fe453d67ecf03df7de5b73d69842  worker2   Shutdown       Rejected 5 minutes ago   "No such image: redis@sha256:6a692a76c2081888b589e26e6ec835743119fe453d67ecf03df7de5b73d69842"
   ```
 
-  ### Filtering
+  ### <a name="filter"></a> Filtering (--filter)
 
   The filtering flag (`-f` or `--filter`) format is a `key=value` pair. If there
   is more than one filter, then pass multiple flags (e.g. `--filter "foo=bar" --filter "bif=baz"`).
@@ -175,7 +175,7 @@ examples: |-
 
   The `desired-state` filter can take the values `running`, `shutdown`, or `accepted`.
 
-  ### Formatting
+  ### <a name="format"></a> Format the output (--format)
 
   The formatting options (`--format`) pretty-prints tasks output
   using a Go template.

--- a/_data/engine-cli/docker_service_update.yaml
+++ b/_data/engine-cli/docker_service_update.yaml
@@ -841,7 +841,7 @@ examples: |-
   $ docker service update --limit-cpu 2 redis
   ```
 
-  ### Perform a rolling restart with no parameter changes
+  ### <a name="update-parallelism"></a> Perform a rolling restart with no parameter changes
 
   ```console
   $ docker service update --force --update-parallelism 1 --update-delay 30s redis
@@ -854,7 +854,7 @@ examples: |-
   `--update-delay 30s` setting introduces a 30 second delay between tasks, so
   that the rolling restart happens gradually.
 
-  ### Add or remove mounts
+  ### <a name="mount-add"></a> Add or remove mounts (--mount-add, --mount-rm)
 
   Use the `--mount-add` or `--mount-rm` options add or remove a service's bind mounts
   or volumes.
@@ -866,7 +866,7 @@ examples: |-
   service name.
 
   - The `--mount-add` flag takes the same parameters as the `--mount` flag on
-    `service create`. Refer to the [volumes and bind mounts](service_create.md#add-bind-mounts-volumes-or-memory-filesystems)
+    `service create`. Refer to the [volumes and bind mounts](service_create.md#mount)
     section in the `service create` reference for details.
 
   - The `--mount-rm` flag takes the `target` path of the mount.
@@ -890,11 +890,11 @@ examples: |-
   myservice
   ```
 
-  ### Add or remove published service ports
+  ### <a name="publish-add"></a> Add or remove published service ports (--publish-add, --publish-rm)
 
   Use the `--publish-add` or `--publish-rm` flags to add or remove a published
   port for a service. You can use the short or long syntax discussed in the
-  [docker service create](service_create.md#publish-service-ports-externally-to-the-swarm--p---publish)
+  [docker service create](service_create.md#publish)
   reference.
 
   The following example adds a published service port to an existing service.
@@ -905,11 +905,11 @@ examples: |-
     myservice
   ```
 
-  ### Add or remove network
+  ### <a name="network-add"></a> Add or remove network (--network-add, --network-rm)
 
   Use the `--network-add` or `--network-rm` flags to add or remove a network for
   a service. You can use the short or long syntax discussed in the
-  [docker service create](service_create.md#attach-a-service-to-an-existing-network---network)
+  [docker service create](service_create.md#network)
   reference.
 
   The following example adds a new alias name to an existing service already connected to network my-network:
@@ -921,7 +921,7 @@ examples: |-
     myservice
   ```
 
-  ### Roll back to the previous version of a service
+  ### <a name="rollback"></a> Roll back to the previous version of a service (--rollback)
 
   Use the `--rollback` option to roll back to the previous version of the service.
 
@@ -987,7 +987,7 @@ examples: |-
   tasks at a time will get rolled back. These rollback parameters are respected both
   during automatic rollbacks and for rollbacks initiated manually using `--rollback`.
 
-  ### Add or remove secrets
+  ### <a name="secret-add"></a> Add or remove secrets (--secret-add, --secret-rm)
 
   Use the `--secret-add` or `--secret-rm` options add or remove a service's
   secrets.
@@ -1007,7 +1007,7 @@ examples: |-
   See [`service create`](service_create.md#create-services-using-templates) for the reference.
 
 
-  ### Specify isolation mode (Windows)
+  ### <a name="isolation"></a> Specify isolation mode on Windows (--isolation)
 
   `service update` supports the same `--isolation` flag as `service create`
   See [`service create`](service_create.md) for the reference.

--- a/_data/engine-cli/docker_stack_deploy.yaml
+++ b/_data/engine-cli/docker_stack_deploy.yaml
@@ -81,7 +81,7 @@ inherited_options:
   kubernetes: false
   swarm: false
 examples: |-
-  ### Compose file
+  ### <a name="compose-file"></a> Compose file (--compose-file)
 
   The `deploy` command supports compose file version `3.0` and above.
 

--- a/_data/engine-cli/docker_stack_ls.yaml
+++ b/_data/engine-cli/docker_stack_ls.yaml
@@ -68,7 +68,7 @@ examples: |-
   vossibility-stack  6                   Swarm
   ```
 
-  ### Formatting
+  ### <a name="format"></a> Format the output (--format)
 
   The formatting option (`--format`) pretty-prints stacks using a Go template.
 

--- a/_data/engine-cli/docker_stack_ps.yaml
+++ b/_data/engine-cli/docker_stack_ps.yaml
@@ -102,7 +102,7 @@ examples: |-
   t72q3z038jeh        voting_redis.2        redis:alpine                                   node3  Running        Running 3 minutes ago
   ```
 
-  ### Filtering
+  ### <a name="filter"></a> Filtering (--filter)
 
   The filtering flag (`-f` or `--filter`) format is a `key=value` pair. If there
   is more than one filter, then pass multiple flags (e.g. `--filter "foo=bar" --filter "bif=baz"`).
@@ -171,7 +171,7 @@ examples: |-
   t72q3z038jeh        voting_redis.2        redis:alpine                                   node3  Running        Running 21 minutes ago
   ```
 
-  ### Formatting
+  ### <a name="format"></a> Format the output (--format)
 
   The formatting options (`--format`) pretty-prints tasks output using a Go template.
 
@@ -208,7 +208,7 @@ examples: |-
   voting_redis.2: redis:alpine
   ```
 
-  ### Do not map IDs to Names
+  ### <a name="no-resolve"></a> Do not map IDs to Names (--no-resolve)
 
   The `--no-resolve` option shows IDs for task name, without mapping IDs to Names.
 
@@ -226,7 +226,7 @@ examples: |-
   t72q3z038jeh        tg61x8myx563ueo3urmn1ic6m.2   redis:alpine                                   kanqcxfajd1r16wlnqcblobmm   Running        Running 31 minutes ago
   ```
 
-  ### Do not truncate output
+  ### <a name="no-trunc"></a> Do not truncate output (--no-trunc)
 
   When deploying a service, docker resolves the digest for the service's
   image, and pins the service to that digest. The digest is not shown by
@@ -247,7 +247,7 @@ examples: |-
   t72q3z038jehe1wbh9gdum076   voting_redis.2        redis:alpine@sha256:9cd405cd1ec1410eaab064a1383d0d8854d1ef74a54e1e4a92fb4ec7bdc3ee7                                   node3  Running        Runnin 32 minutes ago
   ```
 
-  ### Only display task IDs
+  ### <a name="quiet"></a> Only display task IDs (-q, --quiet)
 
   The `-q ` or `--quiet` option only shows IDs of the tasks in the stack.
   This example outputs all task IDs of the "voting" stack;

--- a/_data/engine-cli/docker_stack_services.yaml
+++ b/_data/engine-cli/docker_stack_services.yaml
@@ -76,7 +76,7 @@ examples: |-
   dn7m7nhhfb9y  myapp_db        1/1       mysql@sha256:a9a5b559f8821fe73d58c3606c812d1c044868d42c63817fa5125fd9d8b7b539
   ```
 
-  ### Filtering
+  ### <a name="filter"></a> Filtering (--filter)
 
   The filtering flag (`-f` or `--filter`) format is a `key=value` pair. If there
   is more than one filter, then pass multiple flags (e.g. `--filter "foo=bar" --filter "bif=baz"`).
@@ -113,7 +113,7 @@ examples: |-
     * Swarm: not supported
     * Kubernetes: supported
 
-  ### Formatting
+  ### <a name="format"></a> Format the output (--format)
 
   The formatting options (`--format`) pretty-prints services output
   using a Go template.

--- a/_data/engine-cli/docker_stats.yaml
+++ b/_data/engine-cli/docker_stats.yaml
@@ -81,7 +81,7 @@ examples: |-
   4bda148efbc0        random.1.vnc8on831idyr42slu578u3cr      0.00%               1.672MiB / 1.952GiB   0.08%               110kB / 0B          578kB / 0B          2
   ```
 
-  If you don't [specify a format string using `--format`](#formatting), the
+  If you don't [specify a format string using `--format`](#format), the
   following columns are shown.
 
   | Column name               | Description                                                                                   |
@@ -149,7 +149,7 @@ examples: |-
   9db7aa4d986d        mad_wilson          9.59%               40.09 MiB           27.6 kB / 8.81 kB   17 MB / 20.1 MB
   ```
 
-  ### Formatting
+  ### <a name="format"></a> Format the output (--format)
 
   The formatting option (`--format`) pretty prints container output
   using a Go template.

--- a/_data/engine-cli/docker_swarm_ca.yaml
+++ b/_data/engine-cli/docker_swarm_ca.yaml
@@ -128,7 +128,7 @@ examples: |-
   -----END CERTIFICATE-----
   ```
 
-  ### `--rotate`
+  ### <a name="rotate"></a> Root CA rotation (--rotate)
 
   Root CA Rotation is recommended if one or more of the swarm managers have been
   compromised, so that those managers can no longer connect to or be trusted by
@@ -151,7 +151,7 @@ examples: |-
   see if any nodes are down or otherwise unable to rotate TLS certificates.
 
 
-  ### `--detach`
+  ### <a name="detach"></a> Run root CA rotation in detached mode (--detach)
 
   Initiate the root CA rotation, but do not wait for the completion of or display the
   progress of the rotation.

--- a/_data/engine-cli/docker_system_events.yaml
+++ b/_data/engine-cli/docker_system_events.yaml
@@ -19,6 +19,7 @@ long: |-
   - `die`
   - `exec_create`
   - `exec_detach`
+  - `exec_die`
   - `exec_start`
   - `export`
   - `health_status`
@@ -97,7 +98,7 @@ long: |-
   seconds (aka Unix epoch or Unix time), and the optional .nanoseconds field is a
   fraction of a second no more than nine digits long.
 
-  #### Filtering
+  #### <a name="filter"></a> Filtering (--filter)
 
   The filtering flag (`-f` or `--filter`) format is of "key=value". If you would
   like to use multiple filters, pass multiple flags (e.g.,
@@ -122,16 +123,6 @@ long: |-
   * plugin (`plugin=<name or id>`)
   * type (`type=<container or image or volume or network or daemon or plugin>`)
   * volume (`volume=<name or id>`)
-
-  #### Format
-
-  If a format (`--format`) is specified, the given template will be executed
-  instead of the default
-  format. Go's [text/template](https://golang.org/pkg/text/template/) package
-  describes all the details of the format.
-
-  If a format is set to `{{json .}}`, the events are streamed as valid JSON
-  Lines. For information about JSON Lines, please refer to https://jsonlines.org/ .
 usage: docker system events [OPTIONS]
 pname: docker system
 plink: docker_system.yaml
@@ -306,8 +297,8 @@ examples: |-
 
   $ docker system events --filter 'container=container_1' --filter 'container=container_2'
 
-  2014-09-03T15:49:29.999999999Z07:00 container die 4386fb97867d (image=ubuntu-1:14.04)
-  2014-05-10T17:42:14.999999999Z07:00 container stop 4386fb97867d (image=ubuntu-1:14.04)
+  2014-09-03T15:49:29.999999999Z07:00 container die 4386fb97867d (image=ubuntu:22.04  )
+  2014-05-10T17:42:14.999999999Z07:00 container stop 4386fb97867d (image=ubuntu:22.04  )
   2014-05-10T17:42:14.999999999Z07:00 container die 7805c1d35632 (imager=redis:2.8)
   2014-09-03T15:49:29.999999999Z07:00 container stop 7805c1d35632 (image=redis:2.8)
 
@@ -329,7 +320,11 @@ examples: |-
   2016-07-25T17:30:14.888127370Z plugin enable ec7b87f2ce84330fe076e666f17dfc049d2d7ae0b8190763de94e1f2d105993f (name=tiborvass/sample-volume-plugin:latest)
   ```
 
-  ### Format the output
+  ### <a name="format"></a> Format the output (--format)
+
+  If a format (`--format`) is specified, the given template will be executed
+  instead of the default format. Go's [text/template](https://golang.org/pkg/text/template/)
+  package describes all the details of the format.
 
   ```console
   $ docker system events --filter 'type=container' --format 'Type={{.Type}}  Status={{.Status}}  ID={{.ID}}'
@@ -343,6 +338,9 @@ examples: |-
   ```
 
   #### Format as JSON
+
+  If a format is set to `{{json .}}`, the events are streamed as valid JSON
+  Lines. For information about JSON Lines, please refer to https://jsonlines.org/ .
 
   ```console
   $ docker system events --format '{{json .}}'

--- a/_data/engine-cli/docker_system_prune.yaml
+++ b/_data/engine-cli/docker_system_prune.yaml
@@ -117,7 +117,7 @@ examples: |-
   Total reclaimed space: 13.5 MB
   ```
 
-  ### Filtering
+  ### <a name="filter"></a> Filtering (--filter)
 
   The filtering flag (`--filter`) format is of "key=value". If there is more
   than one filter, then pass multiple flags (e.g., `--filter "foo=bar" --filter "bif=baz"`)

--- a/_data/engine-cli/docker_update.yaml
+++ b/_data/engine-cli/docker_update.yaml
@@ -163,7 +163,7 @@ options:
 examples: |-
   The following sections illustrate ways to use this command.
 
-  ### Update a container's cpu-shares
+  ### <a name="cpu-shares"></a> Update a container's cpu-shares (--cpu-shares)
 
   To limit a container's cpu-shares to 512, first identify the container
   name or ID. You can use `docker ps` to find these values. You can also
@@ -173,7 +173,7 @@ examples: |-
   $ docker update --cpu-shares 512 abebf7571666
   ```
 
-  ### Update a container with cpu-shares and memory
+  ### <a name="memory"></a> Update a container with cpu-shares and memory (-m, --memory)
 
   To update multiple resource configurations for multiple containers:
 
@@ -181,7 +181,7 @@ examples: |-
   $ docker update --cpu-shares 512 -m 300M abebf7571666 hopeful_morse
   ```
 
-  ### Update a container's kernel memory constraints
+  ### <a name="kernel-memory"></a> Update a container's kernel memory constraints (--kernel-memory)
 
   You can update a container's kernel memory limit using the `--kernel-memory`
   option. On kernel version older than 4.6, this option can be updated on a
@@ -218,7 +218,7 @@ examples: |-
   Kernel version newer than (include) 4.6 does not have this limitation, you
   can use `--kernel-memory` the same way as other options.
 
-  ### Update a container's restart policy
+  ### <a name="restart"></a> Update a container's restart policy (--restart)
 
   You can change a container's restart policy on a running container. The new
   restart policy takes effect instantly after you run `docker update` on a

--- a/_data/engine-cli/docker_version.yaml
+++ b/_data/engine-cli/docker_version.yaml
@@ -1,11 +1,101 @@
 command: docker version
 short: Show the Docker version information
 long: |-
-  By default, this will render all version information in an easy to read
-  layout. If a format is specified, the given template will be executed instead.
+  The version command prints the current version number for all independently
+  versioned Docker components. Use the [`--format`](#format) option to customize
+  the output.
 
-  Go's [text/template](https://golang.org/pkg/text/template/) package
-  describes all the details of the format.
+  The version command (`docker version`) outputs the version numbers of Docker
+  components, while the `--version` flag (`docker --version`) outputs the version
+  number of the Docker CLI you are using.
+
+  ### Default output
+
+  The default output renders all version information divided into two sections;
+  the "Client" section contains information about the Docker CLI and client
+  components, and the "Server" section contains information about the Docker
+  Engine and components used by the Engine, such as the "Containerd" and "Runc"
+  OCI Runtimes.
+
+  The information shown may differ depending on how you installed Docker and
+  what components are in use. The following example shows the output on a macOS
+  machine running Docker Desktop:
+
+  ```console
+  $ docker version
+
+  Client:
+   Version:           20.10.16
+   API version:       1.41
+   Go version:        go1.17.10
+   Git commit:        aa7e414
+   Built:             Thu May 12 09:17:28 2022
+   OS/Arch:           darwin/amd64
+   Context:           default
+
+  Server: Docker Desktop 4.8.2 (77141)
+   Engine:
+    Version:          20.10.16
+    API version:      1.41 (minimum version 1.12)
+    Go version:       go1.17.10
+    Git commit:       f756502
+    Built:            Thu May 12 09:15:33 2022
+    OS/Arch:          linux/amd64
+    Experimental:     false
+   containerd:
+    Version:          1.6.4
+    GitCommit:        212e8b6fa2f44b9c21b2798135fc6fb7c53efc16
+   runc:
+    Version:          1.1.1
+    GitCommit:        v1.1.1-0-g52de29d
+   docker-init:
+    Version:          0.19.0
+    GitCommit:        de40ad0
+  ```
+
+  ### Client and server versions
+
+  Docker uses a client/server architecture, which allows you to use the Docker CLI
+  on your local machine to control a Docker Engine running on a remote machine,
+  which can be (for example) a machine running in the Cloud or inside a Virtual Machine.
+
+  The following example switches the Docker CLI to use a [context](context.md)
+  named "remote-test-server", which runs an older version of the Docker Engine
+  on a Linux server:
+
+  ```console
+  $ docker context use remote-test-server
+  remote-test-server
+
+  $ docker version
+
+  Client:
+   Version:           20.10.16
+   API version:       1.40 (downgraded from 1.41)
+   Go version:        go1.17.10
+   Git commit:        aa7e414
+   Built:             Thu May 12 09:17:28 2022
+   OS/Arch:           darwin/amd64
+   Context:           remote-test-server
+
+  Server: Docker Engine - Community
+   Engine:
+    Version:          19.03.8
+    API version:      1.40 (minimum version 1.12)
+    Go version:       go1.12.17
+    Git commit:       afacb8b
+    Built:            Wed Mar 11 01:29:16 2020
+    OS/Arch:          linux/amd64
+   containerd:
+    Version:          v1.2.13
+    GitCommit:        7ad184331fa3e55e52b890ea95e65ba581ae3429
+   runc:
+    Version:          1.0.0-rc10
+    GitCommit:        dc9208a3303feef5b3839f4323d9beb36df0a9dd
+   docker-init:
+    Version:          0.18.0
+    GitCommit:        fec3683
+  ```
 usage: docker version [OPTIONS]
 pname: docker
 plink: docker.yaml
@@ -28,47 +118,19 @@ options:
   kubernetes: true
   swarm: false
 examples: |-
-  ### Default output
+  ### <a name="format"></a> Format the output (--format)
 
-  ```console
-  $ docker version
-
-  Client:
-   Version:           19.03.8
-   API version:       1.40
-   Go version:        go1.12.17
-   Git commit:        afacb8b
-   Built:             Wed Mar 11 01:21:11 2020
-   OS/Arch:           darwin/amd64
-   Context:           default
-   Experimental:      true
-
-  Server:
-   Engine:
-    Version:          19.03.8
-    API version:      1.40 (minimum version 1.12)
-    Go version:       go1.12.17
-    Git commit:       afacb8b
-    Built:            Wed Mar 11 01:29:16 2020
-    OS/Arch:          linux/amd64
-    Experimental:     true
-   containerd:
-    Version:          v1.2.13
-    GitCommit:        7ad184331fa3e55e52b890ea95e65ba581ae3429
-   runc:
-    Version:          1.0.0-rc10
-    GitCommit:        dc9208a3303feef5b3839f4323d9beb36df0a9dd
-   docker-init:
-    Version:          0.18.0
-    GitCommit:        fec3683
-  ```
+  The formatting option (`--format`) pretty-prints the output using a Go template,
+  which allows you to customize the output format, or to obtain specific information
+  from the output. Refer to the [format command and log output](https://docs.docker.com/config/formatting/)
+  page for details of the format.
 
   ### Get the server version
 
   ```console
   $ docker version --format '{{.Server.Version}}'
 
-  19.03.8
+  20.10.16
   ```
 
   ### Dump raw JSON data

--- a/_data/engine-cli/docker_volume_create.yaml
+++ b/_data/engine-cli/docker_volume_create.yaml
@@ -72,7 +72,7 @@ examples: |-
   If you specify a volume name already in use on the current driver, Docker
   assumes you want to re-use the existing volume and does not return an error.
 
-  ### Driver-specific options
+  ### <a name="opt"></a> Driver-specific options (-o, --opt)
 
   Some volume drivers may take options to customize the volume creation. Use the
   `-o` or `--opt` flags to pass driver options:

--- a/_data/engine-cli/docker_volume_inspect.yaml
+++ b/_data/engine-cli/docker_volume_inspect.yaml
@@ -48,6 +48,8 @@ examples: |-
   ]
   ```
 
+  ### <a name="format"></a> Format the output (--format)
+
   Use the `--format` flag to format the output using a Go template, for example,
   to print the `Mountpoint` property:
 

--- a/_data/engine-cli/docker_volume_ls.yaml
+++ b/_data/engine-cli/docker_volume_ls.yaml
@@ -3,7 +3,7 @@ aliases: list
 short: List volumes
 long: |-
   List all the volumes known to Docker. You can filter using the `-f` or
-  `--filter` flag. Refer to the [filtering](#filtering) section for more
+  `--filter` flag. Refer to the [filtering](#filter) section for more
   information about available filter options.
 usage: docker volume ls [OPTIONS]
 pname: docker volume
@@ -55,7 +55,7 @@ examples: |-
   local               tyler
   ```
 
-  ### Filtering
+  ### <a name="filter"></a> Filtering (--filter)
 
   The filtering flag (`-f` or `--filter`) format is of "key=value". If there is more
   than one filter, then pass multiple flags (e.g., `--filter "foo=bar" --filter "bif=baz"`)
@@ -155,7 +155,7 @@ examples: |-
   local               rosemary
   ```
 
-  ### Formatting
+  ### <a name="format"></a> Format the output (--format)
 
   The formatting options (`--format`) pretty-prints volumes output
   using a Go template.

--- a/_data/engine-cli/docker_volume_prune.yaml
+++ b/_data/engine-cli/docker_volume_prune.yaml
@@ -36,6 +36,20 @@ examples: |-
 
   Total reclaimed space: 36 B
   ```
+
+  ### <a name="filter"></a> Filtering (--filter)
+
+  The filtering flag (`--filter`) format is of "key=value". If there is more
+  than one filter, then pass multiple flags (e.g., `--filter "foo=bar" --filter "bif=baz"`)
+
+  The currently supported filters are:
+
+  * label (`label=<key>`, `label=<key>=<value>`, `label!=<key>`, or `label!=<key>=<value>`) - only remove volumes with (or without, in case `label!=...` is used) the specified labels.
+
+  The `label` filter accepts two formats. One is the `label=...` (`label=<key>` or `label=<key>=<value>`),
+  which removes volumes with the specified labels. The other
+  format is the `label!=...` (`label!=<key>` or `label!=<key>=<value>`), which removes
+  volumes without the specified labels.
 deprecated: false
 min_api_version: "1.25"
 experimental: false

--- a/build/building/packaging.md
+++ b/build/building/packaging.md
@@ -36,7 +36,7 @@ without having to specify additional command flags.
 Some projects may need distinct Dockerfiles for specific purposes. A common
 convention is to name these `<something>.Dockerfile`. Such Dockerfiles can then
 be used through the `--file` (or `-f` shorthand) option on the `docker build` command.
-Refer to the ["Specify a Dockerfile" section](../../engine/reference/commandline/build.md#specify-a-dockerfile--f)
+Refer to the ["Specify a Dockerfile" section](../../engine/reference/commandline/build.md#file)
 in the `docker build` reference to learn about the `--file` option.
 
 > **Note**

--- a/compose/compose-file/compose-file-v2.md
+++ b/compose/compose-file/compose-file-v2.md
@@ -271,7 +271,7 @@ An entry with the ip address and hostname is created in `/etc/hosts` inside cont
 Specify a build’s container isolation technology. On Linux, the only supported value
 is `default`. On Windows, acceptable values are `default`, `process` and
 `hyperv`. Refer to the
-[Docker Engine docs](../../engine/reference/commandline/run.md#specify-isolation-technology-for-container---isolation)
+[Docker Engine docs](../../engine/reference/commandline/run.md#isolation)
 for details.
 
 If unspecified, Compose will use the `isolation` value found in the service's definition
@@ -898,7 +898,7 @@ services:
 Specify a container’s isolation technology. On Linux, the only supported value
 is `default`. On Windows, acceptable values are `default`, `process` and
 `hyperv`. Refer to the
-[Docker Engine docs](../../engine/reference/commandline/run.md#specify-isolation-technology-for-container---isolation)
+[Docker Engine docs](../../engine/reference/commandline/run.md#isolation)
 for details.
 
 ### labels

--- a/compose/compose-file/compose-file-v3.md
+++ b/compose/compose-file/compose-file-v3.md
@@ -792,9 +792,9 @@ services:
 
 Specify placement of constraints and preferences. See the docker service create
 documentation for a full description of the syntax and available types of
-[constraints](../../engine/reference/commandline/service_create.md#specify-service-constraints---constraint),
-[preferences](../../engine/reference/commandline/service_create.md#specify-service-placement-preferences---placement-pref),
-and [specifying the maximum replicas per node](../../engine/reference/commandline/service_create.md#specify-maximum-replicas-per-node---replicas-max-per-node)
+[constraints](../../engine/reference/commandline/service_create.md#constraint),
+[preferences](../../engine/reference/commandline/service_create.md#placement-pref),
+and [specifying the maximum replicas per node](../../engine/reference/commandline/service_create.md#replicas-max-per-node)
 
 ```yaml
 version: "{{ site.compose_file_v3 }}"
@@ -814,7 +814,7 @@ services:
 
 > Added in [version 3.8](compose-versioning.md#version-38) file format.
 
-If the service is `replicated` (which is the default), [limit the number of replicas](../../engine/reference/commandline/service_create.md#specify-maximum-replicas-per-node---replicas-max-per-node)
+If the service is `replicated` (which is the default), [limit the number of replicas](../../engine/reference/commandline/service_create.md#replicas-max-per-node)
 that can run on a node at any time.
 
 When there are more tasks requested than running nodes, an error
@@ -1343,7 +1343,7 @@ services:
 Specify a container’s isolation technology. On Linux, the only supported value
 is `default`. On Windows, acceptable values are `default`, `process` and
 `hyperv`. Refer to the
-[Docker Engine docs](../../engine/reference/commandline/run.md#specify-isolation-technology-for-container---isolation)
+[Docker Engine docs](../../engine/reference/commandline/run.md#isolation)
 for details.
 
 ### labels
@@ -1908,7 +1908,7 @@ sysctls:
 You can only use sysctls that are namespaced in the kernel. Docker does not
 support changing sysctls inside a container that also modify the host system.
 For an overview of supported sysctls, refer to
-[configure namespaced kernel parameters (sysctls) at runtime](../../engine/reference/commandline/run.md#configure-namespaced-kernel-parameters-sysctls-at-runtime).
+[configure namespaced kernel parameters (sysctls) at runtime](../../engine/reference/commandline/run.md#sysctl).
 
 > Note when using docker stack deploy
 >

--- a/compose/compose-file/index.md
+++ b/compose/compose-file/index.md
@@ -1756,7 +1756,7 @@ sysctls:
 You can only use sysctls that are namespaced in the kernel. Docker does not
 support changing sysctls inside a container that also modify the host system.
 For an overview of supported sysctls, refer to [configure namespaced kernel
-parameters (sysctls) at runtime](/engine/reference/commandline/run/#configure-namespaced-kernel-parameters-sysctls-at-runtime).
+parameters (sysctls) at runtime](/engine/reference/commandline/run/#sysctl).
 
 ### tmpfs
 

--- a/config/containers/container-networking.md
+++ b/config/containers/container-networking.md
@@ -65,7 +65,7 @@ use Docker's embedded DNS server, which forwards external DNS lookups to the DNS
 servers configured on the host.
 
 Custom hosts defined in `/etc/hosts` are not inherited. To pass additional hosts
-into your container, refer to [add entries to container hosts file](../../engine/reference/commandline/run.md#add-entries-to-container-hosts-file---add-host)
+into your container, refer to [add entries to container hosts file](../../engine/reference/commandline/run.md#add-host)
 in the `docker run` reference documentation. You can override these settings on
 a per-container basis.
 

--- a/config/labels-custom-metadata.md
+++ b/config/labels-custom-metadata.md
@@ -79,10 +79,10 @@ Labels on swarm nodes and services can be updated dynamically.
 
 - Images and containers
   - [Adding labels to images](../engine/reference/builder.md#label)
-  - [Overriding a container's labels at runtime](../engine/reference/commandline/run.md#set-metadata-on-container--l---label---label-file)
+  - [Overriding a container's labels at runtime](../engine/reference/commandline/run.md#label)
   - [Inspecting labels on images or containers](../engine/reference/commandline/inspect.md)
-  - [Filtering images by label](../engine/reference/commandline/images.md#filtering)
-  - [Filtering containers by label](../engine/reference/commandline/ps.md#filtering)
+  - [Filtering images by label](../engine/reference/commandline/images.md#filter)
+  - [Filtering containers by label](../engine/reference/commandline/ps.md#filter)
 
 - Local Docker daemons
   - [Adding labels to a Docker daemon at runtime](../engine/reference/commandline/dockerd.md)
@@ -91,20 +91,20 @@ Labels on swarm nodes and services can be updated dynamically.
 - Volumes
   - [Adding labels to volumes](../engine/reference/commandline/volume_create.md)
   - [Inspecting a volume's labels](../engine/reference/commandline/volume_inspect.md)
-  - [Filtering volumes by label](../engine/reference/commandline/volume_ls.md#filtering)
+  - [Filtering volumes by label](../engine/reference/commandline/volume_ls.md#filter)
 
 - Networks
   - [Adding labels to a network](../engine/reference/commandline/network_create.md)
   - [Inspecting a network's labels](../engine/reference/commandline/network_inspect.md)
-  - [Filtering networks by label](../engine/reference/commandline/network_ls.md#filtering)
+  - [Filtering networks by label](../engine/reference/commandline/network_ls.md#filter)
 
 - Swarm nodes
-  - [Adding or updating a swarm node's labels](../engine/reference/commandline/node_update.md#add-label-metadata-to-a-node)
+  - [Adding or updating a swarm node's labels](../engine/reference/commandline/node_update.md#label-add)
   - [Inspecting a swarm node's labels](../engine/reference/commandline/node_inspect.md)
-  - [Filtering swarm nodes by label](../engine/reference/commandline/node_ls.md#filtering)
+  - [Filtering swarm nodes by label](../engine/reference/commandline/node_ls.md#filter)
 
 - Swarm services
-  - [Adding labels when creating a swarm service](../engine/reference/commandline/service_create.md#set-metadata-on-a-service--l---label)
+  - [Adding labels when creating a swarm service](../engine/reference/commandline/service_create.md#label)
   - [Updating a swarm service's labels](../engine/reference/commandline/service_update.md)
   - [Inspecting a swarm service's labels](../engine/reference/commandline/service_inspect.md)
-  - [Filtering swarm services by label](../engine/reference/commandline/service_ls.md#filtering)
+  - [Filtering swarm services by label](../engine/reference/commandline/service_ls.md#filter)

--- a/docker-hub/builds/advanced.md
+++ b/docker-hub/builds/advanced.md
@@ -113,7 +113,7 @@ $ docker build --build-arg CUSTOM=$VAR -f $DOCKERFILE_PATH -t $IMAGE_NAME .
 used by the builder, so you must include a similar build command in the hook or
 the automated build fails.
 
-Refer to the [docker build documentation](../../engine/reference/commandline/build.md#set-build-time-variables---build-arg)
+Refer to the [docker build documentation](../../engine/reference/commandline/build.md#build-arg)
 to learn more about Docker build-time variables.
 
 #### Push to multiple repos

--- a/engine/swarm/secrets.md
+++ b/engine/swarm/secrets.md
@@ -118,8 +118,8 @@ Use these links to read about specific commands, or continue to the
 - [`docker secret inspect`](../reference/commandline/secret_inspect.md)
 - [`docker secret ls`](../reference/commandline/secret_ls.md)
 - [`docker secret rm`](../reference/commandline/secret_rm.md)
-- [`--secret`](../reference/commandline/service_create.md#create-a-service-with-secrets) flag for `docker service create`
-- [`--secret-add` and `--secret-rm`](../reference/commandline/service_update.md#add-or-remove-secrets) flags for `docker service update`
+- [`--secret`](../reference/commandline/service_create.md#secret) flag for `docker service create`
+- [`--secret-add` and `--secret-rm`](../reference/commandline/service_update.md#secret-add) flags for `docker service update`
 
 ## Examples
 


### PR DESCRIPTION
- relates to / in preparation of https://github.com/docker/docs/pull/16416
- relates to https://github.com/docker/cli/pull/3924
- relates to / depends on https://github.com/docker/cli/pull/3525


This updates the engine reference documentation with the changes from https://github.com/docker/cli/pull/3525. We're using the new anchor tags for the upcoming 23.0 release, and this PR prepares changes related to that, so that updating the docs for v23.0.0 will be easier (all things already updated)..

Once these changes are in, we can also fix the buildx docs to point to the new anchor tags, and remove the htmlproofer exclusion.

