### PR TITLE
Use Debian instructions for 64-bit Raspbian

### DIFF
--- a/engine/install/raspbian.md
+++ b/engine/install/raspbian.md
@@ -16,7 +16,7 @@ To get started with Docker Engine on Raspbian, make sure you
 
 ### OS requirements
 
-To install Docker Engine, you need the 64-bit version of one of these Raspbian
+To install Docker Engine, you need the 64-bit version or 32-bit version of one of these Raspbian
 versions:
 
 - Raspbian Bookworm 12 (testing)
@@ -24,6 +24,8 @@ versions:
 - Raspbian Buster 10 (oldstable)
 
 Docker Engine for Raspbian is compatible with the armhf architecture.
+
+For the 64-bit version of Raspbian follow the instructions for [Debian](debian.md).
 
 ### Uninstall old versions
 


### PR DESCRIPTION
<!--
  Thank you for contributing to Docker documentation!

  Here are a few things to keep in mind:

  - Links between pages should use a relative path
  - Remember to add an alt text for images

  ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
  ┃     Review our contribution guidelines:       ┃
  ┃                                               ┃
  ┃ https://docs.docker.com/contribute/overview/  ┃
  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
-->

### Proposed changes

With the updated [installation instructions for Raspbian](https://docs.docker.com/engine/install/raspbian/) there is a problem for users of the 64-bit version Raspbian. We don't ship special 64-bit Raspbian packages, only the 32-bit because of special differences for armhf. The 64-bit version are compatible with the normal Debian packages.

I propose this small change to guide the readers over to the instruction page for Debian when they run a 64-bit version of Raspbian.

### Related issues (optional)

Closes #17311 
