### PR TITLE
install: remove redundant & mismatched versions

### DIFF
--- a/desktop/install/mac-install.md
+++ b/desktop/install/mac-install.md
@@ -42,7 +42,7 @@ Your Mac must meet the following requirements to install Docker Desktop successf
 
   > **Note**
   >
-  > Docker supports Docker Desktop on the most recent versions of macOS. That is, the current release of macOS and the previous two releases. As new major versions of macOS are made generally available, Docker stops supporting the oldest version and supports the newest version of macOS (in addition to the previous two releases). Docker Desktop currently supports macOS Catalina, macOS Big Sur, and macOS Monterey.
+  > Docker supports Docker Desktop on the most recent versions of macOS. That is, the current release of macOS and the previous two releases. As new major versions of macOS are made generally available, Docker stops supporting the oldest version and supports the newest version of macOS (in addition to the previous two releases).
 
 - At least 4 GB of RAM.
 


### PR DESCRIPTION
### Proposed changes
We list the supported versions and then have an info panel noting our macOS support policy. At the end of this, it then repeated the supported versions. However, this list was out of sync with the one immediately preceding it. Rather than fix it, I removed the sentence entirely as it's literally the bullet point it's providing clarification on in the first place.

### Related issues (optional)
N/A