### PR TITLE
Illustrate use of HOST_PORT better

### DIFF
--- a/compose/networking.md
+++ b/compose/networking.md
@@ -54,7 +54,7 @@ the service is accessible outside the swarm as well.
 
 Within the `web` container, your connection string to `db` would look like
 `postgres://db:5432`, and from the host machine, the connection string would
-look like `postgres://{DOCKER_IP}:5432`.
+look like `postgres://localhost:8001`.
 
 ## Update containers on the network
 


### PR DESCRIPTION
To illustrate the mapping between HOST_PORT and CONTAINER_PORT better I think the last meaning starting in row 55 should be changed as my suggestions. postgres://localhost:8001 maps to postgres://{DOCKER_IP}:5432.

<!--
  Thank you for contributing to Docker documentation!

  Here are a few things to keep in mind:

  - Links between pages should use a relative path
  - Remember to add an alt text for images

  ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
  ┃     Review our contribution guidelines:       ┃
  ┃                                               ┃
  ┃ https://docs.docker.com/contribute/overview/  ┃
  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
-->

### Proposed changes

<!-- Tell us what you did and why -->

### Related issues (optional)

<!--
  Refer to related PRs or issues:

  #1234
  Closes #1234
  Closes docker/cli#1234
-->
