### PR TITLE
swarm: add context to VXLAN port docs

### DIFF
--- a/engine/swarm/ingress.md
+++ b/engine/swarm/ingress.md
@@ -15,7 +15,11 @@ To use the ingress network in the swarm, you need to have the following
 ports open between the swarm nodes before you enable swarm mode:
 
 * Port `7946` TCP/UDP for container network discovery.
-* Port `4789` UDP for the container ingress network.
+* Port `4789` UDP (configurable) for the container ingress network.
+
+When setting up networking in a Swarm, special care should be taken. Consult
+the [tutorial](swarm-tutorial/index.md#open-protocols-and-ports-between-the-hosts)
+for an overview.
 
 You must also open the published port between the swarm nodes and any external
 resources, such as an external load balancer, that require access to the port.

--- a/engine/swarm/networking.md
+++ b/engine/swarm/networking.md
@@ -49,7 +49,7 @@ The following three network concepts are important to swarm services:
   join a swarm. Most users do not need to customize its configuration, but
   Docker allows you to do so.
 
-> **See also** [Networking overview](../../network/index.md) for more details about swarm networking in general.
+> **See also** [Networking overview](../../network/index.md) for more details about Swarm networking in general.
 
 ## Firewall considerations
 
@@ -57,7 +57,11 @@ Docker daemons participating in a swarm need the ability to communicate with
 each other over the following ports:
 
 * Port `7946` TCP/UDP for container network discovery.
-* Port `4789` UDP for the container overlay network.
+* Port `4789` UDP (configurable) for the overlay network (including ingress) data path.
+
+When setting up networking in a Swarm, special care should be taken. Consult
+the [tutorial](swarm-tutorial/index.md#open-protocols-and-ports-between-the-hosts)
+for an overview.
 
 ## Create an overlay network
 

--- a/engine/swarm/swarm-tutorial/index.md
+++ b/engine/swarm/swarm-tutorial/index.md
@@ -71,12 +71,29 @@ The tutorial uses `manager1` : `192.168.99.100`.
 
 The following ports must be available. On some systems, these ports are open by default.
 
-* **TCP port 2377** for cluster management communications
-* **TCP** and **UDP port 7946** for communication among nodes
-* **UDP port 4789** for overlay network traffic
+* Port `2377` TCP for communication with and between manager nodes
+* Port `7946` TCP/UDP for overlay network node discovery
+* Port `4789` UDP (configurable) for overlay network traffic
 
 If you plan on creating an overlay network with encryption (`--opt encrypted`),
-you also need to ensure **ip protocol 50** (**ESP**) traffic is allowed.
+you also need to ensure **IP protocol 50** (**IPSec ESP**) traffic is allowed.
+
+Port `4789` is the default value for the Swarm data path port, also known as the VXLAN port.
+It is important to prevent any untrusted traffic from reaching this port, as VXLAN does not
+provide authentication. This port should only be opened to a trusted network, and never at a
+perimeter firewall.
+
+If the network which Swarm traffic traverses is not fully trusted, it is strongly suggested that
+encrypted overlay networks be used. If encrypted overlay networks are in exclusive use, some
+additional hardening is suggested:
+
+* [Customize the default ingress network](../networking.md) to use encryption
+* Only accept encrypted packets on the Data Path Port:
+
+```
+# Example iptables rule (order and other tools may require customization)
+iptables -I INPUT -m udp —-dport 4789 -m policy --dir in --pol none -j DROP
+```
 
 ## What's next?
 


### PR DESCRIPTION
Add some wording addressing the concerns of https://github.com/moby/moby/security/advisories/GHSA-vwm3-crmr-xfxw -- a lack of appropriate context and caution for the VXLAN port.