### PR TITLE
Remove misleading "This is the newest version." from "Compose file version 3 reference"

### DIFF
--- a/compose/compose-file/compose-file-v3.md
+++ b/compose/compose-file/compose-file-v3.md
@@ -9,8 +9,7 @@ toc_min: 1
 
 ## Reference and guidelines
 
-These topics describe version 3 of the Compose file format. This is the newest
-version.
+These topics describe version 3 of the Compose file format.
 
 ## Compose and Docker compatibility matrix
 


### PR DESCRIPTION
### Proposed changes

Remove misleading "This is the newest version." from "Compose file version 3 reference" article.

This change is consistent with https://github.com/docker/docs/blob/main/compose/compose-file/index.md

### Related issues (optional)

None.
