### PR TITLE
fix: Incorrect link to attestation storage

### DIFF
--- a/build/attestations/index.md
+++ b/build/attestations/index.md
@@ -139,7 +139,7 @@ attestation.
 
 <!-- prettier-ignore -->
 To deep-dive into the specifics about how attestations are stored, see
-[Image Attestation Storage (BuildKit)](https://docs.docker.com/build/attestations/attestation-storage/){: target="blank" rel="noopener" class="_"}.
+[Image Attestation Storage (BuildKit)](attestation-storage.md).
 
 ## What's next
 


### PR DESCRIPTION
Follow-up https://github.com/docker/docs/pull/16717#discussion_r1105579885.

:facepalm: 

<!--
  Thank you for contributing to Docker documentation!

  Here are a few things to keep in mind:

  - Links between pages should use a relative path
  - Remember to add an alt text for images

  ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
  ┃     Review our contribution guidelines:       ┃
  ┃                                               ┃
  ┃ https://docs.docker.com/contribute/overview/  ┃
  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
-->

### Proposed changes

<!-- Tell us what you did and why -->

### Related issues (optional)

<!--
  Refer to related PRs or issues:

  #1234
  Closes #1234
  Closes docker/cli#1234
-->
