### PR TITLE
Update Telepresence link to point to our offering

### DIFF
--- a/develop/remote-development.md
+++ b/develop/remote-development.md
@@ -32,7 +32,7 @@ remote resources helps simplify and speed up the inner loop. There are several
 tools available, commercial and open-source, that you can use to enable a hybrid
 local-and-remote development environment. For example:
 
-- [Telepresence](https://www.cncf.io/projects/telepresence/){: target="_blank" rel="noopener" class="_" }
+- [Telepresence](https://app.getambassador.io/auth/realms/production/protocol/openid-connect/auth?client_id=docker-docs&response_type=code&redirect_uri=https%3A%2F%2Fapp.getambassador.io&utm_source=docker-docs&utm_medium=dockerwebsite&utm_campaign=Docker%26TP){: target="_blank" rel="noopener" class="_" }
 - [CodeZero](https://www.codezero.io/){: target="_blank" rel="noopener" class="_" }
 - [Gefyra](https://gefyra.dev/){: target="_blank" rel="noopener" class="_" }
 - [kubefwd](https://kubefwd.com/){: target="_blank" rel="noopener" class="_" }


### PR DESCRIPTION
All the Telepresence links in our docs should point to our own Ambassador-Docker product offering

<!--
  Thank you for contributing to Docker documentation!

  Here are a few things to keep in mind:

  - Links between pages should use a relative path
  - Remember to add an alt text for images

  ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
  ┃     Review our contribution guidelines:       ┃
  ┃                                               ┃
  ┃ https://docs.docker.com/contribute/overview/  ┃
  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
-->

### Proposed changes

<!-- Tell us what you did and why -->

### Related issues (optional)

<!--
  Refer to related PRs or issues:

  #1234
  Closes #1234
  Closes docker/cli#1234
-->
