### PR TITLE
ci: create placeholder file for new commands before validation

### DIFF
--- a/.github/workflows/validate-upstream.yml
+++ b/.github/workflows/validate-upstream.yml
@@ -16,6 +16,9 @@ on:
       data-files-folder:
         required: false
         type: string
+      data-files-placeholder-folder:
+        required: false
+        type: string
 
 jobs:
   run:
@@ -73,7 +76,41 @@ jobs:
         if: ${{ inputs.data-files-id != '' && inputs.data-files-folder != '' }}
         with:
           name: ${{ inputs.data-files-id }}
-          path: ./_data/${{ inputs.data-files-folder }}
+          path: /tmp/_data/${{ inputs.data-files-folder }}
+      -
+        # Copy data files from /tmp/_data/${{ inputs.data-files-folder }} to
+        # _data/${{ inputs.data-files-folder }}. If data-files-placeholder-folder
+        # is set, then check if a placeholder file exists for each data file in
+        # that folder. If not, then creates a placeholder file with the same
+        # name as the data file, but with a .md extension.
+        name: Copy data files
+        if: ${{ inputs.data-files-id != '' && inputs.data-files-folder != '' }}
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const fs = require('fs');
+            const path = require('path');
+            const dataFilesPlaceholderFolder = `${{ inputs.data-files-placeholder-folder }}`;
+            const globber = await glob.create(`/tmp/_data/${{ inputs.data-files-folder }}/*.yaml`);
+            for await (const yamlSrcPath of globber.globGenerator()) {
+              const yamlSrcFilename = path.basename(yamlSrcPath);
+              const yamlDestPath = path.join('_data', `${{ inputs.data-files-folder }}`, yamlSrcFilename);
+              const placeholderPath = path.join(dataFilesPlaceholderFolder, yamlSrcFilename.replace(/^docker_/, '').replace(/\.yaml$/, '.md'));
+              if (dataFilesPlaceholderFolder !== '' && !fs.existsSync(placeholderPath)) {
+                const placeholderContent = `---
+            datafolder: ${{ inputs.data-files-folder }}
+            datafile: ${yamlSrcFilename.replace(/\.[^/.]+$/, '')}
+            title: ${yamlSrcFilename.replace(/\.[^/.]+$/, "").replaceAll('_', ' ')}
+            ---
+            {% include cli.md datafolder=page.datafolder datafile=page.datafile %}`;
+                await core.group(`creating ${placeholderPath}`, async () => {
+                  core.info(placeholderContent);
+                });
+                await fs.writeFileSync(placeholderPath, placeholderContent);
+              }
+              core.info(`${yamlSrcPath} => ${yamlDestPath}`);
+              await fs.copyFileSync(yamlSrcPath, yamlDestPath);
+            }
       -
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2


### PR DESCRIPTION
### Proposed changes

Our `validate-upstream` workflow does not take into account new commands that don't have (yet) a placeholder markdown file and therefore fails with https://github.com/docker/buildx/actions/runs/4262324143/jobs/7417733008#step:8:3742

```
#0 0.048 - ./_site/engine/reference/commandline/buildx/index.html
#0 0.048   *  internally linking to /engine/reference/commandline/buildx_debug-shell/, which does not exist (line 206)
#0 0.048      <a href="/engine/reference/commandline/buildx_debug-shell/">docker buildx debug-shell</a>
```

This change ensures a placeholder exists and creates it if it's not there.

Tested here: https://github.com/docker/buildx/actions/runs/4263151955/jobs/7419575907#step:7:38

### Related issues (optional)

* will unblock https://github.com/docker/buildx/pull/1640#discussion_r1116943558