### PR TITLE
engine: clarfiy daemon.json configuration for logging drivers

### DIFF
--- a/_includes/configure-daemon-links.md
+++ b/_includes/configure-daemon-links.md
@@ -1,0 +1,9 @@
+For more information about configuring Docker Engine, see the following pages,
+depending on your Docker installation method:
+
+- Docker Desktop
+  - [Change preferences on Mac](../../../../desktop/settings/mac#docker-engine)
+  - [Change preferences on Windows](../../../../desktop/settings/windows#docker-engine)
+  - [Change preferences on Linux](../../../../desktop/settings/linux#docker-engine)
+- Docker Engine, standalone installation
+  - [Docker daemon configuration overview](../../../daemon/)

--- a/config/containers/logging/awslogs.md
+++ b/config/containers/logging/awslogs.md
@@ -16,13 +16,9 @@ and Command Line Tools](https://docs.aws.amazon.com/cli/latest/reference/logs/in
 ## Usage
 
 To use the `awslogs` driver as the default logging driver, set the `log-driver`
-and `log-opt` keys to appropriate values in the `daemon.json` file, which is
-located in `/etc/docker/` on Linux hosts or
-`C:\ProgramData\docker\config\daemon.json` on Windows Server. For more about
-configuring Docker using `daemon.json`, see
-[daemon.json](../../../engine/reference/commandline/dockerd.md#daemon-configuration-file).
-The following example sets the log driver to `awslogs` and sets the
-`awslogs-region` option.
+and `log-opt` keys to appropriate values in the `daemon.json` configuration file.
+
+{% include configure-daemon-links.md %}
 
 ```json
 {

--- a/config/containers/logging/configure.md
+++ b/config/containers/logging/configure.md
@@ -41,9 +41,9 @@ included with Docker, you can also implement and use [logging driver plugins](pl
 
 To configure the Docker daemon to default to a specific logging driver, set the
 value of `log-driver` to the name of the logging driver in the `daemon.json`
-configuration file. Refer to the "daemon configuration file" section in the
-[`dockerd` reference manual](/engine/reference/commandline/dockerd/#daemon-configuration-file)
-for details.
+configuration file.
+
+{% include configure-daemon-links.md %}
 
 The default logging driver is `json-file`. The following example sets the default
 logging driver to the [`local` log driver](local.md):

--- a/config/containers/logging/fluentd.md
+++ b/config/containers/logging/fluentd.md
@@ -33,13 +33,10 @@ Some options are supported by specifying `--log-opt` as many times as needed:
  - `fluentd-address`: specify a socket address to connect to the Fluentd daemon, ex `fluentdhost:24224` or `unix:///path/to/fluentd.sock`
  - `tag`: specify a tag for fluentd message, which interprets some markup, ex {% raw %}`{{.ID}}`, `{{.FullID}}` or `{{.Name}}` `docker.{{.ID}}`{% endraw %}
 
+To use the `fluentd` driver as the default logging driver, set the `log-driver`
+and `log-opt` keys to appropriate values in the `daemon.json` configuration file.
 
- To use the `fluentd` driver as the default logging driver, set the `log-driver`
- and `log-opt` keys to appropriate values in the `daemon.json` file, which is
- located in `/etc/docker/` on Linux hosts or
- `C:\ProgramData\docker\config\daemon.json` on Windows Server. For more about
- +configuring Docker using `daemon.json`, see
- +[daemon.json](../../../engine/reference/commandline/dockerd.md#daemon-configuration-file).
+{% include configure-daemon-links.md %}
 
 The following example sets the log driver to `fluentd` and sets the
 `fluentd-address` option.

--- a/config/containers/logging/gcplogs.md
+++ b/config/containers/logging/gcplogs.md
@@ -13,11 +13,9 @@ Logging.
 ## Usage
 
 To use the `gcplogs` driver as the default logging driver, set the `log-driver`
-and `log-opt` keys to appropriate values in the `daemon.json` file, which is
-located in `/etc/docker/` on Linux hosts or
-`C:\ProgramData\docker\config\daemon.json` on Windows Server. For more about
-configuring Docker using `daemon.json`, see
-[daemon.json](../../../engine/reference/commandline/dockerd.md#daemon-configuration-file).
+and `log-opt` keys to appropriate values in the `daemon.json` configuration file.
+
+{% include configure-daemon-links.md %}
 
 The following example sets the log driver to `gcplogs` and sets the
 `gcp-meta-name` option.

--- a/config/containers/logging/gelf.md
+++ b/config/containers/logging/gelf.md
@@ -22,10 +22,9 @@ In GELF, every log message is a dict with the following fields:
 ## Usage
 
 To use the `gelf` driver as the default logging driver, set the `log-driver` and
-`log-opt` keys to appropriate values in the `daemon.json` file, which is located
-in `/etc/docker/` on Linux hosts or `C:\ProgramData\docker\config\daemon.json`
-on Windows Server. For more about configuring Docker using `daemon.json`, see
-[daemon.json](../../../engine/reference/commandline/dockerd.md#daemon-configuration-file).
+`log-opt` keys to appropriate values in the `daemon.json` configuration file.
+
+{% include configure-daemon-links.md %}
 
 The following example sets the log driver to `gelf` and sets the `gelf-address`
 option.

--- a/config/containers/logging/journald.md
+++ b/config/containers/logging/journald.md
@@ -26,11 +26,9 @@ stores the following metadata in the journal with each message:
 ## Usage
 
 To use the `journald` driver as the default logging driver, set the `log-driver`
-and `log-opts` keys to appropriate values in the `daemon.json` file, which is
-located in `/etc/docker/` on Linux hosts or
-`C:\ProgramData\docker\config\daemon.json` on Windows Server. For more about
-configuring Docker using `daemon.json`, see
-[daemon.json](../../../engine/reference/commandline/dockerd.md#daemon-configuration-file).
+and `log-opts` keys to appropriate values in the `daemon.json` configuration file.
+
+{% include configure-daemon-links.md %}
 
 The following example sets the log driver to `journald`:
 

--- a/config/containers/logging/json-file.md
+++ b/config/containers/logging/json-file.md
@@ -27,11 +27,12 @@ only one container.
 ## Usage
 
 To use the `json-file` driver as the default logging driver, set the `log-driver`
-and `log-opts` keys to appropriate values in the `daemon.json` file, which is
-located in `/etc/docker/` on Linux hosts or
-`C:\ProgramData\docker\config\` on Windows Server. If the file does not exist, create it first. For more information about
-configuring Docker using `daemon.json`, see
-[daemon.json](../../../engine/reference/commandline/dockerd.md#daemon-configuration-file).
+and `log-opts` keys to appropriate values in the `daemon.json` configuration file.
+
+{% include configure-daemon-links.md %}
+
+The following example sets the log driver to `local` and sets the `max-size`
+option.
 
 The following example sets the log driver to `json-file` and sets the `max-size`
 and `max-file` options to enable automatic log-rotation.

--- a/config/containers/logging/local.md
+++ b/config/containers/logging/local.md
@@ -25,11 +25,9 @@ for each file and a default count of 5 for the number of such files (to account 
 ## Usage
 
 To use the `local` driver as the default logging driver, set the `log-driver`
-and `log-opt` keys to appropriate values in the `daemon.json` file, which is
-located in `/etc/docker/` on Linux hosts or
-`C:\ProgramData\docker\config\daemon.json` on Windows Server. For more about
-configuring Docker using `daemon.json`, see
-[daemon.json](../../../engine/reference/commandline/dockerd.md#daemon-configuration-file).
+and `log-opt` keys to appropriate values in the `daemon.json` configuration file.
+
+{% include configure-daemon-links.md %}
 
 The following example sets the log driver to `local` and sets the `max-size`
 option.
@@ -43,7 +41,8 @@ option.
 }
 ```
 
-Restart Docker for the changes to take effect for newly created containers. Existing containers do not use the new logging configuration.
+Restart Docker for the changes to take effect for newly created containers.
+Existing containers do not use the new logging configuration.
 
 You can set the logging driver for a specific container by using the
 `--log-driver` flag to `docker container create` or `docker run`:

--- a/config/containers/logging/splunk.md
+++ b/config/containers/logging/splunk.md
@@ -18,7 +18,10 @@ per-container basis.
 
 To use the `splunk` driver as the default logging driver, set the keys
 `log-driver` and `log-opts` to appropriate values in the `daemon.json`
-configuration file and restart Docker. For example:
+configuration file.
+
+{% include configure-daemon-links.md %}
+
 
 ```json
 {
@@ -31,10 +34,7 @@ configuration file and restart Docker. For example:
 }
 ```
 
-The daemon.json file is located in `/etc/docker/` on Linux hosts or
-`C:\ProgramData\docker\config\daemon.json` on Windows Server. For more about
-configuring Docker using `daemon.json`, see
-[daemon.json](../../../engine/reference/commandline/dockerd.md#daemon-configuration-file).
+Restart Docker for the changes to take effect for newly created containers. Existing containers do not use the new logging configuration.
 
 > **Note**
 >

--- a/config/containers/logging/syslog.md
+++ b/config/containers/logging/syslog.md
@@ -34,11 +34,9 @@ The format is defined in [RFC 5424](https://tools.ietf.org/html/rfc5424) and Doc
 ## Usage
 
 To use the `syslog` driver as the default logging driver, set the `log-driver`
-and `log-opt` keys to appropriate values in the `daemon.json` file, which is
-located in `/etc/docker/` on Linux hosts or
-`C:\ProgramData\docker\config\daemon.json` on Windows Server. For more about
-configuring Docker using `daemon.json`, see
-[daemon.json](../../../engine/reference/commandline/dockerd.md#daemon-configuration-file).
+and `log-opt` keys to appropriate values in the `daemon.json` configuration file.
+
+{% include configure-daemon-links.md %}
 
 The following example sets the log driver to `syslog` and sets the
 `syslog-address` option. The `syslog-address` options supports both UDP and TCP;

--- a/config/daemon/index.md
+++ b/config/daemon/index.md
@@ -25,16 +25,14 @@ redirect_from:
 title: Docker daemon configuration overview
 ---
 
-This page shows you how to customize the Docker daemon, `dockerd`.
+This page shows you how to customize the Docker daemon, `dockerd`, in a
+standalone Docker Engine installation (without Docker Desktop).
 
-> **Note**
->
-> This page is for users who've installed Docker Engine manually. If you're
-> using Docker Desktop, refer to the following pages instead:
->
-> - [Change preferences on Mac](../../desktop/settings/mac#docker-engine)
-> - [Change preferences on Windows](../../desktop/settings/windows#docker-engine)
-> - [Change preferences on Linux](../../desktop/settings/linux#docker-engine)
+If you're using Docker Desktop, refer to the following pages instead:
+
+- [Change preferences on Mac](../../desktop/settings/mac#docker-engine)
+- [Change preferences on Windows](../../desktop/settings/windows#docker-engine)
+- [Change preferences on Linux](../../desktop/settings/linux#docker-engine)
 
 ## Configure the Docker daemon
 
@@ -48,9 +46,10 @@ You can use both of these options together as long as you don't specify the same
 option both as a flag and in the JSON file. If that happens, the Docker daemon
 won't start and prints an error message.
 
-To configure the Docker daemon using a JSON file, create a file at
-`/etc/docker/daemon.json` on Linux systems, or
-`C:\ProgramData\docker\config\daemon.json` on Windows.
+To configure the Docker daemon using a JSON file, create a file at:
+
+- `/etc/docker/daemon.json` for Docker Engine on Linux
+- `C:\ProgramData\docker\config\daemon.json` for Docker Engine on Windows
 
 Here's what the configuration file might look like:
 
@@ -65,6 +64,10 @@ Here's what the configuration file might look like:
   "experimental": false,
   "features": {
     "buildkit": true
+  },
+  "log-driver": "local",
+  "log-opts": {
+    "max-size": "10m"
   }
 }
 ```


### PR DESCRIPTION
<!--
  Thank you for contributing to Docker documentation!

  Here are a few things to keep in mind:

  - Links between pages should use a relative path
  - Remember to add an alt text for images

  ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
  ┃     Review our contribution guidelines:       ┃
  ┃                                               ┃
  ┃ https://docs.docker.com/contribute/overview/  ┃
  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
-->

### Proposed changes

Clarify the location of `daemon.json` (differences between DD and Docker Engine) for configuring logging drivers on Docker Engine.

### Related issues (optional)

#15106
