### PR TITLE
Fix incorrect checksum

### DIFF
--- a/desktop/release-notes.md
+++ b/desktop/release-notes.md
@@ -45,7 +45,7 @@ For frequently asked questions about Docker Desktop releases, see [FAQs](faqs/ge
           <a class="btn btn-primary" href="https://desktop.docker.com/win/main/amd64/Docker%20Desktop%20Installer.exe?utm_source=docker&utm_medium=webreferral&utm_campaign=docs-driven-download-win-amd64" role="button">Download file</a> 
         <br>
         <br>
-        <b>Checksum:</b> e66a76f8f71f7e5e4488163d7da686d1fc669c5cbb47fec15085623c4deaf16a
+        <b>Checksum:</b> 2ea284648a5f708428f3a06bb8e1eb68cbeba6689b53c53d7ca24043a8f34800
         </div>
       </div>
     </div>


### PR DESCRIPTION
<!--
  Thank you for contributing to Docker documentation!

  Here are a few things to keep in mind:

  - Links between pages should use a relative path
  - Remember to add an alt text for images

  ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
  ┃     Review our contribution guidelines:       ┃
  ┃                                               ┃
  ┃ https://docs.docker.com/contribute/overview/  ┃
  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
-->

### Proposed changes

<!-- Tell us what you did and why -->

### Related issues (optional)

<!--
  Refer to related PRs or issues:

  #1234
  Closes #1234
  Closes docker/cli#1234
-->

This is the correct checksum for the 4.17.1 Windows Installer (check https://desktop.docker.com/win/main/amd64/101757/metadata.json – search for the `Docker Desktop Installer.exe` artifact and associated `checksum` field)