### PR TITLE
Need to correct commands for Windows users (PowerShell) in 06_bind_mounts.md

### DIFF
--- a/get-started/06_bind_mounts.md
+++ b/get-started/06_bind_mounts.md
@@ -51,7 +51,7 @@ command prompt (`cmd`).
    bind mount.
 
    ```console
-   $ docker run -it --mount type=bind,src="$(pwd)",target=/src ubuntu bash
+   $ docker run -it --mount "type=bind,src=$pwd,target=/src" ubuntu bash
    ```
 
    The `--mount` option tells Docker to create a bind mount, where `src` is the

--- a/get-started/06_bind_mounts.md
+++ b/get-started/06_bind_mounts.md
@@ -50,7 +50,15 @@ command prompt (`cmd`).
 2. Run the following command to start `bash` in an `ubuntu` container with a
    bind mount.
 
+   If you are using an Mac or Linux device, then use the following command.
+
    ```console
+   $ docker run -it --mount type=bind,src="$(pwd)",target=/src ubuntu bash
+   ```
+
+   If you are using Windows, then use the following command in PowerShell.
+
+   ```powershell
    $ docker run -it --mount "type=bind,src=$pwd,target=/src" ubuntu bash
    ```
 
@@ -138,7 +146,7 @@ So, let's do it!
 
    ```powershell
    $ docker run -dp 3000:3000 `
-       -w /app --mount type=bind,src="$(pwd)",target=/app `
+       -w /app --mount "type=bind,src=$pwd,target=/app" `
        node:18-alpine `
        sh -c "yarn install && yarn run dev"
    ```


### PR DESCRIPTION
<!--
  Thank you for contributing to Docker documentation!

  Here are a few things to keep in mind:

  - Links between pages should use a relative path
  - Remember to add an alt text for images

  ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
  ┃     Review our contribution guidelines:       ┃
  ┃                                               ┃
  ┃ https://docs.docker.com/contribute/overview/  ┃
  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
-->

### Proposed changes

Current version of command does not work **on Windows** (PowerShell)

 `docker run -it --mount type=bind,src="$(pwd)",target=/src ubuntu bash`

on page https://docs.docker.com/get-started/06_bind_mounts/#trying-out-bind-mounts

and this 

```powershell
docker run -dp 3000:3000 `
    -w /app --mount type=bind,src="$(pwd)",target=/app `
    node:18-alpine `
    sh -c "yarn install && yarn run dev"
```

in section https://docs.docker.com/get-started/06_bind_mounts/#run-your-app-in-a-development-container

error in PowerShell shell

```plain
invalid argument "type=bind,src=\"$(pwd)\",target=/src" for "--mount" flag: parse error on line 1, column 15: bare " in non-quoted-field
```

Need to add caveat (note) for Windows users, that they should try this:

`docker run -it --mount "type=bind,src=$pwd,target=/src" ubuntu bash`

**ATTENTION:** This command does NOT work in bash shell (Linux). I pushed the second commit adding appropriate note about that (I copied it from text below).

### Related issues (optional)

Closes #17370 

<!--
  Refer to related PRs or issues:

  #1234
  Closes #1234
  Closes docker/cli#1234
-->
