### PR TITLE
small improvements to the rate-limit docs

### DIFF
--- a/docker-hub/download-rate-limit.md
+++ b/docker-hub/download-rate-limit.md
@@ -86,7 +86,7 @@ This means my limit is 100 pulls per 21600 seconds (6 hours), and I have 76 pull
 
 ### I don't see any RateLimit headers
 
-This could be because the image or your IP is unlimited in partnership with a publisher, provider, or an open-source organization. It could also mean that the user you are pulling as is part of a pain Docker plan. Pulling that image won’t count toward pull limits if you don’t see these headers. However, users with a paid Docker subscription pulling more than 5000 times daily require a [Service Account](../docker-hub/service-accounts.md) subscription.
+This could be because the image or your IP is unlimited in partnership with a publisher, provider, or an open-source organization. It could also mean that the user you are pulling as is part of a paid Docker plan. Pulling that image won’t count toward pull limits if you don’t see these headers. However, users with a paid Docker subscription pulling more than 5000 times daily require a [Service Account](../docker-hub/service-accounts.md) subscription.
 
 ## I'm being limited to a lower rate even though I have a paid Docker subscription
 

--- a/docker-hub/download-rate-limit.md
+++ b/docker-hub/download-rate-limit.md
@@ -49,6 +49,7 @@ Valid manifest API requests to Hub will usually include the following rate limit
 ```
 ratelimit-limit    
 ratelimit-remaining
+docker-ratelimit-source
 ```
 
 These headers will be returned on both GET and HEAD requests. Note that using GET emulates a real pull and will count towards the limit; using HEAD won't, so we will use it in this example. To check your limits, you will need `curl`, `grep`, and `jq` installed.
@@ -76,6 +77,7 @@ Which should return headers including these:
 ```http
 ratelimit-limit: 100;w=21600
 ratelimit-remaining: 76;w=21600
+docker-ratelimit-source: 192.0.2.1
 ```
 
 This means my limit is 100 pulls per 21600 seconds (6 hours), and I have 76 pulls remaining.
@@ -84,7 +86,7 @@ This means my limit is 100 pulls per 21600 seconds (6 hours), and I have 76 pull
 
 ### I don't see any RateLimit headers
 
-This could be because the image or your IP is unlimited in partnership with a publisher, provider, or an open-source organization. Pulling that image won’t count toward pull limits if you don’t see these headers. However, users with a paid Docker subscription pulling more than 5000 times daily require a [Service Account](../docker-hub/service-accounts.md) subscription.
+This could be because the image or your IP is unlimited in partnership with a publisher, provider, or an open-source organization. It could also mean that the user you are pulling as is part of a pain Docker plan. Pulling that image won’t count toward pull limits if you don’t see these headers. However, users with a paid Docker subscription pulling more than 5000 times daily require a [Service Account](../docker-hub/service-accounts.md) subscription.
 
 ## I'm being limited to a lower rate even though I have a paid Docker subscription
 


### PR DESCRIPTION
Signed-off-by: Alex Hokanson <571756+ingshtrom@users.noreply.github.com>

<!--
  Thank you for contributing to Docker documentation!

  Here are a few things to keep in mind:

  - Links between pages should use a relative path
  - Remember to add an alt text for images

  ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
  ┃     Review our contribution guidelines:       ┃
  ┃                                               ┃
  ┃ https://docs.docker.com/contribute/overview/  ┃
  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
-->

### Proposed changes

- added the `docker-ratelimit-source` header to the rate limit documentation
- added a part about rate limit headers not showing up because the user is on a paid plan. Previously, this information was inferred in the paragraph.

### Related issues (optional)

https://github.com/docker/hub-feedback/issues/2311

<!--
  Refer to related PRs or issues:

  #1234
  Closes #1234
  Closes docker/cli#1234
-->
