### PR TITLE
config: fix example for proxies in daemon.json

### DIFF
--- a/config/daemon/systemd.md
+++ b/config/daemon/systemd.md
@@ -42,9 +42,11 @@ behavior for the daemon in the [`daemon.json` file](./index.md#configure-the-doc
 
 ```json
 {
-  "http-proxy": "http://proxy.example.com:3128",
-  "https-proxy": "https://proxy.example.com:3129",
-  "no-proxy": "*.test.example.com,.example.org,127.0.0.0/8"
+  "proxies": {
+    "http-proxy": "http://proxy.example.com:3128",
+    "https-proxy": "https://proxy.example.com:3129",
+    "no-proxy": "*.test.example.com,.example.org,127.0.0.0/8"
+  }
 }
 ```
 


### PR DESCRIPTION
- relates to https://github.com/docker/docs/pull/13786
- relates to https://github.com/docker/cli/pull/4309
- relates to https://github.com/docker/cli/pull/4199
- relates to https://github.com/moby/moby/pull/42835
- relates to https://github.com/moby/moby/pull/43448


commit 073cd2fe24f54ae0e6a31238966369e8ed075ce4 (https://github.com/docker/docs/pull/13786) added proxies to the
example `daemon.json`, based on the implementation that was added in
https://github.com/moby/moby/commit/427c7cc5f86364466c7173e8ca59b97c3876471d (https://github.com/moby/moby/pull/42835).

However, a follow-up pull request changed the proxy-configuration in`daemon.json`
to nest the configuration in a "proxies" struct, and the documentation was
not updated accordingly; see:
https://github.com/moby/moby/commit/101dafd049949a4da65dcefd495828a6644e1ce1 (https://github.com/moby/moby/pull/43448)

This patch fixes the example.
