### PR TITLE
engine: amend 23.0 release notes to acknowledge any ipvlan network is broken on upgrade

### DIFF
--- a/engine/release-notes/23.0.md
+++ b/engine/release-notes/23.0.md
@@ -238,7 +238,7 @@ apt-get install apparmor
 
 #### ipvlan networks ([tracking issue](https://github.com/moby/moby/issues/44925))
 
-When upgrading to the 23.0 branch, some previously created [ipvlan](/network/ipvlan/) networks cause a panic during start:
+When upgrading to the 23.0 branch, the existence of any [ipvlan](/network/ipvlan/) networks will prevent the daemon from starting:
 
 ```
 panic: interface conversion: interface {} is nil, not string


### PR DESCRIPTION
### Proposed changes

This was pointed out by @corhere seconds after merge.
