### PR TITLE
swarm: call out CA rotation as potentially dangerous with MKE

### DIFF
--- a/engine/swarm/how-swarm-mode-works/pki.md
+++ b/engine/swarm/how-swarm-mode-works/pki.md
@@ -60,6 +60,13 @@ reference for details.
 
 ## Rotating the CA certificate
 
+> **Note**
+>
+> Mirantis Kubernetes Engine (MKE), formerly known as Docker UCP, provides an external
+> certificate manager service for the swarm. If you run swarm on MKE, you shouldn't
+> rotate the CA certificates manually. Instead, contact Mirantis support if you need
+> to rotate a certificate.
+
 In the event that a cluster CA key or a manager node is compromised, you can
 rotate the swarm root CA so that none of the nodes trust certificates
 signed by the old root CA anymore.


### PR DESCRIPTION
### Proposed changes

Add a call-out for Mirantis Kubernetes Engine/Docker UCP users re: Swarm CA rotation, which is not supported in the general case and usually dangerous/indicative of other cluster health problems. A PR for the CLI docs will follow once this wording is reviewed.