### PR TITLE
build: improve git context ref

### DIFF
--- a/build/building/context.md
+++ b/build/building/context.md
@@ -125,16 +125,16 @@ $ docker build https://github.com/user/myrepo.git#container:docker
 The following table represents all the valid suffixes with their build
 contexts:
 
-| Build Syntax Suffix            | Commit Used           | Build Context Used |
-|--------------------------------|-----------------------|--------------------|
-| `myrepo.git`                   | `refs/heads/master`   | `/`                |
-| `myrepo.git#mytag`             | `refs/tags/mytag`     | `/`                |
-| `myrepo.git#mybranch`          | `refs/heads/mybranch` | `/`                |
-| `myrepo.git#pull/42/head`      | `refs/pull/42/head`   | `/`                |
-| `myrepo.git#:myfolder`         | `refs/heads/master`   | `/myfolder`        |
-| `myrepo.git#master:myfolder`   | `refs/heads/master`   | `/myfolder`        |
-| `myrepo.git#mytag:myfolder`    | `refs/tags/mytag`     | `/myfolder`        |
-| `myrepo.git#mybranch:myfolder` | `refs/heads/mybranch` | `/myfolder`        |
+| Build Syntax Suffix            | Commit Used                   | Build Context Used |
+| ------------------------------ | ----------------------------- | ------------------ |
+| `myrepo.git`                   | `refs/heads/<default branch>` | `/`                |
+| `myrepo.git#mytag`             | `refs/tags/mytag`             | `/`                |
+| `myrepo.git#mybranch`          | `refs/heads/mybranch`         | `/`                |
+| `myrepo.git#pull/42/head`      | `refs/pull/42/head`           | `/`                |
+| `myrepo.git#:myfolder`         | `refs/heads/<default branch>` | `/myfolder`        |
+| `myrepo.git#master:myfolder`   | `refs/heads/master`           | `/myfolder`        |
+| `myrepo.git#mytag:myfolder`    | `refs/tags/mytag`             | `/myfolder`        |
+| `myrepo.git#mybranch:myfolder` | `refs/heads/mybranch`         | `/myfolder`        |
 
 By default `.git` directory is not kept on Git checkouts. You can set the
 [BuildKit built-in arg `BUILDKIT_CONTEXT_KEEP_GIT_DIR=1`](../../engine/reference/builder.md#buildkit-built-in-build-args)


### PR DESCRIPTION
<!--
  Thank you for contributing to Docker documentation!

  Here are a few things to keep in mind:

  - Links between pages should use a relative path
  - Remember to add an alt text for images

  ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
  ┃     Review our contribution guidelines:       ┃
  ┃                                               ┃
  ┃ https://docs.docker.com/contribute/overview/  ┃
  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
-->

### Proposed changes

Stops assuming `master` is the default and make it explicit that git context ref points to the default branch of the repo.

### Related issues (optional)

moby/buildkit#3596
