### PR TITLE
Add example for avoiding hardcoded SSH_AUTH_SOCK

### DIFF
--- a/desktop/networking.md
+++ b/desktop/networking.md
@@ -81,6 +81,21 @@ services:
     environment:
       - SSH_AUTH_SOCK=/run/host-services/ssh-auth.sock
  ```
+ 
+ To avoid hardcoding SSH_AUTH_SOCK, e.g. when working in a team with diverging host setups, you can take advantage of the host environment variable instead:
+ 
+ ```yaml
+services:
+  web:
+    image: nginx:alpine
+    volumes:
+      - type: bind
+        # Adding a fallback value of /dev/null will prevent hard failing the bind volume mount on hosts without a configured SSH agent
+        source: ${SSH_AUTH_SOCK:-/dev/null}
+        target: ${SSH_AUTH_SOCK:-/dev/null}
+    environment:
+      - SSH_AUTH_SOCK=${SSH_AUTH_SOCK}
+ ```
 
 ## Known limitations for all platforms
 


### PR DESCRIPTION
<!--
  Thank you for contributing to Docker documentation!

  Here are a few things to keep in mind:

  - Links between pages should use a relative path
  - Remember to add an alt text for images

  ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
  ┃     Review our contribution guidelines:       ┃
  ┃                                               ┃
  ┃ https://docs.docker.com/contribute/overview/  ┃
  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
-->

### Proposed changes

<!-- Tell us what you did and why -->
Instead of hardcoding SSH_AUTH_SOCK the user can take advantage of the
hosts environment variable, thus minimizing host specific configuration.

Using /dev/null as fallback value in the bind mount even prevents errors
for users without a running ssh agent, while still printing a warning about
SSH_AUTH_SOCK being undefined.
