### PR TITLE
redirect: add /go link for Compose ECS retirement

### DIFF
--- a/_redirects.yml
+++ b/_redirects.yml
@@ -105,6 +105,8 @@
   - /go/deprecated/
 "/engine/reference/commandline/cli/#experimental-features":
   - /go/experimental/
+"/cloud/ecs-integration/":
+  - /go/compose-ecs-eol/
 "/compose/migrate/":
   - /go/compose-v1-eol/
 "/config/formatting/":


### PR DESCRIPTION
### Proposed changes
Add a `/go/` link for the Compose cloud integration EOL.

Currently, this goes to the main ECS integration page.

### Related issues (optional)
* docker/compose-cli#2245
* docker/compose-cli#2246