### PR TITLE
Note the bug in tmpfs permissions

### DIFF
--- a/storage/tmpfs.md
+++ b/storage/tmpfs.md
@@ -28,6 +28,7 @@ persist in either the host or the container writable layer.
 * Unlike volumes and bind mounts, you can't share `tmpfs` mounts between
 containers.
 * This functionality is only available if you're running Docker on Linux.
+* Setting permissions on tmpfs may still suffer from a bug causing them to [reset after container restart](https://github.com/docker/for-linux/issues/138). In some cases [setting the uid/gid](https://github.com/docker/compose/issues/3425#issuecomment-423091370) can serve as a workaround.
 
 ## Choose the --tmpfs or --mount flag
 

--- a/storage/tmpfs.md
+++ b/storage/tmpfs.md
@@ -28,7 +28,7 @@ persist in either the host or the container writable layer.
 * Unlike volumes and bind mounts, you can't share `tmpfs` mounts between
 containers.
 * This functionality is only available if you're running Docker on Linux.
-* Setting permissions on tmpfs may still suffer from a bug causing them to [reset after container restart](https://github.com/docker/for-linux/issues/138). In some cases [setting the uid/gid](https://github.com/docker/compose/issues/3425#issuecomment-423091370) can serve as a workaround.
+* Setting permissions on tmpfs may cause them to [reset after container restart](https://github.com/docker/for-linux/issues/138). In some cases [setting the uid/gid](https://github.com/docker/compose/issues/3425#issuecomment-423091370) can serve as a workaround.
 
 ## Choose the --tmpfs or --mount flag
 


### PR DESCRIPTION
### Proposed changes

There is an open bug in tmpfs that results in permissions being reset on container restart. At this point it has tripped up quite a few people. This adds a hint about the issue, and a link to a the workaround we ultimately used (a functionality not mentioned elsewhere in the docs).

### Related issues (optional)

- https://github.com/docker/for-linux/issues/138
- https://github.com/moby/moby/issues/20437
- https://github.com/docker/compose/issues/3425#issuecomment-423091370