### PR TITLE
Comply to convention for parser directives

### DIFF
--- a/get-started/02_our_app.md
+++ b/get-started/02_our_app.md
@@ -78,6 +78,7 @@ In order to build the [container image](../get-started/overview.md/#docker-objec
 
    ```dockerfile
    # syntax=docker/dockerfile:1
+   
    FROM node:18-alpine
    WORKDIR /app
    COPY . .


### PR DESCRIPTION
As per [the docs](https://docs.docker.com/engine/reference/builder/#parser-directives:~:text=Convention%20is%20also%20to%20include%20a%20blank%20line%20following%20any%20parser%20directives.)
> Convention is also to include a blank line following any parser directives.

### Proposed changes

Included a blank line after the parser directive in the example `Dockerfile` provided in the [Get started / Part 2: Containerize an application / Build the app’s container image](https://docs.docker.com/get-started/02_our_app/#build-the-apps-container-image) guide