### PR TITLE
fix: duplicate release note entry

### DIFF
--- a/desktop/release-notes.md
+++ b/desktop/release-notes.md
@@ -92,7 +92,6 @@ For frequently asked questions about Docker Desktop releases, see [FAQs](faqs/ge
 
 #### For all platforms
 
-- Fixed a security issue in the Artifactory Integration where it would fallback to sending registry credentials over plain HTTP if HTTPS check failed. Fixes [docker/for-win#13344](https://github.com/docker/for-win/issues/13344).
 - Fixed [CVE-2023-24532](https://github.com/advisories/GHSA-x2w5-7wp4-5qff).
 - Fixed [CVE-2023-25809](https://github.com/advisories/GHSA-m8cg-xc2p-r3fc).
 - Fixed [CVE-2023-27561](https://github.com/advisories/GHSA-vpvm-3wq2-2wvm).


### PR DESCRIPTION
<!--
  Thank you for contributing to Docker documentation!

  Here are a few things to keep in mind:

  - Links between pages should use a relative path
  - Remember to add an alt text for images

  ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
  ┃     Review our contribution guidelines:       ┃
  ┃                                               ┃
  ┃ https://docs.docker.com/contribute/overview/  ┃
  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
-->

### Proposed changes

<!-- Tell us what you did and why -->

Follow up of the discussion here: https://github.com/docker/docs/pull/17167#discussion_r1183549744

@gabriellavengeo spots a duplicated entry in the security section. This was cherrypicked and thus already present in `4.18.0`. This PR remove the duplicated entry.

### Related issues (optional)

<!--
  Refer to related PRs or issues:

  #1234
  Closes #1234
  Closes docker/cli#1234
-->
