### PR TITLE
Add release note about minimum version on macos

### DIFF
--- a/desktop/release-notes.md
+++ b/desktop/release-notes.md
@@ -160,6 +160,7 @@ For frequently asked questions about Docker Desktop releases, see [FAQs](faqs/ge
 
 #### For Mac
 
+- Minimum version to install or update Docker Desktop on macOS is now 11 (Big Sur) or newer.
 - Fixed the Docker engine not starting when Enhanced Container Isolation is enabled if the legacy `osxfs` implementation is used for file sharing.
 - Fixed files created on VirtioFS having the executable bit set. Fixes [docker/for-mac#6614](https://github.com/docker/for-mac/issues/6614).
 - Added back a way to uninstall Docker Desktop from the command line. Fixes [docker/for-mac#6598](https://github.com/docker/for-mac/issues/6598).

--- a/desktop/release-notes.md
+++ b/desktop/release-notes.md
@@ -160,7 +160,7 @@ For frequently asked questions about Docker Desktop releases, see [FAQs](faqs/ge
 
 #### For Mac
 
-- Minimum version to install or update Docker Desktop on macOS is now 11 (Big Sur) or newer.
+- Minimum OS version to install or update Docker Desktop on macOS is now macOS Big Sur (version 11) or later.
 - Fixed the Docker engine not starting when Enhanced Container Isolation is enabled if the legacy `osxfs` implementation is used for file sharing.
 - Fixed files created on VirtioFS having the executable bit set. Fixes [docker/for-mac#6614](https://github.com/docker/for-mac/issues/6614).
 - Added back a way to uninstall Docker Desktop from the command line. Fixes [docker/for-mac#6598](https://github.com/docker/for-mac/issues/6598).


### PR DESCRIPTION
<!--
  Thank you for contributing to Docker documentation!

  Here are a few things to keep in mind:

  - Links between pages should use a relative path
  - Remember to add an alt text for images

  ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
  ┃     Review our contribution guidelines:       ┃
  ┃                                               ┃
  ┃ https://docs.docker.com/contribute/overview/  ┃
  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
-->

### Proposed changes

Adds a release note for Mac to say that Docker Desktop now requires macOS 11.

We had actually deprecated macOS 10.15 months ago (and updated the installation docs accordingly), but forgot to change the minimum version in the product.
Docker Desktop 4.16 now fails to start on macOS 10.15, even when previous versions seem to be fine.

### Related issues (optional)

<!--
  Refer to related PRs or issues:

  #1234
  Closes #1234
  Closes docker/cli#1234
-->
