### PR TITLE
Clarify text around TLS configuration in Docker engine docs

### DIFF
--- a/config/daemon/index.md
+++ b/config/daemon/index.md
@@ -69,7 +69,10 @@ Here's what the configuration file might look like:
 }
 ```
 
-With this configuration, run the Docker daemon in debug mode, using TLS, and
+In addition to Docker Desktop default values, this configuration enables garbage
+collection at a 20GB threshold, and enables buildkit.
+
+Using this configuration file, run the Docker daemon in debug mode, using TLS, and
 listen for traffic routed to `192.168.59.3` on port `2376`. You can learn what
 configuration options are available in the
 [dockerd reference docs](../../engine/reference/commandline/dockerd.md#daemon-configuration-file)

--- a/config/daemon/index.md
+++ b/config/daemon/index.md
@@ -69,8 +69,8 @@ Here's what the configuration file might look like:
 }
 ```
 
-With this configuration the Docker daemon runs in debug mode, uses TLS, and
-listens for traffic routed to `192.168.59.3` on port `2376`. You can learn what
+With this configuration, run the Docker daemon in debug mode, using TLS, and
+listen for traffic routed to `192.168.59.3` on port `2376`. You can learn what
 configuration options are available in the
 [dockerd reference docs](../../engine/reference/commandline/dockerd.md#daemon-configuration-file)
 


### PR DESCRIPTION
### Proposed changes

There was feedback that the config file doesn't show TLS configuration, which is true. The command line example below shows this, so I clarified the ordering of the text.