### PR TITLE
document syntax for watch ignores

### DIFF
--- a/compose/file-watch.md
+++ b/compose/file-watch.md
@@ -103,6 +103,8 @@ services:
         - action: sync
           path: ./web
           target: /src/web
+          ignore:
+            - node_modules/
         - action: rebuild
           path: package.json
 ```


### PR DESCRIPTION
### Proposed changes

documentation recommend to exclude `node_modules` but this isn't reflected in the example configuration

### Related issues (optional)

closes https://github.com/compose-spec/compose-spec/issues/345