### PR TITLE
Fix typo in AWS CloudFormation ECS memory scaling

### DIFF
--- a/cloud/ecs-integration.md
+++ b/cloud/ecs-integration.md
@@ -401,7 +401,7 @@ services:
         min: 1
         max: 10 #required
         cpu: 75
-        # mem: - mutualy exlusive with cpu
+        # memory: - mutualy exlusive with cpu
 ```
 
 ## IAM roles


### PR DESCRIPTION
<!--
  Thank you for contributing to Docker documentation!

  Here are a few things to keep in mind:

  - Links between pages should use a relative path
  - Remember to add an alt text for images

  ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
  ┃     Review our contribution guidelines:       ┃
  ┃                                               ┃
  ┃ https://docs.docker.com/contribute/overview/  ┃
  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
-->

### Proposed changes

The docs are wrong and this is a one line change to fix it. I simply changed the auto scaling argument to `memory`. 

`mem` isn't correct. It creates a `ECSServiceAverageCPUUtilization` with `TargetValue: 0`. But we don't want CPU scaling. We want the CloudFormation file to have `ECSServiceAverageMemoryUtilization`

I found out the correct argument is `memory` by seeing this comment from a maintainer @ndeloof  https://github.com/docker/compose-cli/issues/767#issue-720069839 You can also see the argument in the source code here https://github.com/docker/compose-cli/pull/817/files#diff-38859822f892b13d3f91d2c63f28d431a86748f7ff2083a9d4f3e41e06bbf95bR31
I've tried it and can confirm it works.
