### PR TITLE
Incorrect docker image used registry hasn't htpasswd

### DIFF
--- a/registry/recipes/nginx.md
+++ b/registry/recipes/nginx.md
@@ -155,7 +155,7 @@ Review the [requirements](index.md#requirements), then follow these steps.
 3.  Create a password file `auth/nginx.htpasswd` for "testuser" and "testpassword".
 
     ```console
-    $ docker run --rm --entrypoint htpasswd registry:2 -Bbn testuser testpassword > auth/nginx.htpasswd
+    $ docker run --rm --entrypoint htpasswd httpd:2 -Bbn testuser testpassword > auth/nginx.htpasswd
     ```
 
     > **Note**: If you do not want to use `bcrypt`, you can omit the `-B` parameter.


### PR DESCRIPTION
Incorrect docker image used. (unable to start container process: exec: "htpasswd": executable file not found in $PATH: unknown.)

<!--
  Thank you for contributing to Docker documentation!

  Here are a few things to keep in mind:

  - Links between pages should use a relative path
  - Remember to add an alt text for images

  ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
  ┃     Review our contribution guidelines:       ┃
  ┃                                               ┃
  ┃ https://docs.docker.com/contribute/overview/  ┃
  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
-->

### Proposed changes

replace **registry** docker image with **httpd**

### Related issues (optional)

<!--
  Refer to related PRs or issues:

  #1234
  Closes #1234
  Closes docker/cli#1234
-->
