### PR TITLE
Fix etc. with missing periods

### DIFF
--- a/contribute/contribute-guide.md
+++ b/contribute/contribute-guide.md
@@ -21,7 +21,7 @@ There are two ways to contribute a pull request to the docs repository:
 
     This is the manual, more advanced version of clicking 'Edit this page' on a published docs page. Initiating a docs changes in a PR from your own branch gives you more flexibility, as you can submit changes to multiple pages or files under a single pull request, and even create new topics.
 
-    For a demo of the components, tags, Markdown syntax, styles, etc we use at [https://docs.docker.com/](/), see the Useful components section.
+    For a demo of the components, tags, Markdown syntax, styles, etc. we use at [https://docs.docker.com/](/), see the Useful components section.
 
 ## Important files
 

--- a/single-sign-on/configure/index.md
+++ b/single-sign-on/configure/index.md
@@ -18,7 +18,7 @@ Follow the steps on this page to configure SSO for your organization or company.
 
     >**Note**
     >
-    > Format your domains without protocol or www information, for example, yourcompany.com. This should include all email domains and subdomains users will use to access Docker. Public domains such as gmail.com, outlook.com, etc aren’t permitted. Also, the email domain should be set as the primary email.
+    > Format your domains without protocol or www information, for example, yourcompany.com. This should include all email domains and subdomains users will use to access Docker. Public domains such as gmail.com, outlook.com, etc. aren’t permitted. Also, the email domain should be set as the primary email.
 
 4. Once you have waited 72 hours for the TXT Record verification, you can then select **Verify** next to the domain you've added, and follow the on-screen instructions. 
 


### PR DESCRIPTION
<!--
  Thank you for contributing to Docker documentation!

  Here are a few things to keep in mind:

  - Links between pages should use a relative path
  - Remember to add an alt text for images

  ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
  ┃     Review our contribution guidelines:       ┃
  ┃                                               ┃
  ┃ https://docs.docker.com/contribute/overview/  ┃
  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
-->

### Proposed changes
At several places the abbreviation "etc." has no period.
This PR completes all "etc " by the missing period.

### Related issues (optional)
No issue found.
