### PR TITLE
Pass StopOptions to ContainerStop function

### DIFF
--- a/engine/api/sdk/examples.md
+++ b/engine/api/sdk/examples.md
@@ -331,6 +331,7 @@ import (
 	"fmt"
 
 	"github.com/docker/docker/api/types"
+	containertypes "github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/client"
 )
 
@@ -349,7 +350,8 @@ func main() {
 
 	for _, container := range containers {
 		fmt.Print("Stopping container ", container.ID[:10], "... ")
-		if err := cli.ContainerStop(ctx, container.ID, nil); err != nil {
+		noWaitTimeout := 0 // to not wait for the container to exit gracefully
+		if err := cli.ContainerStop(ctx, container.ID, containertypes.StopOptions{Timeout: &noWaitTimeout}); err != nil {
 			panic(err)
 		}
 		fmt.Println("Success")


### PR DESCRIPTION
Fix #16744

**options** argument in **ContainerStop** [function](https://github.com/moby/moby/blob/master/daemon/stop.go#L23) can't be **nil**

<!--
  Thank you for contributing to Docker documentation!

  Here are a few things to keep in mind:

  - Links between pages should use a relative path
  - Remember to add an alt text for images

  ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
  ┃     Review our contribution guidelines:       ┃
  ┃                                               ┃
  ┃ https://docs.docker.com/contribute/overview/  ┃
  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
-->

### Proposed changes

<!-- Tell us what you did and why -->

### Related issues (optional)

<!--
  Refer to related PRs or issues:

  #1234
  Closes #1234
  Closes docker/cli#1234
-->
