### PR TITLE
styles: adjust centering of social links

### DIFF
--- a/_scss/_layout.scss
+++ b/_scss/_layout.scss
@@ -198,13 +198,14 @@ footer {
 .footer_social_nav ul li {
     float: left;
     position: relative;
+    display: flex;
+    justify-content: center;
+    align-items: center;
 }
 
 .footer_social_nav ul li:before {
     color: $white;
     position: absolute;
-    top: 10px;
-    left: 10px;
 }
 
 .footer_social_nav ul li+li {


### PR DESCRIPTION
### Proposed changes

Updated the layout for social links since some of the icons were misaligned:

before:
<img width="303" alt="Screenshot 2023-03-04 at 10 27 02" src="https://user-images.githubusercontent.com/37013688/222875638-595bc555-6d09-4839-ba35-7b1e017e0bbf.png">

now:
<img width="308" alt="Screenshot 2023-03-04 at 10 27 33" src="https://user-images.githubusercontent.com/37013688/222875641-4a4c60b4-285d-44db-8037-8bcb06c861c7.png">
