### PR TITLE
Document the extension OAuth required API version to 0.3.3, corresponding to Desktop 4.16

### DIFF
--- a/desktop/extensions-sdk/guides/oauth2-flow.md
+++ b/desktop/extensions-sdk/guides/oauth2-flow.md
@@ -55,7 +55,7 @@ window.ddClient.openExternal("https://authorization-server.com/authorize?
 You can get the authorization code from the extension UI by listing `docker-desktop://dashboard/extension-tab?extensionId=awesome/my-extension` as the `redirect_uri` in the OAuth app you're using and concatenating the authorization code as a query parameter. The extension UI code will then be able to read the corresponding code query-param.
 
 > Note
-> using this feature requires the extension SDK 0.3.2 in Docker Desktop. You need to ensure that the required SDK version for your extension set with `com.docker.desktop.extension.api.version` in [image labels](../extensions/labels.md) is higher than 0.3.2.
+> using this feature requires the extension SDK 0.3.3 in Docker Desktop. You need to ensure that the required SDK version for your extension set with `com.docker.desktop.extension.api.version` in [image labels](../extensions/labels.md) is higher than 0.3.3.
 {: .important}
 
 #### Authorization


### PR DESCRIPTION
0.3.2 was an intermediate API version bump before Desktop 4.16 got published. It does work but people might ask why using this and the effective API version seen with Desktop public release is 0.3.3.

Signed-off-by: Guillaume Tardif <guillaume.tardif@gmail.com>

<!--
  Thank you for contributing to Docker documentation!

  Here are a few things to keep in mind:

  - Links between pages should use a relative path
  - Remember to add an alt text for images

  ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
  ┃     Review our contribution guidelines:       ┃
  ┃                                               ┃
  ┃ https://docs.docker.com/contribute/overview/  ┃
  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
-->

### Proposed changes

<!-- Tell us what you did and why -->

### Related issues (optional)

<!--
  Refer to related PRs or issues:

  #1234
  Closes #1234
  Closes docker/cli#1234
-->
