### PR TITLE
Change DSO link to Scout Web App

### DIFF
--- a/scout/index.md
+++ b/scout/index.md
@@ -32,7 +32,7 @@ You can view and interact with Docker Scout from your terminal through the
 `docker scout`
 [plugin for Docker CLI](../engine/reference/commandline/scout_cves.md).
 
-There's also a [web UI](https://dso.docker.com/explore){: target="\_blank"
+There's also a [Web App](https://scout.docker.com){: target="\_blank"
 rel="noopener" } that you can use to explore additional information about
 images, packages, and CVEs.
 


### PR DESCRIPTION
### Proposed changes

Now the Scout Web App is live, we can change the link from DSO to it.