### PR TITLE
docs: added use todos in 07_multi_container.md

### DIFF
--- a/get-started/07_multi_container.md
+++ b/get-started/07_multi_container.md
@@ -242,6 +242,7 @@ With all of that explained, let's start our dev-ready container!
     And in the mysql shell, run the following:
 
     ```console
+    mysql> use todos;
     mysql> select * from todo_items;
     +--------------------------------------+--------------------+-----------+
     | id                                   | name               | completed |


### PR DESCRIPTION
<!--
  Thank you for contributing to Docker documentation!

  Here are a few things to keep in mind:

  - Links between pages should use a relative path
  - Remember to add an alt text for images

  ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
  ┃     Review our contribution guidelines:       ┃
  ┃                                               ┃
  ┃ https://docs.docker.com/contribute/overview/  ┃
  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
-->

### Proposed changes

<!-- Tell us what you did and why -->

Added the `mysql> use todos;` in File: [get-started/07_multi_container.md](https://docs.docker.com/get-started/07_multi_container/)

It fixes #16741 

<!--
  Refer to related PRs or issues:

  #1234
  Closes #1234
  Closes docker/cli#1234
-->
