### PR TITLE
Update: authing ECS to Dockerhub

### DIFF
--- a/cloud/ecs-integration.md
+++ b/cloud/ecs-integration.md
@@ -206,7 +206,9 @@ Compose file `logging.driver_opts` elements. See [AWS documentation](https://doc
 
 ## Private Docker images
 
-The Docker Compose CLI automatically configures authorization so you can pull private images from the Amazon ECR registry on the same AWS account. To pull private images from another registry, including Docker Hub, you’ll have to create a Username + Password (or a Username + Token) secret on the [AWS Secrets Manager service](https://docs.aws.amazon.com/secretsmanager/){: target="_blank" rel="noopener" class="_"}.
+The Docker Compose CLI automatically configures authorization so you can pull private images from the Amazon ECR registry on the same AWS account. 
+
+To pull private images from another registry, including Docker Hub, you’ll have to create a Username + Password (or a Username + Token) secret on the [AWS Secrets Manager service](https://docs.aws.amazon.com/secretsmanager/){: target="_blank" rel="noopener" class="_"}.  If you are using a token, your `auth` string should be `<username>:<token>` as a Base64 encoded string.
 
 For your convenience, the Docker Compose CLI offers the `docker secret` command, so you can manage secrets created on AWS SMS without having to install the AWS CLI.
 

--- a/docker-hub/access-tokens.md
+++ b/docker-hub/access-tokens.md
@@ -71,6 +71,8 @@ When logging in from your Docker CLI client (`docker login --username <username>
 omit the password in the login command. Instead, enter your token when asked for
 a password.
 
+If you are using a token to authenticate to AWS ECS, your `auth` string should be `<username:<token>` as a Base64 encoded string.
+
 > **Note**
 >
 > If you have [two-factor authentication (2FA)](2fa/index.md) enabled, you must


### PR DESCRIPTION
Based on my troubleshooting and subsequent success, it appears `/etc/ecs/ecs.config`, at least in some if not all cases, needs the auth string to be `<username>:<auth_token>` as a Base64 encoded string to work. Adding this here for others who may be fighting the same issue.