### PR TITLE
compose: initial file watch docs

### DIFF
--- a/_data/toc.yaml
+++ b/_data/toc.yaml
@@ -1764,6 +1764,8 @@ manuals:
     title: Extend services in Compose
   - path: /compose/networking/
     title: Networking in Compose
+  - path: /compose/file-watch/
+    title: Development with file watch
   - path: /compose/production/
     title: Using Compose in production
   - path: /compose/startup-order/

--- a/_data/toc.yaml
+++ b/_data/toc.yaml
@@ -1765,7 +1765,7 @@ manuals:
   - path: /compose/networking/
     title: Networking in Compose
   - path: /compose/file-watch/
-    title: Development with file watch
+    title: Automatically update services with file watch (Experimental)
   - path: /compose/production/
     title: Using Compose in production
   - path: /compose/startup-order/

--- a/compose/file-watch.md
+++ b/compose/file-watch.md
@@ -3,6 +3,7 @@ description: File watch automatically updates running services as you work
 keywords: compose, file watch, experimental 
 title: Automatically update services with file watch
 ---
+{% include compose-eol.md %}
 
 > **Note**
 >

--- a/compose/file-watch.md
+++ b/compose/file-watch.md
@@ -47,7 +47,7 @@ Compose also supports sharing a host directory inside service containers. Watch 
 Most importantly, watch mode allows for greater granularity than is practical with a bind mount. Watch rules allow ignoring specific files or entire directories within the watched tree.
 
 For example, in a JavaScript project, ignoring the `node_modules/` directory has a couple benefits:
-* **Performance**: file trees with many small files can cause high I/O load in some configurations
+* Performance: file trees with many small files can cause high I/O load in some configurations
 * Multi-platform: compiled artifacts cannot be shared if the host OS (e.g. Windows, macOS) or architecture (e.g. arm64) is different than the container
 
 For example, in a Node.js project, it's not recommended to sync the `node_modules/` directory. Even though JavaScript is interpreted, npm packages can contain native code that is not portable across platforms.

--- a/compose/file-watch.md
+++ b/compose/file-watch.md
@@ -9,7 +9,11 @@ title: Automatically update services with file watch
 >
 > The Compose file watch feature is currently [Experimental](../release-lifecycle.md).
 
-Use `watch` to automatically update your running Compose services as you edit and save your code. 
+Use `watch` to automatically update your running Compose services as you edit and save your code.
+
+For many projects, this enables a hands-off development workflow once Compose is running: services automatically update themselves as you save your work.
+
+You do not need to enable `watch` for all services in a Compose project. In some instances, only part of the project (e.g. Javascript frontend) might be suitable for automatic updates.
 
 `watch` adheres to the following file path rules:
 
@@ -36,7 +40,7 @@ If `action` is set to `sync`, Compose makes sure any changes made to files on yo
 
 Sync is ideal for frameworks that support "Hot Reload" or equivalent functionality.
 
-More generally, they can be used in place of bind mounts for many development use cases.
+More generally, sync rules can be used in place of bind mounts for many development use cases.
 
 #### Rebuild
 

--- a/compose/file-watch.md
+++ b/compose/file-watch.md
@@ -41,6 +41,17 @@ Sync is ideal for frameworks that support "Hot Reload" or equivalent functionali
 
 More generally, sync rules can be used in place of bind mounts for many development use cases.
 
+##### Comparison to bind mounts
+Compose also supports sharing a host directory inside service containers. Watch mode does not replace this functionality but exists as a companion specifically suited to developing in containers.
+
+Most importantly, watch mode allows for greater granularity than is practical with a bind mount. Watch rules allow ignoring specific files or entire directories within the watched tree.
+
+For example, in a JavaScript project, ignoring the `node_modules/` directory has a couple benefits:
+* **Performance**: file trees with many small files can cause high I/O load in some configurations
+* **Multi-platform**: compiled artifacts cannot be shared if the host OS (e.g. Windows, macOS) or architecture (e.g. arm64) is different than the container
+
+For example, in a Node.js project, it's not recommended to sync the `node_modules/` directory. Even though JavaScript is interpreted, npm packages can contain native code that is not portable across platforms.
+
 #### Rebuild
 
 If `action` is set to `rebuild`, Compose automatically builds a new image with BuildKit and replaces the running service container.

--- a/compose/file-watch.md
+++ b/compose/file-watch.md
@@ -1,17 +1,69 @@
 ---
 description: File watch automatically updates running services as you work
 keywords: compose, file watch, experimental 
-title: Automatically update services during development with Compose file watch
+title: Automatically update services with file watch
 ---
 
-Watch mode monitors files and directories related to Compose services.
+> **Note**
+>
+> The Compose file watch feature is currently [Experimental](../release-lifecycle.md).
 
-On change, multiple actions are available:
+Use `watch` to automatically update your running Compose services as you edit and save your code. 
 
-* **Sync**: create, overwrite, and delete corresponding files within the service container
-* **Rebuild**: build a new image with BuildKit and replace the running service container
+`watch` adheres to the following file path rules:
 
-### Example `watch` configuration
+* All paths are relative to the build context
+* Directories are watched recursively
+* Glob patterns are not supported
+* Rules from `.dockerignore` apply
+  * Use `include` / `exclude` to override
+  * Temporary/backup files for common IDEs (Vim, Emacs, JetBrains, & more) are ignored automatically
+* `.git` directories are ignored automatically
+
+## Configuration
+
+The `watch` attribute defines a list of rules that control automatic service updates based on local file changes.
+
+Each rule requires, a `path` pattern and `action` to take when a modification is detected. There are two possible actions for `watch` and depending on
+the `action`, additional fields might be accepted or required. 
+
+### `action`
+
+#### Sync
+
+If `action` is set to `sync`, Compose makes sure any changes made to files on your host automatically match with the corresponding files within the service container.
+
+Sync is ideal for frameworks that support "Hot Reload" or equivalent functionality.
+
+More generally, they can be used in place of bind mounts for many development use cases.
+
+#### Rebuild
+
+If `action` is set to `rebuild`, Compose automatically builds a new image with BuildKit and replaces the running service container.
+
+The behavior is the same as running `docker compose up --build <svc>`.
+
+Rebuild is ideal for compiled languages or as fallbacks for modifications to particular files that require a full
+image rebuild (e.g. `package.json`).
+
+>**Tip**
+>
+> Optimize your `Dockerfile` for speedy
+incremental rebuilds with [image layer caching](/build/cache)
+and [multi-stage builds](/build/building/multi-stage/).
+{: .tip}
+
+### `path` and `target`
+
+The `target` field controls how the path is mapped into the container.
+
+For `path: ./app/html` and a change to `./app/html/index.html`:
+
+* `target: /app/html` -> `/app/html/index.html`
+* `target: /app/static` -> `/app/static/index.html`
+* `target: /assets` -> `/assets/index.html`
+
+## Example
 
 ```yaml
 services:
@@ -26,67 +78,19 @@ services:
           path: ./app/requirements.txt
 ```
 
-## Feature stability
-This feature is still [**experimental**](/release-lifecycle/).
+## Use `watch`
 
-In Compose YAML, any fields that start with `x-` do not have the same compatibility guarantees.
+1. Add `watch` sections to one or more services in `compose.yaml`.
+2. Launch a Compose project with `docker compose up --build --wait`.
+3. Run `docker compose alpha watch` to start the file watch mode.
+4. Edit service source files using your preferred IDE or editor.
 
-We are actively looking for feedback on the `x-develop` section schema and may make breaking changes if necessary.
+>**Tip**
+>
+> Looking for a sample project to test things out? Check
+out [`dockersamples/avatars`](https://github.com/dockersamples/avatars) for a demonstration of Compose `watch`.
+{: .tip}
 
-## File Paths
+## Feedback
 
-* All paths are relative to the build context
-* Directories are watched recursively
-* Glob patterns are not supported
-* Rules from `.dockerignore` apply
-  * Use `include` / `exclude` to override
-  * Temporary/backup files for common IDEs (Vim, Emacs, JetBrains, & more) are ignored automatically
-  * `.git` directories are ignored automatically
-
-## Usage
-
-> 👀 Looking for a sample project to test things out? Check
-out [`dockersamples/avatars`](https://github.com/dockersamples/avatars) for a whimsical demonstration of Compose file
-watch.
-
-1. Add `watch` sections to one or more services in `compose.yaml`
-2. Launch Compose project with `docker compose up --build --wait`
-3. Run `docker compose alpha watch` to start file watch mode
-4. Start hacking! Edit service source files using your preferred IDE or editor
-5. Compose automatically syncs files and rebuilds containers as needed
-
-## Configuration
-The `watch` field defines a list of rules that control automatic service updates based on local file changes.
-
-For each rule, a `path` pattern and `action` to take when a modification is detected are required. Depending on
-the `action`, additional fields might be accepted or required.
-
-### Syncing files
-Use `action: sync` to configure Compose to automatically copy files from your host into a running service on file
-modification.
-
-Sync rules are ideal for frameworks that support "Hot Reload" or equivalent functionality.
-
-More generally, they can be used in place of bind mounts for many development use cases.
-
-#### Path mapping
-The `target` field controls how the path is mapped into the container.
-
-For `path: ./app/html` and a change to `./app/html/index.html`:
-
-* `target: /app/html` -> `/app/html/index.html`
-* `target: /app/static` -> `/app/static/index.html`
-* `target: /assets` -> `/assets/index.html`
-
-### Rebuilding services
-Use `action: rebuild` to configure Compose to automatically trigger a new image build and replace a running service on
-file modification.
-
-The behavior is equivalent to running `docker compose up --build <svc>` (but automatic).
-
-> Optimize your `Dockerfile` for speedy
-incremental rebuilds with [image layer caching](/build/cache)
-and [multi-stage builds](/build/building/multi-stage/).
-
-Rebuild rules are ideal for compiled languages or as fallbacks for modifications to particular files that require a full
-image rebuild (e.g. `package.json`).
+We are actively looking for feedback on this feature. Give feedback or report any bugs you may find in the [Compose Specification repository](https://github.com/compose-spec/compose-spec/pull/253).

--- a/compose/file-watch.md
+++ b/compose/file-watch.md
@@ -48,7 +48,7 @@ Most importantly, watch mode allows for greater granularity than is practical wi
 
 For example, in a JavaScript project, ignoring the `node_modules/` directory has a couple benefits:
 * **Performance**: file trees with many small files can cause high I/O load in some configurations
-* **Multi-platform**: compiled artifacts cannot be shared if the host OS (e.g. Windows, macOS) or architecture (e.g. arm64) is different than the container
+* Multi-platform: compiled artifacts cannot be shared if the host OS (e.g. Windows, macOS) or architecture (e.g. arm64) is different than the container
 
 For example, in a Node.js project, it's not recommended to sync the `node_modules/` directory. Even though JavaScript is interpreted, npm packages can contain native code that is not portable across platforms.
 
@@ -108,16 +108,16 @@ services:
 ```
 
 In this example, when running `docker compose up --build --wait`, a container for the `web` service is launched using an image built from the `Dockerfile` in the project root.
-The `web` service runs `npm start` for its command, which will launch a development version of the application with Hot Module Reload enabled in the bundler (Webpack, Vite, Turbopack, etc).
+The `web` service runs `npm start` for its command, which then launches a development version of the application with Hot Module Reload enabled in the bundler (Webpack, Vite, Turbopack, etc).
 
-After the service is up, running `docker compose alpha watch` will start watch mode.
-Then, whenever a source file in the `web/` directory is changed, Compose will sync the file to the corresponding location under `/src/web` inside the container.
-For example, `./web/App.jsx` would be copied to `/src/web/App.jsx`.
+After the service is up, running `docker compose alpha watch` starts watch mode.
+Then, whenever a source file in the `web/` directory is changed, Compose syncs the file to the corresponding location under `/src/web` inside the container.
+For example, `./web/App.jsx` is copied to `/src/web/App.jsx`.
 
 Once copied, the bundler updates the running application without a restart.
 
 Unlike source code files, adding a new dependency can’t be done on-the-fly, so whenever `package.json` is changed, Compose
-will rebuild the image and recreate the `web` service container.
+rebuilds the image and recreates the `web` service container.
 
 This pattern can be followed for many languages and frameworks, such as Python with Flask: Python source files can be synced while a change to `requirements.txt` should trigger a rebuild.
 

--- a/compose/file-watch.md
+++ b/compose/file-watch.md
@@ -1,0 +1,92 @@
+---
+description: File watch automatically updates running services as you work
+keywords: compose, file watch, experimental 
+title: Automatically update services during development with Compose file watch
+---
+
+Watch mode monitors files and directories related to Compose services.
+
+On change, multiple actions are available:
+
+* **Sync**: create, overwrite, and delete corresponding files within the service container
+* **Rebuild**: build a new image with BuildKit and replace the running service container
+
+### Example `watch` configuration
+
+```yaml
+services:
+  app:
+    build: ./app
+    x-develop:
+      watch:
+        - action: sync
+          path: ./app/html
+          target: /app/html
+        - action: rebuild
+          path: ./app/requirements.txt
+```
+
+## Feature stability
+This feature is still [**experimental**](/release-lifecycle/).
+
+In Compose YAML, any fields that start with `x-` do not have the same compatibility guarantees.
+
+We are actively looking for feedback on the `x-develop` section schema and may make breaking changes if necessary.
+
+## File Paths
+
+* All paths are relative to the build context
+* Directories are watched recursively
+* Glob patterns are not supported
+* Rules from `.dockerignore` apply
+  * Use `include` / `exclude` to override
+  * Temporary/backup files for common IDEs (Vim, Emacs, JetBrains, & more) are ignored automatically
+  * `.git` directories are ignored automatically
+
+## Usage
+
+> 👀 Looking for a sample project to test things out? Check
+out [`dockersamples/avatars`](https://github.com/dockersamples/avatars) for a whimsical demonstration of Compose file
+watch.
+
+1. Add `watch` sections to one or more services in `compose.yaml`
+2. Launch Compose project with `docker compose up --build --wait`
+3. Run `docker compose alpha watch` to start file watch mode
+4. Start hacking! Edit service source files using your preferred IDE or editor
+5. Compose automatically syncs files and rebuilds containers as needed
+
+## Configuration
+The `watch` field defines a list of rules that control automatic service updates based on local file changes.
+
+For each rule, a `path` pattern and `action` to take when a modification is detected are required. Depending on
+the `action`, additional fields might be accepted or required.
+
+### Syncing files
+Use `action: sync` to configure Compose to automatically copy files from your host into a running service on file
+modification.
+
+Sync rules are ideal for frameworks that support "Hot Reload" or equivalent functionality.
+
+More generally, they can be used in place of bind mounts for many development use cases.
+
+#### Path mapping
+The `target` field controls how the path is mapped into the container.
+
+For `path: ./app/html` and a change to `./app/html/index.html`:
+
+* `target: /app/html` -> `/app/html/index.html`
+* `target: /app/static` -> `/app/static/index.html`
+* `target: /assets` -> `/assets/index.html`
+
+### Rebuilding services
+Use `action: rebuild` to configure Compose to automatically trigger a new image build and replace a running service on
+file modification.
+
+The behavior is equivalent to running `docker compose up --build <svc>` (but automatic).
+
+> Optimize your `Dockerfile` for speedy
+incremental rebuilds with [image layer caching](/build/cache)
+and [multi-stage builds](/build/building/multi-stage/).
+
+Rebuild rules are ideal for compiled languages or as fallbacks for modifications to particular files that require a full
+image rebuild (e.g. `package.json`).

--- a/compose/file-watch.md
+++ b/compose/file-watch.md
@@ -111,7 +111,7 @@ In this example, when running `docker compose up --build --wait`, a container fo
 The `web` service runs `npm start` for its command, which will launch a development version of the application with Hot Module Reload enabled in the bundler (Webpack, Vite, Turbopack, etc).
 
 After the service is up, running `docker compose alpha watch` will start watch mode.
-Then, whenever a source file in the `web/` directory is changed, Compose will copy the file to the corresponding location under `/src/web` inside the container.
+Then, whenever a source file in the `web/` directory is changed, Compose will sync the file to the corresponding location under `/src/web` inside the container.
 For example, `./web/App.jsx` would be copied to `/src/web/App.jsx`.
 
 Once copied, the bundler updates the running application without a restart.
@@ -119,7 +119,7 @@ Once copied, the bundler updates the running application without a restart.
 Unlike source code files, adding a new dependency can’t be done on-the-fly, so whenever `package.json` is changed, Compose
 will rebuild the image and recreate the `web` service container.
 
-This pattern can be followed for many languages and frameworks, such as Python + Flask: Python source files are synced while `requirements.txt`-type files should trigger a rebuild.
+This pattern can be followed for many languages and frameworks, such as Python with Flask: Python source files can be synced while a change to `requirements.txt` should trigger a rebuild.
 
 ## Use `watch`
 


### PR DESCRIPTION
### Proposed changes
Introduction and explainer for Compose file watch mode, which is a new, experimental feature to automatically update running Compose services while you develop.

### Related issues (optional)
https://docker.atlassian.net/browse/ENV-145