### PR TITLE
Update debian.md

### DIFF
--- a/engine/install/debian.md
+++ b/engine/install/debian.md
@@ -96,7 +96,7 @@ Docker from the repository.
 2.  Add Docker's official GPG key:
 
     ```console
-    $ sudo mkdir -m 0755 -p /etc/apt/keyrings 
+    $ sudo mkdir -m 0755 -p /etc/apt/keyrings
     $ curl -fsSL {{ download-url-base }}/gpg | sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg
     ```
 

--- a/engine/install/debian.md
+++ b/engine/install/debian.md
@@ -96,7 +96,7 @@ Docker from the repository.
 2.  Add Docker's official GPG key:
 
     ```console
-    $ sudo mkdir -p /etc/apt/keyrings
+    $ sudo mkdir -m 0755 -p /etc/apt/keyrings 
     $ curl -fsSL {{ download-url-base }}/gpg | sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg
     ```
 


### PR DESCRIPTION
Set correct filemask for `/etc/apt/keyrings` . If this is not 0755, the keys in the directory cannot be used.

<!--
  Thank you for contributing to Docker documentation!

  Here are a few things to keep in mind:

  - Links between pages should use a relative path
  - Remember to add an alt text for images

  ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
  ┃     Review our contribution guidelines:       ┃
  ┃                                               ┃
  ┃ https://docs.docker.com/contribute/overview/  ┃
  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
-->

### Proposed changes

<!-- Tell us what you did and why -->

### Related issues (optional)

<!--
  Refer to related PRs or issues:

  #16626 #16362
  Closes #16626 #16362
-->
