### PR TITLE
Update 07_multi_container.md

### DIFF
--- a/get-started/07_multi_container.md
+++ b/get-started/07_multi_container.md
@@ -193,7 +193,7 @@ The todo app supports the setting of a few environment variables to specify MySQ
 > as the connection password. Docker doesn't do anything to support these env vars. Your app will need to know to look for
 > the variable and get the file contents.
 
-You can now start your dev-ready container. 
+You can now start your dev-ready container.
 
 1. Specify each of the environment variables above, as well as connect the container to your app network. Make sure that you are in the `getting-started/app` directory when you run this command.
 

--- a/get-started/07_multi_container.md
+++ b/get-started/07_multi_container.md
@@ -193,9 +193,9 @@ The todo app supports the setting of a few environment variables to specify MySQ
 > as the connection password. Docker doesn't do anything to support these env vars. Your app will need to know to look for
 > the variable and get the file contents.
 
-You can now start your dev-ready container.
+You can now start your dev-ready container. 
 
-1. Specify each of the environment variables above, as well as connect the container to your app network.
+1. Specify each of the environment variables above, as well as connect the container to your app network. Make sure that you are in the `getting-started/app` directory when you run this command.
 
     <ul class="nav nav-tabs">
     <li class="active"><a data-toggle="tab" data-target="#mac-linux2">Mac / Linux</a></li>


### PR DESCRIPTION
<!--
  Thank you for contributing to Docker documentation!

  Here are a few things to keep in mind:

  - Links between pages should use a relative path
  - Remember to add an alt text for images

  ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
  ┃     Review our contribution guidelines:       ┃
  ┃                                               ┃
  ┃ https://docs.docker.com/contribute/overview/  ┃
  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
-->

### Proposed changes

In line 198: Made it much more clearer about the CWD from where the `docker run` command needs to be run.

In this article, the commands for setting up the `to-do` docker network, running the `mysql` container and finding its IP can be run from any CWD. 

However, the `docker run` command here needs to be specifically run from `getting-started/app` directory. I know this is implied but I just came upon this article while googling and it's better to be explicit about these things than being implicit.

### Related issues (optional)

<!--
  Refer to related PRs or issues:

  #1234
  Closes #1234
  Closes docker/cli#1234
-->
