### PR TITLE
engine: refresh / align installation pages between distros

### DIFF
--- a/engine/install/binaries.md
+++ b/engine/install/binaries.md
@@ -137,6 +137,10 @@ instructions for enabling and configuring AppArmor or SELinux.
     This command downloads a test image and runs it in a container. When the
     container runs, it prints a message and exits.
 
+You have now successfully installed and started Docker Engine.
+
+{% include root-errors.md %}
+
 ## Install client binaries on macOS
 
 > **Note**

--- a/engine/install/binaries.md
+++ b/engine/install/binaries.md
@@ -252,5 +252,5 @@ version.
 ## Next steps
 
 - Continue to [Post-installation steps for Linux](linux-postinstall.md).
-- Take a look at the [Get started](../../get-started/index.md) training modules to learn  how to build an image and run it as a containerized application.
-- Review the topics in [Develop with Docker](../../develop/index.md) to learn how to build new applications using Docker.
+- Review the topics in [Develop with Docker](../../develop/index.md) to learn
+  how to build new applications using Docker.

--- a/engine/install/centos.md
+++ b/engine/install/centos.md
@@ -36,7 +36,8 @@ default, but if you have disabled it, you need to
 ### Uninstall old versions
 
 Older versions of Docker went by the names of `docker` or `docker-engine`.
-Uninstall any such older versions before attempting to install a new version, along with associated dependencies:
+Uninstall any such older versions before attempting to install a new version,
+along with associated dependencies.
 
 ```console
 $ sudo yum remove docker \
@@ -49,9 +50,10 @@ $ sudo yum remove docker \
                   docker-engine
 ```
 
-It's OK if `yum` reports that none of these packages are installed.
+`yum` might report that you have none of these packages installed.
 
-Images, containers, volumes, and networks stored in `/var/lib/docker/` aren’t automatically removed when you uninstall Docker.
+Images, containers, volumes, and networks stored in `/var/lib/docker/` aren't
+automatically removed when you uninstall Docker.
 
 ## Installation methods
 
@@ -70,11 +72,11 @@ You can install Docker Engine in different ways, depending on your needs:
 - In testing and development environments, you can use automated
   [convenience scripts](#install-using-the-convenience-script) to install Docker.
 
-### Install using the repository
+### Install using the rpm repository {#install-using-the-repository}
 
-Before you install Docker Engine for the first time on a new host machine, you need
-to set up the Docker repository. Afterward, you can install and update Docker
-from the repository.
+Before you install Docker Engine for the first time on a new host machine, you
+need to set up the Docker repository. Afterward, you can install and update
+Docker from the repository.
 
 #### Set up the repository
 
@@ -115,7 +117,8 @@ $ sudo yum-config-manager --add-repo {{ download-url-base }}/docker-ce.repo
    </div>
    <div id="tab-version" class="tab-pane fade" markdown="1">
 
-   To install a specific version, start by listing the available versions in the repository:
+   To install a specific version, start by listing the available versions in
+   the repository:
 
    ```console
    $ yum list docker-ce --showduplicates | sort -r
@@ -132,7 +135,8 @@ $ sudo yum-config-manager --add-repo {{ download-url-base }}/docker-ce.repo
    the package name (`docker-ce`) plus the version string (2nd column),
    separated by a hyphen (`-`). For example, `docker-ce-3:23.0.5-1.el8`.
 
-   Replace `<VERSION_STRING>` with the desired version and then run the following command to install:
+   Replace `<VERSION_STRING>` with the desired version and then run the following
+   command to install:
 
    ```console
    $ sudo yum install docker-ce-<VERSION_STRING> docker-ce-cli-<VERSION_STRING> containerd.io docker-buildx-plugin docker-compose-plugin
@@ -151,8 +155,8 @@ $ sudo yum-config-manager --add-repo {{ download-url-base }}/docker-ce.repo
    $ sudo systemctl start docker
    ```
 
-3. Verify that Docker Engine installation is successful by running the `hello-world`
-   image.
+3. Verify that the Docker Engine installation is successful by running the
+   `hello-world` image.
 
    ```console
    $ sudo docker run hello-world
@@ -172,15 +176,16 @@ choosing the new version you want to install.
 
 ### Install from a package
 
-If you can't use Docker's repository to install Docker, you can download the
-`.rpm` file for your release and install it manually. You need to download
-a new file each time you want to upgrade Docker Engine.
+If you can't use Docker's `rpm` repository to install Docker Engine, you can
+download the `.rpm` file for your release and install it manually. You need to
+download a new file each time you want to upgrade Docker Engine.
 
 1. Go to [{{ download-url-base }}/]({{ download-url-base }}/){: target="_blank" rel="noopener" class="_" }
    and choose your version of CentOS. Then browse to `x86_64/stable/Packages/`
    and download the `.rpm` file for the Docker version you want to install.
 
-2. Install Docker Engine, changing the path below to the path where you downloaded the Docker package.
+2. Install Docker Engine, changing the path below to the path where you downloaded
+   the Docker package.
 
    ```console
    $ sudo yum install /path/to/package.rpm
@@ -195,8 +200,8 @@ a new file each time you want to upgrade Docker Engine.
    $ sudo systemctl start docker
    ```
 
-4. Verify that Docker Engine installation is successful by running the `hello-world`
-   image.
+4. Verify that the Docker Engine installation is successful by running the
+   `hello-world` image.
 
    ```console
    $ sudo docker run hello-world
@@ -211,9 +216,9 @@ You have now successfully installed and started Docker Engine.
 
 #### Upgrade Docker Engine
 
-To upgrade Docker Engine, download the newer package file and repeat the
+To upgrade Docker Engine, download the newer package files and repeat the
 [installation procedure](#install-from-a-package), using `yum -y upgrade`
-instead of `yum -y install`, and point to the new file.
+instead of `yum -y install`, and point to the new files.
 
 {% include install-script.md %}
 
@@ -225,16 +230,15 @@ instead of `yum -y install`, and point to the new file.
    $ sudo yum remove docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin docker-ce-rootless-extras
    ```
 
-2. Images, containers, volumes, or customized configuration files on your host
-   are not automatically removed. To delete all images, containers, and
-   volumes:
+2. Images, containers, volumes, or custom configuration files on your host
+   aren't automatically removed. To delete all images, containers, and volumes:
 
    ```console
    $ sudo rm -rf /var/lib/docker
    $ sudo rm -rf /var/lib/containerd
    ```
 
-You must delete any edited configuration files manually.
+You have to delete any edited configuration files manually.
 
 ## Next steps
 

--- a/engine/install/centos.md
+++ b/engine/install/centos.md
@@ -87,10 +87,7 @@ utility) and set up the repository.
 
 ```console
 $ sudo yum install -y yum-utils
-
-$ sudo yum-config-manager \
-    --add-repo \
-    {{ download-url-base }}/docker-ce.repo
+$ sudo yum-config-manager --add-repo {{ download-url-base }}/docker-ce.repo
 ```
 
 #### Install Docker Engine

--- a/engine/install/centos.md
+++ b/engine/install/centos.md
@@ -166,7 +166,7 @@ $ sudo yum-config-manager \
     This command downloads a test image and runs it in a container. When the
     container runs, it prints a confirmation message and exits.
 
-You have now successfully installed and started Docker Engine. 
+You have now successfully installed and started Docker Engine.
 
 {% include root-errors.md %}
 
@@ -210,7 +210,9 @@ a new file each time you want to upgrade Docker Engine.
     This command downloads a test image and runs it in a container. When the
     container runs, it prints a confirmation message and exits.
 
-You have now successfully installed and started Docker Engine. The docker user group exists but contains no users, which is why you’re required to use sudo to run Docker commands. Continue to [Linux postinstall](linux-postinstall.md) to allow non-privileged users to run Docker commands and for other optional configuration steps.
+You have now successfully installed and started Docker Engine.
+
+{% include root-errors.md %}
 
 #### Upgrade Docker Engine
 

--- a/engine/install/centos.md
+++ b/engine/install/centos.md
@@ -33,8 +33,6 @@ The `centos-extras` repository must be enabled. This repository is enabled by
 default, but if you have disabled it, you need to
 [re-enable it](https://wiki.centos.org/AdditionalResources/Repositories){: target="_blank" rel="noopener" class="_" }.
 
-The `overlay2` storage driver is recommended.
-
 ### Uninstall old versions
 
 Older versions of Docker went by the names of `docker` or `docker-engine`.

--- a/engine/install/centos.md
+++ b/engine/install/centos.md
@@ -15,8 +15,8 @@ toc_max: 4
 ---
 
 To get started with Docker Engine on CentOS, make sure you
-[meet the prerequisites](#prerequisites), then
-[install Docker](#installation-methods).
+[meet the prerequisites](#prerequisites), and then follow the
+[installation steps](#installation-methods).
 
 ## Prerequisites
 

--- a/engine/install/centos.md
+++ b/engine/install/centos.md
@@ -244,4 +244,5 @@ You must delete any edited configuration files manually.
 ## Next steps
 
 - Continue to [Post-installation steps for Linux](linux-postinstall.md).
-- Review the topics in [Develop with Docker](../../develop/index.md) to learn how to build new applications using Docker.
+- Review the topics in [Develop with Docker](../../develop/index.md) to learn
+  how to build new applications using Docker.

--- a/engine/install/centos.md
+++ b/engine/install/centos.md
@@ -22,12 +22,12 @@ To get started with Docker Engine on CentOS, make sure you
 
 ### OS requirements
 
-To install Docker Engine, you need a maintained version of one of the following CentOS versions:
-   - CentOS 7
-   - CentOS 8 (stream)
-   - CentOS 9 (stream)
+To install Docker Engine, you need a maintained version of one of the following
+CentOS versions:
 
-Archived versions aren't supported or tested.
+- CentOS 7
+- CentOS 8 (stream)
+- CentOS 9 (stream)
 
 The `centos-extras` repository must be enabled. This repository is enabled by
 default, but if you have disabled it, you need to
@@ -102,46 +102,46 @@ $ sudo yum-config-manager --add-repo {{ download-url-base }}/docker-ce.repo
    <br>
    <div id="tab-latest" class="tab-pane fade in active" markdown="1">
 
-    To install the latest version, run:
+   To install the latest version, run:
 
-    ```console
-    $ sudo yum install docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
-    ```
+   ```console
+   $ sudo yum install docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+   ```
 
-    If prompted to accept the GPG key, verify that the fingerprint matches
-    `060A 61C5 1B55 8A7F 742B 77AA C52F EB6B 621E 9F35`, and if so, accept it.
+   If prompted to accept the GPG key, verify that the fingerprint matches
+   `060A 61C5 1B55 8A7F 742B 77AA C52F EB6B 621E 9F35`, and if so, accept it.
 
-    This command installs Docker, but it doesn't start Docker. It also creates a
-    `docker` group, however, it doesn't add any users to the group by default.
+   This command installs Docker, but it doesn't start Docker. It also creates a
+   `docker` group, however, it doesn't add any users to the group by default.
 
    </div>
    <div id="tab-version" class="tab-pane fade" markdown="1">
 
-    To install a specific version, start by listing the available versions in the repository:
+   To install a specific version, start by listing the available versions in the repository:
 
-    ```console
-    $ yum list docker-ce --showduplicates | sort -r
+   ```console
+   $ yum list docker-ce --showduplicates | sort -r
 
-    docker-ce.x86_64    3:23.0.5-1.el8    docker-ce-stable
-    docker-ce.x86_64    3:23.0.4-1.el8    docker-ce-stable
-    <...>
-    ```
+   docker-ce.x86_64    3:23.0.5-1.el8    docker-ce-stable
+   docker-ce.x86_64    3:23.0.4-1.el8    docker-ce-stable
+   <...>
+   ```
 
-    The list returned depends on which repositories are enabled, and is specific
-    to your version of CentOS (indicated by the `.el8` suffix in this example).
+   The list returned depends on which repositories are enabled, and is specific
+   to your version of CentOS (indicated by the `.el8` suffix in this example).
 
-    Install a specific version by its fully qualified package name, which is
-    the package name (`docker-ce`) plus the version string (2nd column),
-    separated by a hyphen (`-`). For example, `docker-ce-3:23.0.5-1.el8`.
+   Install a specific version by its fully qualified package name, which is
+   the package name (`docker-ce`) plus the version string (2nd column),
+   separated by a hyphen (`-`). For example, `docker-ce-3:23.0.5-1.el8`.
 
-    Replace `<VERSION_STRING>` with the desired version and then run the following command to install:
+   Replace `<VERSION_STRING>` with the desired version and then run the following command to install:
 
-    ```console
-    $ sudo yum install docker-ce-<VERSION_STRING> docker-ce-cli-<VERSION_STRING> containerd.io docker-buildx-plugin docker-compose-plugin
-    ```
+   ```console
+   $ sudo yum install docker-ce-<VERSION_STRING> docker-ce-cli-<VERSION_STRING> containerd.io docker-buildx-plugin docker-compose-plugin
+   ```
 
-    This command installs Docker, but it doesn't start Docker. It also creates a
-    `docker` group, however, it doesn't add any users to the group by default.
+   This command installs Docker, but it doesn't start Docker. It also creates a
+   `docker` group, however, it doesn't add any users to the group by default.
 
    </div>
    <hr>
@@ -149,19 +149,19 @@ $ sudo yum-config-manager --add-repo {{ download-url-base }}/docker-ce.repo
 
 2. Start Docker.
 
-    ```console
-    $ sudo systemctl start docker
-    ```
+   ```console
+   $ sudo systemctl start docker
+   ```
 
 3. Verify that Docker Engine installation is successful by running the `hello-world`
-    image.
+   image.
 
-    ```console
-    $ sudo docker run hello-world
-    ```
+   ```console
+   $ sudo docker run hello-world
+   ```
 
-    This command downloads a test image and runs it in a container. When the
-    container runs, it prints a confirmation message and exits.
+   This command downloads a test image and runs it in a container. When the
+   container runs, it prints a confirmation message and exits.
 
 You have now successfully installed and started Docker Engine.
 
@@ -179,33 +179,33 @@ If you can't use Docker's repository to install Docker, you can download the
 a new file each time you want to upgrade Docker Engine.
 
 1. Go to [{{ download-url-base }}/]({{ download-url-base }}/){: target="_blank" rel="noopener" class="_" }
-    and choose your version of CentOS. Then browse to `x86_64/stable/Packages/`
-    and download the `.rpm` file for the Docker version you want to install.
+   and choose your version of CentOS. Then browse to `x86_64/stable/Packages/`
+   and download the `.rpm` file for the Docker version you want to install.
 
 2. Install Docker Engine, changing the path below to the path where you downloaded the Docker package.
 
-    ```console
-    $ sudo yum install /path/to/package.rpm
-    ```
+   ```console
+   $ sudo yum install /path/to/package.rpm
+   ```
 
-    Docker is installed but not started. The `docker` group is created, but no
-    users are added to the group.
+   Docker is installed but not started. The `docker` group is created, but no
+   users are added to the group.
 
 3. Start Docker.
 
-    ```console
-    $ sudo systemctl start docker
-    ```
+   ```console
+   $ sudo systemctl start docker
+   ```
 
 4. Verify that Docker Engine installation is successful by running the `hello-world`
-    image.
+   image.
 
-    ```console
-    $ sudo docker run hello-world
-    ```
+   ```console
+   $ sudo docker run hello-world
+   ```
 
-    This command downloads a test image and runs it in a container. When the
-    container runs, it prints a confirmation message and exits.
+   This command downloads a test image and runs it in a container. When the
+   container runs, it prints a confirmation message and exits.
 
 You have now successfully installed and started Docker Engine.
 
@@ -223,18 +223,18 @@ instead of `yum -y install`, and point to the new file.
 
 1. Uninstall the Docker Engine, CLI, containerd, and Docker Compose packages:
 
-    ```console
-    $ sudo yum remove docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin docker-ce-rootless-extras
-    ```
+   ```console
+   $ sudo yum remove docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin docker-ce-rootless-extras
+   ```
 
 2. Images, containers, volumes, or customized configuration files on your host
-    are not automatically removed. To delete all images, containers, and
-    volumes:
+   are not automatically removed. To delete all images, containers, and
+   volumes:
 
-    ```console
-    $ sudo rm -rf /var/lib/docker
-    $ sudo rm -rf /var/lib/containerd
-    ```
+   ```console
+   $ sudo rm -rf /var/lib/docker
+   $ sudo rm -rf /var/lib/containerd
+   ```
 
 You must delete any edited configuration files manually.
 

--- a/engine/install/debian.md
+++ b/engine/install/debian.md
@@ -30,24 +30,25 @@ Raspbian versions:
 - Raspbian Bullseye 11 (stable)
 - Raspbian Buster 10 (oldstable)
 
-Docker Engine is compatible with `x86_64` (or `amd64`), `armhf`, and `arm64`
+Docker Engine is compatible with x86_64 (or amd64), armhf, and arm64
 architectures.
 
 ### Uninstall old versions
 
 Older versions of Docker went by the names of `docker`, `docker.io`, or
-`docker-engine`. Uninstall any such older versions before attempting to install
+`docker-engine`, you might also have installations of `containerd` or `runc`.
+Uninstall any such older versions before attempting to install
 a new version:
 
 ```console
 $ sudo apt-get remove docker docker-engine docker.io containerd runc
 ```
 
-It's OK if `apt-get` reports that none of these packages are installed.
+`apt-get` might report that you have none of these packages installed.
 
 Images, containers, volumes, and networks stored in `/var/lib/docker/` aren't
 automatically removed when you uninstall Docker. If you want to start with a
-clean installation, and prefer to clean up any existing data, refer to the
+clean installation, and prefer to clean up any existing data, read the
 [uninstall Docker Engine](#uninstall-docker-engine) section.
 
 ## Installation methods
@@ -58,16 +59,16 @@ You can install Docker Engine in different ways, depending on your needs:
   [Docker Desktop for Linux](../../desktop/install/linux-install.md). This is
   the easiest and quickest way to get started.
 
-- You can also set up and install Docker Engine from
+- Set up and install Docker Engine from
   [Docker's `apt` repository](#install-using-the-repository).
 
 - [Install it manually](#install-from-a-package) and manage upgrades manually.
 
-- Using a [convenience scripts](#install-using-the-convenience-script). Only
+- Use a [convenience scripts](#install-using-the-convenience-script). Only
   recommended for testing and development environments. This is the only
   approach available for Raspbian.
 
-### Install using the repository
+### Install using the apt repository {#install-using-the-repository}
 
 Before you install Docker Engine for the first time on a new host machine, you
 need to set up the Docker repository. Afterward, you can install and update
@@ -137,7 +138,7 @@ Raspbian.
    </div>
    <div id="tab-version" class="tab-pane fade" markdown="1">
 
-   To install a specific version of Docker Engine, start by list the available
+   To install a specific version of Docker Engine, start by listing the available
    versions in the repository:
 
    ```console
@@ -233,8 +234,8 @@ You have now successfully installed and started Docker Engine.
 
 #### Upgrade Docker Engine
 
-To upgrade Docker Engine, download the newer package file and repeat the
-[installation procedure](#install-from-a-package), pointing to the new file.
+To upgrade Docker Engine, download the newer package files and repeat the
+[installation procedure](#install-from-a-package), pointing to the new files.
 
 {% include install-script.md %}
 
@@ -254,7 +255,7 @@ To upgrade Docker Engine, download the newer package file and repeat the
     $ sudo rm -rf /var/lib/containerd
     ```
 
-You must delete any edited configuration files manually.
+You have to delete any edited configuration files manually.
 
 ## Next steps
 

--- a/engine/install/debian.md
+++ b/engine/install/debian.md
@@ -174,7 +174,7 @@ Raspbian.
    This command downloads a test image and runs it in a container. When the
    container runs, it prints a confirmation message and exits.
 
-You have now successfully installed and started Docker Engine. 
+You have now successfully installed and started Docker Engine.
 
 {% include root-errors.md %}
 
@@ -231,11 +231,9 @@ download a new file each time you want to upgrade Docker Engine.
    This command downloads a test image and runs it in a container. When the
    container runs, it prints a confirmation message and exits.
 
-You have now successfully installed and started Docker Engine. The `docker` user
-group exists but contains no users, which is why you're required to use `sudo`
-to run Docker commands. Continue to [Linux post-install](linux-postinstall.md)
-to allow non-privileged users to run Docker commands and for other optional
-configuration steps.
+You have now successfully installed and started Docker Engine.
+
+{% include root-errors.md %}
 
 #### Upgrade Docker Engine
 

--- a/engine/install/debian.md
+++ b/engine/install/debian.md
@@ -87,11 +87,7 @@ Docker from the repository.
 
     ```console
     $ sudo apt-get update
-
-    $ sudo apt-get install \
-        ca-certificates \
-        curl \
-        gnupg
+    $ sudo apt-get install ca-certificates curl gnupg
     ```
 
 2.  Add Docker's official GPG key:

--- a/engine/install/debian.md
+++ b/engine/install/debian.md
@@ -13,8 +13,8 @@ toc_max: 4
 ---
 
 To get started with Docker Engine on Debian, make sure you
-[meet the prerequisites](#prerequisites), then
-[install Docker](#installation-methods).
+[meet the prerequisites](#prerequisites), and then follow the
+[installation steps](#installation-methods).
 
 ## Prerequisites
 

--- a/engine/install/fedora.md
+++ b/engine/install/fedora.md
@@ -27,8 +27,9 @@ Fedora versions:
 
 ### Uninstall old versions
 
-Older versions of Docker were called `docker` or `docker-engine`. If these are
-installed, uninstall them, along with associated dependencies.
+Older versions of Docker went by the names of `docker` or `docker-engine`.
+Uninstall any such older versions before attempting to install a new version,
+along with associated dependencies.
 
 ```console
 $ sudo dnf remove docker \
@@ -43,33 +44,33 @@ $ sudo dnf remove docker \
                   docker-engine
 ```
 
-It's OK if `dnf` reports that none of these packages are installed.
+`dnf` might report that you have none of these packages installed.
 
-The contents of `/var/lib/docker/`, including images, containers, volumes, and
-networks, are preserved. The Docker Engine package is now called `docker-ce`.
+Images, containers, volumes, and networks stored in `/var/lib/docker/` aren't
+automatically removed when you uninstall Docker.
 
 ## Installation methods
 
 You can install Docker Engine in different ways, depending on your needs:
 
-- Most users
+- You can
   [set up Docker's repositories](#install-using-the-repository) and install
   from them, for ease of installation and upgrade tasks. This is the
   recommended approach.
 
-- Some users download the RPM package and
+- You can download the RPM package and
   [install it manually](#install-from-a-package) and manage
   upgrades completely manually. This is useful in situations such as installing
   Docker on air-gapped systems with no access to the internet.
 
-- In testing and development environments, some users choose to use automated
+- In testing and development environments, you can use automated
   [convenience scripts](#install-using-the-convenience-script) to install Docker.
 
-### Install using the repository
+### Install using the rpm repository {#install-using-the-repository}
 
-Before you install Docker Engine for the first time on a new host machine, you need
-to set up the Docker repository. Afterward, you can install and update Docker
-from the repository.
+Before you install Docker Engine for the first time on a new host machine, you
+need to set up the Docker repository. Afterward, you can install and update
+Docker from the repository.
 
 #### Set up the repository
 
@@ -105,7 +106,7 @@ $ sudo dnf config-manager --add-repo {{ download-url-base }}/docker-ce.repo
       results by version number, highest to lowest, and is truncated:
 
    ```console
-   $ dnf list docker-ce  --showduplicates | sort -r
+   $ dnf list docker-ce --showduplicates | sort -r
 
    docker-ce.x86_64    3:23.0.5-1.fc37    docker-ce-stable
    docker-ce.x86_64    3:23.0.4-1.fc37    docker-ce-stable
@@ -132,15 +133,15 @@ $ sudo dnf config-manager --add-repo {{ download-url-base }}/docker-ce.repo
    $ sudo systemctl start docker
    ```
 
-4. Verify that Docker Engine is installed correctly by running the `hello-world`
-   image.
+4. Verify that the Docker Engine installation is successful by running the
+   `hello-world` image.
 
    ```console
    $ sudo docker run hello-world
    ```
 
    This command downloads a test image and runs it in a container. When the
-   container runs, it prints a message and exits.
+   container runs, it prints a confirmation message and exits.
 
 You have now successfully installed and started Docker Engine.
 
@@ -153,9 +154,9 @@ choosing the new version you want to install.
 
 ### Install from a package
 
-If you cannot use Docker's repository to install Docker, you can download the
-`.rpm` file for your release and install it manually. You need to download
-a new file each time you want to upgrade Docker Engine.
+If you can't use Docker's `rpm` repository to install Docker Engine, you can
+download the `.rpm` file for your release and install it manually. You need to
+download a new file each time you want to upgrade Docker Engine.
 
 1. Go to [{{ download-url-base }}/]({{ download-url-base }}/){: target="_blank" rel="noopener" class="_" }
    and choose your version of Fedora. Then browse to `x86_64/stable/Packages/`
@@ -177,15 +178,15 @@ a new file each time you want to upgrade Docker Engine.
    $ sudo systemctl start docker
    ```
 
-4. Verify that Docker Engine is installed correctly by running the `hello-world`
-   image.
+4. Verify that the Docker Engine installation is successful by running the
+   `hello-world` image.
 
    ```console
    $ sudo docker run hello-world
    ```
 
    This command downloads a test image and runs it in a container. When the
-   container runs, it prints a message and exits.
+   container runs, it prints a confirmation message and exits.
 
 You have now successfully installed and started Docker Engine.
 
@@ -193,30 +194,29 @@ You have now successfully installed and started Docker Engine.
 
 #### Upgrade Docker Engine
 
-To upgrade Docker Engine, download the newer package file and repeat the
+To upgrade Docker Engine, download the newer package files and repeat the
 [installation procedure](#install-from-a-package), using `dnf -y upgrade`
-instead of `dnf -y install`, and point to the new file.
+instead of `dnf -y install`, and point to the new files.
 
 {% include install-script.md %}
 
 ## Uninstall Docker Engine
 
-1. Uninstall the Docker Engine, CLI, Containerd, and Docker Compose packages:
+1. Uninstall the Docker Engine, CLI, containerd, and Docker Compose packages:
 
    ```console
    $ sudo dnf remove docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin docker-ce-rootless-extras
    ```
 
-2. Images, containers, volumes, or customized configuration files on your host
-   are not automatically removed. To delete all images, containers, and
-   volumes:
+2. Images, containers, volumes, or custom configuration files on your host
+   aren't automatically removed. To delete all images, containers, and volumes:
 
    ```console
    $ sudo rm -rf /var/lib/docker
    $ sudo rm -rf /var/lib/containerd
    ```
 
-You must delete any edited configuration files manually.
+You have to delete any edited configuration files manually.
 
 ## Next steps
 

--- a/engine/install/fedora.md
+++ b/engine/install/fedora.md
@@ -18,7 +18,8 @@ To get started with Docker Engine on Fedora, make sure you
 
 ### OS requirements
 
-To install Docker Engine, you need the 64-bit version of one of these Fedora versions:
+To install Docker Engine, you need a maintained version of one of the following
+Fedora versions:
 
 - Fedora 36
 - Fedora 37
@@ -84,62 +85,62 @@ $ sudo dnf config-manager --add-repo {{ download-url-base }}/docker-ce.repo
 
 #### Install Docker Engine
 
-1.  Install the _latest version_ of Docker Engine, containerd, and Docker Compose
-    or go to the next step to install a specific version:
+1. Install the _latest version_ of Docker Engine, containerd, and Docker Compose
+   or go to the next step to install a specific version:
 
-    ```console
-    $ sudo dnf install docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
-    ```
+   ```console
+   $ sudo dnf install docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+   ```
 
-    If prompted to accept the GPG key, verify that the fingerprint matches
-    `060A 61C5 1B55 8A7F 742B 77AA C52F EB6B 621E 9F35`, and if so, accept it.
+   If prompted to accept the GPG key, verify that the fingerprint matches
+   `060A 61C5 1B55 8A7F 742B 77AA C52F EB6B 621E 9F35`, and if so, accept it.
 
-    This command installs Docker, but it doesn't start Docker. It also creates a
-    `docker` group, however, it doesn't add any users to the group by default.
+   This command installs Docker, but it doesn't start Docker. It also creates a
+   `docker` group, however, it doesn't add any users to the group by default.
 
-2.  To install a _specific version_ of Docker Engine, list the available versions
-    in the repo, then select and install:
+2. To install a _specific version_ of Docker Engine, list the available versions
+   in the repo, then select and install:
 
-    a. List and sort the versions available in your repo. This example sorts
-       results by version number, highest to lowest, and is truncated:
+   a. List and sort the versions available in your repo. This example sorts
+      results by version number, highest to lowest, and is truncated:
 
-    ```console
-    $ dnf list docker-ce  --showduplicates | sort -r
+   ```console
+   $ dnf list docker-ce  --showduplicates | sort -r
 
-    docker-ce.x86_64    3:23.0.5-1.fc37    docker-ce-stable
-    docker-ce.x86_64    3:23.0.4-1.fc37    docker-ce-stable
-    <...>
-    ```
+   docker-ce.x86_64    3:23.0.5-1.fc37    docker-ce-stable
+   docker-ce.x86_64    3:23.0.4-1.fc37    docker-ce-stable
+   <...>
+   ```
 
-    The list returned depends on which repositories are enabled, and is specific
-    to your version of Fedora (indicated by the `.fc37` suffix in this example).
+   The list returned depends on which repositories are enabled, and is specific
+   to your version of Fedora (indicated by the `.fc37` suffix in this example).
 
-    b. Install a specific version by its fully qualified package name, which is
-       the package name (`docker-ce`) plus the version string (2nd column),
-       separated by a hyphen (`-`). For example, `docker-ce-3:23.0.5-1.fc37`.
+   b. Install a specific version by its fully qualified package name, which is
+      the package name (`docker-ce`) plus the version string (2nd column),
+      separated by a hyphen (`-`). For example, `docker-ce-3:23.0.5-1.fc37`.
 
-    ```console
-    $ sudo dnf -y install docker-ce-<VERSION_STRING> docker-ce-cli-<VERSION_STRING> containerd.io docker-buildx-plugin docker-compose-plugin
-    ```
+   ```console
+   $ sudo dnf -y install docker-ce-<VERSION_STRING> docker-ce-cli-<VERSION_STRING> containerd.io docker-buildx-plugin docker-compose-plugin
+   ```
 
-    This command installs Docker, but it doesn't start Docker. It also creates a
-    `docker` group, however, it doesn't add any users to the group by default.
+   This command installs Docker, but it doesn't start Docker. It also creates a
+   `docker` group, however, it doesn't add any users to the group by default.
 
-3.  Start Docker.
+3. Start Docker.
 
-    ```console
-    $ sudo systemctl start docker
-    ```
+   ```console
+   $ sudo systemctl start docker
+   ```
 
-4.  Verify that Docker Engine is installed correctly by running the `hello-world`
-    image.
+4. Verify that Docker Engine is installed correctly by running the `hello-world`
+   image.
 
-    ```console
-    $ sudo docker run hello-world
-    ```
+   ```console
+   $ sudo docker run hello-world
+   ```
 
-    This command downloads a test image and runs it in a container. When the
-    container runs, it prints a message and exits.
+   This command downloads a test image and runs it in a container. When the
+   container runs, it prints a message and exits.
 
 You have now successfully installed and started Docker Engine.
 
@@ -156,35 +157,35 @@ If you cannot use Docker's repository to install Docker, you can download the
 `.rpm` file for your release and install it manually. You need to download
 a new file each time you want to upgrade Docker Engine.
 
-1.  Go to [{{ download-url-base }}/]({{ download-url-base }}/){: target="_blank" rel="noopener" class="_" }
-    and choose your version of Fedora. Then browse to `x86_64/stable/Packages/`
-    and download the `.rpm` file for the Docker version you want to install.
+1. Go to [{{ download-url-base }}/]({{ download-url-base }}/){: target="_blank" rel="noopener" class="_" }
+   and choose your version of Fedora. Then browse to `x86_64/stable/Packages/`
+   and download the `.rpm` file for the Docker version you want to install.
 
-2.  Install Docker Engine, changing the path below to the path where you downloaded
-    the Docker package.
+2. Install Docker Engine, changing the path below to the path where you downloaded
+   the Docker package.
 
-    ```console
-    $ sudo dnf -y install /path/to/package.rpm
-    ```
+   ```console
+   $ sudo dnf -y install /path/to/package.rpm
+   ```
 
-    Docker is installed but not started. The `docker` group is created, but no
-    users are added to the group.
+   Docker is installed but not started. The `docker` group is created, but no
+   users are added to the group.
 
-3.  Start Docker.
+3. Start Docker.
 
-    ```console
-    $ sudo systemctl start docker
-    ```
+   ```console
+   $ sudo systemctl start docker
+   ```
 
-4.  Verify that Docker Engine is installed correctly by running the `hello-world`
-    image.
+4. Verify that Docker Engine is installed correctly by running the `hello-world`
+   image.
 
-    ```console
-    $ sudo docker run hello-world
-    ```
+   ```console
+   $ sudo docker run hello-world
+   ```
 
-    This command downloads a test image and runs it in a container. When the
-    container runs, it prints a message and exits.
+   This command downloads a test image and runs it in a container. When the
+   container runs, it prints a message and exits.
 
 You have now successfully installed and started Docker Engine.
 
@@ -200,20 +201,20 @@ instead of `dnf -y install`, and point to the new file.
 
 ## Uninstall Docker Engine
 
-1.  Uninstall the Docker Engine, CLI, Containerd, and Docker Compose packages:
+1. Uninstall the Docker Engine, CLI, Containerd, and Docker Compose packages:
 
-    ```console
-    $ sudo dnf remove docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin docker-ce-rootless-extras
-    ```
+   ```console
+   $ sudo dnf remove docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin docker-ce-rootless-extras
+   ```
 
-2.  Images, containers, volumes, or customized configuration files on your host
-    are not automatically removed. To delete all images, containers, and
-    volumes:
+2. Images, containers, volumes, or customized configuration files on your host
+   are not automatically removed. To delete all images, containers, and
+   volumes:
 
-    ```console
-    $ sudo rm -rf /var/lib/docker
-    $ sudo rm -rf /var/lib/containerd
-    ```
+   ```console
+   $ sudo rm -rf /var/lib/docker
+   $ sudo rm -rf /var/lib/containerd
+   ```
 
 You must delete any edited configuration files manually.
 

--- a/engine/install/fedora.md
+++ b/engine/install/fedora.md
@@ -144,10 +144,9 @@ $ sudo dnf config-manager \
     This command downloads a test image and runs it in a container. When the
     container runs, it prints a message and exits.
 
-This installs and runs Docker Engine. Use `sudo` to run Docker
-commands. Continue to [Linux postinstall](linux-postinstall.md) to allow
-non-privileged users to run Docker commands and for other optional configuration
-steps.
+You have now successfully installed and started Docker Engine.
+
+{% include root-errors.md %}
 
 #### Upgrade Docker Engine
 
@@ -190,7 +189,7 @@ a new file each time you want to upgrade Docker Engine.
     This command downloads a test image and runs it in a container. When the
     container runs, it prints a message and exits.
 
-This installs and runs Docker Engine.
+You have now successfully installed and started Docker Engine.
 
 {% include root-errors.md %}
 

--- a/engine/install/fedora.md
+++ b/engine/install/fedora.md
@@ -11,8 +11,8 @@ toc_max: 4
 ---
 
 To get started with Docker Engine on Fedora, make sure you
-[meet the prerequisites](#prerequisites), then
-[install Docker](#installation-methods).
+[meet the prerequisites](#prerequisites), and then follow the
+[installation steps](#installation-methods).
 
 ## Prerequisites
 

--- a/engine/install/fedora.md
+++ b/engine/install/fedora.md
@@ -79,10 +79,7 @@ your DNF repositories) and set up the repository.
 
 ```console
 $ sudo dnf -y install dnf-plugins-core
-
-$ sudo dnf config-manager \
-    --add-repo \
-    {{ download-url-base }}/docker-ce.repo
+$ sudo dnf config-manager --add-repo {{ download-url-base }}/docker-ce.repo
 ```
 
 #### Install Docker Engine

--- a/engine/install/fedora.md
+++ b/engine/install/fedora.md
@@ -86,8 +86,17 @@ $ sudo dnf config-manager --add-repo {{ download-url-base }}/docker-ce.repo
 
 #### Install Docker Engine
 
-1. Install the _latest version_ of Docker Engine, containerd, and Docker Compose
-   or go to the next step to install a specific version:
+1. Install Docker Engine, containerd, and Docker Compose:
+
+   <ul class="nav nav-tabs">
+    <li class="active"><a data-toggle="tab" data-target="#tab-latest">Latest</a></li>
+    <li><a data-toggle="tab" data-target="#tab-version">Specific version</a></li>
+   </ul>
+   <div class="tab-content">
+   <br>
+   <div id="tab-latest" class="tab-pane fade in active" markdown="1">
+
+   To install the latest version, run:
 
    ```console
    $ sudo dnf install docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
@@ -99,11 +108,11 @@ $ sudo dnf config-manager --add-repo {{ download-url-base }}/docker-ce.repo
    This command installs Docker, but it doesn't start Docker. It also creates a
    `docker` group, however, it doesn't add any users to the group by default.
 
-2. To install a _specific version_ of Docker Engine, list the available versions
-   in the repo, then select and install:
+   </div>
+   <div id="tab-version" class="tab-pane fade" markdown="1">
 
-   a. List and sort the versions available in your repo. This example sorts
-      results by version number, highest to lowest, and is truncated:
+   To install a specific version, start by listing the available versions in
+   the repository:
 
    ```console
    $ dnf list docker-ce --showduplicates | sort -r
@@ -116,9 +125,12 @@ $ sudo dnf config-manager --add-repo {{ download-url-base }}/docker-ce.repo
    The list returned depends on which repositories are enabled, and is specific
    to your version of Fedora (indicated by the `.fc37` suffix in this example).
 
-   b. Install a specific version by its fully qualified package name, which is
-      the package name (`docker-ce`) plus the version string (2nd column),
-      separated by a hyphen (`-`). For example, `docker-ce-3:23.0.5-1.fc37`.
+   Install a specific version by its fully qualified package name, which is
+   the package name (`docker-ce`) plus the version string (2nd column),
+   separated by a hyphen (`-`). For example, `docker-ce-3:23.0.5-1.fc37`.
+
+   Replace `<VERSION_STRING>` with the desired version and then run the following
+   command to install:
 
    ```console
    $ sudo dnf -y install docker-ce-<VERSION_STRING> docker-ce-cli-<VERSION_STRING> containerd.io docker-buildx-plugin docker-compose-plugin
@@ -127,13 +139,17 @@ $ sudo dnf config-manager --add-repo {{ download-url-base }}/docker-ce.repo
    This command installs Docker, but it doesn't start Docker. It also creates a
    `docker` group, however, it doesn't add any users to the group by default.
 
-3. Start Docker.
+   </div>
+   <hr>
+   </div>
+
+2. Start Docker.
 
    ```console
    $ sudo systemctl start docker
    ```
 
-4. Verify that the Docker Engine installation is successful by running the
+3. Verify that the Docker Engine installation is successful by running the
    `hello-world` image.
 
    ```console

--- a/engine/install/fedora.md
+++ b/engine/install/fedora.md
@@ -223,4 +223,5 @@ You must delete any edited configuration files manually.
 ## Next steps
 
 - Continue to [Post-installation steps for Linux](linux-postinstall.md).
-- Review the topics in [Develop with Docker](../../develop/index.md) to learn how to build new applications using Docker.
+- Review the topics in [Develop with Docker](../../develop/index.md) to learn
+  how to build new applications using Docker.

--- a/engine/install/rhel.md
+++ b/engine/install/rhel.md
@@ -89,10 +89,7 @@ utility) and set up the repository.
 
 ```console
 $ sudo yum install -y yum-utils
-
-$ sudo yum-config-manager \
-    --add-repo \
-    {{ download-url-base }}/docker-ce.repo
+$ sudo yum-config-manager --add-repo {{ download-url-base }}/docker-ce.repo
 ```
 
 #### Install Docker Engine

--- a/engine/install/rhel.md
+++ b/engine/install/rhel.md
@@ -154,7 +154,7 @@ $ sudo yum-config-manager \
     This command downloads a test image and runs it in a container. When the
     container runs, it prints a message and exits.
 
-This installs and runs Docker Engine. 
+You have now successfully installed and started Docker Engine.
 
 {% include root-errors.md %}
 
@@ -199,10 +199,9 @@ a new file each time you want to upgrade Docker Engine.
     This command downloads a test image and runs it in a container. When the
     container runs, it prints a message and exits.
 
-This installs and runs Docker Engine. Use `sudo` to run Docker commands.
-Continue to [Post-installation steps for Linux](linux-postinstall.md) to allow
-non-privileged users to run Docker commands and for other optional configuration
-steps.
+You have now successfully installed and started Docker Engine.
+
+{% include root-errors.md %}
 
 #### Upgrade Docker Engine
 

--- a/engine/install/rhel.md
+++ b/engine/install/rhel.md
@@ -28,8 +28,12 @@ To get started with Docker Engine on RHEL, make sure you
 
 ### OS requirements
 
-To install Docker Engine, you need a maintained version of RHEL 7, RHEL 8 or RHEL 9 on s390x (IBM Z).
-Archived versions aren't supported or tested.
+To install Docker Engine, you need a maintained version of one of the following
+RHEL versions:
+
+- RHEL 7 on s390x (IBM Z)
+- RHEL 8 on s390x (IBM Z)
+- RHEL 9 on s390x (IBM Z)
 
 The `overlay2` storage driver is recommended.
 
@@ -94,62 +98,62 @@ $ sudo yum-config-manager --add-repo {{ download-url-base }}/docker-ce.repo
 
 #### Install Docker Engine
 
-1.  Install the _latest version_ of Docker Engine, containerd, and Docker Compose
-    or go to the next step to install a specific version:
+1. Install the _latest version_ of Docker Engine, containerd, and Docker Compose
+   or go to the next step to install a specific version:
 
-    ```console
-    $ sudo yum install docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
-    ```
+   ```console
+   $ sudo yum install docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+   ```
 
-    If prompted to accept the GPG key, verify that the fingerprint matches
-    `060A 61C5 1B55 8A7F 742B 77AA C52F EB6B 621E 9F35`, and if so, accept it.
+   If prompted to accept the GPG key, verify that the fingerprint matches
+   `060A 61C5 1B55 8A7F 742B 77AA C52F EB6B 621E 9F35`, and if so, accept it.
 
-    This command installs Docker, but it doesn't start Docker. It also creates a
-    `docker` group, however, it doesn't add any users to the group by default.
+   This command installs Docker, but it doesn't start Docker. It also creates a
+   `docker` group, however, it doesn't add any users to the group by default.
 
-2.  To install a _specific version_ of Docker Engine, list the available versions
-    in the repo, then select and install:
+2. To install a _specific version_ of Docker Engine, list the available versions
+   in the repo, then select and install:
 
-    a. List and sort the versions available in your repo. This example sorts
-       results by version number, highest to lowest, and is truncated:
+   a. List and sort the versions available in your repo. This example sorts
+      results by version number, highest to lowest, and is truncated:
 
-    ```console
-    $ yum list docker-ce --showduplicates | sort -r
+   ```console
+   $ yum list docker-ce --showduplicates | sort -r
 
-    docker-ce.s390x    3:23.0.5-1.el8    docker-ce-stable
-    docker-ce.s390x    3:23.0.4-1.el8    docker-ce-stable
-    <...>
-    ```
+   docker-ce.s390x    3:23.0.5-1.el8    docker-ce-stable
+   docker-ce.s390x    3:23.0.4-1.el8    docker-ce-stable
+   <...>
+   ```
 
-    The list returned depends on which repositories are enabled, and is specific
-    to your version of RHEL (indicated by the `.el8` suffix in this example).
+   The list returned depends on which repositories are enabled, and is specific
+   to your version of RHEL (indicated by the `.el8` suffix in this example).
 
-    b. Install a specific version by its fully qualified package name, which is
-       the package name (`docker-ce`) plus the version string (2nd column),
-       separated by a hyphen (`-`). For example, `docker-ce-3:23.0.5-1.el8`.
+   b. Install a specific version by its fully qualified package name, which is
+      the package name (`docker-ce`) plus the version string (2nd column),
+      separated by a hyphen (`-`). For example, `docker-ce-3:23.0.5-1.el8`.
 
-    ```console
-    $ sudo yum install docker-ce-<VERSION_STRING> docker-ce-cli-<VERSION_STRING> containerd.io docker-buildx-plugin docker-compose-plugin
-    ```
+   ```console
+   $ sudo yum install docker-ce-<VERSION_STRING> docker-ce-cli-<VERSION_STRING> containerd.io docker-buildx-plugin docker-compose-plugin
+   ```
 
-    This command installs Docker, but it doesn't start Docker. It also creates a
-    `docker` group, however, it doesn't add any users to the group by default.
+   This command installs Docker, but it doesn't start Docker. It also creates a
+   `docker` group, however, it doesn't add any users to the group by default.
 
-3.  Start Docker.
+3. Start Docker.
 
-    ```console
-    $ sudo systemctl start docker
-    ```
+   ```console
+   $ sudo systemctl start docker
+   ```
 
-4.  Verify that Docker Engine is installed correctly by running the `hello-world`
-    image.
+4. Verify that Docker Engine is installed correctly by running the `hello-world`
+   image.
 
-    ```console
-    $ sudo docker run hello-world
-    ```
+   ```console
+   $ sudo docker run hello-world
+   ```
 
-    This command downloads a test image and runs it in a container. When the
-    container runs, it prints a message and exits.
+   This command downloads a test image and runs it in a container. When the
+   container runs, it prints a message and exits.
 
 You have now successfully installed and started Docker Engine.
 
@@ -166,35 +170,35 @@ If you cannot use Docker's repository to install Docker, you can download the
 `.rpm` file for your release and install it manually. You need to download
 a new file each time you want to upgrade Docker Engine.
 
-1.  Go to [{{ download-url-base }}/]({{ download-url-base }}/){: target="_blank" rel="noopener" class="_" }
-    and choose your version of RHEL. Then browse to `s390x/stable/Packages/`
-    and download the `.rpm` file for the Docker version you want to install.
+1. Go to [{{ download-url-base }}/]({{ download-url-base }}/){: target="_blank" rel="noopener" class="_" }
+   and choose your version of RHEL. Then browse to `s390x/stable/Packages/`
+   and download the `.rpm` file for the Docker version you want to install.
 
-2.  Install Docker Engine, changing the path below to the path where you downloaded
-    the Docker package.
+2. Install Docker Engine, changing the path below to the path where you downloaded
+   the Docker package.
 
-    ```console
-    $ sudo yum install /path/to/package.rpm
-    ```
+   ```console
+   $ sudo yum install /path/to/package.rpm
+   ```
 
-    Docker is installed but not started. The `docker` group is created, but no
-    users are added to the group.
+   Docker is installed but not started. The `docker` group is created, but no
+   users are added to the group.
 
-3.  Start Docker.
+3. Start Docker.
 
-    ```console
-    $ sudo systemctl start docker
-    ```
+   ```console
+   $ sudo systemctl start docker
+   ```
 
-4.  Verify that Docker Engine is installed correctly by running the `hello-world`
-    image.
+4. Verify that Docker Engine is installed correctly by running the `hello-world`
+   image.
 
-    ```console
-    $ sudo docker run hello-world
-    ```
+   ```console
+   $ sudo docker run hello-world
+   ```
 
-    This command downloads a test image and runs it in a container. When the
-    container runs, it prints a message and exits.
+   This command downloads a test image and runs it in a container. When the
+   container runs, it prints a message and exits.
 
 You have now successfully installed and started Docker Engine.
 
@@ -210,20 +214,20 @@ instead of `yum -y install`, and point to the new file.
 
 ## Uninstall Docker Engine
 
-1.  Uninstall the Docker Engine, CLI, Containerd, and Docker Compose packages:
+1. Uninstall the Docker Engine, CLI, Containerd, and Docker Compose packages:
 
-    ```console
-    $ sudo yum remove docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin docker-ce-rootless-extras
-    ```
+   ```console
+   $ sudo yum remove docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin docker-ce-rootless-extras
+   ```
 
-2.  Images, containers, volumes, or customized configuration files on your host
-    are not automatically removed. To delete all images, containers, and
-    volumes:
+2. Images, containers, volumes, or customized configuration files on your host
+   are not automatically removed. To delete all images, containers, and
+   volumes:
 
-    ```console
-    $ sudo rm -rf /var/lib/docker
-    $ sudo rm -rf /var/lib/containerd
-    ```
+   ```console
+   $ sudo rm -rf /var/lib/docker
+   $ sudo rm -rf /var/lib/containerd
+   ```
 
 You must delete any edited configuration files manually.
 

--- a/engine/install/rhel.md
+++ b/engine/install/rhel.md
@@ -15,8 +15,8 @@ toc_max: 4
 ---
 
 To get started with Docker Engine on RHEL, make sure you
-[meet the prerequisites](#prerequisites), then
-[install Docker](#installation-methods).
+[meet the prerequisites](#prerequisites), and then follow the
+[installation steps](#installation-methods).
 
 ## Prerequisites
 

--- a/engine/install/rhel.md
+++ b/engine/install/rhel.md
@@ -35,8 +35,6 @@ RHEL versions:
 - RHEL 8 on s390x (IBM Z)
 - RHEL 9 on s390x (IBM Z)
 
-The `overlay2` storage driver is recommended.
-
 ### Uninstall old versions
 
 Older versions of Docker were called `docker` or `docker-engine`. If these are

--- a/engine/install/rhel.md
+++ b/engine/install/rhel.md
@@ -37,9 +37,10 @@ RHEL versions:
 
 ### Uninstall old versions
 
-Older versions of Docker were called `docker` or `docker-engine`. If these are
-installed, uninstall them, along with associated dependencies. Also uninstall 
-`Podman` and the associated dependencies if installed already. 
+Older versions of Docker went by the names of `docker` or `docker-engine`.
+Uninstall any such older versions before attempting to install a new version,
+along with associated dependencies. Also uninstall `Podman` and the associated
+dependencies if installed already:
 
 ```console
 $ sudo yum remove docker \
@@ -54,33 +55,33 @@ $ sudo yum remove docker \
                   runc
 ```
 
-It's OK if `yum` reports that none of these packages are installed.
+`yum` might report that you have none of these packages installed.
 
-The contents of `/var/lib/docker/`, including images, containers, volumes, and
-networks, are preserved. The Docker Engine package is now called `docker-ce`.
+Images, containers, volumes, and networks stored in `/var/lib/docker/` aren't
+automatically removed when you uninstall Docker.
 
 ## Installation methods
 
 You can install Docker Engine in different ways, depending on your needs:
 
-- Most users
+- You can
   [set up Docker's repositories](#install-using-the-repository) and install
   from them, for ease of installation and upgrade tasks. This is the
   recommended approach.
 
-- Some users download the RPM package and
+- You can download the RPM package and
   [install it manually](#install-from-a-package) and manage
   upgrades completely manually. This is useful in situations such as installing
   Docker on air-gapped systems with no access to the internet.
 
-- In testing and development environments, some users choose to use automated
+- In testing and development environments, you can use automated
   [convenience scripts](#install-using-the-convenience-script) to install Docker.
 
-### Install using the repository
+### Install using the rpm repository {#install-using-the-repository}
 
-Before you install Docker Engine for the first time on a new host machine, you need
-to set up the Docker repository. Afterward, you can install and update Docker
-from the repository.
+Before you install Docker Engine for the first time on a new host machine, you
+need to set up the Docker repository. Afterward, you can install and update
+Docker from the repository.
 
 #### Set up the repository
 
@@ -143,15 +144,15 @@ $ sudo yum-config-manager --add-repo {{ download-url-base }}/docker-ce.repo
    $ sudo systemctl start docker
    ```
 
-4. Verify that Docker Engine is installed correctly by running the `hello-world`
-   image.
+4. Verify that the Docker Engine installation is successful by running the
+   `hello-world` image.
 
    ```console
    $ sudo docker run hello-world
    ```
 
    This command downloads a test image and runs it in a container. When the
-   container runs, it prints a message and exits.
+   container runs, it prints a confirmation message and exits.
 
 You have now successfully installed and started Docker Engine.
 
@@ -164,9 +165,9 @@ choosing the new version you want to install.
 
 ### Install from a package
 
-If you cannot use Docker's repository to install Docker, you can download the
-`.rpm` file for your release and install it manually. You need to download
-a new file each time you want to upgrade Docker Engine.
+If you can't use Docker's `rpm` repository to install Docker Engine, you can
+download the `.rpm` file for your release and install it manually. You need to
+download a new file each time you want to upgrade Docker Engine.
 
 1. Go to [{{ download-url-base }}/]({{ download-url-base }}/){: target="_blank" rel="noopener" class="_" }
    and choose your version of RHEL. Then browse to `s390x/stable/Packages/`
@@ -188,15 +189,15 @@ a new file each time you want to upgrade Docker Engine.
    $ sudo systemctl start docker
    ```
 
-4. Verify that Docker Engine is installed correctly by running the `hello-world`
-   image.
+4. Verify that the Docker Engine installation is successful by running the
+   `hello-world` image.
 
    ```console
    $ sudo docker run hello-world
    ```
 
    This command downloads a test image and runs it in a container. When the
-   container runs, it prints a message and exits.
+   container runs, it prints a confirmation message and exits.
 
 You have now successfully installed and started Docker Engine.
 
@@ -204,30 +205,29 @@ You have now successfully installed and started Docker Engine.
 
 #### Upgrade Docker Engine
 
-To upgrade Docker Engine, download the newer package file and repeat the
+To upgrade Docker Engine, download the newer package files and repeat the
 [installation procedure](#install-from-a-package), using `yum -y upgrade`
-instead of `yum -y install`, and point to the new file.
+instead of `yum -y install`, and point to the new files.
 
 {% include install-script.md %}
 
 ## Uninstall Docker Engine
 
-1. Uninstall the Docker Engine, CLI, Containerd, and Docker Compose packages:
+1. Uninstall the Docker Engine, CLI, containerd, and Docker Compose packages:
 
    ```console
    $ sudo yum remove docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin docker-ce-rootless-extras
    ```
 
-2. Images, containers, volumes, or customized configuration files on your host
-   are not automatically removed. To delete all images, containers, and
-   volumes:
+2. Images, containers, volumes, or custom configuration files on your host
+   aren't automatically removed. To delete all images, containers, and volumes:
 
    ```console
    $ sudo rm -rf /var/lib/docker
    $ sudo rm -rf /var/lib/containerd
    ```
 
-You must delete any edited configuration files manually.
+You have to delete any edited configuration files manually.
 
 ## Next steps
 

--- a/engine/install/rhel.md
+++ b/engine/install/rhel.md
@@ -97,8 +97,17 @@ $ sudo yum-config-manager --add-repo {{ download-url-base }}/docker-ce.repo
 
 #### Install Docker Engine
 
-1. Install the _latest version_ of Docker Engine, containerd, and Docker Compose
-   or go to the next step to install a specific version:
+1. Install Docker Engine, containerd, and Docker Compose:
+
+   <ul class="nav nav-tabs">
+    <li class="active"><a data-toggle="tab" data-target="#tab-latest">Latest</a></li>
+    <li><a data-toggle="tab" data-target="#tab-version">Specific version</a></li>
+   </ul>
+   <div class="tab-content">
+   <br>
+   <div id="tab-latest" class="tab-pane fade in active" markdown="1">
+
+   To install the latest version, run:
 
    ```console
    $ sudo yum install docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
@@ -110,11 +119,11 @@ $ sudo yum-config-manager --add-repo {{ download-url-base }}/docker-ce.repo
    This command installs Docker, but it doesn't start Docker. It also creates a
    `docker` group, however, it doesn't add any users to the group by default.
 
-2. To install a _specific version_ of Docker Engine, list the available versions
-   in the repo, then select and install:
+   </div>
+   <div id="tab-version" class="tab-pane fade" markdown="1">
 
-   a. List and sort the versions available in your repo. This example sorts
-      results by version number, highest to lowest, and is truncated:
+   To install a specific version, start by listing the available versions in
+   the repository:
 
    ```console
    $ yum list docker-ce --showduplicates | sort -r
@@ -127,9 +136,12 @@ $ sudo yum-config-manager --add-repo {{ download-url-base }}/docker-ce.repo
    The list returned depends on which repositories are enabled, and is specific
    to your version of RHEL (indicated by the `.el8` suffix in this example).
 
-   b. Install a specific version by its fully qualified package name, which is
-      the package name (`docker-ce`) plus the version string (2nd column),
-      separated by a hyphen (`-`). For example, `docker-ce-3:23.0.5-1.el8`.
+   Install a specific version by its fully qualified package name, which is
+   the package name (`docker-ce`) plus the version string (2nd column),
+   separated by a hyphen (`-`). For example, `docker-ce-3:23.0.5-1.el8`.
+
+   Replace `<VERSION_STRING>` with the desired version and then run the following
+   command to install:
 
    ```console
    $ sudo yum install docker-ce-<VERSION_STRING> docker-ce-cli-<VERSION_STRING> containerd.io docker-buildx-plugin docker-compose-plugin
@@ -138,13 +150,17 @@ $ sudo yum-config-manager --add-repo {{ download-url-base }}/docker-ce.repo
    This command installs Docker, but it doesn't start Docker. It also creates a
    `docker` group, however, it doesn't add any users to the group by default.
 
-3. Start Docker.
+   </div>
+   <hr>
+   </div>
+
+2. Start Docker.
 
    ```console
    $ sudo systemctl start docker
    ```
 
-4. Verify that the Docker Engine installation is successful by running the
+3. Verify that the Docker Engine installation is successful by running the
    `hello-world` image.
 
    ```console

--- a/engine/install/rhel.md
+++ b/engine/install/rhel.md
@@ -233,4 +233,5 @@ You must delete any edited configuration files manually.
 ## Next steps
 
 - Continue to [Post-installation steps for Linux](linux-postinstall.md).
-- Review the topics in [Develop with Docker](../../develop/index.md) to learn how to build new applications using Docker.
+- Review the topics in [Develop with Docker](../../develop/index.md) to learn
+  how to build new applications using Docker.

--- a/engine/install/sles.md
+++ b/engine/install/sles.md
@@ -22,8 +22,8 @@ toc_max: 4
 ---
 
 To get started with Docker Engine on SLES, make sure you
-[meet the prerequisites](#prerequisites), then
-[install Docker](#installation-methods).
+[meet the prerequisites](#prerequisites), and then follow the
+[installation steps](#installation-methods).
 
 ## Prerequisites
 

--- a/engine/install/sles.md
+++ b/engine/install/sles.md
@@ -119,8 +119,17 @@ $ sudo zypper addrepo {{ download-url-base }}/docker-ce.repo
 
 #### Install Docker Engine
 
-1. Install the _latest version_ of Docker Engine, containerd, and Docker Compose
-   or go to the next step to install a specific version:
+1. Install Docker Engine, containerd, and Docker Compose:
+
+   <ul class="nav nav-tabs">
+    <li class="active"><a data-toggle="tab" data-target="#tab-latest">Latest</a></li>
+    <li><a data-toggle="tab" data-target="#tab-version">Specific version</a></li>
+   </ul>
+   <div class="tab-content">
+   <br>
+   <div id="tab-latest" class="tab-pane fade in active" markdown="1">
+
+   To install the latest version, run:
 
    ```console
    $ sudo zypper install docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
@@ -132,11 +141,11 @@ $ sudo zypper addrepo {{ download-url-base }}/docker-ce.repo
    This command installs Docker, but it doesn't start Docker. It also creates a
    `docker` group, however, it doesn't add any users to the group by default.
 
-2. To install a _specific version_ of Docker Engine, list the available versions
-   in the repo, then select and install:
+   </div>
+   <div id="tab-version" class="tab-pane fade" markdown="1">
 
-   a. List and sort the versions available in your repo. This example sorts
-      results by version number, highest to lowest, and is truncated:
+   To install a specific version, start by listing the available versions in
+   the repository:
 
    ```console
    $ sudo zypper search -s --match-exact docker-ce | sort -r
@@ -148,9 +157,12 @@ $ sudo zypper addrepo {{ download-url-base }}/docker-ce.repo
    The list returned depends on which repositories are enabled, and is specific
    to your version of SLES.
 
-   b. Install a specific version by its fully qualified package name, which is
-      the package name (`docker-ce`) plus the version string (fourth column),
-      separated by a hyphen (`-`). For example, `docker-ce-3:23.0.5`.
+   Install a specific version by its fully qualified package name, which is
+   the package name (`docker-ce`) plus the version string (2nd column),
+   separated by a hyphen (`-`). For example, `docker-ce-3:23.0.5`.
+
+   Replace `<VERSION_STRING>` with the desired version and then run the following
+   command to install:
 
    ```console
    $ sudo zypper install docker-ce-<VERSION_STRING> docker-ce-cli-<VERSION_STRING> containerd.io docker-buildx-plugin docker-compose-plugin
@@ -159,13 +171,17 @@ $ sudo zypper addrepo {{ download-url-base }}/docker-ce.repo
    This command installs Docker, but it doesn't start Docker. It also creates a
    `docker` group, however, it doesn't add any users to the group by default.
 
-3. Start Docker.
+   </div>
+   <hr>
+   </div>
+
+2. Start Docker.
 
    ```console
    $ sudo systemctl start docker
    ```
 
-4. Verify that the Docker Engine installation is successful by running the
+3. Verify that the Docker Engine installation is successful by running the
    `hello-world` image.
 
    ```console

--- a/engine/install/sles.md
+++ b/engine/install/sles.md
@@ -34,8 +34,11 @@ To get started with Docker Engine on SLES, make sure you
 
 ### OS requirements
 
-To install Docker Engine, you need a maintained version of SLES 15-SP3 or SLES 15-SP4 on s390x (IBM Z).
-Archived versions aren't supported or tested.
+To install Docker Engine, you need a maintained version of one of the following
+SLES versions:
+
+- SLES 15-SP3 on s390x (IBM Z)
+- SLES 15-SP4 on s390x (IBM Z)
 
 The [`SCC SUSE`](https://scc.suse.com/packages?name=SUSE%20Linux%20Enterprise%20Server&version=15.3&arch=s390x)
 repositories must be enabled.
@@ -117,61 +120,61 @@ $ sudo zypper addrepo {{ download-url-base }}/docker-ce.repo
 
 #### Install Docker Engine
 
-1.  Install the _latest version_ of Docker Engine, containerd, and Docker Compose
-    or go to the next step to install a specific version:
+1. Install the _latest version_ of Docker Engine, containerd, and Docker Compose
+   or go to the next step to install a specific version:
 
-    ```console
-    $ sudo zypper install docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
-    ```
+   ```console
+   $ sudo zypper install docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+   ```
 
-    If prompted to accept the GPG key, verify that the fingerprint matches
-    `060A 61C5 1B55 8A7F 742B 77AA C52F EB6B 621E 9F35`, and if so, accept it.
+   If prompted to accept the GPG key, verify that the fingerprint matches
+   `060A 61C5 1B55 8A7F 742B 77AA C52F EB6B 621E 9F35`, and if so, accept it.
 
-    This command installs Docker, but it doesn't start Docker. It also creates a
-    `docker` group, however, it doesn't add any users to the group by default.
+   This command installs Docker, but it doesn't start Docker. It also creates a
+   `docker` group, however, it doesn't add any users to the group by default.
 
-2.  To install a _specific version_ of Docker Engine, list the available versions
-    in the repo, then select and install:
+2. To install a _specific version_ of Docker Engine, list the available versions
+   in the repo, then select and install:
 
-    a. List and sort the versions available in your repo. This example sorts
-       results by version number, highest to lowest, and is truncated:
+   a. List and sort the versions available in your repo. This example sorts
+      results by version number, highest to lowest, and is truncated:
 
-    ```console
-    $ sudo zypper search -s --match-exact docker-ce | sort -r
-    
-      v  | docker-ce | package | 3:23.0.5-3 | s390x | Docker CE Stable - s390x
-      v  | docker-ce | package | 3:23.0.4-3 | s390x | Docker CE Stable - s390x
-    ```
+   ```console
+   $ sudo zypper search -s --match-exact docker-ce | sort -r
+ 
+     v  | docker-ce | package | 3:23.0.5-3 | s390x | Docker CE Stable - s390x
+     v  | docker-ce | package | 3:23.0.4-3 | s390x | Docker CE Stable - s390x
+   ```
 
-    The list returned depends on which repositories are enabled, and is specific
-    to your version of SLES.
+   The list returned depends on which repositories are enabled, and is specific
+   to your version of SLES.
 
-    b. Install a specific version by its fully qualified package name, which is
-       the package name (`docker-ce`) plus the version string (fourth column),
-       separated by a hyphen (`-`). For example, `docker-ce-3:23.0.5`.
+   b. Install a specific version by its fully qualified package name, which is
+      the package name (`docker-ce`) plus the version string (fourth column),
+      separated by a hyphen (`-`). For example, `docker-ce-3:23.0.5`.
 
-    ```console
-    $ sudo zypper install docker-ce-<VERSION_STRING> docker-ce-cli-<VERSION_STRING> containerd.io docker-buildx-plugin docker-compose-plugin
-    ```
+   ```console
+   $ sudo zypper install docker-ce-<VERSION_STRING> docker-ce-cli-<VERSION_STRING> containerd.io docker-buildx-plugin docker-compose-plugin
+   ```
 
-    This command installs Docker, but it doesn't start Docker. It also creates a
-    `docker` group, however, it doesn't add any users to the group by default.
+   This command installs Docker, but it doesn't start Docker. It also creates a
+   `docker` group, however, it doesn't add any users to the group by default.
 
-3.  Start Docker.
+3. Start Docker.
 
-    ```console
-    $ sudo systemctl start docker
-    ```
+   ```console
+   $ sudo systemctl start docker
+   ```
 
-4.  Verify that Docker Engine is installed correctly by running the `hello-world`
-    image.
+4. Verify that Docker Engine is installed correctly by running the `hello-world`
+   image.
 
-    ```console
-    $ sudo docker run hello-world
-    ```
+   ```console
+   $ sudo docker run hello-world
+   ```
 
-    This command downloads a test image and runs it in a container. When the
-    container runs, it prints a message and exits.
+   This command downloads a test image and runs it in a container. When the
+   container runs, it prints a message and exits.
 
 You have now successfully installed and started Docker Engine.
 
@@ -188,35 +191,35 @@ If you cannot use Docker's repository to install Docker, you can download the
 `.rpm` file for your release and install it manually. You need to download
 a new file each time you want to upgrade Docker Engine.
 
-1.  Go to [{{ download-url-base }}/]({{ download-url-base }}/){: target="_blank" rel="noopener" class="_" }
-    and choose your version of SLES. Then browse to `15/s390x/stable/Packages/`
-    and download the `.rpm` file for the Docker version you want to install.
+1. Go to [{{ download-url-base }}/]({{ download-url-base }}/){: target="_blank" rel="noopener" class="_" }
+   and choose your version of SLES. Then browse to `15/s390x/stable/Packages/`
+   and download the `.rpm` file for the Docker version you want to install.
 
-2.  Install Docker Engine, changing the path below to the path where you downloaded
-    the Docker package.
+2. Install Docker Engine, changing the path below to the path where you downloaded
+   the Docker package.
 
-    ```console
-    $ sudo zypper install /path/to/package.rpm
-    ```
+   ```console
+   $ sudo zypper install /path/to/package.rpm
+   ```
 
-    Docker is installed but not started. The `docker` group is created, but no
-    users are added to the group.
+   Docker is installed but not started. The `docker` group is created, but no
+   users are added to the group.
 
-3.  Start Docker.
+3. Start Docker.
 
-    ```console
-    $ sudo systemctl start docker
-    ```
+   ```console
+   $ sudo systemctl start docker
+   ```
 
-4.  Verify that Docker Engine is installed correctly by running the `hello-world`
-    image.
+4. Verify that Docker Engine is installed correctly by running the `hello-world`
+   image.
 
-    ```console
-    $ sudo docker run hello-world
-    ```
+   ```console
+   $ sudo docker run hello-world
+   ```
 
-    This command downloads a test image and runs it in a container. When the
-    container runs, it prints a message and exits.
+   This command downloads a test image and runs it in a container. When the
+   container runs, it prints a message and exits.
 
 You have now successfully installed and started Docker Engine.
 
@@ -232,20 +235,20 @@ instead of `zypper -y install`, and point to the new file.
 
 ## Uninstall Docker Engine
 
-1.  Uninstall the Docker Engine, CLI, Containerd, and Docker Compose packages:
+1. Uninstall the Docker Engine, CLI, Containerd, and Docker Compose packages:
 
-    ```console
-    $ sudo zypper remove docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin docker-ce-rootless-extras
-    ```
+   ```console
+   $ sudo zypper remove docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin docker-ce-rootless-extras
+   ```
 
-2.  Images, containers, volumes, or customized configuration files on your host
-    are not automatically removed. To delete all images, containers, and
-    volumes:
+2. Images, containers, volumes, or customized configuration files on your host
+   are not automatically removed. To delete all images, containers, and
+   volumes:
 
-    ```console
-    $ sudo rm -rf /var/lib/docker
-    $ sudo rm -rf /var/lib/containerd
-    ```
+   ```console
+   $ sudo rm -rf /var/lib/docker
+   $ sudo rm -rf /var/lib/containerd
+   ```
 
 You must delete any edited configuration files manually.
 

--- a/engine/install/sles.md
+++ b/engine/install/sles.md
@@ -173,7 +173,7 @@ $ sudo zypper addrepo {{ download-url-base }}/docker-ce.repo
     This command downloads a test image and runs it in a container. When the
     container runs, it prints a message and exits.
 
-This installs and runs Docker Engine.
+You have now successfully installed and started Docker Engine.
 
 {% include root-errors.md %}
 
@@ -218,10 +218,9 @@ a new file each time you want to upgrade Docker Engine.
     This command downloads a test image and runs it in a container. When the
     container runs, it prints a message and exits.
 
-This installs and runs Docker Engine. Use `sudo` to run Docker commands.
-Continue to [Post-installation steps for Linux](linux-postinstall.md) to allow
-non-privileged users to run Docker commands and for other optional configuration
-steps.
+You have now successfully installed and started Docker Engine.
+
+{% include root-errors.md %}
 
 #### Upgrade Docker Engine
 

--- a/engine/install/sles.md
+++ b/engine/install/sles.md
@@ -252,4 +252,5 @@ You must delete any edited configuration files manually.
 ## Next steps
 
 - Continue to [Post-installation steps for Linux](linux-postinstall.md).
-- Review the topics in [Develop with Docker](../../develop/index.md) to learn how to build new applications using Docker.
+- Review the topics in [Develop with Docker](../../develop/index.md) to learn
+  how to build new applications using Docker.

--- a/engine/install/sles.md
+++ b/engine/install/sles.md
@@ -63,8 +63,9 @@ $ sudo zypper addrepo $opensuse_repo
 
 ### Uninstall old versions
 
-Older versions of Docker were called `docker` or `docker-engine`. If these are
-installed, uninstall them, along with associated dependencies.
+Older versions of Docker went by the names of `docker` or `docker-engine`.
+Uninstall any such older versions before attempting to install a new version,
+along with associated dependencies.
 
 ```console
 $ sudo zypper remove docker \
@@ -78,33 +79,33 @@ $ sudo zypper remove docker \
                   runc
 ```
 
-It's OK if `zypper` reports that none of these packages are installed.
+`zypper` might report that you have none of these packages installed.
 
-The contents of `/var/lib/docker/`, including images, containers, volumes, and
-networks, are preserved. The Docker Engine package is now called `docker-ce`.
+Images, containers, volumes, and networks stored in `/var/lib/docker/` aren't
+automatically removed when you uninstall Docker.
 
 ## Installation methods
 
 You can install Docker Engine in different ways, depending on your needs:
 
-- Most users
+- You can
   [set up Docker's repositories](#install-using-the-repository) and install
   from them, for ease of installation and upgrade tasks. This is the
   recommended approach.
 
-- Some users download the RPM package and
+- You can download the RPM package and
   [install it manually](#install-from-a-package) and manage
   upgrades completely manually. This is useful in situations such as installing
   Docker on air-gapped systems with no access to the internet.
 
-- In testing and development environments, some users choose to use automated
+- In testing and development environments, you can use automated
   [convenience scripts](#install-using-the-convenience-script) to install Docker.
 
-### Install using the repository
+### Install using the rpm repository {#install-using-the-repository}
 
-Before you install Docker Engine for the first time on a new host machine, you need
-to set up the Docker repository. Afterward, you can install and update Docker
-from the repository.
+Before you install Docker Engine for the first time on a new host machine, you
+need to set up the Docker repository. Afterward, you can install and update
+Docker from the repository.
 
 #### Set up the repository
 
@@ -164,15 +165,15 @@ $ sudo zypper addrepo {{ download-url-base }}/docker-ce.repo
    $ sudo systemctl start docker
    ```
 
-4. Verify that Docker Engine is installed correctly by running the `hello-world`
-   image.
+4. Verify that the Docker Engine installation is successful by running the
+   `hello-world` image.
 
    ```console
    $ sudo docker run hello-world
    ```
 
    This command downloads a test image and runs it in a container. When the
-   container runs, it prints a message and exits.
+   container runs, it prints a confirmation message and exits.
 
 You have now successfully installed and started Docker Engine.
 
@@ -185,12 +186,12 @@ choosing the new version you want to install.
 
 ### Install from a package
 
-If you cannot use Docker's repository to install Docker, you can download the
-`.rpm` file for your release and install it manually. You need to download
-a new file each time you want to upgrade Docker Engine.
+If you can't use Docker's `rpm` repository to install Docker Engine, you can
+download the `.rpm` file for your release and install it manually. You need to
+download a new file each time you want to upgrade Docker Engine.
 
 1. Go to [{{ download-url-base }}/]({{ download-url-base }}/){: target="_blank" rel="noopener" class="_" }
-   and choose your version of SLES. Then browse to `15/s390x/stable/Packages/`
+   and choose your version of SLES. Then browse to `s390x/stable/Packages/`
    and download the `.rpm` file for the Docker version you want to install.
 
 2. Install Docker Engine, changing the path below to the path where you downloaded
@@ -209,15 +210,15 @@ a new file each time you want to upgrade Docker Engine.
    $ sudo systemctl start docker
    ```
 
-4. Verify that Docker Engine is installed correctly by running the `hello-world`
-   image.
+4. Verify that the Docker Engine installation is successful by running the
+   `hello-world` image.
 
    ```console
    $ sudo docker run hello-world
    ```
 
    This command downloads a test image and runs it in a container. When the
-   container runs, it prints a message and exits.
+   container runs, it prints a confirmation message and exits.
 
 You have now successfully installed and started Docker Engine.
 
@@ -225,30 +226,29 @@ You have now successfully installed and started Docker Engine.
 
 #### Upgrade Docker Engine
 
-To upgrade Docker Engine, download the newer package file and repeat the
+To upgrade Docker Engine, download the newer package files and repeat the
 [installation procedure](#install-from-a-package), using `zypper -y upgrade`
-instead of `zypper -y install`, and point to the new file.
+instead of `zypper -y install`, and point to the new files.
 
 {% include install-script.md %}
 
 ## Uninstall Docker Engine
 
-1. Uninstall the Docker Engine, CLI, Containerd, and Docker Compose packages:
+1. Uninstall the Docker Engine, CLI, containerd, and Docker Compose packages:
 
    ```console
    $ sudo zypper remove docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin docker-ce-rootless-extras
    ```
 
-2. Images, containers, volumes, or customized configuration files on your host
-   are not automatically removed. To delete all images, containers, and
-   volumes:
+2. Images, containers, volumes, or custom configuration files on your host
+   aren't automatically removed. To delete all images, containers, and volumes:
 
    ```console
    $ sudo rm -rf /var/lib/docker
    $ sudo rm -rf /var/lib/containerd
    ```
 
-You must delete any edited configuration files manually.
+You have to delete any edited configuration files manually.
 
 ## Next steps
 

--- a/engine/install/sles.md
+++ b/engine/install/sles.md
@@ -61,8 +61,6 @@ $ opensuse_repo="https://download.opensuse.org/repositories/security:SELinux/15.
 $ sudo zypper addrepo $opensuse_repo
 ```
 
-The `overlay2` storage driver is recommended.
-
 ### Uninstall old versions
 
 Older versions of Docker were called `docker` or `docker-engine`. If these are

--- a/engine/install/ubuntu.md
+++ b/engine/install/ubuntu.md
@@ -171,11 +171,7 @@ Docker from the repository.
 
 You have now successfully installed and started Docker Engine.
 
-> Receiving errors when trying to run without root?
->
-> The `docker` user group exists but contains no users, which is why you're required 
-> to use `sudo` to run Docker commands. Continue to [Linux post-install](linux-postinstall.md)
-> to allow non-privileged users to run Docker commands and for other optional configuration steps.
+{% include root-errors.md %}
 
 #### Upgrade Docker Engine
 
@@ -230,11 +226,9 @@ download a new file each time you want to upgrade Docker Engine.
    This command downloads a test image and runs it in a container. When the
    container runs, it prints a confirmation message and exits.
 
-You have now successfully installed and started Docker Engine. The `docker` user
-group exists but contains no users, which is why you're required to use `sudo`
-to run Docker commands. Read [Linux post-install](linux-postinstall.md)
-to allow non-privileged users to run Docker commands and for other optional
-configuration steps.
+You have now successfully installed and started Docker Engine.
+
+{% include root-errors.md %}
 
 #### Upgrade Docker Engine
 

--- a/engine/install/ubuntu.md
+++ b/engine/install/ubuntu.md
@@ -235,19 +235,19 @@ To upgrade Docker Engine, download the newer package files and repeat the
 
 ## Uninstall Docker Engine
 
-1.  Uninstall the Docker Engine, CLI, containerd, and Docker Compose packages:
+1. Uninstall the Docker Engine, CLI, containerd, and Docker Compose packages:
 
-    ```console
-    $ sudo apt-get purge docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin docker-ce-rootless-extras
-    ```
+   ```console
+   $ sudo apt-get purge docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin docker-ce-rootless-extras
+   ```
 
-2.  Images, containers, volumes, or custom configuration files on your host
-    aren't automatically removed. To delete all images, containers, and volumes:
+2. Images, containers, volumes, or custom configuration files on your host
+   aren't automatically removed. To delete all images, containers, and volumes:
 
-    ```console
-    $ sudo rm -rf /var/lib/docker
-    $ sudo rm -rf /var/lib/containerd
-    ```
+   ```console
+   $ sudo rm -rf /var/lib/docker
+   $ sudo rm -rf /var/lib/containerd
+   ```
 
 You have to delete any edited configuration files manually.
 

--- a/engine/install/ubuntu.md
+++ b/engine/install/ubuntu.md
@@ -85,11 +85,7 @@ Docker from the repository.
 
     ```console
     $ sudo apt-get update
-
-    $ sudo apt-get install \
-        ca-certificates \
-        curl \
-        gnupg
+    $ sudo apt-get install ca-certificates curl gnupg
     ```
 
 2.  Add Docker's official GPG key:

--- a/engine/install/ubuntu.md
+++ b/engine/install/ubuntu.md
@@ -156,7 +156,7 @@ Docker from the repository.
    </div>
 
 3. Verify that the Docker Engine installation is successful by running the
-   `hello-world` image:
+   `hello-world` image.
 
    ```console
    $ sudo docker run hello-world
@@ -171,9 +171,8 @@ You have now successfully installed and started Docker Engine.
 
 #### Upgrade Docker Engine
 
-To upgrade Docker Engine, follow the
-[installation instructions](#install-docker-engine), choosing the new version
-you want to install.
+To upgrade Docker Engine, follow the [installation instructions](#install-using-the-repository),
+choosing the new version you want to install.
 
 ### Install from a package
 
@@ -181,8 +180,7 @@ If you can't use Docker's `apt` repository to install Docker Engine, you can
 download the `deb` file for your release and install it manually. You need to
 download a new file each time you want to upgrade Docker Engine.
 
-1. Go to [`{{ download-url-base }}/dists/`]({{ download-url-base }}/dists/){:
-   target="_blank" rel="noopener" class="_" }.
+1. Go to [`{{ download-url-base }}/dists/`]({{ download-url-base }}/dists/){: target="_blank" rel="noopener" class="_" }.
 
 2. Select your Ubuntu version in the list.
 
@@ -212,7 +210,7 @@ download a new file each time you want to upgrade Docker Engine.
    The Docker daemon starts automatically.
 
 6. Verify that the Docker Engine installation is successful by running the
-   `hello-world` image:
+   `hello-world` image.
 
    ```console
    $ sudo service docker start


### PR DESCRIPTION
- follow-up to https://github.com/docker/docs/pull/17233

Still some things to do, but these were changes I had stashed, and are mostly rephrasing to align between pages, and introducing tabs on all distros.

### Proposed changes

<!-- Tell us what you did and why -->

### Related issues (optional)

<!--
  Refer to related PRs or issues:

  #1234
  Closes #1234
  Closes docker/cli#1234
-->
