### PR TITLE
ENGDOCS-1229

### DIFF
--- a/desktop/hardened-desktop/registry-access-management.md
+++ b/desktop/hardened-desktop/registry-access-management.md
@@ -12,11 +12,13 @@ redirect_from:
 
 With Registry Access Management, administrators can ensure that their developers using Docker Desktop only access registries that are allowed. This is done through the Registry Access Management dashboard on Docker Hub. 
 
-Below are some example registries administrators can allow: 
+RAM supports both cloud and on-prem registries. Example registries administrators can allow include: 
  - Docker Hub. This is enabled by default.
  - Amazon ECR
  - GitHub Container Registry
  - Google Container Registry
+ - Nexus
+ - Artifactory
 
 ## Prerequisites 
 

--- a/desktop/hardened-desktop/registry-access-management.md
+++ b/desktop/hardened-desktop/registry-access-management.md
@@ -12,7 +12,7 @@ redirect_from:
 
 With Registry Access Management, administrators can ensure that their developers using Docker Desktop only access registries that are allowed. This is done through the Registry Access Management dashboard on Docker Hub. 
 
-RAM supports both cloud and on-prem registries. Example registries administrators can allow include: 
+Registry Access Management supports both cloud and on-prem registries. Example registries administrators can allow include: 
  - Docker Hub. This is enabled by default.
  - Amazon ECR
  - GitHub Container Registry


### PR DESCRIPTION
Clarifies RAM registries can be both cloud and on-prem and gives examples