### PR TITLE
docs: Move Post install link to infobox

### DIFF
--- a/_includes/root-errors.md
+++ b/_includes/root-errors.md
@@ -1,0 +1,7 @@
+> **Tip**
+> 
+> Receiving errors when trying to run without root?
+>
+> The `docker` user group exists but contains no users, which is why you’re required 
+> to use `sudo` to run Docker commands. Continue to [Linux postinstall](linux-postinstall.md) 
+> to allow non-privileged users to run Docker commands and for other optional configuration steps.

--- a/_includes/root-errors.md
+++ b/_includes/root-errors.md
@@ -3,5 +3,6 @@
 > Receiving errors when trying to run without root?
 >
 > The `docker` user group exists but contains no users, which is why you’re required 
-> to use `sudo` to run Docker commands. Continue to [Linux postinstall](linux-postinstall.md) 
+> to use `sudo` to run Docker commands. Continue to [Linux postinstall](/engine/install/linux-postinstall) 
 > to allow non-privileged users to run Docker commands and for other optional configuration steps.
+{: .tip}

--- a/engine/install/centos.md
+++ b/engine/install/centos.md
@@ -168,7 +168,13 @@ $ sudo yum-config-manager \
     This command downloads a test image and runs it in a container. When the
     container runs, it prints a confirmation message and exits.
 
-You have now successfully installed and started Docker Engine. The docker user group exists but contains no users, which is why you’re required to use sudo to run Docker commands. Continue to [Linux postinstall](linux-postinstall.md) to allow non-privileged users to run Docker commands and for other optional configuration steps.
+You have now successfully installed and started Docker Engine. 
+
+> Receiving errors when trying to run without root?
+>
+> The `docker` user group exists but contains no users, which is why you’re required 
+> to use `sudo` to run Docker commands. Continue to [Linux postinstall](linux-postinstall.md) 
+> to allow non-privileged users to run Docker commands and for other optional configuration steps.
 
 #### Upgrade Docker Engine
 

--- a/engine/install/centos.md
+++ b/engine/install/centos.md
@@ -170,11 +170,7 @@ $ sudo yum-config-manager \
 
 You have now successfully installed and started Docker Engine. 
 
-> Receiving errors when trying to run without root?
->
-> The `docker` user group exists but contains no users, which is why you’re required 
-> to use `sudo` to run Docker commands. Continue to [Linux postinstall](linux-postinstall.md) 
-> to allow non-privileged users to run Docker commands and for other optional configuration steps.
+{% include root-errors.md %}
 
 #### Upgrade Docker Engine
 

--- a/engine/install/debian.md
+++ b/engine/install/debian.md
@@ -184,11 +184,13 @@ Raspbian.
    This command downloads a test image and runs it in a container. When the
    container runs, it prints a confirmation message and exits.
 
-You have now successfully installed and started Docker Engine. The `docker` user
-group exists but contains no users, which is why you're required to use `sudo`
-to run Docker commands. Continue to [Linux post-install](linux-postinstall.md)
-to allow non-privileged users to run Docker commands and for other optional
-configuration steps.
+You have now successfully installed and started Docker Engine. 
+
+> Receiving errors when trying to run without root?
+> 
+> The `docker` user group exists but contains no users, which is why you're required 
+> to use `sudo` to run Docker commands. Continue to [Linux post-install](linux-postinstall.md)
+> to allow non-privileged users to run Docker commands and for other optional configuration steps.
 
 #### Upgrade Docker Engine
 

--- a/engine/install/debian.md
+++ b/engine/install/debian.md
@@ -186,11 +186,7 @@ Raspbian.
 
 You have now successfully installed and started Docker Engine. 
 
-> Receiving errors when trying to run without root?
-> 
-> The `docker` user group exists but contains no users, which is why you're required 
-> to use `sudo` to run Docker commands. Continue to [Linux post-install](linux-postinstall.md)
-> to allow non-privileged users to run Docker commands and for other optional configuration steps.
+{% include root-errors.md %}
 
 #### Upgrade Docker Engine
 

--- a/engine/install/fedora.md
+++ b/engine/install/fedora.md
@@ -191,10 +191,12 @@ a new file each time you want to upgrade Docker Engine.
     This command downloads a test image and runs it in a container. When the
     container runs, it prints a message and exits.
 
-This installs and runs Docker Engine. Use `sudo` to run Docker commands.
-Continue to [Post-installation steps for Linux](linux-postinstall.md) to allow
-non-privileged users to run Docker commands and for other optional configuration
-steps.
+This installs and runs Docker Engine.
+
+> Receiving errors when trying to run without root?
+> 
+> Continue to [Linux post-install](linux-postinstall.md) to allow non-privileged users to run Docker commands 
+> and for other optional configuration steps.
 
 #### Upgrade Docker Engine
 

--- a/engine/install/fedora.md
+++ b/engine/install/fedora.md
@@ -193,10 +193,7 @@ a new file each time you want to upgrade Docker Engine.
 
 This installs and runs Docker Engine.
 
-> Receiving errors when trying to run without root?
-> 
-> Continue to [Linux post-install](linux-postinstall.md) to allow non-privileged users to run Docker commands 
-> and for other optional configuration steps.
+{% include root-errors.md %}
 
 #### Upgrade Docker Engine
 

--- a/engine/install/rhel.md
+++ b/engine/install/rhel.md
@@ -157,10 +157,7 @@ $ sudo yum-config-manager \
 
 This installs and runs Docker Engine. 
 
-> Receiving errors when trying to run without root?
-> 
-> Continue to [Linux post-install](linux-postinstall.md) to allow non-privileged users to run Docker commands 
-> and for other optional configuration steps.
+{% include root-errors.md %}
 
 #### Upgrade Docker Engine
 

--- a/engine/install/rhel.md
+++ b/engine/install/rhel.md
@@ -155,10 +155,12 @@ $ sudo yum-config-manager \
     This command downloads a test image and runs it in a container. When the
     container runs, it prints a message and exits.
 
-This installs and runs Docker Engine. Use `sudo` to run Docker
-commands. Continue to [Linux postinstall](linux-postinstall.md) to allow
-non-privileged users to run Docker commands and for other optional configuration
-steps.
+This installs and runs Docker Engine. 
+
+> Receiving errors when trying to run without root?
+> 
+> Continue to [Linux post-install](linux-postinstall.md) to allow non-privileged users to run Docker commands 
+> and for other optional configuration steps.
 
 #### Upgrade Docker Engine
 

--- a/engine/install/sles.md
+++ b/engine/install/sles.md
@@ -173,10 +173,12 @@ $ sudo zypper addrepo {{ download-url-base }}/docker-ce.repo
     This command downloads a test image and runs it in a container. When the
     container runs, it prints a message and exits.
 
-This installs and runs Docker Engine. Use `sudo` to run Docker
-commands. Continue to [Linux postinstall](linux-postinstall.md) to allow
-non-privileged users to run Docker commands and for other optional configuration
-steps.
+This installs and runs Docker Engine.
+
+> Receiving errors when trying to run without root?
+> 
+> Continue to [Linux post-install](linux-postinstall.md) to allow non-privileged users to run Docker commands 
+> and for other optional configuration steps.
 
 #### Upgrade Docker Engine
 

--- a/engine/install/sles.md
+++ b/engine/install/sles.md
@@ -175,10 +175,7 @@ $ sudo zypper addrepo {{ download-url-base }}/docker-ce.repo
 
 This installs and runs Docker Engine.
 
-> Receiving errors when trying to run without root?
-> 
-> Continue to [Linux post-install](linux-postinstall.md) to allow non-privileged users to run Docker commands 
-> and for other optional configuration steps.
+{% include root-errors.md %}
 
 #### Upgrade Docker Engine
 

--- a/engine/install/ubuntu.md
+++ b/engine/install/ubuntu.md
@@ -180,11 +180,10 @@ Docker from the repository.
    This command downloads a test image and runs it in a container. When the
    container runs, it prints a confirmation message and exits.
 
-You have now successfully installed and started Docker Engine. The `docker` user
-group exists but contains no users, which is why you're required to use `sudo`
-to run Docker commands. Continue to [Linux post-install](linux-postinstall.md)
-to allow non-privileged users to run Docker commands and for other optional
-configuration steps.
+You have now successfully installed and started Docker Engine. 
+> The `docker` user group exists but contains no users, which is why you're required 
+> to use `sudo` to run Docker commands. Continue to [Linux post-install](linux-postinstall.md)
+> to allow non-privileged users to run Docker commands and for other optional configuration steps.
 
 #### Upgrade Docker Engine
 

--- a/engine/install/ubuntu.md
+++ b/engine/install/ubuntu.md
@@ -181,6 +181,8 @@ Docker from the repository.
    container runs, it prints a confirmation message and exits.
 
 You have now successfully installed and started Docker Engine. 
+> Receiving errors when trying to run without root?
+>
 > The `docker` user group exists but contains no users, which is why you're required 
 > to use `sudo` to run Docker commands. Continue to [Linux post-install](linux-postinstall.md)
 > to allow non-privileged users to run Docker commands and for other optional configuration steps.

--- a/engine/install/ubuntu.md
+++ b/engine/install/ubuntu.md
@@ -180,7 +180,8 @@ Docker from the repository.
    This command downloads a test image and runs it in a container. When the
    container runs, it prints a confirmation message and exits.
 
-You have now successfully installed and started Docker Engine. 
+You have now successfully installed and started Docker Engine.
+
 > Receiving errors when trying to run without root?
 >
 > The `docker` user group exists but contains no users, which is why you're required 


### PR DESCRIPTION
Moved Post-Install link to inbobox to make it more visible.



### Proposed changes

This was done as when people are trying to install Docker to use software I assist in maintain. I have countless times had to link them to the post-install instructions, to the point of one of the people maintain it has suggested linking to it in our own README.md. As they are so unclear to find unless you read what looks to be boilerplate "You have completed install" text
