### PR TITLE
Bake target interpolation

### DIFF
--- a/build/bake/compose-file.md
+++ b/build/bake/compose-file.md
@@ -40,6 +40,7 @@ services:
 ```console
 $ docker buildx bake --print
 ```
+
 ```json
 {
   "group": {
@@ -124,6 +125,7 @@ TAG=v1.1.0
 ```console
 $ docker buildx bake --print
 ```
+
 ```json
 {
   "group": {
@@ -200,6 +202,7 @@ services:
 ```console
 $ docker buildx bake --print
 ```
+
 ```json
 {
   "group": {

--- a/build/bake/configuring-build.md
+++ b/build/bake/configuring-build.md
@@ -38,6 +38,7 @@ You can use this file directly:
 ```console
 $ docker buildx bake --print app
 ```
+
 ```json
 {
   "group": {
@@ -72,6 +73,7 @@ And invoke bake together with both of the files:
 ```console
 $ docker buildx bake -f docker-bake.hcl -f env.hcl --print app
 ```
+
 ```json
 {
   "group": {
@@ -113,6 +115,7 @@ You can use this file directly:
 ```console
 $ docker buildx bake --print foo bar
 ```
+
 ```json
 {
   "group": {
@@ -159,6 +162,7 @@ target "app" {
 ```console
 $ docker buildx bake --set app.args.mybuildarg=bar --set app.platform=linux/arm64 app --print
 ```
+
 ```json
 {
   "group": {
@@ -247,6 +251,7 @@ target "app" {
 ```console
 $ docker buildx bake -f docker-bake1.hcl -f docker-bake2.hcl --print app
 ```
+
 ```json
 {
   "group": {

--- a/build/bake/configuring-build.md
+++ b/build/bake/configuring-build.md
@@ -93,6 +93,55 @@ $ docker buildx bake -f docker-bake.hcl -f env.hcl --print app
 }
 ```
 
+You can also refer to attributes defined as part of other targets, to help
+reduce duplication between targets.
+
+```hcl
+# docker-bake.hcl
+target "foo" {
+  dockerfile = "${target.foo.name}.Dockerfile"
+  tags       = [target.foo.name]
+}
+target "bar" {
+  dockerfile = "${target.foo.name}.Dockerfile"
+  tags       = [target.bar.name]
+}
+```
+
+You can use this file directly:
+
+```console
+$ docker buildx bake --print foo bar
+```
+```json
+{
+  "group": {
+    "default": {
+      "targets": [
+        "foo",
+        "bar"
+      ]
+    }
+  },
+  "target": {
+    "foo": {
+      "context": ".",
+      "dockerfile": "foo.Dockerfile",
+      "tags": [
+        "foo"
+      ]
+    },
+    "bar": {
+      "context": ".",
+      "dockerfile": "foo.Dockerfile",
+      "tags": [
+        "bar"
+      ]
+    }
+  }
+}
+```
+
 ## From command line
 
 You can also override target configurations from the command line with the

--- a/build/bake/configuring-build.md
+++ b/build/bake/configuring-build.md
@@ -5,8 +5,8 @@ redirect_from:
 - /build/customize/bake/configuring-build/
 ---
 
-Bake supports loading build definition from files, but sometimes you need even
-more flexibility to configure this definition.
+Bake supports loading build definitions from files, but sometimes you need even
+more flexibility to configure these definitions.
 
 For this use case, you can define variables inside the bake files that can be
 set by the user with environment variables or by [attribute definitions](#global-scope-attributes)

--- a/build/bake/file-definition.md
+++ b/build/bake/file-definition.md
@@ -328,6 +328,7 @@ $ docker buildx bake "https://github.com/docker/cli.git#v20.10.11" --print
 #1 2.022  * [new tag]         v20.10.11  -> v20.10.11
 #1 DONE 2.9s
 ```
+
 ```json
 {
   "group": {
@@ -383,6 +384,7 @@ EOT
 ```console
 $ docker buildx bake "https://github.com/tonistiigi/buildx.git#remote-test" --print
 ```
+
 ```json
 {
   "target": {
@@ -414,6 +416,7 @@ $ docker buildx bake "https://github.com/tonistiigi/buildx.git#remote-test" "htt
 #1 0.429 577303add004dd7efeb13434d69ea030d35f7888       refs/heads/remote-test
 #1 CACHED
 ```
+
 ```json
 {
   "target": {

--- a/build/bake/hcl-funcs.md
+++ b/build/bake/hcl-funcs.md
@@ -51,6 +51,7 @@ alternatively, in json format:
 ```console
 $ docker buildx bake --print webapp
 ```
+
 ```json
 {
   "group": {
@@ -75,6 +76,7 @@ $ docker buildx bake --print webapp
 ```console
 $ TAG=$(git rev-parse --short HEAD) docker buildx bake --print webapp
 ```
+
 ```json
 {
   "group": {
@@ -121,6 +123,7 @@ target "webapp" {
 ```console
 $ docker buildx bake --print webapp
 ```
+
 ```json
 {
   "group": {
@@ -168,6 +171,7 @@ target "webapp" {
 ```console
 $ docker buildx bake --print webapp
 ```
+
 ```json
 {
   "group": {
@@ -217,6 +221,7 @@ target "webapp" {
 ```console
 $ docker buildx bake --print webapp
 ```
+
 ```json
 {
   "group": {
@@ -262,6 +267,7 @@ target "webapp" {
 ```console
 $ docker buildx bake --print webapp
 ```
+
 ```json
 {
   "group": {
@@ -309,6 +315,7 @@ target "app" {
 ```console
 $ docker buildx bake --print app
 ```
+
 ```json
 {
   "group": {

--- a/config/containers/logging/splunk.md
+++ b/config/containers/logging/splunk.md
@@ -131,6 +131,7 @@ For example:
     "line": "my message"
 }
 ```
+
 ```json
 {
     "attrs": {
@@ -161,6 +162,7 @@ object. If it cannot parse the message, it is sent `inline`. For example:
     "line": "my message"
 }
 ```
+
 ```json
 {
     "attrs": {


### PR DESCRIPTION
Document resource interpolation support implemented in https://github.com/docker/buildx/pull/1434, to be released in Buildx v0.10.