### PR TITLE
htmlproofer: add temporary exclusion rules to help with migration to new anchor links in reference

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -65,11 +65,12 @@ EOT
 
 # htmlproofer checks for broken links
 FROM gem AS htmlproofer-base
+# FIXME(thaJeztah): remove temporary exclusion rule for buildx_build once anchor links are updated.
 RUN --mount=type=bind,from=generate,source=/out,target=_site <<EOF
   htmlproofer ./_site \
     --disable-external \
     --internal-domains="docs.docker.com,docs-stage.docker.com,localhost:4000" \
-    --file-ignore="/^./_site/engine/api/.*$/,./_site/registry/configuration/index.html" \
+    --file-ignore="/^./_site/engine/api/.*$/,./_site/registry/configuration/index.html,./_site/engine/reference/commandline/buildx_build/index.html" \
     --url-ignore="/^/docker-hub/api/latest/.*$/,/^/engine/api/v.+/#.*$/,/^/glossary/.*$/" > /results 2>&1
   rc=$?
   if [[ $rc -eq 0 ]]; then

--- a/Dockerfile
+++ b/Dockerfile
@@ -66,11 +66,12 @@ EOT
 # htmlproofer checks for broken links
 FROM gem AS htmlproofer-base
 # FIXME(thaJeztah): remove temporary exclusion rule for buildx_build once anchor links are updated.
+# FIXME(thaJeztah): remove temporary exclusion rule for commandline/cli once https://github.com/docker/cli/pull/3525 is merged.
 RUN --mount=type=bind,from=generate,source=/out,target=_site <<EOF
   htmlproofer ./_site \
     --disable-external \
     --internal-domains="docs.docker.com,docs-stage.docker.com,localhost:4000" \
-    --file-ignore="/^./_site/engine/api/.*$/,./_site/registry/configuration/index.html,./_site/engine/reference/commandline/buildx_build/index.html" \
+    --file-ignore="/^./_site/engine/api/.*$/,./_site/registry/configuration/index.html,./_site/engine/reference/commandline/buildx_build/index.html,./_site/engine/reference/commandline/cli/index.html" \
     --url-ignore="/^/docker-hub/api/latest/.*$/,/^/engine/api/v.+/#.*$/,/^/glossary/.*$/" > /results 2>&1
   rc=$?
   if [[ $rc -eq 0 ]]; then


### PR DESCRIPTION
- relates to https://github.com/docker/docs/pull/16460
- relates to https://github.com/docker/docs/pull/16416
- relates to https://github.com/docker/cli/pull/3924
- relates to https://github.com/docker/cli/pull/3525

