### PR TITLE
compose: update envvars path in reference toc

### DIFF
--- a/_data/toc.yaml
+++ b/_data/toc.yaml
@@ -339,7 +339,7 @@ reference:
       section:
         - path: /compose/reference/
           title: overview
-        - path: /compose/reference/envvars/
+        - path: /compose/environment-variables/envvars/
           title: environment variables
         - path: /engine/reference/commandline/compose/
           title: docker compose


### PR DESCRIPTION
Signed-off-by: David Karlsson <david.karlsson@docker.com>

<!--
  Thank you for contributing to Docker documentation!

  Here are a few things to keep in mind:

  - Links between pages should use a relative path
  - Remember to add an alt text for images

  ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
  ┃     Review our contribution guidelines:       ┃
  ┃                                               ┃
  ┃ https://docs.docker.com/contribute/overview/  ┃
  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
-->

### Proposed changes

Fix the link path for compose envvars in Reference TOC since it changed

### Related issues (optional)

#16628
