### PR TITLE
Update naming of wordsmith sample app

### DIFF
--- a/_data/samples.yaml
+++ b/_data/samples.yaml
@@ -313,8 +313,8 @@ samples:
       - javascript
       - nginx
       - postgresql
-  - title: k8s-wordsmith-demo
-    url: https://github.com/dockersamples/k8s-wordsmith-demo
+  - title: wordsmith
+    url: https://github.com/dockersamples/wordsmith
     description: A demo app that runs three containers, including PostgreSQL, Java, and Go.
     dev_env: false
     services:


### PR DESCRIPTION
### Proposed changes

The wordsmith sample app repo has been renamed, so updating docs to reflect that (old URL will still redirect to the new).

### Related issues (optional)

None