### PR TITLE
build: update since buildinfo removal

### DIFF
--- a/build/exporters/image-registry.md
+++ b/build/exporters/image-registry.md
@@ -37,16 +37,13 @@ The following table describes the available parameters that you can pass to
 | `compression-level`    | `0..22`                                |         | Compression level, see [compression][1]                                                                                                                                                                                             |
 | `force-compression`    | `true`,`false`                         | `false` | Forcefully apply compression, see [compression][1]                                                                                                                                                                                  |
 | `oci-mediatypes`       | `true`,`false`                         | `false` | Use OCI media types in exporter manifests, see [OCI Media types][2]                                                                                                                                                                 |
-| `buildinfo`            | `true`,`false`                         | `true`  | Attach inline [build info][3]                                                                                                                                                                                                       |
-| `buildinfo-attrs`      | `true`,`false`                         | `false` | Attach inline [build info attributes][3]                                                                                                                                                                                            |
 | `unpack`               | `true`,`false`                         | `false` | Unpack image after creation (for use with containerd)                                                                                                                                                                               |
 | `store`                | `true`,`false`                         | `true`  | Store the result images to the worker's (for example, containerd) image store, and ensures that the image has all blobs in the content store. Ignored if the worker doesn't have image store (when using OCI workers, for example). |
-| `annotation.<key>`     | String                                 |         | Attach an annotation with the respective `key` and `value` to the built image,see [annotations][4]                                                                                                                                  |
+| `annotation.<key>`     | String                                 |         | Attach an annotation with the respective `key` and `value` to the built image,see [annotations][3]                                                                                                                                  |
 
 [1]: index.md#compression
 [2]: index.md#oci-media-types
-[3]: index.md#build-info
-[4]: #annotations
+[3]: #annotations
 
 ## Annotations
 

--- a/build/exporters/index.md
+++ b/build/exporters/index.md
@@ -259,24 +259,6 @@ $ docker buildx build \
   --output type=image,name=<registry>/<image>,push=true,oci-mediatypes=true .
 ```
 
-### Build info
-
-Exporters that output container images, allow embedding information about the
-build, including information on the original build request and sources used
-during the build. This is supported by the `image`, `registry`, `oci` and
-`docker` exporters.
-
-This build info is attached to the image configuration:
-
-```json
-{
-  "moby.buildkit.buildinfo.v0": "<base64>"
-}
-```
-
-By default, build dependencies are attached to the image configuration. You can
-turn off this behavior by setting `buildinfo=false`.
-
 ## What's next
 
 Read about each of the exporters to learn about how they work and how to use

--- a/build/exporters/oci-docker.md
+++ b/build/exporters/oci-docker.md
@@ -38,14 +38,11 @@ The following table describes the available parameters:
 | `compression-level` | `0..22`                                |         | Compression level, see [compression][1]                                                                                               |
 | `force-compression` | `true`,`false`                         | `false` | Forcefully apply compression, see [compression][1]                                                                                    |
 | `oci-mediatypes`    | `true`,`false`                         |         | Use OCI media types in exporter manifests. Defaults to `true` for `type=oci`, and `false` for `type=docker`. See [OCI Media types][2] |
-| `buildinfo`         | `true`,`false`                         | `true`  | Attach inline [build info][3]                                                                                                         |
-| `buildinfo-attrs`   | `true`,`false`                         | `false` | Attach inline [build info attributes][3]                                                                                              |
-| `annotation.<key>`  | String                                 |         | Attach an annotation with the respective `key` and `value` to the built image,see [annotations][4]                                    |
+| `annotation.<key>`  | String                                 |         | Attach an annotation with the respective `key` and `value` to the built image,see [annotations][3]                                    |
 
 [1]: index.md#compression
 [2]: index.md#oci-media-types
-[3]: index.md#build-info
-[4]: #annotations
+[3]: #annotations
 
 ## Annotations
 


### PR DESCRIPTION
follow-up https://github.com/moby/buildkit/pull/3582

### Proposed changes

Update docs since buildinfo has been removed from BuildKit.

Keeping in draft until Buildx v-next.

### Related issues (optional)

<!--
  Refer to related PRs or issues:

  #1234
  Closes #1234
  Closes docker/cli#1234
-->
