### PR TITLE
Update https://docs.docker.com/compose/networking/

### DIFF
--- a/compose/networking.md
+++ b/compose/networking.md
@@ -54,7 +54,7 @@ the service is accessible outside the swarm as well.
 
 Within the `web` container, your connection string to `db` would look like
 `postgres://db:5432`, and from the host machine, the connection string would
-look like `postgres://{DOCKER_IP}:5432`.
+look like `postgres://{DOCKER_IP}:5432` or `postgres://localhost:8001`.
 
 ## Update containers on the network
 

--- a/compose/networking.md
+++ b/compose/networking.md
@@ -54,7 +54,7 @@ the service is accessible outside the swarm as well.
 
 Within the `web` container, your connection string to `db` would look like
 `postgres://db:5432`, and from the host machine, the connection string would
-look like `postgres://{DOCKER_IP}:5432` or `postgres://localhost:8001`.
+look like `postgres://{DOCKER_IP}:8001` for example `postgres://localhost:8001` if your container is running locally.
 
 ## Update containers on the network
 


### PR DESCRIPTION
### Proposed changes

Updated information on how to reach the container from the host. This will help beginners not get confused in the networks.

Another proposal by @mlnorthernswe
> ... look like `postgres://{DOCKER_IP}:5432` or `postgres://{DOCKER_HOST_IP}:8001`


### Related issues (optional)

Discussion: [#16711](https://github.com/docker/docs/pull/16711#issuecomment-1470258105)
Similar prs:
https://github.com/docker/docs/pull/16729
https://github.com/docker/docs/pull/16894

