### PR TITLE
Update intext.md - one word typo in composer's aliases section

### DIFF
--- a/compose/compose-file/index.md
+++ b/compose/compose-file/index.md
@@ -1343,7 +1343,7 @@ services:
 
 In the example below, service `frontend` will be able to reach the `backend` service at
 the hostname `backend` or `database` on the `back-tier` network, and service `monitoring`
-will be able to reach same `backend` service at `db` or `mysql` on the `admin` network.
+will be able to reach same `backend` service at `backend` or `mysql` on the `admin` network.
 
 ```yml
 services:


### PR DESCRIPTION
Fix typo in aliases section

### Proposed changes

While reading documentation I found typo in `aliases` section. According to [networking in compose](https://docs.docker.com/compose/networking/) services within one network can reach each other by their corresponding service name declared in `docker-compose.yaml` file. Additionally, whole example content does not contain word `db`.