### PR TITLE
do not append anchorLink for tiles

### DIFF
--- a/assets/js/anchorlinks.js
+++ b/assets/js/anchorlinks.js
@@ -1,7 +1,7 @@
 (function (d) {
     "use strict";
     for (const h of d.querySelectorAll("H1, H2, H3")) {
-        if (h.id != null && h.id.length > 0) {
+        if (h.id != null && h.id.length > 0 && !h.parentElement.classList.contains("component")) {
             h.insertAdjacentHTML('beforeend', `<a href="#${h.id}" class="anchorLink">🔗</a>`)
         }
     }


### PR DESCRIPTION
### Proposed changes

Having tile's title not centered correctly was bothering me for quite some time:

![image](https://user-images.githubusercontent.com/1951866/225952502-2b02c08d-1854-4ce8-8586-ba871e7c456f.png)

Does not seem necessary to have an anchor link for tiles imo.

Before:

![image](https://user-images.githubusercontent.com/1951866/225952732-0cb49c72-b73d-458f-9434-4ec6d9e79cae.png)

After:

![image](https://user-images.githubusercontent.com/1951866/225952812-1f7f0b03-e4c4-47c1-88a8-005b9d57321e.png)

### Related issues (optional)

<!--
  Refer to related PRs or issues:

  #1234
  Closes #1234
  Closes docker/cli#1234
-->
