### PR TITLE
fix: Pin Testcontainers for .NET version

### DIFF
--- a/language/dotnet/run-tests.md
+++ b/language/dotnet/run-tests.md
@@ -26,7 +26,7 @@ $ dotnet new xunit -n myWebApp.Tests -o tests
 Next, we'll update the test project and add the Testcontainers for .NET package that allows us to run tests against Docker resources. Switch to the `tests` directory and run the following command:
 
 ```console
-$ dotnet add package Testcontainers
+$ dotnet add package Testcontainers --version 2.3.0
 ```
 
 ## Add a test


### PR DESCRIPTION
<!--
  Thank you for contributing to Docker documentation!

  Here are a few things to keep in mind:

  - Links between pages should use a relative path
  - Remember to add an alt text for images

  ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
  ┃     Review our contribution guidelines:       ┃
  ┃                                               ┃
  ┃ https://docs.docker.com/contribute/overview/  ┃
  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
-->

### Proposed changes

This pull request pins Testcontainers for .NET to version 2.3.0. Although we could also use the latest version (2.4.0) with some small adjustments, I recommend to stick with version 2.3.0 for now. We are currently preparing a major release that will make it easier for Docker customers to test .NET applications and services, and we plan to update the Docker docs accordingly.

This pull request fixes an issue where Testcontainers expected an already created network, which is not necessary at that point.

### Related issues (optional)

Refer to related PRs or issues:

- Closes #16710
