### PR TITLE
redirect: add /go link for Compose v1 EOL

### DIFF
--- a/_redirects.yml
+++ b/_redirects.yml
@@ -105,6 +105,8 @@
   - /go/deprecated/
 "/engine/reference/commandline/cli/#experimental-features":
   - /go/experimental/
+"/compose/compose-v2/":
+  - /go/compose-v1-eol/
 "/config/formatting/":
   # Instructions on using Go templates to format CLI output with --format
   - /go/formatting/


### PR DESCRIPTION
### Proposed changes
Add a `/go` link for Compose v1 EOL info.

Redirecting to the "Evolution of Compose" page for the moment. We will probably adjust this page once Compose V1 is removed from Docker Desktop in a couple months.

### Related issues (optional)
* #16641 (Compose v1 EOL banner in docs)
