### PR TITLE
build: change sections order in toc

### DIFF
--- a/_data/toc.yaml
+++ b/_data/toc.yaml
@@ -1581,6 +1581,16 @@ manuals:
           title: Kubernetes driver
         - path: /build/drivers/remote/
           title: Remote driver
+    - sectiontitle: Exporters
+      section:
+        - path: /build/exporters/
+          title: Overview
+        - path: /build/exporters/image-registry/
+          title: Image and registry exporters
+        - path: /build/exporters/local-tar/
+          title: Local and tar exporters
+        - path: /build/exporters/oci-docker/
+          title: OCI and Docker exporters
     - sectiontitle: Cache
       section:
         - path: /build/cache/
@@ -1603,50 +1613,6 @@ manuals:
               title: Azure Blob Storage
             - path: /build/cache/backends/s3/
               title: Amazon S3
-    - sectiontitle: Exporters
-      section:
-      - path: /build/exporters/
-        title: Overview
-      - path: /build/exporters/image-registry/
-        title: Image and registry exporters
-      - path: /build/exporters/local-tar/
-        title: Local and tar exporters
-      - path: /build/exporters/oci-docker/
-        title: OCI and Docker exporters
-    - sectiontitle: Continuous integration
-      section:
-        - path: /build/ci/
-          title: CI with Docker
-        - sectiontitle: GitHub Actions
-          section:
-          - path: /build/ci/github-actions/
-            title: Introduction
-          - path: /build/ci/github-actions/configure-builder/
-            title: Configuring your builder
-          - path: /build/ci/github-actions/multi-platform/
-            title: Multi-platform image
-          - path: /build/ci/github-actions/secrets/
-            title: Secrets
-          - path: /build/ci/github-actions/push-multi-registries/
-            title: Push to multi-registries
-          - path: /build/ci/github-actions/manage-tags-labels/
-            title: Manage tags and labels
-          - path: /build/ci/github-actions/cache/
-            title: Cache management
-          - path: /build/ci/github-actions/export-docker/
-            title: Export to Docker
-          - path: /build/ci/github-actions/test-before-push/
-            title: Test before push
-          - path: /build/ci/github-actions/local-registry/
-            title: Local registry
-          - path: /build/ci/github-actions/share-image-jobs/
-            title: Share built image between jobs
-          - path: /build/ci/github-actions/named-contexts/
-            title: Named contexts
-          - path: /build/ci/github-actions/copy-image-registries/
-            title: Copy image between registries
-          - path: /build/ci/github-actions/update-dockerhub-desc/
-            title: Update Docker Hub repo description
     - sectiontitle: Bake
       section:
         - path: /build/bake/
@@ -1683,6 +1649,40 @@ manuals:
           title: Configure
         - path: /build/buildkit/toml-configuration/
           title: TOML configuration
+    - sectiontitle: Continuous integration
+      section:
+        - path: /build/ci/
+          title: CI with Docker
+        - sectiontitle: GitHub Actions
+          section:
+          - path: /build/ci/github-actions/
+            title: Introduction
+          - path: /build/ci/github-actions/configure-builder/
+            title: Configuring your builder
+          - path: /build/ci/github-actions/multi-platform/
+            title: Multi-platform image
+          - path: /build/ci/github-actions/secrets/
+            title: Secrets
+          - path: /build/ci/github-actions/push-multi-registries/
+            title: Push to multi-registries
+          - path: /build/ci/github-actions/manage-tags-labels/
+            title: Manage tags and labels
+          - path: /build/ci/github-actions/cache/
+            title: Cache management
+          - path: /build/ci/github-actions/export-docker/
+            title: Export to Docker
+          - path: /build/ci/github-actions/test-before-push/
+            title: Test before push
+          - path: /build/ci/github-actions/local-registry/
+            title: Local registry
+          - path: /build/ci/github-actions/share-image-jobs/
+            title: Share built image between jobs
+          - path: /build/ci/github-actions/named-contexts/
+            title: Named contexts
+          - path: /build/ci/github-actions/copy-image-registries/
+            title: Copy image between registries
+          - path: /build/ci/github-actions/update-dockerhub-desc/
+            title: Update Docker Hub repo description
     - path: /build/release-notes/
       title: Release notes
 - sectiontitle: Docker Compose

--- a/build/index.md
+++ b/build/index.md
@@ -99,34 +99,6 @@ advanced scenarios.
     <div class="col-xs-12 col-sm-12 col-md-12 col-lg-4 block">
       <div class="component">
         <div class="component-icon">
-          <a href="/build/cache/">
-           <img src="/assets/images/build-cache.svg" alt="Two arrows rotating in a circle" width="70px" height="70px">
-          </a>
-        </div>
-        <h2><a href="/build/cache/">Build caching</a></h2>
-        <p>
-          Avoid unnecessary repetitions of costly operations, such as package installs.
-        </p>
-      </div>
-    </div>
-    <div class="col-xs-12 col-sm-12 col-md-12 col-lg-4 block">
-      <div class="component">
-        <div class="component-icon">
-          <a href="/build/ci/">
-           <img src="/assets/images/build-ci.svg" alt="Infinity loop" width="70px" height="70px">
-          </a>
-        </div>
-        <h2><a href="/build/ci/">Continuous integration</a></h2>
-        <p>
-          Learn how to use Docker in your continuous integration pipelines.
-        </p>
-      </div>
-    </div>
-  </div>
-  <div class="row">
-    <div class="col-xs-12 col-sm-12 col-md-12 col-lg-4 block">
-      <div class="component">
-        <div class="component-icon">
           <a href="/build/exporters/">
            <img src="/assets/images/build-exporters.svg" alt="Arrow coming out of a box" width="70px" height="70px">
           </a>
@@ -140,6 +112,21 @@ advanced scenarios.
     <div class="col-xs-12 col-sm-12 col-md-12 col-lg-4 block">
       <div class="component">
         <div class="component-icon">
+          <a href="/build/cache/">
+           <img src="/assets/images/build-cache.svg" alt="Two arrows rotating in a circle" width="70px" height="70px">
+          </a>
+        </div>
+        <h2><a href="/build/cache/">Build caching</a></h2>
+        <p>
+          Avoid unnecessary repetitions of costly operations, such as package installs.
+        </p>
+      </div>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-xs-12 col-sm-12 col-md-12 col-lg-4 block">
+      <div class="component">
+        <div class="component-icon">
           <a href="/build/bake/">
            <img src="/assets/images/build-bake.svg" alt="Cake silhouette" width="70px" height="70px">
           </a>
@@ -147,6 +134,19 @@ advanced scenarios.
         <h2><a href="/build/bake/">Bake</a></h2>
         <p>
           Orchestrate your builds with Bake.
+        </p>
+      </div>
+    </div>
+    <div class="col-xs-12 col-sm-12 col-md-12 col-lg-4 block">
+      <div class="component">
+        <div class="component-icon">
+          <a href="/build/ci/">
+           <img src="/assets/images/build-ci.svg" alt="Infinity loop" width="70px" height="70px">
+          </a>
+        </div>
+        <h2><a href="/build/ci/">Continuous integration</a></h2>
+        <p>
+          Learn how to use Docker in your continuous integration pipelines.
         </p>
       </div>
     </div>


### PR DESCRIPTION
### Proposed changes

As discussed internally with @dvdksn and @jedevc, change sections order in toc and overview page.

Before:

![image](https://user-images.githubusercontent.com/1951866/225917195-185e46d9-ff8d-4164-b088-d911b868e520.png)

After:

![image](https://user-images.githubusercontent.com/1951866/225917236-569782b0-0007-4647-ac19-4754a123b5ed.png)

Maybe we could also add an extra card for attestations in the Overview page. WDYT?

Let me know if that looks good.

### Related issues (optional)

<!--
  Refer to related PRs or issues:

  #1234
  Closes #1234
  Closes docker/cli#1234
-->
