### PR TITLE
Revert "engine: add 23.0.2 release notes"

### DIFF
--- a/engine/release-notes/23.0.md
+++ b/engine/release-notes/23.0.md
@@ -41,42 +41,6 @@ Changing the version format is a stepping-stone towards Go module compatibility,
 but the repository doesn't yet use Go modules, and still requires using a "+incompatible" version.
 Work continues towards Go module compatibility in a future release.
 
-## 23.0.2
-
-{% include release-date.html date="2023-03-27" %}
-
-For a full list of pull requests and changes in this release, refer to the relevant GitHub milestones:
-
-- [docker/cli, 23.0.2 milestone](https://github.com/docker/cli/milestone/75?closed=1)
-- [moby/moby, 23.0.2 milestone](https://github.com/moby/moby/milestone/114?closed=1)
-
-### Bug fixes and enhancements
-
-- Fully resolve missing checks for `apparmor_parser` when an AppArmor enabled kernel is detected. [containerd/containerd#8087](https://github.com/containerd/containerd/pull/8087), [moby/moby#45043](https://github.com/moby/moby/pull/45043)
-- Ensure that credentials are redacted from Git URLs when generating BuildKit buildinfo. Fixes [CVE-2023-26054](https://github.com/moby/buildkit/security/advisories/GHSA-gc89-7gcr-jxqc). [moby/moby#45110](https://github.com/moby/moby/pull/45110)
-- Fix anonymous volumes created by a `VOLUME` line in a Dockerfile being excluded from volume prune. [moby/moby#45159](https://github.com/moby/moby/pull/45159)
-- Fix a failure to properly propagate errors during removal of volumes on a Swarm node. [moby/moby#45155](https://github.com/moby/moby/pull/45155)
-- Temporarily work around a bug in BuildKit `COPY --link` by disabling mergeop/diffop optimization. [moby/moby#45112](https://github.com/moby/moby/pull/45112)
-- Properly clean up child tasks when a parent Swarm job is removed. [moby/swarmkit#3112](https://github.com/moby/swarmkit/pull/3112), [moby/moby#45107](https://github.com/moby/moby/pull/45107)
-- Fix Swarm service creation logic so that both a GenericResource and a non-default network can be used together. [moby/swarmkit#3082](https://github.com/moby/swarmkit/pull/3082), [moby/moby#45107](https://github.com/moby/moby/pull/45107)
-- Fix Swarm CSI support requiring the CSI plugin to offer staging endpoints in order to publish a volume. [moby/swarmkit#3116](https://github.com/moby/swarmkit/pull/3116), [moby/moby#45107](https://github.com/moby/moby/pull/45107)
-- Fix a segmentation fault caused by log buffering in some configurations. [containerd/fifo#47](https://github.com/containerd/fifo/pull/47), [moby/moby#45051](https://github.com/moby/moby/pull/45051)
-- Log errors in the REST to Swarm gRPC API translation layer at the debug level to reduce redundancy and noise. [moby/moby#45016](https://github.com/moby/moby/pull/45016)
-- Fix a DNS resolution issue affecting containers created with `--dns-opt` or `--dns-search` when `systemd-resolved` is used outside the container. [moby/moby#45000](https://github.com/moby/moby/pull/45000)
-- Fix a segmentation fault caused by malformed DNS queries originating from inside a container. [moby/moby#44980](https://github.com/moby/moby/pull/44980)
-- Improve the speed of `docker ps` by allowing users to opt out of size calculations with `--size=false`. [docker/cli#4107](https://github.com/docker/cli/pull/4107)
-- Extend support for Bash completion to all plugins. [docker/cli#4092](https://github.com/docker/cli/pull/4092)
-- Fix `docker stack deploy` failing on Windows when special environment variables set by `cmd.exe` are present. [docker/cli#4083](https://github.com/docker/cli/pull/4083)
-- Add forward compatibility for future API versions by considering empty image tags to be the same as `<none>`. [docker/cli#4065](https://github.com/docker/cli/pull/4065)
-- Atomically write context files to greatly reduce the probability of corruption, and improve the error message for a corrupt context. [docker/cli#4063](https://github.com/docker/cli/pull/4063)
-
-### Packaging
-
-- Upgrade Go to `1.19.7`. [docker/docker-ce-packaging#857](https://github.com/docker/docker-ce-packaging/pull/857), [docker/cli#4086](https://github.com/docker/cli/pull/4086), [moby/moby#45137](https://github.com/moby/moby/pull/45137)
-- Upgrade `containerd` to `v1.6.19`. [moby/moby#45084](https://github.com/moby/moby/pull/45084), [moby/moby#45099](https://github.com/moby/moby/pull/45099)
-- Upgrade Buildx to `v0.10.4`. [docker/docker-ce-packaging#855](https://github.com/docker/docker-ce-packaging/pull/855)
-- Upgrade Compose to `v2.17.0`. [docker/docker-ce-packaging#861](https://github.com/docker/docker-ce-packaging/pull/861)
-
 ## 23.0.1
 
 {% include release-date.html date="2023-02-09" %}


### PR DESCRIPTION
Reverts docker/docs#16946

- see https://github.com/docker/docs/pull/16946#issuecomment-1483067324