### PR TITLE
remote-development: make sure cross-domain links with ambassador have the same params

### DIFF
--- a/develop/remote-development.md
+++ b/develop/remote-development.md
@@ -72,9 +72,9 @@ You have a few options for how the local containers can integrate with the clust
 
 Telepresence is free and open-source, and you can try it out by heading to
 the
-[Telepresence quickstart guide](https://www.telepresence.io/docs/latest/quick-start/){: target="_blank" rel="noopener" class="_" }.
+[Telepresence quickstart guide](https://www.telepresence.io/docs/latest/quick-start/?utm_source=docker-docs&utm_medium=dockerwebsite&utm_campaign=Docker-TP){: target="_blank" rel="noopener" class="_" }.
 There’s also a
-[Telepresence extension for Docker Desktop](https://www.getambassador.io/docs/telepresence/latest/extension/intro){: target="_blank" rel="noopener" class="_" },
+[Telepresence extension for Docker Desktop](https://www.getambassador.io/docs/telepresence/latest/extension/intro?utm_source=docker-docs&utm_medium=dockerwebsite&utm_campaign=Docker-TP){: target="_blank" rel="noopener" class="_" },
 which helps you manage intercepts for your containers.
 
 ### Docker × Ambassador


### PR DESCRIPTION
### Proposed changes

make sure cross-domain links with ambassador have the same params,
so ambassador can see where they came from on the other end
