### PR TITLE
Clarify security extension trust model, and move UI specific section in front-end code tutorial

### DIFF
--- a/desktop/extensions-sdk/build/frontend-extension-tutorial.md
+++ b/desktop/extensions-sdk/build/frontend-extension-tutorial.md
@@ -341,6 +341,21 @@ export function App() {
 
 ![Screenshot of the container list.](images/react-extension.png)
 
+## Policies enforced for the front-end code
+
+Extension UI code is rendered in a separate electron session and doesn't have a node.js environment initialized, nor direct access to the electron APIs. 
+
+This is to limit the possible unexpected side effects to the overall Docker Dashboard.
+
+The extension UI code can't perform privileged tasks, such as making changes to the system, or spawning sub-processes, except by using the SDK APIs provided with the extension framework.
+The Extension UI code can also perform interactions with Docker Desktop, such as navigating to various places in the Dashboard, only through the extension SDK APIs.
+
+Extensions UI parts are isolated from each other and extension UI code is running in its own session for each extension. Extensions can't access other extensions’ session data.
+
+`localStorage` is one of the mechanisms of a browser’s web storage. It allows users to save data as key-value pairs in the browser for later use. `localStorage` doesn't clear data when the browser (the extension pane) closes. This makes it ideal for persisting data when navigating out of the extension to other parts of Docker Desktop.
+
+If your extension uses `localStorage` to store data, other extensions running in Docker Desktop can't access the local storage of your extension. The extension’s local storage is persisted even after Docker Desktop is stopped or restarted. When an extension is upgraded, its local storage is persisted, whereas when it is uninstalled, its local storage is completely removed.
+
 ## Re-build the extension and update it
 
 Since you have modified the code of the extension, you must build again the extension.

--- a/desktop/extensions-sdk/guides/security.md
+++ b/desktop/extensions-sdk/guides/security.md
@@ -6,30 +6,17 @@ keywords: Docker, extensions, sdk, security
 
 ## Extension capabilities
 
-An extension can have the following optional parts; a user interface in HTML or JavaScript, a backend part that runs as a container, and executables deployed on the host machine.
+An extension can have the following optional parts: 
+* a user interface in HTML or JavaScript, displayed in Docker Desktop Dashboard
+* a backend part that runs as a container
+* executables deployed on the host machine.
 
-Extensions are executed with the same permissions as the Docker Desktop user. Extension capabilities include running any docker commands (including running containers and mounting folders), running extension binaries, and accessing files on your machine.
+Extensions are executed with the same permissions as the Docker Desktop user. Extension capabilities include running any Docker commands (including running containers and mounting folders), running extension binaries, and accessing files on your machine that are accessible by the user running Docker Desktop.
 
-The Extensions SDK provides a set of JavaScript APIs to invoke commands or execute these binaries from the extension UI code. Extensions can also provide a backend part that starts a long-lived running container in the background.
+The Extensions SDK provides a set of JavaScript APIs to invoke commands or invoke these binaries from the extension UI code. Extensions can also provide a backend part that starts a long-lived running container in the background.
+
+> Note
+> Make sure you trust the publisher or author of the extension when you install it, as the extension has the same access rights as the user running Docker Desktop.
+{: .important}
 
 Learn more in the [architecture section](https://docs.docker.com/desktop/extensions-sdk/architecture/)
-
-An extension's code is loaded into the Docker Desktop UI electron app. The extension UI code is subject to some constraints for security reasons, described below.
-
-## Sandboxing
-
-Extension UI code is rendered in a sandboxed environment and does not have a node.js environment initialized, nor direct access to the electron APIs.
-The extension UI code cannot perform privileged tasks, such as making changes to the system, or spawning subprocesses, except by using the SDK APIs provided with the extension framework.
-It can also perform interactions with Docker Desktop, such as navigating to various places in the Dashboard, only through the extension SDK APIs.
-
-## Extension isolation
-
-Extensions are isolated from each other and extension UI code is running in its own session for each extension. Extensions cannot access other extensions’ session data.
-
-`localStorage` is one of the mechanisms of a browser’s web storage. It allows users to save data as key-value pairs in the browser for later use. `localStorage` does not clear data when the browser (the extension pane) closes. This makes it ideal for persisting data when navigating out of the extension to other parts of Docker Desktop.
-
-If your extension uses `localStorage` to store data, other extensions running in Docker Desktop cannot access the local storage of your extension. The extension’s local storage is persisted even after Docker Desktop is stopped or restarted. When an extension is upgraded, its local storage is persisted, whereas when it is uninstalled, its local storage is completely removed.
-
-## Cross site-scripting
-
-CORS rules are enforced with same-origin policy enabled, so the extension UI code cannot load external scripts.


### PR DESCRIPTION
Signed-off-by: Guillaume Tardif <guillaume.tardif@gmail.com>

<!--
  Thank you for contributing to Docker documentation!

  Here are a few things to keep in mind:

  - Links between pages should use a relative path
  - Remember to add an alt text for images

  ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
  ┃     Review our contribution guidelines:       ┃
  ┃                                               ┃
  ┃ https://docs.docker.com/contribute/overview/  ┃
  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
-->

### Proposed changes

Following discussions with @gabriellavengeo, make the extension security section more explicit, and avoid any wrong assumptions. Move section that does not affect the threat model outside of the security section, in the UI code part and avoid using the term "sandboxing" that might lead to wrong assumptions

<!-- Tell us what you did and why -->

### Related issues (optional)

<!--
  Refer to related PRs or issues:

  #1234
  Closes #1234
  Closes docker/cli#1234
-->
