### PR TITLE
Update nodejs version in guide

### DIFF
--- a/language/nodejs/build-images.md
+++ b/language/nodejs/build-images.md
@@ -21,7 +21,7 @@ Now that we have a good overview of containers and the Docker platform, let’s 
 
 To complete this tutorial, you need the following:
 
-- Node.js version 12.18 or later. [Download Node.js](https://nodejs.org/en/){: target="_blank" rel="noopener" class="_"}
+- Node.js version 18 or later. [Download Node.js](https://nodejs.org/en/){: target="_blank" rel="noopener" class="_"}
 - Docker running locally: Follow the instructions to [download and install Docker](../../desktop/index.md).
 - An IDE or a text editor to edit files. We recommend using Visual Studio Code.
 
@@ -100,7 +100,7 @@ we would like to use for our application.
 ```dockerfile
 # syntax=docker/dockerfile:1
 
-FROM node:12.18.1
+FROM node:18-alpine
 ```
 
 Docker images can be inherited from other images. Therefore, instead of creating our own base image, we’ll use the official Node.js image that already has all the tools and packages that we need to run a Node.js application. You can think of this in the same way you would think about class inheritance in object oriented programming. For example, if we were able to create Docker images in JavaScript, we might write something like the following.
@@ -109,7 +109,7 @@ Docker images can be inherited from other images. Therefore, instead of creating
 
 This would create a class called `MyImage` that inherited functionality from the base class `NodeBaseImage`.
 
-In the same way, when we use the `FROM` command, we tell Docker to include in our image all the functionality from the `node:12.18.1` image.
+In the same way, when we use the `FROM` command, we tell Docker to include in our image all the functionality from the `node:18-alpine` image.
 
 > **Note**
 >
@@ -149,7 +149,7 @@ Once we have our files inside the image, we can use the `RUN` command to execute
 RUN npm install --production
 ```
 
-At this point, we have an image that is based on node version 12.18.1 and we have installed our dependencies. The next thing we need to do is to add our source code into the image. We’ll use the COPY command just like we did with our `package.json` files above.
+At this point, we have an image that is based on node version 18 and we have installed our dependencies. The next thing we need to do is to add our source code into the image. We’ll use the COPY command just like we did with our `package.json` files above.
 
 ```dockerfile
 COPY . .
@@ -166,7 +166,7 @@ Here's the complete Dockerfile.
 ```dockerfile
 # syntax=docker/dockerfile:1
 
-FROM node:12.18.1
+FROM node:18-alpine
 ENV NODE_ENV=production
 
 WORKDIR /app

--- a/language/nodejs/run-tests.md
+++ b/language/nodejs/run-tests.md
@@ -109,7 +109,7 @@ In addition to running the tests on command, we can run them when we build our i
 
 ```dockerfile
 # syntax=docker/dockerfile:1
-FROM node:14.15.4 as base
+FROM node:18-alpine as base
 
 WORKDIR /code
 
@@ -127,7 +127,7 @@ COPY . .
 CMD [ "node", "server.js" ]
 ```
 
-We first add a label `as base` to the `FROM node:14.15.4` statement. This allows us to refer to this build stage in other build stages. Next we add a new build stage labeled test. We will use this stage for running our tests.
+We first add a label `as base` to the `FROM node:18-alpine` statement. This allows us to refer to this build stage in other build stages. Next we add a new build stage labeled test. We will use this stage for running our tests.
 
 Now let’s rebuild our image and run our tests. We will run the same docker build command as above but this time we will add the `--target test` flag so that we specifically run the test build stage.
 
@@ -174,7 +174,7 @@ Update your Dockerfile with the highlighted line below.
 
 ```dockerfile
 # syntax=docker/dockerfile:1
-FROM node:14.15.4 as base
+FROM node:18-alpine as base
 
 WORKDIR /code
 
@@ -240,7 +240,7 @@ Now, run the same docker build command from above and observe that the build fai
 ```console
 $ docker build -t node-docker --target test .
 Sending build context to Docker daemon  22.35MB
-Step 1/8 : FROM node:14.15.4 as base
+Step 1/8 : FROM node:18-alpine as base
  ---> 995ff80c793e
 ...
 Step 8/8 : RUN npm run test


### PR DESCRIPTION
### Proposed changes
nodejs version 12 is EOL.
Updated nodejs language-specific guide to change the base image from version 12 (and 14.15.4) to 18. 
