### PR TITLE
Removed minor grammatical mistake

### DIFF
--- a/build/guide/multi-stage.md
+++ b/build/guide/multi-stage.md
@@ -26,7 +26,7 @@ REPOSITORY   TAG       IMAGE ID       CREATED         SIZE
 buildme      latest    c021c8a7051f   5 seconds ago   150MB
 ```
 
-The program compiles to executable binaries, so you don’t need to Go language
+The program compiles to executable binaries, so you don’t need Go language
 utilities to exist in the final image.
 
 ## Add stages


### PR DESCRIPTION
Removed a minor grammatical mistake which was creating confusion when going through the documentation

<!--
  Thank you for contributing to Docker documentation!

  Here are a few things to keep in mind:

  - Links between pages should use a relative path
  - Remember to add an alt text for images

  ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
  ┃     Review our contribution guidelines:       ┃
  ┃                                               ┃
  ┃ https://docs.docker.com/contribute/overview/  ┃
  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
-->

### Proposed changes

<!-- Tell us what you did and why -->

### Related issues (optional)

<!--
  Refer to related PRs or issues:

  #1234
  Closes #1234
  Closes docker/cli#1234
-->
