### PR TITLE
scout: add consistent banners for "early access"

### DIFF
--- a/_data/toc.yaml
+++ b/_data/toc.yaml
@@ -619,7 +619,7 @@ reference:
       title: docker run
     - path: /engine/reference/commandline/save/
       title: docker save
-    - sectiontitle: docker scout
+    - sectiontitle: docker scout (Early Access)
       section:
       - path: /engine/reference/commandline/scout/
         title: docker scout

--- a/_includes/scout-early-access.md
+++ b/_includes/scout-early-access.md
@@ -1,0 +1,8 @@
+> **Early Access**
+>
+> Docker Scout is an [early access](/release-lifecycle/#early-access-ea)
+> product, and requires a Docker Pro, Team, or Business subscription.
+>
+> If you're interested in Docker Scout for your organization and want to
+> learn more, get in touch by filling out the contact form on the
+> [Docker Scout product page](https://docker.com/products/docker-scout){: target="_blank" rel="noopener" }.

--- a/engine/reference/commandline/scout.md
+++ b/engine/reference/commandline/scout.md
@@ -10,4 +10,7 @@ in the source repository on GitHub:
 
 https://github.com/docker/scout-cli-plugin
 -->
+
+{% include scout-early-access.md %}
+
 {% include cli.md datafolder=page.datafolder datafile=page.datafile %}

--- a/engine/reference/commandline/scout_compare.md
+++ b/engine/reference/commandline/scout_compare.md
@@ -10,4 +10,7 @@ in the source repository on GitHub:
 
 https://github.com/docker/scout-cli-plugin
 -->
+
+{% include scout-early-access.md %}
+
 {% include cli.md datafolder=page.datafolder datafile=page.datafile %}

--- a/engine/reference/commandline/scout_cves.md
+++ b/engine/reference/commandline/scout_cves.md
@@ -10,4 +10,7 @@ in the source repository on GitHub:
 
 https://github.com/docker/scout-cli-plugin
 -->
+
+{% include scout-early-access.md %}
+
 {% include cli.md datafolder=page.datafolder datafile=page.datafile %}

--- a/engine/reference/commandline/scout_quickview.md
+++ b/engine/reference/commandline/scout_quickview.md
@@ -10,4 +10,7 @@ in the source repository on GitHub:
 
 https://github.com/docker/scout-cli-plugin
 -->
+
+{% include scout-early-access.md %}
+
 {% include cli.md datafolder=page.datafolder datafile=page.datafile %}

--- a/engine/reference/commandline/scout_recommendations.md
+++ b/engine/reference/commandline/scout_recommendations.md
@@ -10,4 +10,7 @@ in the source repository on GitHub:
 
 https://github.com/docker/scout-cli-plugin
 -->
+
+{% include scout-early-access.md %}
+
 {% include cli.md datafolder=page.datafolder datafile=page.datafile %}

--- a/engine/reference/commandline/scout_sbom.md
+++ b/engine/reference/commandline/scout_sbom.md
@@ -10,4 +10,7 @@ in the source repository on GitHub:
 
 https://github.com/docker/scout-cli-plugin
 -->
+
+{% include scout-early-access.md %}
+
 {% include cli.md datafolder=page.datafolder datafile=page.datafile %}

--- a/engine/reference/commandline/scout_version.md
+++ b/engine/reference/commandline/scout_version.md
@@ -10,4 +10,7 @@ in the source repository on GitHub:
 
 https://github.com/docker/scout-cli-plugin
 -->
+
+{% include scout-early-access.md %}
+
 {% include cli.md datafolder=page.datafolder datafile=page.datafile %}

--- a/scout/advanced-image-analysis.md
+++ b/scout/advanced-image-analysis.md
@@ -4,15 +4,7 @@ keywords: scanning, vulnerabilities, Hub, supply chain, security
 title: Advanced image analysis
 ---
 
-> **Note**
->
-> Docker Scout is an [early access](../release-lifecycle.md#early-access-ea)
-> product, and requires a Docker Pro, Team, or Business subscription.
->
-> If you're interested in Docker Scout for your organization and want to
-> learn more, get in touch by filling out the contact form on the
-> [Docker Scout product page](https://docker.com/products/docker-scout){:
-> target="\_blank" rel="noopener" }.
+{% include scout-early-access.md %}
 
 Advanced image analysis is a Docker Scout feature for Docker Hub.
 

--- a/scout/artifactory.md
+++ b/scout/artifactory.md
@@ -7,15 +7,7 @@ keywords: >
 title: Artifactory integration
 ---
 
-> **Note**
->
-> Docker Scout is an [early access](../release-lifecycle.md#early-access-ea)
-> product.
->
-> If you're interested in this integration for your organization and want to
-> learn more, get in touch by filling out the contact form on the
-> [Docker Scout product page](https://docker.com/products/docker-scout){:
-> target="\_blank" rel="noopener" }.
+{% include scout-early-access.md %}
 
 Integrating Docker Scout with JFrog Artifactory lets you run image analysis
 automatically on images in your Artifactory registries.

--- a/scout/image-details-view.md
+++ b/scout/image-details-view.md
@@ -5,15 +5,7 @@ description: >
   Docker Scout helps you understand your images and their dependencies
 ---
 
-> **Note**
->
-> Docker Scout is an [early access](../release-lifecycle.md#early-access-ea)
-> product, and requires a Docker Pro, Team, or Business subscription.
->
-> If you're interested in Docker Scout for your organization and want to
-> learn more, get in touch by filling out the contact form on the
-> [Docker Scout product page](https://docker.com/products/docker-scout){:
-> target="\_blank" rel="noopener" }.
+{% include scout-early-access.md %}
 
 The image details view shows a breakdown of the Docker Scout analysis. You can
 access the image view from within Docker Desktop and from the image tag

--- a/scout/index.md
+++ b/scout/index.md
@@ -13,15 +13,7 @@ redirect_from:
   - /atomist/integrate/deploys/
 ---
 
-> **Note**
->
-> Docker Scout is an [early access](../release-lifecycle.md#early-access-ea)
-> product, and requires a Docker Pro, Team, or Business subscription.
->
-> If you're interested in Docker Scout for your organization and want to
-> learn more, get in touch by filling out the contact form on the
-> [Docker Scout product page](https://docker.com/products/docker-scout){:
-> target="\_blank" rel="noopener" }.
+{% include scout-early-access.md %}
 
 Docker Scout is a collection of software supply chain features that appear
 throughout Docker user interfaces and the command line interface (CLI). These features provide detailed


### PR DESCRIPTION
Docker Scout is in early access, but some parts of the documentation (reference docs) did not contain a banner for this.

This patch:

- Changes the "note" to "early access" (just a minor improvment)
- Adds banners to all the CLI reference pages
- Adds (Early Access) in the CLI reference navigation (TOC)


Banners now use "early access" as heading, instead of the blanket "note"

Before:

<img width="993" alt="Screenshot 2023-04-07 at 15 25 19" src="https://user-images.githubusercontent.com/1804568/230617346-8c22b91d-9ae1-4e70-ba49-807ee016b101.png">

After:

<img width="1006" alt="Screenshot 2023-04-07 at 15 25 07" src="https://user-images.githubusercontent.com/1804568/230617351-2a652e14-c8dc-4123-9c29-5a7148d5b1f4.png">

The CLI reference docs now has "(Early Access)" in the TOC, and pages have a "Early Access" banner;


<img width="270" alt="Screenshot 2023-04-07 at 15 27 23" src="https://user-images.githubusercontent.com/1804568/230617464-a4bf47c1-3600-4a25-b25f-6057748292e6.png">
<img width="1290" alt="Screenshot 2023-04-07 at 15 27 57" src="https://user-images.githubusercontent.com/1804568/230617468-4a15e134-ff54-4911-8efc-3814722580a3.png">




<!--
  Thank you for contributing to Docker documentation!

  Here are a few things to keep in mind:

  - Links between pages should use a relative path
  - Remember to add an alt text for images

  ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
  ┃     Review our contribution guidelines:       ┃
  ┃                                               ┃
  ┃ https://docs.docker.com/contribute/overview/  ┃
  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
-->

### Proposed changes

<!-- Tell us what you did and why -->

### Related issues (optional)

<!--
  Refer to related PRs or issues:

  #1234
  Closes #1234
  Closes docker/cli#1234
-->
