### PR TITLE
Put docker-compose into the cli-plugins folder

### DIFF
--- a/compose/install/other.md
+++ b/compose/install/other.md
@@ -46,7 +46,7 @@ When asked if you want to allow this app to make changes to your device, click *
 3. Run the following command to download the latest release of Compose ({{site.compose_version}}):
 
     ```powershell
-     Start-BitsTransfer -Source "https://github.com/docker/compose/releases/download/{{site.compose_version}}/docker-compose-Windows-x86_64.exe" -Destination $Env:ProgramFiles\Docker\docker-compose.exe
+     Start-BitsTransfer -Source "https://github.com/docker/compose/releases/download/{{site.compose_version}}/docker-compose-Windows-x86_64.exe" -Destination $Env:ProgramFiles\Docker\cli-plugins\docker-compose.exe
     ```
 
     > **Note**


### PR DESCRIPTION
<!--
  Thank you for contributing to Docker documentation!

  Here are a few things to keep in mind:

  - Links between pages should use a relative path
  - Remember to add an alt text for images

  ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
  ┃     Review our contribution guidelines:       ┃
  ┃                                               ┃
  ┃ https://docs.docker.com/contribute/overview/  ┃
  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
-->

### Proposed changes

Docker compose v2 is a plugin, and it needs to be installed in a `cli-plugins` directory. Only this way will the next step `docker compose version` work and the note about _also_ being able to put it just to `Program Files/Docker` makes sense.

The amount of time it took me to figure it out is maddening, so I'm putting this fix in the docs for the future generation. Mostly the documentation recommends just installing docker desktop which is not supported on Windows Server.

### Related issues (optional)

N/A
<!--
  Refer to related PRs or issues:

  #1234
  Closes #1234
  Closes docker/cli#1234
-->
