### PR TITLE
Link CVE ID CVE-2023-1802 in the Security section of the 4.18 release notes

### DIFF
--- a/desktop/release-notes.md
+++ b/desktop/release-notes.md
@@ -82,7 +82,7 @@ For frequently asked questions about Docker Desktop releases, see [FAQs](faqs/ge
 
 #### For all platforms
 
-- Fixed a security issue with the Artifactory Integration where it would fall back to sending registry credentials over plain HTTP if HTTPS check failed. Only users who have `Access experimental features` enabled are affected. Fixes [docker/for-win#13344](https://github.com/docker/for-win/issues/13344).
+- Fixed [CVE-2023-1802](https://www.cve.org/cverecord?id=CVE-2023-1802){: target="_blank" rel="noopener" class="_"} where a security issue with the Artifactory Integration would cause it to fall back to sending registry credentials over plain HTTP if HTTPS check failed. Only users who have `Access experimental features` enabled are affected. Fixes [docker/for-win#13344](https://github.com/docker/for-win/issues/13344).
 
 #### For Mac
 


### PR DESCRIPTION
<!--
  Thank you for contributing to Docker documentation!

  Here are a few things to keep in mind:

  - Links between pages should use a relative path
  - Remember to add an alt text for images

  ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
  ┃     Review our contribution guidelines:       ┃
  ┃                                               ┃
  ┃ https://docs.docker.com/contribute/overview/  ┃
  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
-->

### Proposed changes

Link CVE ID CVE-2023-1802 for the Artifactory Integration creds leak over HTTP in the Security section of the 4.18 release notes

### Related issues (optional)

<!--
  Refer to related PRs or issues:

  #1234
  Closes #1234
  Closes docker/cli#1234
-->
