### PR TITLE
Fix typo in SCIM overview page

### DIFF
--- a/docker-hub/scim.md
+++ b/docker-hub/scim.md
@@ -36,7 +36,7 @@ You must make sure you have [configured SSO](../single-sign-on/index.md) before 
 
 1. Sign in to Docker Hub, navigate to the **Organizations** page and select your organization or company.
 2. Select **Settings**. If you are setting up SCIM for an organization you then need to select **Security**. 
-3. n the **Single Sign-On Connection** table, select the **Actions** icon and **Setup SCIM**.
+3. In the **Single Sign-On Connection** table, select the **Actions** icon and **Setup SCIM**.
 4. Copy the **SCIM Base URL** and **API Token** and paste the values into your IdP.
 
 ### Step two: Enable SCIM in your IdP


### PR DESCRIPTION
<!--
  Thank you for contributing to Docker documentation!

  Here are a few things to keep in mind:

  - Links between pages should use a relative path
  - Remember to add an alt text for images

  ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
  ┃     Review our contribution guidelines:       ┃
  ┃                                               ┃
  ┃ https://docs.docker.com/contribute/overview/  ┃
  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
-->

### Proposed changes

<!-- Tell us what you did and why -->

This PR fixes a typo in the SCIM overview. 

I updated the following file:
- `docker-hub/scim.md`

<!--
  Refer to related PRs or issues:

  #1234
  Closes #1234
  Closes docker/cli#1234
-->
