### PR TITLE
#15625 make documentation link more explicit

### DIFF
--- a/_data/engine-cli/docker_container_ls.yaml
+++ b/_data/engine-cli/docker_container_ls.yaml
@@ -1,7 +1,7 @@
 command: docker container ls
 aliases: docker container ls, docker container list, docker container ps, docker ps
 short: List containers
-long: See [docker ps](ps.md) for more information.
+long: This command is an alias for 'docker ps'. See [docker ps](ps.md) for more information.
 usage: docker container ls [OPTIONS]
 pname: docker container
 plink: docker_container.yaml

--- a/_data/engine-cli/docker_image_ls.yaml
+++ b/_data/engine-cli/docker_image_ls.yaml
@@ -1,7 +1,7 @@
 command: docker image ls
 aliases: docker image ls, docker image list, docker images
 short: List images
-long: See [docker images](images.md) for more information.
+long: This command is an alias for 'docker images'. See [docker images](images.md) for more information.
 usage: docker image ls [OPTIONS] [REPOSITORY[:TAG]]
 pname: docker image
 plink: docker_image.yaml


### PR DESCRIPTION
as stated in the linked issue #15625 :
'docker image ls' is an alias to 'docker images'
'docker container ls' is an alias to 'docker ps'

### Proposed changes

make these facts explicit in the documentation, to make it clearer that the suggested documentation link is actually: "go read that other page for the complete documentation"

