### PR TITLE
standalone docker-compose is still supported, while discouraged

### DIFF
--- a/compose/install/index.md
+++ b/compose/install/index.md
@@ -41,5 +41,5 @@ You can [install the Compose standalone](other.md) on Linux or on Windows Server
 
 >Note
 >
->This install scenario is not recommended and only supported for backward compatibility purpose.
+>This install scenario is not recommended and is only supported for backward compatibility purposes.
 {: .important}

--- a/compose/install/index.md
+++ b/compose/install/index.md
@@ -41,5 +41,5 @@ You can [install the Compose standalone](other.md) on Linux or on Windows Server
 
 >Note
 >
->This install scenario is no longer supported.
+>This install scenario is not recommended and only supported for backward compatibility purpose.
 {: .important}


### PR DESCRIPTION
### Proposed changes
don't tell users we no longer support docker-compose used as standalone executable, just discourage this usage

### Related issues (optional)
closes https://github.com/docker/compose/issues/10485