### PR TITLE
engine: fix apt-get remove command for uninstall preexisting packages

### DIFF
--- a/engine/install/debian.md
+++ b/engine/install/debian.md
@@ -31,13 +31,29 @@ architectures.
 
 ### Uninstall old versions
 
-Older versions of Docker went by the names of `docker`, `docker.io`, or
-`docker-engine`, you might also have installations of `containerd` or `runc`.
-Uninstall any such older versions before attempting to install
-a new version:
+Before you can install Docker Engine, you must first make sure that any
+conflicting packages are uninstalled.
+
+Distro maintainers provide an unofficial distributions of Docker packages in
+APT. You must uninstall these packages before you can install the official
+version of Docker Engine.
+
+The unofficial packages to uninstall are:
+
+- `docker.io`
+- `docker-compose`
+- `docker-doc`
+- `podman-docker`
+
+Moreover, Docker Engine depends on `containerd` and `runc`. Docker Engine
+bundles these dependencies as one bundle: `containerd.io`. If you have
+installed the `containerd` or `runc` previously, uninstall them to avoid
+conflicts with the versions bundled with Docker Engine.
+
+Run the following command to uninstall all conflicting packages:
 
 ```console
-$ sudo apt-get remove docker docker-engine docker.io containerd runc
+$ for pkg in docker.io docker-doc docker-compose podman-docker containerd runc; do sudo apt-get remove $pkg; done
 ```
 
 `apt-get` might report that you have none of these packages installed.

--- a/engine/install/raspbian.md
+++ b/engine/install/raspbian.md
@@ -29,13 +29,29 @@ For the 64-bit version of Raspbian follow the instructions for [Debian](debian.m
 
 ### Uninstall old versions
 
-Older versions of Docker went by the names of `docker`, `docker.io`, or
-`docker-engine`, you might also have installations of `containerd` or `runc`.
-Uninstall any such older versions before attempting to install
-a new version:
+Before you can install Docker Engine, you must first make sure that any
+conflicting packages are uninstalled.
+
+Distro maintainers provide an unofficial distributions of Docker packages in
+APT. You must uninstall these packages before you can install the official
+version of Docker Engine.
+
+The unofficial packages to uninstall are:
+
+- `docker.io`
+- `docker-compose`
+- `docker-doc`
+- `podman-docker`
+
+Moreover, Docker Engine depends on `containerd` and `runc`. Docker Engine
+bundles these dependencies as one bundle: `containerd.io`. If you have
+installed the `containerd` or `runc` previously, uninstall them to avoid
+conflicts with the versions bundled with Docker Engine.
+
+Run the following command to uninstall all conflicting packages:
 
 ```console
-$ sudo apt-get remove docker docker-engine docker.io containerd runc
+$ for pkg in docker.io docker-doc docker-compose podman-docker containerd runc; do sudo apt-get remove $pkg; done
 ```
 
 `apt-get` might report that you have none of these packages installed.

--- a/engine/install/ubuntu.md
+++ b/engine/install/ubuntu.md
@@ -38,13 +38,29 @@ s390x architectures.
 
 ### Uninstall old versions
 
-Older versions of Docker went by the names of `docker`, `docker.io`, or
-`docker-engine`, you might also have installations of `containerd` or `runc`.
-Uninstall any such older versions before attempting to install
-a new version:
+Before you can install Docker Engine, you must first make sure that any
+conflicting packages are uninstalled.
+
+Distro maintainers provide an unofficial distributions of Docker packages in
+APT. You must uninstall these packages before you can install the official
+version of Docker Engine.
+
+The unofficial packages to uninstall are:
+
+- `docker.io`
+- `docker-compose`
+- `docker-doc`
+- `podman-docker`
+
+Moreover, Docker Engine depends on `containerd` and `runc`. Docker Engine
+bundles these dependencies as one bundle: `containerd.io`. If you have
+installed the `containerd` or `runc` previously, uninstall them to avoid
+conflicts with the versions bundled with Docker Engine.
+
+Run the following command to uninstall all conflicting packages:
 
 ```console
-$ sudo apt-get remove docker docker-engine docker.io containerd runc
+$ for pkg in docker.io docker-doc docker-compose podman-docker containerd runc; do sudo apt-get remove $pkg; done
 ```
 
 `apt-get` might report that you have none of these packages installed.


### PR DESCRIPTION
Signed-off-by: David Karlsson <david.karlsson@docker.com>

<!--
  Thank you for contributing to Docker documentation!

  Here are a few things to keep in mind:

  - Links between pages should use a relative path
  - Remember to add an alt text for images

  ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
  ┃     Review our contribution guidelines:       ┃
  ┃                                               ┃
  ┃ https://docs.docker.com/contribute/overview/  ┃
  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
-->

### Proposed changes

The `apt-get remove` command in docs for removing old versions of docker engine and deps would fail if a package isn't found.

This changes the command to remove the packages one-by-one

### Related issues (optional)

Closes #17405
