### PR TITLE
Update develop.md

### DIFF
--- a/language/nodejs/develop.md
+++ b/language/nodejs/develop.md
@@ -139,7 +139,7 @@ services:
    - SERVER_PORT=8000
    - CONNECTIONSTRING=mongodb://mongo:27017/notes
   volumes:
-   - ./:/app
+   - ./:/usr/src/app
   command: npm run debug
 
  mongo:


### PR DESCRIPTION
Node docker-compose.yml no longer works line 142 is the culprit. 
Fix is to ensure the node_modules folder is correct.
It can now be found inside of /usr/src/app 

sample error is:
test-notes-1  | > image@1.0.0 debug
test-notes-1  | > nodemon --inspect=0.0.0.0:9229 server.js test-notes-1  | 
test-notes-1  | sh: 1: nodemon: not found
test-notes-1 exited with code 127


