### PR TITLE
Update extension publishers' feedback form link

### DIFF
--- a/_data/toc.yaml
+++ b/_data/toc.yaml
@@ -1207,6 +1207,8 @@ manuals:
               path: /desktop/extensions-sdk/architecture/
             - title: Metadata
               path: /desktop/extensions-sdk/architecture/metadata/
+            - title: Security
+              path: /desktop/extensions-sdk/architecture/security/
         - sectiontitle: "Design and UI styling"
           section:
              - title: UI styling guidelines
@@ -1227,8 +1229,6 @@ manuals:
               path: /desktop/extensions-sdk/guides/kubernetes/
             - title: Authentication
               path: /desktop/extensions-sdk/guides/oauth2-flow/
-            - title: Security
-              path: /desktop/extensions-sdk/guides/security/
         - sectiontitle: Developer SDK tools
           section:
             - title: "Test and debug"

--- a/_includes/extensions-form.md
+++ b/_includes/extensions-form.md
@@ -1,3 +1,3 @@
 > Already built an extension?
 >
-> Let us know about your experience using the [feedback form](https://docs.docker.com/feedback/extension/).
+> Let us know about your experience using the [feedback form](https://survey.alchemer.com/s3/7184948/Publishers-Feedback-Form).

--- a/desktop/extensions-sdk/architecture/security.md
+++ b/desktop/extensions-sdk/architecture/security.md
@@ -2,6 +2,8 @@
 title: Security
 description: Aspects of the security model of extensions
 keywords: Docker, extensions, sdk, security
+redirect_from:
+- /desktop/extensions-sdk/guides/security/
 ---
 
 ## Extension capabilities


### PR DESCRIPTION
<!--
  Thank you for contributing to Docker documentation!

  Here are a few things to keep in mind:

  - Links between pages should use a relative path
  - Remember to add an alt text for images

  ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
  ┃     Review our contribution guidelines:       ┃
  ┃                                               ┃
  ┃ https://docs.docker.com/contribute/overview/  ┃
  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
-->

### Proposed changes

We (the extension team) updated the form to collect the feedback from extension publishers.

This PR also moves the extension security page under the architecture section.

<!-- Tell us what you did and why -->

### Related issues (optional)

<!--
  Refer to related PRs or issues:

  #1234
  Closes #1234
  Closes docker/cli#1234
-->
