### PR TITLE
Update onboarding prereqs

### DIFF
--- a/docker-hub/onboard-business.md
+++ b/docker-hub/onboard-business.md
@@ -10,7 +10,7 @@ The following section contains step-by-step instructions on how to get started o
 
 ## Prerequisites
 
-Before you start to on board your organization, ensure that you've completed the following:
+Before you start to on board your organization, ensure that you:
 - [Create an organization](../docker-hub/orgs.md#create-an-organization) with a Docker Business subscription.
 - Familiarize yourself with Docker concepts and terminology in the [glossary](../glossary.md) and [FAQs](../docker-hub/onboarding-faqs.md).
 

--- a/docker-hub/onboard-business.md
+++ b/docker-hub/onboard-business.md
@@ -6,15 +6,13 @@ toc_min: 1
 toc_max: 2
 ---
 
-The following section contains step-by-step instructions on how to get started onboarding your organization after you obtain a Docker Business subscription.
+The following section contains step-by-step instructions on how to get started onboarding your organization after you have an organization with a Docker Business subscription.
 
 ## Prerequisites
 
 Before you start to on board your organization, ensure that you've completed the following:
-- You have a Docker Business subscription. You can verify your subscription in Docker Hub's [Billing Details](https://hub.docker.com/billing){: target="_blank" rel="noopener" class="_"}. If you haven't subscribed to Docker Business yet, see [Upgrade your subscription](../subscription/upgrade.md) for details about upgrading.
-- Your Docker Business subscription is new. If you upgraded your Docker Team subscription or renewed your Docker Business subscription, see [what's next](#whats-next).
-- Your Docker Business subscription has started. You can't complete all the steps until after your subscription start date.
--  You are familiar with Docker terminology. If you discover any unfamiliar terms, see the [glossary](/glossary/#docker) or [FAQs](../docker-hub/onboarding-faqs.md).
+- [Create an organization](../docker-hub/orgs.md#create-an-organization) with a Docker Business subscription.
+- Familiarize yourself with Docker concepts and terminology in the [glossary](../glossary.md) and [FAQs](../docker-hub/onboarding-faqs.md).
 
 ## Step 1: Identify your Docker users and their Docker accounts
 

--- a/docker-hub/onboard-team.md
+++ b/docker-hub/onboard-team.md
@@ -6,13 +6,13 @@ toc_min: 1
 toc_max: 2
 ---
 
-The following section contains step-by-step instructions on how to get started onboarding your organization after you obtain a Docker Team subscription.
+The following section contains step-by-step instructions on how to get started onboarding your organization after you have an organization with a Docker Team subscription.
 
 ## Prerequisites
 
 Before you start to on board your organization, ensure that you've completed the following:
-- You have a Docker Team subscription. You can verify your subscription in Docker Hub's [Billing Details](https://hub.docker.com/billing){: target="_blank" rel="noopener" class="_"}. If you haven't subscribed to Docker Team yet, see [Upgrade your subscription](../subscription/upgrade.md) for details about upgrading.
-- You are familiar with Docker terminology. If you discover any unfamiliar terms, see the [glossary](/glossary/#docker) or [FAQs](../docker-hub/onboarding-faqs.md).
+- [Create an organization](../docker-hub/orgs.md#create-an-organization) with a Docker Team subscription.
+- Familiarize yourself with Docker concepts and terminology in the [glossary](../glossary.md) and [FAQs](../docker-hub/onboarding-faqs.md).
 
 ## Step 1: Identify your Docker users and their Docker accounts
 

--- a/docker-hub/onboard-team.md
+++ b/docker-hub/onboard-team.md
@@ -10,7 +10,7 @@ The following section contains step-by-step instructions on how to get started o
 
 ## Prerequisites
 
-Before you start to on board your organization, ensure that you've completed the following:
+Before you start to on board your organization, ensure that you:
 - [Create an organization](../docker-hub/orgs.md#create-an-organization) with a Docker Team subscription.
 - Familiarize yourself with Docker concepts and terminology in the [glossary](../glossary.md) and [FAQs](../docker-hub/onboarding-faqs.md).
 


### PR DESCRIPTION
### Proposed changes

During onboarding, users are confused about converting users accounts to organization accounts. This is caused by an unintended flow started by the "Upgrade your subscription" prereq. Using "Create an organization" leads to the correct flow.
The other prereqs are also confusing and unnecessary since the process has been updated.

- Updated prereqs

### Related issues (optional)

ENGDOCS-1363
