### PR TITLE
Add additional info on remote syntax

### DIFF
--- a/_data/engine-cli/docker_push.yaml
+++ b/_data/engine-cli/docker_push.yaml
@@ -83,9 +83,15 @@ examples: |-
     ```
 
     Now, push the image to the registry using the image ID. In this example the
-    registry is on host named `registry-host` and listening on port `5000`. To do
+    registry is on host named `registry-host` and listening on port `5000`. Additionally, the username for authentication is specified as "myadmin" and the remote name/tag is "rhel-httpd:latest". Note, the syntax generally follows the format: 
+    
+    ```console
+    $ docker image tag [OPTIONS] IMAGE[:TAG] [REGISTRYHOST:][PORT/][USERNAME/]NAME[:TAG]
+    ```
+    
+    To do
     this, tag the image with the host name or IP address, and the port of the
-    registry:
+    registry: 
 
     ```console
     $ docker image tag rhel-httpd:latest registry-host:5000/myadmin/rhel-httpd:latest


### PR DESCRIPTION
### Proposed changes

Added more information about the remote syntax in the push manual page ([engine/reference/commandline/push.md](https://docs.docker.com/engine/reference/commandline/push/)).

### Refer to related PRs or issues:
Closes #16891