### PR TITLE
Change Docker status URL

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -75,7 +75,7 @@
                 <nav class="footer_sub_nav">
                     <ul class="menu">
                         <li><a href="https://www.docker.com/legal/docker-terms-service" target="_blank" rel="noopener">Terms of Service</a></li>
-                        <li><a href="https://status.docker.com/" target="_blank" rel="noopener">Status</a></li>
+                        <li><a href="https://dockerstatus.com/" target="_blank" rel="noopener">Status</a></li>
                         <li><a href="https://www.docker.com/legal" target="_blank" rel="noopener">Legal</a></li>
                     </ul>
                 </nav>


### PR DESCRIPTION
### Proposed changes

This updates docs to point to new Docker status URL that allows for access of Docker domains go down.