### PR TITLE
Change "mentioned above" to "mentioned below"

### DIFF
--- a/desktop/install/windows-install.md
+++ b/desktop/install/windows-install.md
@@ -97,7 +97,7 @@ For more information, see [Running Docker Desktop in a VM or VDI environment](..
 Looking for information on using Windows containers?
 
 * [Switch between Windows and Linux containers](../faqs/windowsfaqs.md#how-do-i-switch-between-windows-and-linux-containers)
-  describes how you can toggle between Linux and Windows containers in Docker Desktop and points you to the tutorial mentioned above.
+  describes how you can toggle between Linux and Windows containers in Docker Desktop and points you to the tutorial mentioned below.
 - [Getting Started with Windows Containers (Lab)](https://github.com/docker/labs/blob/master/windows/windows-containers/README.md)
   provides a tutorial on how to set up and run Windows containers on Windows 10, Windows Server 2016 and Windows Server 2019. It shows you how to use a MusicStore application
   with Windows containers.


### PR DESCRIPTION
<!--
  Thank you for contributing to Docker documentation!

  Here are a few things to keep in mind:

  - Links between pages should use a relative path
  - Remember to add an alt text for images

  ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
  ┃     Review our contribution guidelines:       ┃
  ┃                                               ┃
  ┃ https://docs.docker.com/contribute/overview/  ┃
  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
-->

### Proposed changes
One-word change. The tutorial that this line is referring to is mentioned in the following line, so not "above".

This has been wrong since https://github.com/docker/docs/commit/ea5aba3bc4a9034d13dbde1747521a997aacfa8c.

