### PR TITLE
Update 07_multi_container.md [typo]

### DIFF
--- a/get-started/07_multi_container.md
+++ b/get-started/07_multi_container.md
@@ -40,7 +40,7 @@ In the following steps, you'll create the network first and then attach the MySQ
    ```
 
 2. Start a MySQL container and attach it to the network. You're also going to define a few environment variables that the
-  database will use to initialize the database. To learn more about the MySQL environment variables, see the "Environment Variables" section in the [MySQL Docker Hub listing](https://hub.docker.com/_/mysql/)).
+  database will use to initialize the database. To learn more about the MySQL environment variables, see the "Environment Variables" section in the [MySQL Docker Hub listing](https://hub.docker.com/_/mysql/).
 
     <ul class="nav nav-tabs">
     <li class="active"><a data-toggle="tab" data-target="#mac-linux">Mac / Linux</a></li>


### PR DESCRIPTION
Typo - Removes extra close parenthesis

<!--
  Thank you for contributing to Docker documentation!

  Here are a few things to keep in mind:

  - Links between pages should use a relative path
  - Remember to add an alt text for images

  ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
  ┃     Review our contribution guidelines:       ┃
  ┃                                               ┃
  ┃ https://docs.docker.com/contribute/overview/  ┃
  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
-->

### Proposed changes


<img width="1045" alt="Cursor_and_Multi_container_apps___Docker_Documentation_🔊" src="https://user-images.githubusercontent.com/26127185/234948272-b80093f5-9b52-4e7c-9744-b3d4c2315e48.png">

Just removing a small typo with an extra parenthesis

<!-- Tell us what you did and why -->


<!--
  Refer to related PRs or issues:

  #1234
  Closes #1234
  Closes docker/cli#1234
-->
