### PR TITLE
fix(registry): correct IAM policy for s3 storage driver

### DIFF
--- a/registry/storage-drivers/s3.md
+++ b/registry/storage-drivers/s3.md
@@ -78,6 +78,7 @@ The following AWS policy is required by the registry for push and pull. Make sur
         "s3:PutObject",
         "s3:GetObject",
         "s3:DeleteObject",
+        "s3:CreateMultipartUpload",
         "s3:ListMultipartUploadParts",
         "s3:AbortMultipartUpload"
       ],


### PR DESCRIPTION
### Proposed changes

The s3 storage driver explicitly uses the `CreateMultipartUpload` s3 API call and this is needed in the suggested IAM policy in the documentation, otherwise the registry will fail to upload blobs with the generic error "AccessDenied".

https://github.com/distribution/distribution/blob/main/registry/storage/driver/s3-aws/s3.go#L651

### Related issues (optional)

None.