### PR TITLE
chore(fix-config.md): config.md contains a misleading command, that will only give a result if called in the node running the container

### DIFF
--- a/engine/swarm/configs.md
+++ b/engine/swarm/configs.md
@@ -172,7 +172,7 @@ real-world example, continue to
     completion to do this automatically.
 
     ```console
-    $ docker service ps --format "{{.Node}}" redis
+    $ docker service ps --format '{{.Node}}' redis
     
     ip-172-31-46-109
     

--- a/engine/swarm/configs.md
+++ b/engine/swarm/configs.md
@@ -166,11 +166,18 @@ real-world example, continue to
 4.  Get the ID of the `redis` service task container using `docker ps`, so that
     you can use `docker container exec` to connect to the container and read the contents
     of the config data file, which defaults to being readable by all and has the
-    same name as the name of the config. The first command below illustrates
-    how to find the container ID, and the second and third commands use shell
+    same name as the name of the config. The first command retrieves the node ID
+    the container is running on, from the node  `ip-172-31-46-109` run the second command below illustrates
+    how to find the container ID, and the third and fourth commands use shell
     completion to do this automatically.
 
     ```console
+    $ docker service ps --format "{{.Node}}" redis
+    
+    ip-172-31-46-109
+    
+    # from now, the below commands should be executed from node ip-172-31-46-109
+
     $ docker ps --filter name=redis -q
 
     5cb1c2348a59


### PR DESCRIPTION


<!--
  Thank you for contributing to Docker documentation!

  Here are a few things to keep in mind:

  - Links between pages should use a relative path
  - Remember to add an alt text for images

  ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
  ┃     Review our contribution guidelines:       ┃
  ┃                                               ┃
  ┃ https://docs.docker.com/contribute/overview/  ┃
  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
-->

### Proposed changes

The command for getting the ID of a container in swarm mode is 50% wrong and 50% correct, the initial content assumes that the container was created in the node (master) that initiated the `docker service create command.

In a one-node swarm cluster or a service created with `--mode=global`, the command `docker ps --filter name=redis -q` is fine, but when the nodes in the cluster are `N + 1`, the possibility of this command `docker ps --filter name=redis -q` producing the correct result is not certain. 

The update made here, instructs the user to get the node the container is running on, proceed to the node and run the rest of the commands.


### Related issues (optional)

<!--
  Refer to related PRs or issues:

  #1234
  Closes #1234
  Closes docker/cli#1234
-->
