### PR TITLE
Fix grammer in `ipam` description

### DIFF
--- a/compose/compose-file/index.md
+++ b/compose/compose-file/index.md
@@ -2003,7 +2003,7 @@ networks:
 
 ### ipam
 
-`ipam` specifies custom a IPAM configuration. This is an object with several properties, each of which is optional:
+`ipam` specifies a custom IPAM configuration. This is an object with several properties, each of which is optional:
 
 - `driver`: Custom IPAM driver, instead of the default.
 - `config`: A list with zero or more configuration elements, each containing:


### PR DESCRIPTION
### Proposed changes

Fix grammer in `ipam` description.