### PR TITLE
Fix "it's" typo on container-networking.md

### DIFF
--- a/config/containers/container-networking.md
+++ b/config/containers/container-networking.md
@@ -20,7 +20,7 @@ This page describes networking from the point of view of the container.
 ## Published ports
 
 By default, when you create or run a container using `docker create` or `docker run`,
-the container doesn't expose any of it's ports to the outside world.
+the container doesn't expose any of its ports to the outside world.
 To make a port available to services outside of Docker,
 or to Docker containers running on a different network,
 use the `--publish` or `-p` flag.


### PR DESCRIPTION
### Proposed changes

Fixed a typo from "it's" to "its"