### PR TITLE
build: fix typo for BUILDX_NO_DEFAULT_ATTESTATIONS env var sample

### DIFF
--- a/build/building/env-vars.md
+++ b/build/building/env-vars.md
@@ -183,7 +183,7 @@ attestations.
 Usage:
 
 ```console
-$ export BUILDX_NO_DEFAULT_ATTESTATION=1
+$ export BUILDX_NO_DEFAULT_ATTESTATIONS=1
 ```
 
 ## BUILDX_NO_DEFAULT_LOAD


### PR DESCRIPTION
### Proposed changes

Fix typo for `BUILDX_NO_DEFAULT_ATTESTATIONS` env var in code sample

### Related issues (optional)

fixes https://github.com/docker/buildx/issues/1695
