### PR TITLE
docs: Remove firewalld zone instructions

### DIFF
--- a/content/network/packet-filtering-firewalls.md
+++ b/content/network/packet-filtering-firewalls.md
@@ -160,16 +160,6 @@ on your system with `--iptables` enabled, Docker automatically creates a `firewa
 zone called `docker` and inserts all the network interfaces it creates (for example,
 `docker0`) into the `docker` zone to allow seamless networking.
 
-Consider running the following `firewalld` command to remove the docker interface from the zone.
-
-```console
-# Please substitute the appropriate zone and docker interface
-$ firewall-cmd --zone=trusted --remove-interface=docker0 --permanent
-$ firewall-cmd --reload
-```
-
-Restarting `dockerd` daemon inserts the interface into the `docker` zone.
-
 ## Docker and ufw
 
 [Uncomplicated Firewall](https://launchpad.net/ufw)


### PR DESCRIPTION
### Proposed changes

Remove [instructions for migrating to the `docker` zone](https://github.com/docker/docs/pull/11883#discussion_r540972400), which [landed in moby releases since 2020H2](https://github.com/moby/libnetwork/pull/2548).

A recent PR commit [modified these docs for v23 to remove the `20.10.0` qualifier](https://github.com/docker/docs/pull/17233/commits/c0f70775ba3082426fbe998aeab74ce3ffe27e38) (_which lost that context_).

---

### Additional Context

This makes the current information confusing, and implies a user should run similar commands to get integration with firewalld.
- AFAIK, the feature review discussed a future improvement to support changing the zone, or assigning user-defined networks to custom zones, but this does not appear to have been pursued since.
- Removing `docker0` from the `docker` zone, will reassign it back, or if assigned to another zone with `--permanent` cause a failure for `dockerd` starting due to a conflicting zone already assigned `docker0`.

Thus given the recent change, these instructions should be dropped, or additional context provided (_**note:** [third-party guides created in 2023](https://dev.to/soerenmetje/how-to-secure-a-docker-host-using-firewalld-2joo) can be found advising to assign `docker0` to `trusted` zone_).