### PR TITLE
Added link to the docs.docker.com text #17055

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ We've made it really easy for you to file new issues.
 
 - Click **[New issue](https://github.com/docker/docs/issues/new)** on the docs repository and fill in the details, or
 - Click **Request docs changes** in the right column of every page on
-  docs.docker.com and add the details, or
+  [docs.docker.com](https://docs.docker.com/) and add the details, or
 
   ![Request changes link](/assets/images/docs-site-feedback.png)
 


### PR DESCRIPTION
Added link to the docs.docker.com text which will now redirect to the docs.docker.com

<!--
  Thank you for contributing to Docker documentation!

  Here are a few things to keep in mind:

  - Links between pages should use a relative path
  - Remember to add an alt text for images

  ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
  ┃     Review our contribution guidelines:       ┃
  ┃                                               ┃
  ┃ https://docs.docker.com/contribute/overview/  ┃
  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
-->

### Proposed changes

<!-- Tell us what you did and why -->

### Related issues (optional)

<!--
  Refer to related PRs or issues:

  #1234
  Closes #1234
  Closes docker/cli#1234
-->
