### PR TITLE
Updated mysql output to 2023 version

### DIFF
--- a/language/python/develop.md
+++ b/language/python/develop.md
@@ -54,9 +54,9 @@ $ docker exec -ti mysqldb mysql -u root -p
 Enter password:
 Welcome to the MySQL monitor.  Commands end with ; or \g.
 Your MySQL connection id is 8
-Server version: 8.0.23 MySQL Community Server - GPL
+Server version: 8.0.33 MySQL Community Server - GPL
 
-Copyright (c) 2000, 2021, Oracle and/or its affiliates.
+Copyright (c) 2000, 2023, Oracle and/or its affiliates.
 
 Oracle is a registered trademark of Oracle Corporation and/or its
 affiliates. Other names may be trademarks of their respective


### PR DESCRIPTION
### Proposed changes

Example shows the output from launching container to the mysql terminal, the welcome output has changed for 2023. This PR updates the example output for what is shown using the latest version.

### Related issues (optional)
None.
