### PR TITLE
engine: 23.0.0 errata

### DIFF
--- a/engine/release-notes/23.0.md
+++ b/engine/release-notes/23.0.md
@@ -78,6 +78,7 @@ For a full list of pull requests and changes in this release, refer to the relev
 - API: Add a `CreateMountPoint` parameter to `POST /containers/create`. [moby/moby#43484](https://github.com/moby/moby/pull/43484)
 - API: Add a `shared-size` parameter to `GET /images/json` to enable shared-size computation of images. [moby/moby#42531](https://github.com/moby/moby/pull/42531)
 - API: Add a `type` parameter to `GET /system/df`, to control what object types to are considered when computing disk usage. [moby/moby#42559](https://github.com/moby/moby/pull/42559)
+- systemd: Use a systemd-managed containerd instead of a daemon-managed containerd. [moby/moby#42373](https://github.com/moby/moby/pull/42373)
 - systemd: Start `docker.service` after `time-set.target`. [moby/moby#43107](https://github.com/moby/moby/pull/43107)
 
 ### Removed

--- a/engine/release-notes/23.0.md
+++ b/engine/release-notes/23.0.md
@@ -45,11 +45,11 @@ For a full list of pull requests and changes in this release, refer to the relev
 - Add support for alternate OCI runtimes on Linux, compatible with the containerd runtime v2 API. [moby/moby#43887](https://github.com/moby/moby/pull/43887), [moby/moby#43993](https://github.com/moby/moby/pull/43993)
 - Add support for the containerd `runhcs` shim on Windows (off by default). [moby/moby#42089](https://github.com/moby/moby/pull/42089)
 - Add `dockerd --validate` to check the daemon JSON config and exit. [moby/moby#42393](https://github.com/moby/moby/pull/42393)
-- Add the ability to configure the daemon's HTTP proxy via flags or JSON config [moby/moby#42835](https://github.com/moby/moby/pull/42835)
+- Add the ability to configure the daemon's HTTP proxy via flags or JSON config. [moby/moby#42835](https://github.com/moby/moby/pull/42835)
 - Add support for RFC 3021 point-to-point networks (IPv4 /31s) and single hosts (IPv4 /32s). For networks with two or fewer addresses, IPAM won't reserve a network and broadcast address. [moby/moby#42626](https://github.com/moby/moby/pull/42626)
 - Add support for setting `ipvlan_flag` and using the `l3s` `ipvlan_mode` in the `ipvlan` network driver. [moby/moby#42542](https://github.com/moby/moby/pull/42542)
 - Add support for displaying the value of the `metacopy` option for the `overlay2` storage driver. [moby/moby#43557](https://github.com/moby/moby/pull/43557)
-- Add support for describing Windows devices using the syntax `IDType://ID`.[moby/moby#43368](https://github.com/moby/moby/pull/43368)
+- Add support for describing Windows devices using the syntax `IDType://ID`. [moby/moby#43368](https://github.com/moby/moby/pull/43368)
 - Add `RootlessKit`, `slirp4netns`, and `VPNKit` version reporting. [moby/moby#42330](https://github.com/moby/moby/pull/42330)
 - Add experimental support for SwarmKit cluster volumes (CSI). [moby/moby#41982](https://github.com/moby/moby/pull/41982)
   - CLI: Add cluster volume (CSI) options to `docker volume`. [docker/cli#3606](https://github.com/docker/cli/pull/3606)
@@ -218,8 +218,10 @@ For a full list of pull requests and changes in this release, refer to the relev
 
 ### Known issues
 
-Some Debian users have reported issues with containers failing to start after upgrading to the 23.0 version.
-The error message indicates that the issue is due to a missing `apparmor_parser` dependency:
+#### apparmor_parser
+
+Some Debian users have reported issues with containers failing to start after upgrading to the 23.0 branch.
+The error message indicates that the issue is due to a missing `apparmor_parser` binary:
 
 ```console
 Error response from daemon: AppArmor enabled on system but the docker-default profile could not be loaded: running `apparmor_parser apparmor_parser --version` failed with output: 
@@ -227,8 +229,8 @@ error: exec: "apparmor_parser": executable file not found in $PATH
 Error: failed to start containers: somecontainer
 ```
 
-The workaround to this issue is to install the `apparmor-utils` package manually:
+The workaround to this issue is to install the `apparmor` package manually:
 
 ```console
-apt-get install apparmor-utils
+apt-get install apparmor
 ```

--- a/engine/release-notes/23.0.md
+++ b/engine/release-notes/23.0.md
@@ -234,3 +234,11 @@ The workaround to this issue is to install the `apparmor` package manually:
 ```console
 apt-get install apparmor
 ```
+
+#### Kata Containers
+
+The 23.0 branch brings support for alternate containerd shims, such as `io.containerd.runsc.v1` (gVisor) and `io.containerd.kata.v2` (Kata Containers).
+
+When using the Kata Containers runtime, exiting an `exec` session stops the running container, and hangs the connected CLI if a TTY was opened. There is no mitigation at this time beyond avoiding execing into containers running on the Kata runtime.
+
+The root cause of this issue is a long-standing bug in Moby. This will be resolved in a future release. Be advised that support for alternate OCI runtimes is a new feature and that similar issues may be discovered as more users start exercising this functionality.

--- a/engine/release-notes/23.0.md
+++ b/engine/release-notes/23.0.md
@@ -219,7 +219,7 @@ For a full list of pull requests and changes in this release, refer to the relev
 
 ### Known issues
 
-#### apparmor_parser
+#### apparmor_parser ([tracking issue](https://github.com/moby/moby/issues/44900))
 
 Some Debian users have reported issues with containers failing to start after upgrading to the 23.0 branch.
 The error message indicates that the issue is due to a missing `apparmor_parser` binary:
@@ -236,7 +236,7 @@ The workaround to this issue is to install the `apparmor` package manually:
 apt-get install apparmor
 ```
 
-#### Kata Containers
+#### Kata Containers ([tracking issue](https://github.com/kata-containers/kata-containers/issues/6154))
 
 The 23.0 branch brings support for alternate containerd shims, such as `io.containerd.runsc.v1` (gVisor) and `io.containerd.kata.v2` (Kata Containers).
 


### PR DESCRIPTION
- Closes https://github.com/moby/moby/issues/44912

This is a rollup of various corrections to the 23.0.0 release notes I have prepared over the last 12 hours:

- engine: amend 23.0 release notes for typos/minor factual errors
- engine: amend 23.0 release notes with known Kata issue
- engine: amend 23.0 release notes with overlooked change to the example systemd units
- engine: amend 23.0 release notes with tracking issues for known issues 

/cc @corhere to look at the Kata wording, @dvdksn @thaJeztah for review.