### PR TITLE
engine: add 23.0.1 release notes

### DIFF
--- a/engine/release-notes/23.0.md
+++ b/engine/release-notes/23.0.md
@@ -25,6 +25,33 @@ Changing the version format is a stepping-stone towards Go module compatibility,
 but the repository doesn't yet use Go modules, and still requires using a "+incompatible" version.
 Work continues towards Go module compatibility in a future release.
 
+## 23.0.1
+
+{% include release-date.html date="2023-02-09" %}
+
+For a full list of pull requests and changes in this release, refer to the relevant GitHub milestones:
+
+- [docker/cli, 23.0.1 milestone](https://github.com/docker/cli/milestone/73?closed=1)
+- [moby/moby, 23.0.1 milestone](https://github.com/moby/moby/milestone/113?closed=1)
+
+### Bug fixes and enhancements
+
+- Fix containers not starting if the kernel has AppArmor enabled, but `apparmor_parser` is not available. [moby/moby#44942](https://github.com/moby/moby/pull/44942)
+- Fix BuildKit-enabled builds with inline caching causing the daemon to crash. [moby/moby#44944](https://github.com/moby/moby/pull/44944)
+- Fix BuildKit improperly loading cached layers created by previous versions. [moby/moby#44959](https://github.com/moby/moby/pull/44959)
+- Fix an issue where `ipvlan` networks created prior to upgrading would prevent the daemon from starting. [moby/moby#44937](https://github.com/moby/moby/pull/44937)
+- Fix the `overlay2` storage driver failing early in `metacopy` testing when initialized on an unsupported backing filesystem. [moby/moby#44922](https://github.com/moby/moby/pull/44922)
+- Fix `exec` exit events being misinterpreted as container exits under some runtimes, such as Kata Containers. [moby/moby#44892](https://github.com/moby/moby/pull/44892)
+- Improve the error message returned by the CLI when recieving a truncated JSON response caused by the API hanging up mid-request. [docker/cli#4004](https://github.com/docker/cli/pull/4004)
+- Fix an incorrect CLI exit code when attempting to execute a directory with a `runc` compiled using Go 1.20. [docker/cli#4004](https://github.com/docker/cli/pull/4004)
+- Fix mishandling the size argument to `--device-write-bps` as a path. [docker/cli#4004](https://github.com/docker/cli/pull/4004)
+
+### Packaging
+
+- Add `/etc/docker` to RPM and DEB packaging. [docker/docker-ce-packaging#842](https://github.com/docker/docker-ce-packaging/pull/842)
+  - Not all use cases will benefit; if you depend on this, you should explicitly `mkdir -p /etc/docker`.
+- Upgrade Compose to `v2.16.0`. [docker/docker-ce-packaging#844](https://github.com/docker/docker-ce-packaging/pull/844)
+
 ## 23.0.0
 
 {% include release-date.html date="2023-02-01" %}


### PR DESCRIPTION
### Proposed changes

Proposed 23.0.1 release notes

### Related issues (optional)

- [docker/cli, 23.0.1 milestone](https://github.com/docker/cli/milestone/73?closed=1)
- [moby/moby, 23.0.1 milestone](https://github.com/moby/moby/milestone/113?closed=1)

