### PR TITLE
Clarify email domains and subdomains on SSO config page

### DIFF
--- a/single-sign-on/configure/index.md
+++ b/single-sign-on/configure/index.md
@@ -18,7 +18,7 @@ Follow the steps on this page to configure SSO for your organization or company.
 
     >**Note**
     >
-    > Format your domains without protocol or www information, for example, `yourcompany.com`. This should include all email domains and subdomains users will use to access Docker, for example `user@yourcompany.com` and `user@us.yourcompany.com`. Public domains such as `gmail.com`, `outlook.com`, etc. aren’t permitted. Also, the email domain should be set as the primary email.
+    > Format your domains without protocol or www information, for example, `yourcompany.com`. This should include all email domains and subdomains users will use to access Docker, for example `yourcompany.com` and `us.yourcompany.com`. Public domains such as `gmail.com`, `outlook.com`, etc. aren’t permitted. Also, the email domain should be set as the primary email.
 
 4. Once you have waited 72 hours for the TXT Record verification, you can then select **Verify** next to the domain you've added, and follow the on-screen instructions. 
 

--- a/single-sign-on/configure/index.md
+++ b/single-sign-on/configure/index.md
@@ -18,7 +18,7 @@ Follow the steps on this page to configure SSO for your organization or company.
 
     >**Note**
     >
-    > Format your domains without protocol or www information, for example, `yourcompany.com`. This should include all email domains and subdomains users will use to access Docker, for example `yourcompany.com` and `us.yourcompany.com`. Public domains such as `gmail.com`, `outlook.com`, etc. aren’t permitted. Also, the email domain should be set as the primary email.
+    > Format your domains without protocol or www information, for example, `yourcompany.example`. This should include all email domains and subdomains users will use to access Docker, for example `yourcompany.example` and `us.yourcompany.example`. Public domains such as `gmail.com`, `outlook.com`, etc. aren’t permitted. Also, the email domain should be set as the primary email.
 
 4. Once you have waited 72 hours for the TXT Record verification, you can then select **Verify** next to the domain you've added, and follow the on-screen instructions. 
 

--- a/single-sign-on/configure/index.md
+++ b/single-sign-on/configure/index.md
@@ -18,7 +18,7 @@ Follow the steps on this page to configure SSO for your organization or company.
 
     >**Note**
     >
-    > Format your domains without protocol or www information, for example, yourcompany.com. This should include all email domains and subdomains users will use to access Docker. Public domains such as gmail.com, outlook.com, etc. aren’t permitted. Also, the email domain should be set as the primary email.
+    > Format your domains without protocol or www information, for example, `yourcompany.com`. This should include all email domains and subdomains users will use to access Docker, for example `user@yourcompany.com` and `user@us.yourcompany.com`. Public domains such as `gmail.com`, `outlook.com`, etc. aren’t permitted. Also, the email domain should be set as the primary email.
 
 4. Once you have waited 72 hours for the TXT Record verification, you can then select **Verify** next to the domain you've added, and follow the on-screen instructions. 
 


### PR DESCRIPTION
<!--
  Thank you for contributing to Docker documentation!

  Here are a few things to keep in mind:

  - Links between pages should use a relative path
  - Remember to add an alt text for images

  ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
  ┃     Review our contribution guidelines:       ┃
  ┃                                               ┃
  ┃ https://docs.docker.com/contribute/overview/  ┃
  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
-->

### Proposed changes

This PR addresses a question that came from a customer that needed clarity and an example of what the SSO docs mean when they tell users to include email domains and subdomains. In this PR, I added an example domain and subdomain. I also opted to style this as inline code to be consistent with domain examples in [this docs page](https://docs.docker.com/config/daemon/systemd/).

Page updated:
- `single-sign-on/configure/index.md`
