### PR TITLE
Make specified working directory match Dockerfile

### DIFF
--- a/language/dotnet/build-images.md
+++ b/language/dotnet/build-images.md
@@ -155,7 +155,7 @@ FROM mcr.microsoft.com/dotnet/aspnet:6.0 as runtime
 Next, specify the working directory for this stage.
 
 ```dockerfile
-WORKDIR /app
+WORKDIR /publish
 ```
 
 Next, copy the /publish directory from the build-env stage into the runtime image.


### PR DESCRIPTION
<!--
  Thank you for contributing to Docker documentation!

  Here are a few things to keep in mind:

  - Links between pages should use a relative path
  - Remember to add an alt text for images

  ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
  ┃     Review our contribution guidelines:       ┃
  ┃                                               ┃
  ┃ https://docs.docker.com/contribute/overview/  ┃
  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
-->

### Proposed changes
This change is to update the documentation step specifying the WORKDIR to match the WORKDIR provided in the completed dockerfile a few steps lower.
<!-- Tell us what you did and why -->

### Related issues (optional)

<!--
  Refer to related PRs or issues:

  #1234
  Closes #1234
  Closes docker/cli#1234
-->
