### PR TITLE
Fix typo in build cache

### DIFF
--- a/build/cache/index.md
+++ b/build/cache/index.md
@@ -264,7 +264,7 @@ RUN echo "the second command"
 ```
 
 It's possible to run both of these commands inside a single `RUN`, which means
-that they will share the same cache! This can is achievable using the `&&` shell
+that they will share the same cache! This is achievable using the `&&` shell
 operator to run one command after another:
 
 ```dockerfile


### PR DESCRIPTION
<!--
  Thank you for contributing to Docker documentation!

  Here are a few things to keep in mind:

  - Links between pages should use a relative path
  - Remember to add an alt text for images

  ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
  ┃     Review our contribution guidelines:       ┃
  ┃                                               ┃
  ┃ https://docs.docker.com/contribute/overview/  ┃
  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
-->

### Proposed changes

Fixed a typo in build cache documentation about merging RUN commands together.

### Related issues (optional)

<!--
  Refer to related PRs or issues:

  #1234
  Closes #1234
  Closes docker/cli#1234
-->
