### PR TITLE
Update chmod command in GPG Error Tip

### DIFF
--- a/engine/install/ubuntu.md
+++ b/engine/install/ubuntu.md
@@ -123,7 +123,7 @@ Docker from the repository.
    > public key file before updating the package index:
    >
    > ```console
-   > $ sudo chmod a+r /etc/apt/keyrings/docker.gpg
+   > $ sudo chmod -R a+rx /etc/apt/keyrings
    > $ sudo apt-get update
    > ```
 


### PR DESCRIPTION
<!--
  Thank you for contributing to Docker documentation!

  Here are a few things to keep in mind:

  - Links between pages should use a relative path
  - Remember to add an alt text for images

  ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
  ┃     Review our contribution guidelines:       ┃
  ┃                                               ┃
  ┃ https://docs.docker.com/contribute/overview/  ┃
  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
-->

### Proposed changes

Updated the command in the GPG error tip section to resolve an issue where the parent directory still does not have the required permissions needed to prevent further GPG errors.

### Related issues (optional)

* Closes #16626
* Closes #16418
* Closes #16362