### PR TITLE
registry: note restriction on URL to pull-through registry mirrors

### DIFF
--- a/registry/recipes/mirror.md
+++ b/registry/recipes/mirror.md
@@ -19,6 +19,8 @@ there, to avoid this extra internet traffic.
 > **Note**
 >
 > Docker Official Images are an intellectual property of Docker.
+>
+> Mirrors of Docker Hub are subject to Docker's [fair usage policy](https://www.docker.com/pricing/resource-consumption-updates){: target="blank" rel="noopener" class=“”}.
 
 ### Alternatives
 
@@ -30,12 +32,20 @@ relying entirely on your local registry is the simplest scenario.
 
 ### Gotcha
 
-It's currently not possible to mirror another private registry. Only the central
-Hub can be mirrored.
+It's currently not possible to mirror another private registry.
+Only the central Hub can be mirrored.
 
-> **Note**
->
-> Mirrors of Docker Hub are still subject to Docker's [fair usage policy](https://www.docker.com/pricing/resource-consumption-updates){: target="blank" rel="noopener" class=“”}.
+The URL of a pull-through registry mirror must be the root of a domain.
+No path components other than an optional trailing slash (`/`) are allowed.
+The following table shows examples of allowed and disallowed mirror URLs.
+
+| URL                                    | Allowed |
+| -------------------------------------- | ------- |
+| `https://mirror.company.example`       | Yes     |
+| `https://mirror.company.example/`      | Yes     |
+| `https://mirror.company.example/foo`   | No      |
+| `https://mirror.company.example#bar`   | No      |
+| `https://mirror.company.example?baz=1` | No      |
 
 ### Solution
 
@@ -112,9 +122,13 @@ and add the `registry-mirrors` key and value, to make the change persistent.
 
 ```json
 {
-  "registry-mirrors": ["https://<my-docker-mirror-host>"]
+  "registry-mirrors": ["https://mirror.company.example"]
 }
 ```
+
+> **Note**
+>
+> The mirror URL must be the root of the domain.
 
 Save the file and reload Docker for the change to take effect.
 


### PR DESCRIPTION
Signed-off-by: David Karlsson <david.karlsson@docker.com>

<!--
  Thank you for contributing to Docker documentation!

  Here are a few things to keep in mind:

  - Links between pages should use a relative path
  - Remember to add an alt text for images

  ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
  ┃     Review our contribution guidelines:       ┃
  ┃                                               ┃
  ┃ https://docs.docker.com/contribute/overview/  ┃
  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
-->

### Proposed changes

Clarify the restriction that pull-through mirrors must use the root of a domain
with no path components.

### Related issues (optional)

#17414
