### PR TITLE
docs: extend Golang's testing tutorial with Testcontainers for Go

### DIFF
--- a/.github/vale/Vocab/Industry/accept.txt
+++ b/.github/vale/Vocab/Industry/accept.txt
@@ -43,6 +43,7 @@ Python
 QEMU
 RHEL
 Raspbian
+Ryuk
 S3
 SBOMs?
 SLES
@@ -55,6 +56,7 @@ Solr
 SonarQube
 Syft
 TLS
+Testcontainers
 Twilio
 Ubuntu
 WSL

--- a/language/golang/run-tests.md
+++ b/language/golang/run-tests.md
@@ -10,7 +10,13 @@ redirect_from:
 
 Testing is an essential part of modern software development. Yet, testing can mean a lot of things to different development teams. In the name of brevity, we'll only take a look at running isolated, high-level, functional tests.
 
-## Test structure
+> **Acknowledgment**
+>
+> In this section we are going to consider using two competing approaches to manage containerised tests: [dockertest](https://github.com/ory/dockertest) and [Testcontainers for Go](https://github.com/testcontainers/testcontainers-go). We let readers choose which approach is more convenient for their use case.
+
+## Using dockertest
+
+### Test structure
 
 Each test is meant to verify a single business requirement for our example application. The following test is an excerpt from `main_test.go` test suite in our example application.
 
@@ -59,7 +65,7 @@ As you can see, this is a high-level test, unconcerned with the implementation d
 
 The second test in `main_test.go` has almost identical structure but it tests _another_ business requirement of our application. You are welcome to have a look at all available tests in [`docker-gs-ping/main_test.go`](https://github.com/olliefr/docker-gs-ping/blob/main/main_test.go).
 
-## Run tests locally
+### Run tests locally
 
 In order to run the tests, we must make sure that our application Docker image is up-to-date.
 
@@ -76,14 +82,14 @@ Note, that the image is tagged with `latest` which is the same label we've chose
 Now that the Docker image for our application had been built, we can run the tests that depend on it:
 
 ```console
-$ go test ./...
+$ go test ./... -tags=dockertest
 ok      github.com/olliefr/docker-gs-ping       2.564s
 ```
 
 That was a bit... underwhelming? Let's ask it to print a bit more detail, just to be sure:
 
 ```console
-$ go test -v ./...
+$ go test -v ./... -tags=dockertest
 === RUN   TestRespondsWithLove
     main_test.go:47: container not ready, waiting...
 --- PASS: TestRespondsWithLove (5.24s)
@@ -95,6 +101,109 @@ ok      github.com/olliefr/docker-gs-ping       6.670s
 ```
 
 So, the tests do, indeed, pass. Note, how retrying using exponential back-off helped avoiding failing tests while the containers are being initialised. What happens in each test is that `ory/dockertest` module connects to the local Docker engine instance and instructs it to spin up a container using the image, identified by the tag `docker-gs-ping:latest`. Starting up a container may take a while, so our tests retry accessing the container until the container is ready to respond to requests.
+
+## Using Testcontainers for Go
+
+### Test structure
+
+Each test is meant to verify a single business requirement for our example application. The following test is an excerpt from `main_testcontainers_test.go` test suite in our example application.
+
+{% raw %}
+```go
+func TestRespondsWithLoveTestcontainers(t *testing.T) {
+	req := testcontainers.ContainerRequest{
+		Image:        "docker.io/olliefr/docker-gs-ping:latest",
+		Env:          map[string]string{},
+		ExposedPorts: []string{"8080/tcp"},
+		WaitingFor:   wait.ForHTTP("/").WithPort("8080/tcp"), // wait for port to be ready
+	}
+
+	ctx := context.Background()
+	container, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
+		ContainerRequest: req,
+		Started:          true,
+	})
+	require.NoError(t, err, "could not start container")
+
+	endpoint, err := container.PortEndpoint(ctx, "8080/tcp", "http")
+	require.NoError(t, err, "port not available")
+
+	t.Cleanup(func() {
+		require.NoError(t, container.Terminate(ctx), "failed to remove container")
+	})
+
+	var resp *http.Response
+
+	resp, err = http.Get(endpoint)
+	require.NoError(t, err, "HTTP error")
+	defer resp.Body.Close()
+
+	require.Equal(t, http.StatusOK, resp.StatusCode, "HTTP status code")
+
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err, "failed to read HTTP body")
+
+	// Finally, test the business requirement!
+	require.Contains(t, string(body), "<3", "does not respond with love?")
+}
+```
+{% endraw %}
+
+As you can see, this is a high-level test, unconcerned with the implementation details of our example application.
+
+* the test is using [`testcontainers/testcontainers-go`](https://github.com/testcontainers/testcontainers-go) Go module;
+* the test assumes that the Docker engine instance is running on the same machine where the test is being run, although it could be possible to run the tests against a remote Docker engine.
+
+The second test in `main_testcontainers_test.go` has almost identical structure but it tests _another_ business requirement of our application. You are welcome to have a look at all available tests in [`docker-gs-ping/main_testcontainers_test.go`](https://github.com/olliefr/docker-gs-ping/blob/main/main_testcontainers_test.go).
+
+### Run tests locally
+
+In order to run the tests, we must make sure that our application Docker image is up-to-date.
+
+```console
+$ docker build -t docker-gs-ping:latest .
+[+] Building 3.0s (13/13) FINISHED
+...
+```
+
+In the above example we've omitted most of the output, only displaying the first line indicating that the build was successful.
+
+Note, that the image is tagged with `latest` which is the same label we've chosen to use in our `main_testcontainers_test.go` tests. 
+
+Now that the Docker image for our application had been built, we can run the tests that depend on it:
+
+```console
+$ go test ./... -tags=testcontainers
+ok  	github.com/olliefr/docker-gs-ping	1.790s
+```
+
+That was a bit... underwhelming? Let's ask it to print a bit more detail, just to be sure:
+
+```console
+go test ./... -count=1 -tags=testcontainers -v
+=== RUN   TestRespondsWithLoveTestcontainers
+2023/01/25 13:16:16 github.com/testcontainers/testcontainers-go - Connected to docker: 
+  Server Version: 20.10.21
+  API Version: 1.41
+  Operating System: Docker Desktop
+  Total Memory: 7851 MB
+2023/01/25 13:16:16 Starting container id: b074ee900ace image: docker.io/testcontainers/ryuk:0.3.4
+2023/01/25 13:16:16 Waiting for container id b074ee900ace image: docker.io/testcontainers/ryuk:0.3.4
+2023/01/25 13:16:16 Container is ready id: b074ee900ace image: docker.io/testcontainers/ryuk:0.3.4
+2023/01/25 13:16:16 Starting container id: 894bb575f712 image: docker.io/olliefr/docker-gs-ping:latest
+2023/01/25 13:16:16 Waiting for container id 894bb575f712 image: docker.io/olliefr/docker-gs-ping:latest
+2023/01/25 13:16:17 Container is ready id: 894bb575f712 image: docker.io/olliefr/docker-gs-ping:latest
+--- PASS: TestRespondsWithLoveTestcontainers (1.03s)
+=== RUN   TestHealthCheckTestcontainers
+2023/01/25 13:16:17 Starting container id: 2da2fa2876c6 image: docker.io/olliefr/docker-gs-ping:latest
+2023/01/25 13:16:17 Waiting for container id 2da2fa2876c6 image: docker.io/olliefr/docker-gs-ping:latest
+2023/01/25 13:16:17 Container is ready id: 2da2fa2876c6 image: docker.io/olliefr/docker-gs-ping:latest
+--- PASS: TestHealthCheckTestcontainers (0.42s)
+PASS
+ok  	github.com/olliefr/docker-gs-ping	1.753s
+```
+
+So, the tests do, indeed, pass. Note, how using a [wait strategy](https://golang.testcontainers.org/features/wait/introduction/) helped avoiding failing tests while the containers are being initialised. What happens in each test is that `Testcontainers for Go` module connects to the local Docker engine instance and instructs it to spin up a container using the image, identified by the tag `docker-gs-ping:latest`. Starting up a container and the application in it may take a while, so our tests retry accessing the container until the container is ready to respond to requests. It's important to mention that `Testcontainers for Go` spins up a [Ryuk](https://github.com/testcontainers/moby-ryuk) container before the test execution; this special container takes care of cleaning up the Docker resources created in your tests: containers, networks and volumes, being removed after all tests have finished.
 
 ## Next steps
 


### PR DESCRIPTION
<!--
  Thank you for contributing to Docker documentation!

  Here are a few things to keep in mind:

  - Links between pages should use a relative path
  - Remember to add an alt text for images

  ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
  ┃     Review our contribution guidelines:       ┃
  ┃                                               ┃
  ┃ https://docs.docker.com/contribute/overview/  ┃
  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
-->

### Proposed changes

We'd like to consider using two competing approaches to manage containerised tests: [dockertest](https://github.com/ory/dockertest) and [Testcontainers for Go](https://github.com/testcontainers/testcontainers-go), so readers are able to choose which approach is more convenient for their use case.

To achieve it:
1. we are adding an acknowledge block at the top of the page explaining why we have two different alternatives to write the Go tests. 
1. we are not modifying the existing dockertest section, keeping it as the first section (deserved as it landed in the docs first)
1. we are adding an H2 heading that will enclose the existing sections for dockertest. Therefore, those headings are pushed from H2 to H3.
1. we are cloning the dockertest section (texts and codeblocks) but adapting them to Testcontainers for Go. We do not want to create confusion and use the same language and words than the existing texts.
1. we are just updating the sentences that are specific to Testcontainers for Go, such as the usage of wait strategies or the usage of Ryuk as resource cleaner.
1. we are adding Testcontainers and Ryuk to the Vale vocabulary, to avoid errors in the Vale checks.
1. we are updating how the dockertest tests are run adding Go build tags. This is needed because of the changes in https://github.com/olliefr/docker-gs-ping/pull/7/files#diff-79ce3229c13921b79b1175dcb211336aaf84dfd8edcf19c07698934d4fe70e5eR1, that separates the execution of both test types.

One thing that we would like to notice is the current execution time for dockertest: it says around [6 seconds](https://github.com/docker/docs/blame/c68b34e6055c0ae3c2a489341120421f42fba1c0/language/golang/run-tests.md?plain=1#L94), but we have run the very same tests locally and the times are way low. We'd like to update those numbers to https://github.com/olliefr/docker-gs-ping/pull/7/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R28, which seems fair (and more realistic). If this PR is accepted, we'd like to updated them accordingly (here in this PR or in a follow-up one).

<!-- Tell us what you did and why -->

### Related issues (optional)

<!--
  Refer to related PRs or issues:

  #1234
  Closes #1234
  Closes docker/cli#1234
-->
- Depends on https://github.com/olliefr/docker-gs-ping/pull/7 (cc/ @olliefr)
- Closes #16221