### PR TITLE
Update 07_multi_container.md

### DIFF
--- a/get-started/07_multi_container.md
+++ b/get-started/07_multi_container.md
@@ -78,6 +78,9 @@ For now, we will create the network first and attach the MySQL container at star
     ```console
     $ docker exec -it <mysql-container-id> mysql -u root -p
     ```
+    > **Tip**
+    >
+    > If you get an error `ERROR 2002 (HY000): Can't connect to local MySQL server through socket /path/to/socket`, it maybe because docker is trying to connect using the default tcp port. It can be resolved with `docker exec -it <CONTAINER_ID> mysql -h 127.0.0.1 -P 3306 -u root -p` replace `<CONTAINER_ID>` with your container ID. If unsure about the port (3306) and the url (127.0.0.1), you can find it from `docker ps`.
 
     When the password prompt comes up, type in **secret**. In the MySQL shell, list the databases and verify
     you see the `todos` database.


### PR DESCRIPTION
Added a tip for cases when docker exec cannot execute mysql using the default port.

<!--
  Thank you for contributing to Docker documentation!

  Here are a few things to keep in mind:

  - Links between pages should use a relative path
  - Remember to add an alt text for images

  ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
  ┃     Review our contribution guidelines:       ┃
  ┃                                               ┃
  ┃ https://docs.docker.com/contribute/overview/  ┃
  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
-->

### Proposed changes

<!-- Tell us what you did and why -->

### Related issues (optional)

<!--
  Refer to related PRs or issues:

  #1234
  Closes #1234
  Closes docker/cli#1234
-->
