### PR TITLE
Add example of passing build args

### DIFF
--- a/build/ci/github-actions/build-args.md
+++ b/build/ci/github-actions/build-args.md
@@ -1,0 +1,20 @@
+---
+title: Pass build arguments with GitHub Actions
+keywords: ci, github actions, gha, buildkit, buildx, args
+---
+
+To pass build arguments to the Dockerfile, you can use the build-args option.
+
+Note that the list of build arguments should be passed as a multi-line string, e.g.
+
+```yaml
+      -
+        name: Build and push
+        uses: docker/build-push-action@v4
+        with:
+          push: true
+          tags: ghcr.io/username/app:latest
+          build-args: |
+            UBUNTU_VERSION=${{ matrix.ubuntu_version }}
+            RUBY_VERSION=${{ matrix.ruby_version }}
+```


### PR DESCRIPTION
<!--
  Thank you for contributing to Docker documentation!

  Here are a few things to keep in mind:

  - Links between pages should use a relative path
  - Remember to add an alt text for images

  ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
  ┃     Review our contribution guidelines:       ┃
  ┃                                               ┃
  ┃ https://docs.docker.com/contribute/overview/  ┃
  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
-->

### Proposed changes

Added an example for passing build args in a GitHub action.

I did this because the syntax was not obvious, I had to find it from a GitHub issue: https://github.com/docker/build-push-action/issues/557

### Related issues (optional)

https://github.com/docker/build-push-action/issues/557
