### PR TITLE
desktop: install: remove link to "apple silicon" next steps

### DIFF
--- a/desktop/install/mac-install.md
+++ b/desktop/install/mac-install.md
@@ -111,11 +111,10 @@ The `install` command accepts the following flags:
 
 ## Where to go next
 
-- [Docker Desktop for Apple silicon](../install/mac-install.md) for detailed information about Docker Desktop for Apple silicon.
 - [Troubleshooting](../troubleshoot/overview.md) describes common problems, workarounds, how
   to run and submit diagnostics, and submit issues.
 - [FAQs](../faqs/general.md) provide answers to frequently asked questions.
 - [Release notes](../release-notes.md) lists component updates, new features, and improvements associated with Docker Desktop releases.
 - [Get started with Docker](../../get-started/index.md) provides a general Docker tutorial.
-* [Back up and restore data](../backup-and-restore.md) provides instructions
+- [Back up and restore data](../backup-and-restore.md) provides instructions
   on backing up and restoring data related to Docker.


### PR DESCRIPTION
- relates to https://github.com/docker/docs/pull/17113

It's now pointing to the same page

<!--
  Thank you for contributing to Docker documentation!

  Here are a few things to keep in mind:

  - Links between pages should use a relative path
  - Remember to add an alt text for images

  ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
  ┃     Review our contribution guidelines:       ┃
  ┃                                               ┃
  ┃ https://docs.docker.com/contribute/overview/  ┃
  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
-->

### Proposed changes

<!-- Tell us what you did and why -->

### Related issues (optional)

<!--
  Refer to related PRs or issues:

  #1234
  Closes #1234
  Closes docker/cli#1234
-->
