### PR TITLE
Update "Ways to set environment variables in Compose"

### DIFF
--- a/content/compose/environment-variables/set-environment-variables.md
+++ b/content/compose/environment-variables/set-environment-variables.md
@@ -91,7 +91,7 @@ web:
 
 The result is similar to the one above but Compose will give you a warning if the `DEBUG` variable is not set in the shell environment.
 
-See [`environment` attribute](../compose-file/05-services.md#environment) and [variable interpolation](../compose-file/12-interpolation/) for more information.
+See [`environment` attribute](../compose-file/05-services.md#environment) and [variable interpolation](../compose-file/12-interpolation.md) for more information.
 
 ### Use the `env_file` attribute
 

--- a/content/compose/environment-variables/set-environment-variables.md
+++ b/content/compose/environment-variables/set-environment-variables.md
@@ -78,9 +78,20 @@ web:
     - DEBUG
 ```
 
-The value of the `DEBUG` variable in the container is taken from the value for the same variable in the shell in which Compose is run.
+The value of the `DEBUG` variable in the container is taken from the value for the same variable in the shell in which Compose is run. 
+Note that in this case no warning will be issued if the `DEBUG` variable in the shell environment is not set. 
 
-See [`environment` attribute](../compose-file/05-services.md#environment) for more information.
+You can also explicitly assign a variable using a Bash-like syntax `${DEBUG}`:
+
+```yaml
+web:
+  environment:
+    - DEBUG=${DEBUG}
+```
+
+The result is similar to the one above but Compose will give you a warning if the `DEBUG` variable is not set in the shell environment.
+
+See [`environment` attribute](../compose-file/05-services.md#environment) and [variable interpolation](../compose-file/12-interpolation/) for more information.
 
 ### Use the `env_file` attribute
 


### PR DESCRIPTION


<!--
  Thank you for contributing to Docker documentation!

  Here are a few things to keep in mind:

  - Links between pages should use a relative path
  - Remember to add an alt text for images

  ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
  ┃     Review our contribution guidelines:       ┃
  ┃                                               ┃
  ┃ https://docs.docker.com/contribute/overview/  ┃
  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
-->

### Proposed changes
* Add information that if an environment variable is declared by a single key (no value to equals sign), no warning will be printed if the variable is not set in the shell environment.
* Add an example of setting variables explicitly to get a warning from Compose if variables are not set. 

### Related issues (optional)

Relates to https://github.com/docker/compose/issues/10551
<!--
  Refer to related PRs or issues:

  #1234
  Closes #1234
  Closes docker/cli#1234
-->
