### PR TITLE
FIX - switch docker repo to centos

### DIFF
--- a/engine/install/rhel.md
+++ b/engine/install/rhel.md
@@ -82,7 +82,7 @@ from the repository.
 
 #### Set up the repository
 
-{% assign download-url-base = "https://download.docker.com/linux/rhel" %}
+{% assign download-url-base = "https://download.docker.com/linux/centos" %}
 
 Install the `yum-utils` package (which provides the `yum-config-manager`
 utility) and set up the repository.
@@ -90,7 +90,7 @@ utility) and set up the repository.
 ```console
 $ sudo yum install -y yum-utils
 
-$ sudo yum-config-manager \
+$ sudo dnf config-manager \
     --add-repo \
     {{ download-url-base }}/docker-ce.repo
 ```


### PR DESCRIPTION
### Proposed changes
Update config-manager repo to point to centos instead of RHEL as referenced in https://access.redhat.com/discussions/6249651 and graciously solved by https://stackoverflow.com/questions/70358656/rhel8-fedora-yum-dns-causes-cannot-download-repodata-repomd-xml-for-docker-ce

This was done because RHEL7 is nearing EOL (https://endoflife.date/rhel), and while RHEL8 is nearing EOL too, 8 is at least more relevant.

### Related issues (optional)

#13463
Closes #13463
