### PR TITLE
fix typo in env-file argument

### DIFF
--- a/compose/environment-variables/set-environment-variables.md
+++ b/compose/environment-variables/set-environment-variables.md
@@ -42,7 +42,7 @@ services:
 
 The `.env` file should be placed at the root of the project directory next to your `docker-compose.yml` file. You can use an alternative path with one of the following methods:
 - The [`--file` option in the CLI](../reference/index.md#use--f-to-specify-name-and-path-of-one-or-more-compose-files) 
-- The [`- -env-file` option in the CLI](#substitute-with---env-file)
+- The [`--env-file` option in the CLI](#substitute-with---env-file)
 - Using the [`env_file` attribute in the Compose file](../compose-file/index.md#env_file)
 
 For more information on formatting an environment file, see [Use an environment file](env-file.md).


### PR DESCRIPTION
<!--
  Thank you for contributing to Docker documentation!

  Here are a few things to keep in mind:

  - Links between pages should use a relative path
  - Remember to add an alt text for images

  ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
  ┃     Review our contribution guidelines:       ┃
  ┃                                               ┃
  ┃ https://docs.docker.com/contribute/overview/  ┃
  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
-->

### Proposed changes

This is a rather obvious typo.

```
$ docker compose --help | grep env-file
      --env-file string            Specify an alternate environment file.
```

<!-- Tell us what you did and why -->

### Related issues (optional)

none

<!--
  Refer to related PRs or issues:

  #1234
  Closes #1234
  Closes docker/cli#1234
-->
