### PR TITLE
Fix links on 'Back up and restore data' page

### DIFF
--- a/desktop/backup-and-restore.md
+++ b/desktop/backup-and-restore.md
@@ -38,7 +38,7 @@ and [install a different version](release-notes.md) or reset Docker Desktop to f
 
 ## Restore your data
 
-1. Use [`docker pull`](../engine/reference/commandline/load.md) to restore images
+1. Use [`docker pull`](../engine/reference/commandline/pull.md) to restore images
    you pushed to Docker Hub.
 
    If you backed up your images to a local tar file, use [`docker image load -i images.tar`](../engine/reference/commandline/load.md)

--- a/desktop/backup-and-restore.md
+++ b/desktop/backup-and-restore.md
@@ -44,7 +44,7 @@ and [install a different version](release-notes.md) or reset Docker Desktop to f
    If you backed up your images to a local tar file, use [`docker image load -i images.tar`](../engine/reference/commandline/load.md)
    to restore previously saved images.
 
-2. Re-create your containers if needed, using [`docker run`](../engine/reference/commandline/load.md),
+2. Re-create your containers if needed, using [`docker run`](../engine/reference/commandline/run.md),
    or [Docker Compose](../compose/index.md).
 
 Refer to the [backup, restore, or migrate data volumes](../storage/volumes.md#back-up-restore-or-migrate-data-volumes) page in the storage section to restore volume data.


### PR DESCRIPTION
### Proposed changes

"docker run" link was pointing to "docker load" documentation, fixed this link.
