### PR TITLE
Add Docker v24 to release notes sidebar

### DIFF
--- a/_data/toc.yaml
+++ b/_data/toc.yaml
@@ -1578,10 +1578,12 @@ manuals:
     title: Deprecated features
   - sectiontitle: Release notes
     section:
-    - path: /engine/release-notes/23.0/
-      title: Engine 23.0
+    - path: /engine/release-notes/24.0/
+      title: Engine 24.0
     - sectiontitle: Previous versions
       section:
+      - path: /engine/release-notes/23.0/
+        title: Engine 23.0
       - path: /engine/release-notes/20.10/
         title: Engine 20.10
       - path: /engine/release-notes/19.03/


### PR DESCRIPTION
<!--
  Thank you for contributing to Docker documentation!

  Here are a few things to keep in mind:

  - Links between pages should use a relative path
  - Remember to add an alt text for images

  ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
  ┃     Review our contribution guidelines:       ┃
  ┃                                               ┃
  ┃ https://docs.docker.com/contribute/overview/  ┃
  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
-->

### Proposed changes

Add Docker v24.0 to the release notes sidebar and move the v23 to the previous versions.

### Related issues (optional)

Fixes the find in the [#moby-project Slack](https://dockercommunity.slack.com/archives/C50QFMRC2/p1684314415197549) thread.

<!--
  Refer to related PRs or issues:

  #1234
  Closes #1234
  Closes docker/cli#1234
-->
