### PR TITLE
fix get-docker invocation with DRY_RUN

### DIFF
--- a/_includes/install-script.md
+++ b/_includes/install-script.md
@@ -34,12 +34,12 @@ of the convenience script:
 
 > Tip: preview script steps before running
 >
-> You can run the script with the `DRY_RUN=1` option to learn what steps the
+> You can run the script with the `--dry-run` option to learn what steps the
 > script will run when invoked:
 >
 > ```console
 > $ curl -fsSL https://get.docker.com -o get-docker.sh
-> $ DRY_RUN=1 sudo sh ./get-docker.sh
+> $ sudo sh ./get-docker.sh --dry-run
 > ```
 
 This example downloads the script from


### PR DESCRIPTION

### Proposed changes

In this block:

https://github.com/docker/docs/blob/3affff66e4c1197162a751071a17052a9ceab97a/_includes/install-script.md#L37-L43

sudo does not pass its env to command, so the current invocation is not a dry run, as `DRY_RUN` never gets passed to sh:

```
$ DRY_RUN=1 sudo env | grep -c DRY
0
```

It does accept env variables before the command, like so:

```
$ sudo DRY_RUN=1 sh ./get-docker.sh
```

but those are subject to restrictions imposed by the security policy plugin, so it's better to just use the script argument instead.


### Related issues (optional)


