### PR TITLE
Change Daemon to Docker Engine in prometheus doc

### DIFF
--- a/config/daemon/prometheus.md
+++ b/config/daemon/prometheus.md
@@ -36,7 +36,7 @@ exist, create it.
 - **Linux**: `/etc/docker/daemon.json`
 - **Windows Server**: `C:\ProgramData\docker\config\daemon.json`
 - **Docker Desktop for Mac / Docker Desktop for Windows**: Click the Docker icon in the toolbar,
-  select **Settings**, then select **Daemon**. Click **Advanced**.
+  select **Settings**, then select **Docker Engine**.
 
 If the file is currently empty, paste the following:
 


### PR DESCRIPTION
### Proposed changes

While looking at https://github.com/docker/docs/pull/16900 I noticed the surrounding text was out of date.