### PR TITLE
cli reference: do not display hidden flags

### DIFF
--- a/_includes/cli.md
+++ b/_includes/cli.md
@@ -115,6 +115,7 @@ For example uses of this command, refer to the [examples section](#examples) bel
 </thead>
 <tbody>
 {% for option in alloptions %}
+  {% unless option.hidden %}
   {% capture deprecated-badge %}{% if option.deprecated %}<a href="/engine/deprecated/" target="_blank" rel="noopener" class="_"><span class="badge badge-danger" data-toggle="tooltip" title="Read the deprecation reference (in a new window).">deprecated</span></a>{% endif %}{% endcapture %}
   {% capture experimental-daemon-badge %}{% if option.experimental %}<a href="/engine/reference/commandline/dockerd/#daemon-configuration-file" target="_blank" rel="noopener" class="_"><span class="badge badge-warning" data-toggle="tooltip" title="Read about experimental daemon options (in a new window).">experimental (daemon)</span></a>{% endif %}{% endcapture %}
   {% capture experimental-cli-badge %}{% if option.experimentalcli %}<a href="/engine/reference/commandline/cli/#configuration-files" target="_blank" rel="noopener" class="_"><span class="badge badge-warning"  data-toggle="tooltip" title="Read about experimental CLI options (in a new window).">experimental (CLI)</span></a>{% endif %}{% endcapture %}
@@ -140,6 +141,7 @@ For example uses of this command, refer to the [examples section](#examples) bel
     <td markdown="span">{{ option-default }}</td>
     <td markdown="span">{% if all-badges != '' %}{{ all-badges | strip }}<br />{% endif %}{{ option.description | strip }}</td>
   </tr>
+  {% endunless %}
 {% endfor %} <!-- end for option -->
 </tbody>
 </table>


### PR DESCRIPTION
### Proposed changes

Hidden flags should not be displayed in the docs.

### Related issues (optional)

* https://github.com/docker/buildx/issues/1287#issuecomment-1428554533
