### PR TITLE
add buildx and link to issue trackers directly

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -4,17 +4,20 @@ contact_links:
     url: https://dockr.ly/comm-slack
     about: Ask questions in the Docker Community Slack
   - name: Moby
-    url: https://github.com/moby/moby
+    url: https://github.com/moby/moby/issues
     about: Bug reports for Docker Engine
   - name: Docker Desktop for Windows
-    url: https://github.com/docker/for-win
+    url: https://github.com/docker/for-win/issues
     about: Bug reports for Docker Desktop for Windows 
   - name: Docker Desktop for Mac
-    url: https://github.com/docker/for-mac
+    url: https://github.com/docker/for-mac/issues
     about: Bug reports for Docker Desktop for Mac 
   - name: Docker Desktop for Linux
-    url: https://github.com/docker/for-linux
+    url: https://github.com/docker/for-linux/issues
     about: Bug reports for Docker Desktop for Linux 
   - name: Docker Compose
-    url: https://github.com/docker/compose
+    url: https://github.com/docker/compose/issues
     about: Bug reports for Docker Compose
+  - name: Docker Buildx
+    url: https://github.com/docker/buildx/issues
+    about: Bug reports for Docker Buildx


### PR DESCRIPTION
Signed-off-by: David Karlsson <david.karlsson@docker.com>

<!--
  Thank you for contributing to Docker documentation!

  Here are a few things to keep in mind:

  - Links between pages should use a relative path
  - Remember to add an alt text for images

  ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
  ┃     Review our contribution guidelines:       ┃
  ┃                                               ┃
  ┃ https://docs.docker.com/contribute/overview/  ┃
  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
-->

### Proposed changes

Added buildx link and updated links to point directly to the issue trackers for product repos.

### Related issues (optional)

https://github.com/docker/docs/pull/17331#discussion_r1198115864
