### PR TITLE
fix(desktop): temporarily makes 4.16.3 default windows version

### DIFF
--- a/_includes/desktop-install.html
+++ b/_includes/desktop-install.html
@@ -10,10 +10,10 @@
       </div>
       <div id="collapseOne" class="panel-collapse collapse" role="tabpanel" aria-labelledby="headingOne">
         <div class="panel-body">
-          <a class="btn btn-primary" href="https://desktop.docker.com/win/main/amd64/Docker%20Desktop%20Installer.exe?utm_source=docker&utm_medium=webreferral&utm_campaign=docs-driven-download-win-amd64" role="button">Download file</a> 
+          <a class="btn btn-primary" href="https://desktop.docker.com/win/main/amd64/96739/Docker%20Desktop%20Installer.exe?utm_source=docker&utm_medium=webreferral&utm_campaign=docs-driven-download-win-amd64" role="button">Download file</a>
         <br>
         <br>
-        <b>Checksum:</b> SHA-256 69ea659b0ca0e160a1de9bd63dc5697f5eb89fff1d33484fb8ef9793e43d0d45
+        <b>Checksum:</b> SHA-256 5f6db3cf5a2084fc7c584c90792f38a0caac91c4eed4f8653dde7bb8148517f1
         </div>
       </div>
     </div>

--- a/desktop/install/windows-install.md
+++ b/desktop/install/windows-install.md
@@ -17,7 +17,7 @@ redirect_from:
 
 Welcome to Docker Desktop for Windows. This page contains information about Docker Desktop for Windows system requirements, download URL, instructions to install and update Docker Desktop for Windows.
 
-[Docker Desktop for Windows](https://desktop.docker.com/win/main/amd64/Docker%20Desktop%20Installer.exe){: .button .primary-btn }
+[Docker Desktop for Windows](https://desktop.docker.com/win/main/amd64/96739/Docker%20Desktop%20Installer.exe){: .button .primary-btn }
 
 _For checksums, see [Release notes](../release-notes.md)_
 

--- a/desktop/windows/wsl.md
+++ b/desktop/windows/wsl.md
@@ -23,7 +23,7 @@ Before you turn on the Docker Desktop WSL 2, ensure you have:
 
 ## Turn on Docker Desktop WSL 2
 
-1. Download [Docker Desktop for Windows](https://desktop.docker.com/win/main/amd64/Docker%20Desktop%20Installer.exe).
+1. Download [Docker Desktop for Windows](https://desktop.docker.com/win/main/amd64/96739/Docker%20Desktop%20Installer.exe).
 2. Follow the usual installation instructions to install Docker Desktop. If you are running a supported system, Docker Desktop prompts you to enable WSL 2 during installation. Read the information displayed on the screen and enable WSL 2 to continue.
 3. Start Docker Desktop from the Windows Start menu.
 4. From the Docker menu, select **Settings** and then **General**.

--- a/engine/scan/index.md
+++ b/engine/scan/index.md
@@ -472,7 +472,7 @@ requirements:
 
    - [Download for Mac with Intel chip](https://desktop.docker.com/mac/main/amd64/Docker.dmg?utm_source=docker&utm_medium=webreferral&utm_campaign=docs-driven-download-mac-amd64)
    - [Download for Mac with Apple chip](https://desktop.docker.com/mac/main/arm64/Docker.dmg?utm_source=docker&utm_medium=webreferral&utm_campaign=docs-driven-download-mac-arm64)
-   - [Download for Windows](https://desktop.docker.com/win/main/amd64/Docker%20Desktop%20Installer.exe)
+   - [Download for Windows](https://desktop.docker.com/win/main/amd64/96739/Docker%20Desktop%20Installer.exe)
 
 2. Sign into [Docker Hub](https://hub.docker.com){: target="_blank"
    rel="noopener" class="_"}.


### PR DESCRIPTION


<!--
  Thank you for contributing to Docker documentation!

  Here are a few things to keep in mind:

  - Links between pages should use a relative path
  - Remember to add an alt text for images

  ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
  ┃     Review our contribution guidelines:       ┃
  ┃                                               ┃
  ┃ https://docs.docker.com/contribute/overview/  ┃
  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
-->

### Proposed changes

<!-- Tell us what you did and why -->
Temporarily makes `4.16.3` default Windows version. 


### Related issues (optional)

https://github.com/docker/for-win/issues/13335

<!--
  Refer to related PRs or issues:

  #1234
  Closes #1234
  Closes docker/cli#1234
-->
