### PR TITLE
Update 'Run your tests' to the new Testcontainers for .NET module API

### DIFF
--- a/language/dotnet/run-tests.md
+++ b/language/dotnet/run-tests.md
@@ -26,7 +26,7 @@ $ dotnet new xunit -n myWebApp.Tests -o tests
 Next, we'll update the test project and add the Testcontainers for .NET package that allows us to run tests against Docker resources. Switch to the `tests` directory and run the following command:
 
 ```console
-$ dotnet add package Testcontainers --version 2.3.0
+$ dotnet add package Testcontainers.PostgreSql
 ```
 
 ## Add a test
@@ -34,10 +34,16 @@ $ dotnet add package Testcontainers --version 2.3.0
 Open the test project in your favorite IDE and replace the contents of `UnitTest1` with the following code:
 
 ```c#
+using System;
 using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
 using DotNet.Testcontainers.Builders;
 using DotNet.Testcontainers.Containers;
 using DotNet.Testcontainers.Networks;
+using Testcontainers.PostgreSql;
+using Xunit;
 
 public sealed class UnitTest1 : IAsyncLifetime, IDisposable
 {
@@ -45,26 +51,25 @@ public sealed class UnitTest1 : IAsyncLifetime, IDisposable
 
     private readonly CancellationTokenSource _cts = new(TimeSpan.FromMinutes(1));
 
-    private readonly IDockerNetwork _network;
+    private readonly INetwork _network;
 
-    private readonly IDockerContainer _dbContainer;
+    private readonly IContainer _dbContainer;
 
-    private readonly IDockerContainer _appContainer;
+    private readonly IContainer _appContainer;
 
     public UnitTest1()
     {
-        _network = new TestcontainersNetworkBuilder()
-            .WithName(Guid.NewGuid().ToString("D"))
+        _network = new NetworkBuilder()
             .Build();
 
-        _dbContainer = new TestcontainersBuilder<TestcontainersContainer>()
+        _dbContainer = new PostgreSqlBuilder()
             .WithImage("postgres")
             .WithNetwork(_network)
             .WithNetworkAliases("db")
             .WithVolumeMount("postgres-data", "/var/lib/postgresql/data")
             .Build();
 
-        _appContainer = new TestcontainersBuilder<TestcontainersContainer>()
+        _appContainer = new ContainerBuilder()
             .WithImage("dotnet-docker")
             .WithNetwork(_network)
             .WithPortBinding(HttpPort, true)


### PR DESCRIPTION
### Proposed changes

In the latest release, Testcontainers no longer uses reflection to instantiate Docker containers. Instead, it has moved modules to independent packages and now provides a dedicated API for each module (Docker image). As a result, the "Run your tests" section has been updated to reflect the new module API in this PR.

### Related issues (optional)

\-
