### PR TITLE
Add docs for new expanded Image Details page

### DIFF
--- a/desktop/use-desktop/images.md
+++ b/desktop/use-desktop/images.md
@@ -41,14 +41,34 @@ When prompted you can either:
 
 ## Inspect an image
 
-Inspecting an image displays detailed information about the image such as the:
+To inspect an image, simply click on the image row. Inspecting an image displays detailed information about the image such as the:
 
 - Image history
 - Image ID
 - Date the image was created
 - Size of the image
+- Layers making up the image
+- Base images used
+- Vulnerabilities found
+- Packages inside the image
 
-To inspect an image, hover over an image, select the **More options** button and then select **View details** from the dropdown menu. 
+### Image Hierarchy
+
+The image you inspect may have one or more base images listed in the Image Hierarchy section. This means the author of the image used another image as a starting point when building the image. Often these base images are either operating system images such as Debian, Ubuntu and Alpine, or programming language images such as php, python, and java. A base image may have it's own parent base image so there is a chain of base images represented in the Image Hierarchy, and clicking on each image in the chain lets you see which layers originate from each base image. Clicking the 'ALL' row brings you back to selecting all the layers and base images for the entire image.
+
+One or more of the base images may have updates available, which may include updated security patches that remove vulnerabilities from your image. Any base images with available updates will be noted on the right-hand side "Images" tab.
+
+### Layers
+
+A Docker image consists of layers. The image layers will be listed top to bottom, with the earliest layer at the top and the most recent layer at the bottom. Often, the layers at the top of the list originate from a base image, and the layers towards the bottom will be layers added by the image author, often by adding commands to a Dockerfile. To see which layers originate from a base image, simply select a base image from the Image Hierarchy view and the relevant layers will be highlighted.
+
+Selecting individual or multiple layers will filter the packages and vulnerabilities on the right-hand side to see what has been added by the selected layers.
+
+### Vulnerabilities
+
+Images may be exposed to vulnerabilities and exploits. These are detected and listed on the right-hand side, grouped by package, and sorted in order of severity. Further information can be examined by expanding the sections such as if the vulnerability has an available fix. For even more details, you can click through to the link on dso.docker.com.
+
+If you have any feedback about this feature can you use the "Give Feedback" link inside Docker Desktop to contact the development team, we would love to hear from you!
 
 ## Pull the latest image from Docker Hub
 

--- a/desktop/use-desktop/images.md
+++ b/desktop/use-desktop/images.md
@@ -41,7 +41,7 @@ When prompted you can either:
 
 ## Inspect an image
 
-To inspect an image, simply click on the image row. Inspecting an image displays detailed information about the image such as the:
+To inspect an image, simply select the image row. Inspecting an image displays detailed information about the image such as the:
 
 - Image history
 - Image ID
@@ -54,21 +54,23 @@ To inspect an image, simply click on the image row. Inspecting an image displays
 
 ### Image Hierarchy
 
-The image you inspect may have one or more base images listed in the Image Hierarchy section. This means the author of the image used another image as a starting point when building the image. Often these base images are either operating system images such as Debian, Ubuntu and Alpine, or programming language images such as php, python, and java. A base image may have it's own parent base image so there is a chain of base images represented in the Image Hierarchy, and clicking on each image in the chain lets you see which layers originate from each base image. Clicking the 'ALL' row brings you back to selecting all the layers and base images for the entire image.
+The image you inspect may have one or more base images listed under **Image hierarchy**. This means the author of the image used another image as a starting point when building the image. Often these base images are either operating system images such as Debian, Ubuntu, and Alpine, or programming language images such as PHP, Python, and Java. 
 
-One or more of the base images may have updates available, which may include updated security patches that remove vulnerabilities from your image. Any base images with available updates will be noted on the right-hand side "Images" tab.
+A base image may have its own parent base image so there is a chain of base images represented in **Image hierarchy**. Selecting each image in the chain lets you see which layers originate from each base image. Selecting the **ALL** row reselects all the layers and base images for the entire image.
+
+One or more of the base images may have updates available, which may include updated security patches that remove vulnerabilities from your image. Any base images with available updates are noted to the right of **Image hierarchy**.
 
 ### Layers
 
-A Docker image consists of layers. The image layers will be listed top to bottom, with the earliest layer at the top and the most recent layer at the bottom. Often, the layers at the top of the list originate from a base image, and the layers towards the bottom will be layers added by the image author, often by adding commands to a Dockerfile. To see which layers originate from a base image, simply select a base image from the Image Hierarchy view and the relevant layers will be highlighted.
+A Docker image consists of layers. Image layers are listed from top to bottom, with the earliest layer at the top and the most recent layer at the bottom. Often, the layers at the top of the list originate from a base image, and the layers towards the bottom are layers added by the image author, often by adding commands to a Dockerfile. To see which layers originate from a base image, simply select a base image under **Image hierarchy** and the relevant layers are highlighted.
 
-Selecting individual or multiple layers will filter the packages and vulnerabilities on the right-hand side to see what has been added by the selected layers.
+Selecting individual or multiple layers filters the packages and vulnerabilities on the right-hand side to see what has been added by the selected layers.
 
 ### Vulnerabilities
 
-Images may be exposed to vulnerabilities and exploits. These are detected and listed on the right-hand side, grouped by package, and sorted in order of severity. Further information can be examined by expanding the sections such as if the vulnerability has an available fix. For even more details, you can click through to the link on dso.docker.com.
+Images may be exposed to vulnerabilities and exploits. These are detected and listed on the right-hand side, grouped by package, and sorted in order of severity. Further information on whether the vulnerability has an available fix, for example, can be examined by expanding the sections. For even more details, you can visit dso.docker.com by selecting the link. 
 
-If you have any feedback about this feature can you use the "Give Feedback" link inside Docker Desktop to contact the development team, we would love to hear from you!
+If you have any feedback about this feature you can use the **Give feedback** link to contact the development team.
 
 ## Pull the latest image from Docker Hub
 


### PR DESCRIPTION
### Proposed changes

Added docs for new expanded Image Details page which now shows vulnerabilities for local docker images.

3 thoughts:
1. I'm wary of adding too much technical information about how images are created, the interaction with base images, hierarchy and security updates. I've tried to strike the right balance but please let me know if any of it is too heavy or light.
2. I haven't added any screenshots. Let me know if this is a good idea. We will be changing the design of this page more in the next few weeks and months so screenshots are likely to be outdated quickly, but maybe an outdated screenshot is better than nothing.
3. This detail could potentially be on it's own page (at some point?). I've left it in place for now. 