### PR TITLE
Remove experimental flag for metrics-addr as it is not required

### DIFF
--- a/config/daemon/prometheus.md
+++ b/config/daemon/prometheus.md
@@ -42,12 +42,11 @@ If the file is currently empty, paste the following:
 
 ```json
 {
-  "metrics-addr" : "127.0.0.1:9323",
-  "experimental" : true
+  "metrics-addr" : "127.0.0.1:9323"
 }
 ```
 
-If the file is not empty, add those two keys, making sure that the resulting
+If the file is not empty, add the new key, making sure that the resulting
 file is valid JSON. Be careful that every line ends with a comma (`,`) except
 for the last line.
 


### PR DESCRIPTION
<!--
  Thank you for contributing to Docker documentation!

  Here are a few things to keep in mind:

  - Links between pages should use a relative path
  - Remember to add an alt text for images

  ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
  ┃     Review our contribution guidelines:       ┃
  ┃                                               ┃
  ┃ https://docs.docker.com/contribute/overview/  ┃
  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
-->

### Proposed changes

<!-- Tell us what you did and why -->
This PR removes the experimental flag from the `metrics-addr` config key as it is not required (tested) since [this PR in moby](https://github.com/moby/moby/pull/40427).

### Related issues (optional)

<!--
  Refer to related PRs or issues:

  #1234
  Closes #1234
  Closes docker/cli#1234
-->
moby/moby#40427