### PR TITLE
ci: fix validate upstream workflow

### DIFF
--- a/.github/workflows/validate-upstream.yml
+++ b/.github/workflows/validate-upstream.yml
@@ -67,7 +67,7 @@ jobs:
           yq _config.yml
           # cleanup js-yaml module and data files
           rm -rf ./node_modules
-          if [ -n "./_data/${{ inputs.data-files-folder }}" ]; then
+          if [[ -n "${{ inputs.data-files-folder }}" ]] && [[ -d "./_data/${{ inputs.data-files-folder }}" ]]; then
             rm -rf ./_data/${{ inputs.data-files-folder }}/*
           fi
       -


### PR DESCRIPTION
### Proposed changes

Encounter this issue while adding the upstream workflow to the buildkit repo: https://github.com/moby/buildkit/actions/runs/4406503730/jobs/7718839413#step:9:3815

That's because we are not checking `inputs.data-files-folder` and therefore it will remove the `./_data` folder.

### Related issues (optional)

<!--
  Refer to related PRs or issues:

  #1234
  Closes #1234
  Closes docker/cli#1234
-->
