### PR TITLE
Update desktop-install.md links

### DIFF
--- a/_includes/desktop-install.md
+++ b/_includes/desktop-install.md
@@ -8,9 +8,9 @@
 > [Mac with Apple chip](https://desktop.docker.com/mac/main/arm64{{ include.build_path }}Docker.dmg) ([checksum](https://desktop.docker.com/mac/main/arm64{{ include.build_path }}checksums.txt){: target="_blank" rel="noopener" class="_"}) {% if include.all or include.linux %} | {% endif %}
 {% endif -%}
 {% if include.all or include.linux -%}
-> [Debian](https://desktop.docker.com/linux/main/amd64{{ include.build_path }}docker-desktop-4.17.0-amd64.deb) - 
-> [RPM](https://desktop.docker.com/linux/main/amd64{{ include.build_path }}docker-desktop-4.17.0-x86_64.rpm) - 
-> [Arch package](https://desktop.docker.com/linux/main/amd64{{ include.build_path }}docker-desktop-4.17.0-x86_64.pkg.tar.zst) ([checksum](https://desktop.docker.com/linux/main/amd64{{ include.build_path }}checksums.txt){: target="_blank" rel="noopener" class="_"}) 
+> [Debian](https://desktop.docker.com/linux/main/amd64{{ include.build_path }}docker-desktop-4.18.0-amd64.deb) - 
+> [RPM](https://desktop.docker.com/linux/main/amd64{{ include.build_path }}docker-desktop-4.18.0-x86_64.rpm) - 
+> [Arch package](https://desktop.docker.com/linux/main/amd64{{ include.build_path }}docker-desktop-4.18.0-x86_64.pkg.tar.zst) ([checksum](https://desktop.docker.com/linux/main/amd64{{ include.build_path }}checksums.txt){: target="_blank" rel="noopener" class="_"}) 
 {% endif -%}
 {% if include.build_path == "/" -%}
 {: .tip}


### PR DESCRIPTION

### Proposed changes

Updated Linux distro links for v4.18.0 as they were sending to v4.17.0


 Closes docker/docs#17119