### PR TITLE
Add info invalid references

### DIFF
--- a/compose/environment-variables/set-environment-variables.md
+++ b/compose/environment-variables/set-environment-variables.md
@@ -109,7 +109,11 @@ db:
 
 When you run `docker compose up` with this configuration, Compose looks for the `POSTGRES_VERSION` environment variable in the shell and substitutes its value in. For this example, Compose resolves the image to `postgres:9.3` before running the configuration.
 
-If an environment variable is not set, Compose substitutes with an empty string. In the example above, if `POSTGRES_VERSION` is not set, the value for the image option is `postgres:.`
+If an environment variable is not set, Compose substitutes with an empty string. In the example above, if `POSTGRES_VERSION` is not set, the value for the image option is `postgres:`.
+
+> **Important**
+>
+> `postgres:` is **not** valid image reference. Docker expects either a reference without a tag like `postgres` which defaults to latest or with a tag `postgres:15`.
 
 > **Important**
 >


### PR DESCRIPTION
The example shows a configuration that would raise a invalid image reference error if the environment variable for the image is set to an empty string or is not set at all.

Also the code format ticks included the period.

#17192

A warning was added to highlight the incorrect configuration and the ticks now exclude the period.

<!--
  Thank you for contributing to Docker documentation!

  Here are a few things to keep in mind:

  - Links between pages should use a relative path
  - Remember to add an alt text for images

  ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
  ┃     Review our contribution guidelines:       ┃
  ┃                                               ┃
  ┃ https://docs.docker.com/contribute/overview/  ┃
  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
-->

### Proposed changes

<!-- Tell us what you did and why -->

### Related issues (optional)

<!--
  Refer to related PRs or issues:

  #1234
  Closes #1234
  Closes docker/cli#1234
-->
