### PR TITLE
Prevent node_modules from override via mount

### DIFF
--- a/language/nodejs/develop.md
+++ b/language/nodejs/develop.md
@@ -140,6 +140,7 @@ services:
    - CONNECTIONSTRING=mongodb://mongo:27017/notes
   volumes:
    - ./:/app
+   - /app/node_modules
   command: npm run debug
 
  mongo:


### PR DESCRIPTION
<!--
  Thank you for contributing to Docker documentation!

  Here are a few things to keep in mind:

  - Links between pages should use a relative path
  - Remember to add an alt text for images

  ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
  ┃     Review our contribution guidelines:       ┃
  ┃                                               ┃
  ┃ https://docs.docker.com/contribute/overview/  ┃
  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
-->

### Proposed changes

In the section `Use Compose to develop locally`, a docker-compose file is shown which mounts the app directory into the `notes` container to be able to change the code without rebuilding the image. Unfortunately, the node_modules directory which was created during the build will be overridden as the whole working directory /app gets mounted. Therefore, this directory needs to be secured by adding it to the volumes.

### Related issues (optional)
Closes #15850

