### PR TITLE
Update networkingcontainers.md

### DIFF
--- a/engine/tutorials/networkingcontainers.md
+++ b/engine/tutorials/networkingcontainers.md
@@ -136,9 +136,9 @@ To build web applications that act in concert but do so securely, create a
 network. Networks, by definition, provide complete isolation for containers. You
 can add containers to a network when you first run a container.
 
-Launch a container running a PostgreSQL database and pass it the `--net=my_bridge` flag to connect it to your new network:
+Launch a container running a PostgreSQL database and pass it the `--network my_bridge` flag to connect it to your new network:
 
-    $ docker run -d --net=my_bridge --name db training/postgres
+    $ docker run -d --network my_bridge --name db training/postgres
 
 If you inspect your `my_bridge` you can see it has a container attached.
 You can also inspect your container to see where it is connected:


### PR DESCRIPTION
The syntax  '_--net=my_bridge_'  is not the same indicated when run Docker cli help.

So the correct is:
```
--network my_bridge
```

<!--
  Thank you for contributing to Docker documentation!

  Here are a few things to keep in mind:

  - Links between pages should use a relative path
  - Remember to add an alt text for images

  ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
  ┃     Review our contribution guidelines:       ┃
  ┃                                               ┃
  ┃ https://docs.docker.com/contribute/overview/  ┃
  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
-->

### Proposed changes

<!-- Tell us what you did and why -->

### Related issues (optional)

<!--
  Refer to related PRs or issues:

  #1234
  Closes #1234
  Closes docker/cli#1234
-->
