### PR TITLE
reference: prevent options/flags column from wrapping

### DIFF
--- a/_includes/cli.md
+++ b/_includes/cli.md
@@ -134,9 +134,9 @@ For example uses of this command, refer to the [examples section](#examples) bel
   {% capture option-default %}{% if option.default_value %}{% unless defaults-to-skip contains option.default_value or defaults-to-skip == blank %}`{{ option.default_value }}`{% endunless %}{% endif %}{% endcapture %}
   <tr>
     {% if option.details_url and option.details_url != '' -%}
-    <td markdown="span">[`--{{ option.option }}`]({{ option.details_url }}){% if option.shorthand %} , [`-{{ option.shorthand }}`]({{ option.details_url }}){% endif %}</td>
+    <td markdown="span" nowrap>[`--{{ option.option }}`]({{ option.details_url }}){% if option.shorthand %} , [`-{{ option.shorthand }}`]({{ option.details_url }}){% endif %}</td>
     {%- else -%}
-    <td markdown="span">`--{{ option.option }}`{% if option.shorthand %} , `-{{ option.shorthand }}`{% endif %}</td>
+    <td markdown="span" nowrap>`--{{ option.option }}`{% if option.shorthand %} , `-{{ option.shorthand }}`{% endif %}</td>
     {%- endif %}
     <td markdown="span">{{ option-default }}</td>
     <td markdown="span">{% if all-badges != '' %}{{ all-badges | strip }}<br />{% endif %}{{ option.description | strip }}</td>


### PR DESCRIPTION
Make sure that options (flags) are not wrapped in the table.

Before:

<img width="998" alt="Screenshot 2023-05-22 at 23 18 46" src="https://github.com/docker/docs/assets/1804568/b7b553c5-2801-4e83-9572-8e4d56c2a512">


After:

<img width="1018" alt="Screenshot 2023-05-22 at 23 18 05" src="https://github.com/docker/docs/assets/1804568/b3cddbbb-0058-4dfd-b886-7032ed2f2bf8">




<!--
  Thank you for contributing to Docker documentation!

  Here are a few things to keep in mind:

  - Links between pages should use a relative path
  - Remember to add an alt text for images

  ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
  ┃     Review our contribution guidelines:       ┃
  ┃                                               ┃
  ┃ https://docs.docker.com/contribute/overview/  ┃
  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
-->

### Proposed changes

<!-- Tell us what you did and why -->

### Related issues (optional)

<!--
  Refer to related PRs or issues:

  #1234
  Closes #1234
  Closes docker/cli#1234
-->
