### PR TITLE
Handle undefined error in EULA

### DIFF
--- a/assets/js/docs.js
+++ b/assets/js/docs.js
@@ -190,11 +190,24 @@ $(document).ready(function () {
     });
 });
 
+
+// Store the original modal body content in a variable
+var originalModalBody = $('#accept-eula .modal-body').html();
+
 function initAcceptEULAModal() {
     $("main").on("click", "a.accept-eula", function (e) {
         e.preventDefault();
-        _("#accept-eula .btn-primary").href = e.target.href;
-        $('#accept-eula').modal('show')
+        // Check for undefined. Occurs when loaded via proxy.
+        if (e.target.href && e.target.href !== 'undefined') {
+            $("#accept-eula .btn-primary").attr('href', e.target.href);
+            $('#accept-eula .modal-body').html(originalModalBody);
+            $("#accept-eula .btn-primary").show();
+        } else {
+            var errorMessage = 'Unable to process the download link. If you are using a proxy, like a translation service, try accessing the the page without using the proxy.';
+            $('#accept-eula .modal-body').html('<div class="alert alert-danger">' + errorMessage + '</div>');
+            $("#accept-eula .btn-primary").hide();
+        }
+        $('#accept-eula').modal('show');
     });
 }
 


### PR DESCRIPTION


### Proposed changes

The the `Accept and Download` button in the EULA component doesn't work when viewing the page through a proxy like Google Translate.
When a user clicks the `Accept and Download` button, they are redirected to a 404 page with no indication of what happened. Follow the image below to replicate.
![error](https://user-images.githubusercontent.com/103533812/234400252-84674eef-6e99-4cb0-9377-b8f47d22f8b1.gif)

In my mind, there are 3 options:

1. Fix the EULA component to work with a proxy.
   I was unable to do this. Can it be done?
2. Create some workaround to prevent the undefined 404 page and give the user a message on how to resolve. In the main issue, it was proposed to just redirect, but I think that's confusing for the user.
   I attempted this in this PR. Is there better UX or way to handle this?
3. Remove the EULA component and add callouts near each download link. The same as we do for the current version, https://docs.docker.com/desktop/install/windows-install/ 
   This seems simple and therefore preferred. Can we do this without any legal ramifications? 

To verify, follow the steps in the image.
![fix](https://user-images.githubusercontent.com/103533812/234401166-389f5ce9-fa9f-4886-bccd-f59a0383f951.gif)

### Related issues (optional)
Fixes #13553
