### PR TITLE
Add Docker Desktop installer CLI flags for proxy configuration

### DIFF
--- a/desktop/install/mac-install.md
+++ b/desktop/install/mac-install.md
@@ -101,15 +101,15 @@ As macOS typically performs security checks the first time an application is use
 The `install` command accepts the following flags:
 - `--accept-license`: accepts the [Docker Subscription Service Agreement](https://www.docker.com/legal/docker-subscription-service-agreement){: target="_blank" rel="noopener" class="_"} now, rather than requiring it to be accepted when the application is first run
 - `--allowed-org=<org name>`: requires the user to sign in and be part of the specified Docker Hub organization when running the application
-- `--user=<username>`: Performs the privileged configurations once during installation. This removes the need for the user to grant root privileges on first run. For more information, see [Privileged helper permission requirements](../mac/permission-requirements.md#permission-requirements){: target="_blank" rel="noopener" class="_"}. To find the username, enter `ls /Users` in the CLI.
-- `--admin-settings`: Automatically creates an `admin-settings.json` file which is used by admins to control certain Docker Desktop settings on client machines within their organization. For more information, see [Settings Management](../hardened-desktop/settings-management/index.md).
+- `--user=<username>`: performs the privileged configurations once during installation. This removes the need for the user to grant root privileges on first run. For more information, see [Privileged helper permission requirements](../mac/permission-requirements.md#permission-requirements){: target="_blank" rel="noopener" class="_"}. To find the username, enter `ls /Users` in the CLI.
+- `--admin-settings`: automatically creates an `admin-settings.json` file which is used by admins to control certain Docker Desktop settings on client machines within their organization. For more information, see [Settings Management](../hardened-desktop/settings-management/index.md).
   - It must be used together with the `--allowed-org=<org name>` flag. 
   - For example:
     `--allowed-org=<org name> --admin-settings='{"configurationFileVersion": 2, "enhancedContainerIsolation": {"value": true, "locked": false}}'`
 - `--proxy-http-mode=<mode>`: sets the HTTP Proxy mode, `system` (default) or `manual`.
-- `--override-proxy-http=<URL>`: URL of the HTTP proxy that must be used for outgoing HTTP requests, requires `--proxy-http-mode` to be `manual`.
-- `--override-proxy-https=<URL>`: URL of the HTTP proxy that must be used for outgoing HTTPS requests, requires `--proxy-http-mode` to be `manual`.
-- `--override-proxy-exclude=<hosts/domains>`: Bypass proxy settings for these hosts & domains, a comma-separated list.
+- `--override-proxy-http=<URL>`: sets the URL of the HTTP proxy that must be used for outgoing HTTP requests, requires `--proxy-http-mode` to be `manual`.
+- `--override-proxy-https=<URL>`: sets the URL of the HTTP proxy that must be used for outgoing HTTPS requests, requires `--proxy-http-mode` to be `manual`.
+- `--override-proxy-exclude=<hosts/domains>`: bypasses proxy settings for these hosts and domains, a comma-separated list.
 
 ## Where to go next
 

--- a/desktop/install/mac-install.md
+++ b/desktop/install/mac-install.md
@@ -106,7 +106,7 @@ The `install` command accepts the following flags:
   - It must be used together with the `--allowed-org=<org name>` flag. 
   - For example:
     `--allowed-org=<org name> --admin-settings='{"configurationFileVersion": 2, "enhancedContainerIsolation": {"value": true, "locked": false}}'`
-- `--proxy-http-mode=<mode>`: HTTP Proxy mode, `system` (default) or `manual`.
+- `--proxy-http-mode=<mode>`: sets the HTTP Proxy mode, `system` (default) or `manual`.
 - `--override-proxy-http=<URL>`: URL of the HTTP proxy that must be used for outgoing HTTP requests, requires `--proxy-http-mode` to be `manual`.
 - `--override-proxy-https=<URL>`: URL of the HTTP proxy that must be used for outgoing HTTPS requests, requires `--proxy-http-mode` to be `manual`.
 - `--override-proxy-exclude=<hosts/domains>`: Bypass proxy settings for these hosts & domains, a comma-separated list.

--- a/desktop/install/mac-install.md
+++ b/desktop/install/mac-install.md
@@ -106,6 +106,10 @@ The `install` command accepts the following flags:
   - It must be used together with the `--allowed-org=<org name>` flag. 
   - For example:
     `--allowed-org=<org name> --admin-settings='{"configurationFileVersion": 2, "enhancedContainerIsolation": {"value": true, "locked": false}}'`
+- `--proxy-http-mode=<mode>`: HTTP Proxy mode, `system` (default) or `manual`.
+- `--override-proxy-http=<URL>`: URL of the HTTP proxy that must be used for outgoing HTTP requests, requires `--proxy-http-mode` to be `manual`.
+- `--override-proxy-https=<URL>`: URL of the HTTP proxy that must be used for outgoing HTTPS requests, requires `--proxy-http-mode` to be `manual`.
+- `--override-proxy-exclude=<hosts/domains>`: Bypass proxy settings for these hosts & domains, a comma-separated list.
 
 ## Where to go next
 

--- a/desktop/install/windows-install.md
+++ b/desktop/install/windows-install.md
@@ -157,14 +157,14 @@ The `install` command accepts the following flags:
 - `--allowed-org=<org name>`: requires the user to sign in and be part of the specified Docker Hub organization when running the application
 - `--backend=<backend name>`: selects the default backend to use for Docker Desktop, `hyper-v`, `windows` or `wsl-2` (default)
 - `--installation-dir=<path>`: changes the default installation location (`C:\Program Files\Docker\Docker`)
-- `--admin-settings`: Automatically creates an `admin-settings.json` file which is used by admins to control certain Docker Desktop settings on client machines within their organization. For more information, see [Settings Management](../hardened-desktop/settings-management/index.md).
+- `--admin-settings`: automatically creates an `admin-settings.json` file which is used by admins to control certain Docker Desktop settings on client machines within their organization. For more information, see [Settings Management](../hardened-desktop/settings-management/index.md).
   - It must be used together with the `--allowed-org=<org name>` flag. 
   - For example:
     `--allowed-org=<org name> --admin-settings='{"configurationFileVersion": 2, "enhancedContainerIsolation": {"value": true, "locked": false}}'`
-- `--proxy-http-mode=<mode>`: HTTP Proxy mode, `system` (default) or `manual`.
-- `--override-proxy-http=<URL>`: URL of the HTTP proxy that must be used for outgoing HTTP requests, requires `--proxy-http-mode` to be `manual`.
-- `--override-proxy-https=<URL>`: URL of the HTTP proxy that must be used for outgoing HTTPS requests, requires `--proxy-http-mode` to be `manual`.
-- `--override-proxy-exclude=<hosts/domains>`: Bypass proxy settings for these hosts & domains, a comma-separated list.
+- `--proxy-http-mode=<mode>`: sets the HTTP Proxy mode, `system` (default) or `manual`.
+- `--override-proxy-http=<URL>`: sets the URL of the HTTP proxy that must be used for outgoing HTTP requests, requires `--proxy-http-mode` to be `manual`.
+- `--override-proxy-https=<URL>`: sets the URL of the HTTP proxy that must be used for outgoing HTTPS requests, requires `--proxy-http-mode` to be `manual`.
+- `--override-proxy-exclude=<hosts/domains>`: bypasses proxy settings for these hosts and domains, a comma-separated list.
 
 If your admin account is different to your user account, you must add the user to the **docker-users** group:
 

--- a/desktop/install/windows-install.md
+++ b/desktop/install/windows-install.md
@@ -161,6 +161,10 @@ The `install` command accepts the following flags:
   - It must be used together with the `--allowed-org=<org name>` flag. 
   - For example:
     `--allowed-org=<org name> --admin-settings='{"configurationFileVersion": 2, "enhancedContainerIsolation": {"value": true, "locked": false}}'`
+- `--proxy-http-mode=<mode>`: HTTP Proxy mode, `system` (default) or `manual`.
+- `--override-proxy-http=<URL>`: URL of the HTTP proxy that must be used for outgoing HTTP requests, requires `--proxy-http-mode` to be `manual`.
+- `--override-proxy-https=<URL>`: URL of the HTTP proxy that must be used for outgoing HTTPS requests, requires `--proxy-http-mode` to be `manual`.
+- `--override-proxy-exclude=<hosts/domains>`: Bypass proxy settings for these hosts & domains, a comma-separated list.
 
 If your admin account is different to your user account, you must add the user to the **docker-users** group:
 


### PR DESCRIPTION
<!--
  Thank you for contributing to Docker documentation!

  Here are a few things to keep in mind:

  - Links between pages should use a relative path
  - Remember to add an alt text for images

  ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
  ┃     Review our contribution guidelines:       ┃
  ┃                                               ┃
  ┃ https://docs.docker.com/contribute/overview/  ┃
  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
-->

### Proposed changes

<!-- Tell us what you did and why -->
Add Docker Desktop installer CLI flags for proxy configuration for Mac and Windows (to be released in 4.19)

### Related issues (optional)
https://github.com/docker/pinata/pull/21729
<!--
  Refer to related PRs or issues:

  #1234
  Closes #1234
  Closes docker/cli#1234
-->
