### PR TITLE
Update Python example to use Python 3 syntax

### DIFF
--- a/engine/api/sdk/index.md
+++ b/engine/api/sdk/index.md
@@ -144,7 +144,7 @@ func main() {
 ```python
 import docker
 client = docker.from_env()
-print client.containers.run("alpine", ["echo", "hello", "world"])
+print(client.containers.run("alpine", ["echo", "hello", "world"]))
 ```
 
   </div>


### PR DESCRIPTION
<!--
  Thank you for contributing to Docker documentation!

  Here are a few things to keep in mind:

  - Links between pages should use a relative path
  - Remember to add an alt text for images

  ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
  ┃     Review our contribution guidelines:       ┃
  ┃                                               ┃
  ┃ https://docs.docker.com/contribute/overview/  ┃
  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
-->

### Proposed changes

Changed the Python SDK code snippet to use Python 3 syntax. `print` statements without parentheses are only valid in Python 2, which [reached EOL 3 years ago](https://www.python.org/doc/sunset-python-2/)

### Related issues (optional)

<!--
  Refer to related PRs or issues:

  #1234
  Closes #1234
  Closes docker/cli#1234
-->
