### PR TITLE
Fix wrong port number since vite migration

### DIFF
--- a/desktop/extensions-sdk/dev/test-debug.md
+++ b/desktop/extensions-sdk/dev/test-debug.md
@@ -26,7 +26,9 @@ After an extension is deployed, it is also possible to open Chrome DevTools from
 
 ### Hot reloading whilst developing the UI
 
-During UI development, it’s helpful to use hot reloading to test your changes without rebuilding your entire extension. To do this, you can configure Docker Desktop to load your UI from a development server, such as the one Create React App starts when invoked with yarn start.
+During UI development, it’s helpful to use hot reloading to test your changes without rebuilding your entire
+extension. To do this, you can configure Docker Desktop to load your UI from a development server, such as the one
+[Vite](https://vitejs.dev/) starts when invoked with `npm start`.
 
 Assuming your app runs on the default port, start your UI app and then run:
 
@@ -35,12 +37,12 @@ $ cd ui
 $ npm run dev
 ```
 
-This starts a development server that listens on port 5173.
+This starts a development server that listens on port 3000.
 
 You can now tell Docker Desktop to use this as the frontend source. In another terminal run:
 
 ```console
-$ docker extension dev ui-source <name-of-your-extensions> http://localhost:5173
+$ docker extension dev ui-source <name-of-your-extensions> http://localhost:3000
 ```
 
 Close and reopen the Docker Desktop dashboard and go to your extension. All the changes to the frontend code are immediately visible.


### PR DESCRIPTION
<!--
  Thank you for contributing to Docker documentation!

  Here are a few things to keep in mind:

  - Links between pages should use a relative path
  - Remember to add an alt text for images

  ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
  ┃     Review our contribution guidelines:       ┃
  ┃                                               ┃
  ┃ https://docs.docker.com/contribute/overview/  ┃
  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
-->

### Proposed changes

With this PR, I fixed the port number to use to start the hot reloading of the frontend of an extension.
This was reported to me on the #extensions community Slack channel.

<!-- Tell us what you did and why -->

### Related issues (optional)

<!--
  Refer to related PRs or issues:

  #1234
  Closes #1234
  Closes docker/cli#1234
-->
