### PR TITLE
engine: No lsb-release for setting up the repo

### DIFF
--- a/engine/install/debian.md
+++ b/engine/install/debian.md
@@ -89,8 +89,7 @@ Docker from the repository.
     $ sudo apt-get install \
         ca-certificates \
         curl \
-        gnupg \
-        lsb-release
+        gnupg
     ```
 
 2.  Add Docker's official GPG key:
@@ -103,9 +102,9 @@ Docker from the repository.
 3.  Use the following command to set up the repository:
 
     ```console
-    $ echo \
+    $ . /etc/os-release && echo \
       "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] {{ download-url-base }} \
-      $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+      $VERSION_CODENAME stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
     ```
 
 #### Install Docker Engine

--- a/engine/install/ubuntu.md
+++ b/engine/install/ubuntu.md
@@ -88,8 +88,7 @@ Docker from the repository.
     $ sudo apt-get install \
         ca-certificates \
         curl \
-        gnupg \
-        lsb-release
+        gnupg
     ```
 
 2.  Add Docker's official GPG key:
@@ -102,9 +101,9 @@ Docker from the repository.
 3.  Use the following command to set up the repository:
 
     ```console
-    $ echo \
+    $ . /etc/os-release && echo \
       "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] {{ download-url-base }} \
-      $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+      $VERSION_CODENAME stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
     ```
 
 #### Install Docker Engine


### PR DESCRIPTION
<!--
  Thank you for contributing to Docker documentation!

  Here are a few things to keep in mind:

  - Links between pages should use a relative path
  - Remember to add an alt text for images

  ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
  ┃     Review our contribution guidelines:       ┃
  ┃                                               ┃
  ┃ https://docs.docker.com/contribute/overview/  ┃
  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
-->

### Proposed changes

Do not use `lsb-release` to set up the repository. `lsb-release` depends on `python3`.

`docker-ce`, `docker-ce-cli`, `containerd.io`, `docker-buildx-plugin` and `docker-compose-plugin` do not depend on `python3`.

### Related issues (optional)

\-

<!--
  Refer to related PRs or issues:

  #1234
  Closes #1234
  Closes docker/cli#1234
-->
