### PR TITLE
add docker init (carry)

### DIFF
--- a/_data/init-cli/docker_init.yaml
+++ b/_data/init-cli/docker_init.yaml
@@ -1,0 +1,150 @@
+command: docker init
+short: Creates Docker-related starter files for your project
+long: |-
+  Initialize a project with the files necessary to run the project in a container.
+
+  Docker Desktop 4.18 and later provides the Docker Init plugin with the `docker init` CLI command. Run `docker init` in your project directory to be walked through the creation of the following files with sensible defaults for your project:
+    
+    * .dockerignore
+    * Dockerfile
+    * docker-compose.yaml
+    
+    If any of the files already exist, a prompt appears and provides a warning as well as giving you the option to overwrite all the files.
+    
+    > **Warning**
+    >
+    > You can't recover overwritten files.
+    > To back up an existing file before selecting to overwrite it, rename the file or copy it to another directory.
+    {: .warning}
+  
+  After running `docker init`, you can choose one of the following templates:
+    
+    * Go: Suitable for a Go server application.
+    * Other: General purpose starting point for containerizing your application.
+  
+  After `docker init` has completed, you must modify the created files and tailor them to your project. Visit the following topics to learn more about the files:
+    
+    * [.dockerignore](../../../engine/reference/builder.md#dockerignore-file)
+    * [Dockerfile](../../../engine/reference/builder.md)
+    * [docker-compose.yaml](../../../compose/compose-file/03-compose-file.md)
+
+usage: docker init [OPTIONS]
+pname: docker
+plink: docker.yaml
+options:
+    - option: version
+      value_type: bool
+      default_value: "false"
+      description: Display version of the init plugin
+      deprecated: false
+      hidden: false
+      experimental: false
+      experimentalcli: false
+      kubernetes: false
+      swarm: false
+deprecated: false
+experimental: false
+experimentalcli: false
+kubernetes: false
+swarm: false
+examples: |-
+  ### Example of selecting Other
+  
+  The following example runs `docker init` and walks through the options after selecting `Other`.
+  
+  ```console
+  $ docker init
+  
+  Welcome to the Docker Init CLI!
+  
+  This utility will walk you through creating the following files with sensible defaults for your project:
+    - .dockerignore
+    - Dockerfile
+    - docker-compose.yaml
+  
+  Let's get started!
+  
+  ? What application platform does your project use?  [Use arrows to move, type to filter]
+  > Go - suitable for a Go server application
+    Other - general purpose starting point for containerizing your application
+    Don't see something you need? Let us know!
+    Quit
+  ```
+  
+  The following appears after selecting `Other`.
+  
+  ```console
+  CREATED: .dockerignore
+  CREATED: Dockerfile
+  CREATED: docker-compose.yaml
+  
+  ✔ Your Docker files are ready!
+  
+  Take a moment to review them and tailor them to your application.
+  
+  When you're ready, start your application by running: docker compose up --build
+  ```
+  
+  ### Example of selecting Go
+  
+  The following example runs `docker init` and walks through the options after selecting `Go`.
+  
+  ```console
+  $ docker init
+  
+  Welcome to the Docker Init CLI!
+  
+  This utility will walk you through creating the following files with sensible defaults for your project:
+    - .dockerignore
+    - Dockerfile
+    - docker-compose.yaml
+  
+  Let's get started!
+  
+  ? What application platform does your project use?  [Use arrows to move, type to filter]
+  > Go - (detected) suitable for a Go server application
+    Other - general purpose starting point for containerizing your application
+    Don't see something you need? Let us know!
+    Quit
+  ```
+  
+  The following appears after selecting `Go`.
+  
+  ```console
+  ? What application platform does your project use? Go
+  ? What version of Go do you want to use? (1.20)
+  ```
+  
+  The following appears after selecting the default `1.20`.
+  
+  ```console
+  ? What version of Go do you want to use? 1.20
+  ? What's the relative directory (with a leading .) of your main package? (.)
+  ```
+  
+  The following appears after selecting the default `.`.
+  
+  ```console
+  ? What's the relative directory (with a leading .) of your main package? .
+  ? What port does your server listen on? (3333)
+  ```
+  
+  The following appears after selecting the default `3333`.
+  
+  ```console
+  ? What port does your server listen on? 3333
+  
+  CREATED: .dockerignore
+  CREATED: Dockerfile
+  CREATED: docker-compose.yaml
+  
+  ✔ Your Docker files are ready!
+  
+  Take a moment to review them and tailor them to your application.
+  
+  When you're ready, start your application by running: docker compose up --build -d
+  
+  Your application will be available at http://localhost:3333
+  
+  To stop your application, run: docker compose down
+  ```

--- a/_data/toc.yaml
+++ b/_data/toc.yaml
@@ -511,6 +511,8 @@ reference:
       title: docker import
     - path: /engine/reference/commandline/info/
       title: docker info
+    - path: /engine/reference/commandline/init/
+      title: docker init (Beta)
     - path: /engine/reference/commandline/inspect/
       title: docker inspect
     - path: /engine/reference/commandline/kill/

--- a/engine/reference/commandline/init.md
+++ b/engine/reference/commandline/init.md
@@ -1,0 +1,17 @@
+---
+datafolder: init-cli
+datafile: docker_init
+title: docker init
+---
+<!--
+This page is automatically generated from Docker's source code. If you want to
+suggest a change to the text that appears here, open a ticket or pull request
+in the source repository on GitHub:
+
+https://github.com/docker/docker-init
+-->
+> **Beta**
+>
+> The Docker Init plugin is currently in [Beta](../../../release-lifecycle.md#beta). Docker recommends that you do not use this in production environments.
+
+{% include cli.md datafolder=page.datafolder datafile=page.datafile %}


### PR DESCRIPTION
- alternative to / replaces https://github.com/docker/docs/pull/16998
- closes https://github.com/docker/docs/pull/16998


Manually combining the generated YAML docs with the Markdown that was written by Craig.

<img width="1331" alt="Screenshot 2023-03-31 at 22 05 22" src="https://user-images.githubusercontent.com/1804568/229219544-532d34ec-a1d8-4845-b062-55c47537845e.png">
<img width="1319" alt="Screenshot 2023-03-31 at 22 06 09" src="https://user-images.githubusercontent.com/1804568/229219555-b233a0ea-dda2-436f-a121-5e3b442b20ed.png">



<!--
  Thank you for contributing to Docker documentation!

  Here are a few things to keep in mind:

  - Links between pages should use a relative path
  - Remember to add an alt text for images

  ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
  ┃     Review our contribution guidelines:       ┃
  ┃                                               ┃
  ┃ https://docs.docker.com/contribute/overview/  ┃
  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
-->

### Proposed changes

<!-- Tell us what you did and why -->

### Related issues (optional)

<!--
  Refer to related PRs or issues:

  #1234
  Closes #1234
  Closes docker/cli#1234
-->
