### PR TITLE
Add CVEs to the 4.17.0 release notes

### DIFF
--- a/desktop/release-notes.md
+++ b/desktop/release-notes.md
@@ -100,6 +100,13 @@ For frequently asked questions about Docker Desktop releases, see [FAQs](faqs/ge
 - Changed compression algorithm to `xz` for RPM and Arch Linux distribution.
 - Fixed a bug that caused leftover files to be left in the root directory of the Debian package. Fixes [docker/for-linux#123](https://github.com/docker/desktop-linux/issues/123).
 
+### Security
+
+#### For all platforms
+
+- Fixed [CVE-2023-0628](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-0628){: target="_blank" rel="noopener" class="_"}, which allows an attacker to execute an arbitrary command inside a Dev Environments container during initialization by tricking an user to open a crafted malicious `docker-desktop://` URL.
+- Fixed [CVE-2023-0629](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-0629){: target="_blank" rel="noopener" class="_"}, which allows an unprivileged user to bypass Enhanced Container Isolation (ECI) restrictions by setting the Docker host to `docker.raw.sock`, or `npipe:////.pipe/docker_engine_linux` on Windows, via the `-H` (`--host`) CLI flag or the `DOCKER_HOST` environment variable and launch containers without the additional hardening features provided by ECI. This does not affect already running containers, nor containers launched through the usual approach (without Docker's raw socket).
+
 ## 4.16.3
 
 {% include release-date.html date="2023-01-30" %}

--- a/desktop/release-notes.md
+++ b/desktop/release-notes.md
@@ -104,7 +104,7 @@ For frequently asked questions about Docker Desktop releases, see [FAQs](faqs/ge
 
 #### For all platforms
 
-- Fixed [CVE-2023-0628](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-0628){: target="_blank" rel="noopener" class="_"}, which allows an attacker to execute an arbitrary command inside a Dev Environments container during initialization by tricking an user to open a crafted malicious `docker-desktop://` URL.
+- Fixed [CVE-2023-0628](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-0628){: target="_blank" rel="noopener" class="_"}, which allows an attacker to execute an arbitrary command inside a Dev Environments container during initialization by tricking a user to open a crafted malicious `docker-desktop://` URL.
 - Fixed [CVE-2023-0629](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-0629){: target="_blank" rel="noopener" class="_"}, which allows an unprivileged user to bypass Enhanced Container Isolation (ECI) restrictions by setting the Docker host to `docker.raw.sock`, or `npipe:////.pipe/docker_engine_linux` on Windows, via the `-H` (`--host`) CLI flag or the `DOCKER_HOST` environment variable and launch containers without the additional hardening features provided by ECI. This does not affect already running containers, nor containers launched through the usual approach (without Docker's raw socket).
 
 ## 4.16.3


### PR DESCRIPTION
<!--
  Thank you for contributing to Docker documentation!

  Here are a few things to keep in mind:

  - Links between pages should use a relative path
  - Remember to add an alt text for images

  ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
  ┃     Review our contribution guidelines:       ┃
  ┃                                               ┃
  ┃ https://docs.docker.com/contribute/overview/  ┃
  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
-->

### Proposed changes

Add CVE-2023-0628 and CVE-2023-0629 to the 4.17.0 release notes.
NOTE: The linked CVE records are reserved and will be published once the release notes are updated.

<!-- Tell us what you did and why -->

### Related issues (optional)

<!--
  Refer to related PRs or issues:

  #1234
  Closes #1234
  Closes docker/cli#1234
-->
