### PR TITLE
compose: add release notes for v2.18.1

### DIFF
--- a/compose/release-notes.md
+++ b/compose/release-notes.md
@@ -8,6 +8,12 @@ redirect_from:
 ---
 {% include compose-eol.md %}
 
+## 2.18.1
+{% include release-date.html date="2023-05-17" %}
+
+### Bug fixes and enhancements
+- Fixed "Image not found" errors when building images
+
 ## 2.18.0
 {% include release-date.html date="2023-05-16" %}
 


### PR DESCRIPTION
### Proposed changes
Add release notes for Compose v2.18.1: https://github.com/docker/compose/releases/tag/v2.18.1

### Related issues (optional)
n/a