### PR TITLE
storage: updates for deprecated/removed AuFS and overlay drivers

### DIFF
--- a/_data/toc.yaml
+++ b/_data/toc.yaml
@@ -1334,8 +1334,6 @@ manuals:
         title: Overview
       - path: /storage/storagedriver/select-storage-driver/
         title: Select a storage driver
-      - path: /storage/storagedriver/aufs-driver/
-        title: Use the AUFS storage driver
       - path: /storage/storagedriver/btrfs-driver/
         title: Use the Btrfs storage driver
       - path: /storage/storagedriver/device-mapper-driver/
@@ -1346,6 +1344,8 @@ manuals:
         title: Use the ZFS storage driver
       - path: /storage/storagedriver/vfs-driver/
         title: Use the VFS storage driver
+      - path: /storage/storagedriver/aufs-driver/
+        title: Use the AUFS storage driver (deprecated)
   - sectiontitle: Networking
     section:
     - path: /network/

--- a/storage/storagedriver/aufs-driver.md
+++ b/storage/storagedriver/aufs-driver.md
@@ -2,9 +2,19 @@
 description: Learn how to optimize your use of AUFS driver.
 keywords: 'container, storage, driver, AUFS '
 title: Use the AUFS storage driver
+sitemap: false
 redirect_from:
 - /engine/userguide/storagedriver/aufs-driver/
 ---
+
+
+> **Deprecated**
+>
+> The AuFS storage driver has been deprecated, and is removed in Docker Engine
+> v24.0. If you are using AufS, you must migrate to a supported storage driver
+> before upgrading to Docker Engine v24.0. Read the [Docker storage drivers](select-storage-driver.md)
+> page for supported storage drivers.
+{:.warning}
 
 AUFS is a *union filesystem*. The `aufs` storage driver was previously the default
 storage driver used for managing images and layers on Docker for Ubuntu, and for
@@ -12,12 +22,6 @@ Debian versions prior to Stretch. If your Linux kernel is version 4.0 or higher,
 and you use Docker Engine - Community, consider using the newer
 [overlay2](overlayfs-driver.md){: target="_blank" rel="noopener" class="_" }, which has
 potential performance advantages over the `aufs` storage driver.
-
-> **Note**
->
-> AUFS is not supported on some distributions and Docker editions. See
-> [Prerequisites](#prerequisites) for more information about supported
-> platforms.
 
 ## Prerequisites
 

--- a/storage/storagedriver/index.md
+++ b/storage/storagedriver/index.md
@@ -1,6 +1,6 @@
 ---
 description: Learn the technologies that support storage drivers.
-keywords: container, storage, driver, AUFS, btrfs, devicemapper, overlayfs, vfs, zfs
+keywords: container, storage, driver, btrfs, devicemapper, overlayfs, vfs, zfs
 title: About storage drivers
 redirect_from:
 - /en/latest/terms/layer/
@@ -386,8 +386,8 @@ layer. This means that the writable layer is as small as possible.
 
 When an existing file in a container is modified, the storage driver performs a
 copy-on-write operation. The specifics steps involved depend on the specific
-storage driver. For the `overlay2`, `overlay`, and `aufs` drivers, the 
-copy-on-write operation follows this rough sequence:
+storage driver. For the `overlay2` driver, the  copy-on-write operation follows
+this rough sequence:
 
 *  Search through the image layers for the file to update. The process starts
    at the newest layer and works down to the base layer one layer at a time.


### PR DESCRIPTION
The AuFS and legacy overlay storage drivers have been removed in Docker Engine 24.0

<!--
  Thank you for contributing to Docker documentation!

  Here are a few things to keep in mind:

  - Links between pages should use a relative path
  - Remember to add an alt text for images

  ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
  ┃     Review our contribution guidelines:       ┃
  ┃                                               ┃
  ┃ https://docs.docker.com/contribute/overview/  ┃
  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
-->

### Proposed changes

<!-- Tell us what you did and why -->

### Related issues (optional)

<!--
  Refer to related PRs or issues:

  #1234
  Closes #1234
  Closes docker/cli#1234
-->
