### PR TITLE
Update https://docs.docker.com/compose/networking/

### DIFF
--- a/compose/networking.md
+++ b/compose/networking.md
@@ -54,7 +54,7 @@ the service is accessible outside the swarm as well.
 
 Within the `web` container, your connection string to `db` would look like
 `postgres://db:5432`, and from the host machine, the connection string would
-look like `postgres://{DOCKER_IP}:8001`.
+look like `postgres://{DOCKER_IP}:5432`.
 
 ## Update containers on the network
 


### PR DESCRIPTION
In row 55 to 57 it is written following (document https://docs.docker.com/compose/networking/):
Within the `web` container, your connection string to `db` would look like `postgres://db:5432`, and from the host machine, the connection string would look like `postgres://{DOCKER_IP}:8001`.
As the container is running postgres on port 5432 it should be `postgres://{DOCKER_IP}:5432` in the end of that sentence.

<!--
  Thank you for contributing to Docker documentation!

  Here are a few things to keep in mind:

  - Links between pages should use a relative path
  - Remember to add an alt text for images

  ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
  ┃     Review our contribution guidelines:       ┃
  ┃                                               ┃
  ┃ https://docs.docker.com/contribute/overview/  ┃
  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
-->

### Proposed changes

<!-- Tell us what you did and why -->

### Related issues (optional)

<!--
  Refer to related PRs or issues:

  #1234
  Closes #1234
  Closes docker/cli#1234
-->
