### PR TITLE
build: add missing line in k8s builder example

### DIFF
--- a/build/drivers/kubernetes.md
+++ b/build/drivers/kubernetes.md
@@ -283,6 +283,7 @@ Prerequisites:
      --bootstrap \
      --name=kube \
      --driver=kubernetes \
+     --driver-opt=namespace=buildkit
    ```
 
 3. List available Buildx builders using `docker buildx ls`


### PR DESCRIPTION
Signed-off-by: David Karlsson <david.karlsson@docker.com>

<!--
  Thank you for contributing to Docker documentation!

  Here are a few things to keep in mind:

  - Links between pages should use a relative path
  - Remember to add an alt text for images

  ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
  ┃     Review our contribution guidelines:       ┃
  ┃                                               ┃
  ┃ https://docs.docker.com/contribute/overview/  ┃
  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
-->

### Proposed changes

Fixes a broken example for the `kubernetes` buildx driver

### Related issues (optional)

<!--
  Refer to related PRs or issues:

  #1234
  Closes #1234
  Closes docker/cli#1234
-->
