### PR TITLE
build: add note that node name is optional for the kubernetes driver

### DIFF
--- a/build/drivers/kubernetes.md
+++ b/build/drivers/kubernetes.md
@@ -186,9 +186,12 @@ $ docker buildx create \
 ```
 
 This creates a Buildx builder named `kube`, containing a single builder node
-`builder-amd64`. Note that the Buildx concept of a node isn't the same as the
-Kubernetes concept of a node. A Buildx node in this case could connect multiple
-Kubernetes nodes of the same architecture together.
+named `builder-amd64`. Assigning a node name using `--node` is optional. Buildx
+generates a random node name if you don't provide one.
+
+Note that the Buildx concept of a node isn't the same as the Kubernetes concept
+of a node. A Buildx node in this case could connect multiple Kubernetes nodes of
+the same architecture together.
 
 With the `kube` builder created, you can now introduce another architecture into
 the mix using `--append`. For example, to add `arm64`:


### PR DESCRIPTION
Signed-off-by: David Karlsson <david.karlsson@docker.com>

<!--
  Thank you for contributing to Docker documentation!

  Here are a few things to keep in mind:

  - Links between pages should use a relative path
  - Remember to add an alt text for images

  ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
  ┃     Review our contribution guidelines:       ┃
  ┃                                               ┃
  ┃ https://docs.docker.com/contribute/overview/  ┃
  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
-->

### Proposed changes

Adds a brief statement that `--node` is optional when creating/appending builder nodes for the k8s driver

### Related issues (optional)

Follow-up: docker/buildx#1673
