### PR TITLE
Further engine 23.0.0 errata

### DIFF
--- a/engine/release-notes/23.0.md
+++ b/engine/release-notes/23.0.md
@@ -237,6 +237,28 @@ The workaround to this issue is to install the `apparmor` package manually:
 apt-get install apparmor
 ```
 
+#### BuildKit inline cache ([tracking issue](https://github.com/moby/moby/issues/44918))
+
+Attempting to build an image with BuildKit's inline cache feature (e.g. `docker build --build-arg BUILDKIT_INLINE_CACHE=1 .`, `docker buildx build --cache-to type=inline .`) will result in the daemon unexpectedly exiting:
+
+```
+panic: runtime error: invalid memory address or nil pointer dereference
+[signal SIGSEGV: segmentation violation code=0x1 addr=0x18 pc=0x147ff00]
+
+goroutine 693 [running]:
+github.com/docker/docker/vendor/github.com/moby/buildkit/cache.computeBlobChain.func4.1({0x245cca8, 0x4001394960})
+        /go/src/github.com/docker/docker/vendor/github.com/moby/buildkit/cache/blobs.go:206 +0xc90
+github.com/docker/docker/vendor/github.com/moby/buildkit/util/flightcontrol.(*call).run(0x40013c2240)
+        /go/src/github.com/docker/docker/vendor/github.com/moby/buildkit/util/flightcontrol/flightcontrol.go:121 +0x64
+sync.(*Once).doSlow(0x0?, 0x4001328240?)
+        /usr/local/go/src/sync/once.go:74 +0x100
+sync.(*Once).Do(0x4001328240?, 0x0?)
+        /usr/local/go/src/sync/once.go:65 +0x24
+created by github.com/docker/docker/vendor/github.com/moby/buildkit/util/flightcontrol.(*call).wait
+```
+
+The daemon will restart if configured to do so (e.g. via systemd) after such a crash. The only available mitigation in this release is to avoid performing builds with the inline cache feature enabled.
+
 #### ipvlan networks ([tracking issue](https://github.com/moby/moby/issues/44925))
 
 When upgrading to the 23.0 branch, the existence of any [ipvlan](/network/ipvlan/) networks will prevent the daemon from starting:

--- a/engine/release-notes/23.0.md
+++ b/engine/release-notes/23.0.md
@@ -201,6 +201,7 @@ For a full list of pull requests and changes in this release, refer to the relev
 - API: Only anonymous volumes now pruned by default on API version >= v1.42. Pass the filter `all=true` to prune named volumes in addition to anonymous. [moby/moby#44259](https://github.com/moby/moby/pull/44259)
 - API: Support concurrent calls on the `GET /system/df` endpoint. [moby/moby#42715](https://github.com/moby/moby/pull/42715)
 - Improve the reliability of the daemon dumping the stack and exits with code 2 when sent a SIGQUIT. [moby/moby#44831](https://github.com/moby/moby/pull/44831)
+- Improve the reliability of `docker logs -f` on Windows, and prevent newlines from being dropped in the `local` log driver. [moby/moby#43294](https://github.com/moby/moby/pull/43294)
 - Fix a rare deadlock in the daemon caused by buffering of container logs. [moby/moby#44856](https://github.com/moby/moby/pull/44856)
 - Improve error handling in misc filesystem operations so that the daemon can start on a overlayfs backing filesystem. [moby/moby#44834](https://github.com/moby/moby/pull/44834)
 - Fix an issue where `--ipc=host` wasn't handled correctly when the daemon is running in rootless mode. [moby/moby#44863](https://github.com/moby/moby/pull/44863)


### PR DESCRIPTION
### Proposed changes
- engine: amend 23.0 release notes with skipped logging fix
- engine: amend 23.0 release notes with known BuildKit inline cache issue