### PR TITLE
engine: add note about installing on debian derivatives

### DIFF
--- a/engine/install/debian.md
+++ b/engine/install/debian.md
@@ -114,6 +114,16 @@ Docker from the repository.
       sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
     ```
 
+    > **Note**
+    >
+    > If you use a derivative distro, such as Kali Linux,
+    > you may need to substitute the part of this command that's expected to
+    > print the version codename:
+    >
+    > ```console
+    > $(. /etc/os-release && echo "$VERSION_CODENAME")
+    > ```
+
 #### Install Docker Engine
 
 1. Update the `apt` package index:


### PR DESCRIPTION
Signed-off-by: David Karlsson <david.karlsson@docker.com>

<!--
  Thank you for contributing to Docker documentation!

  Here are a few things to keep in mind:

  - Links between pages should use a relative path
  - Remember to add an alt text for images

  ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
  ┃     Review our contribution guidelines:       ┃
  ┃                                               ┃
  ┃ https://docs.docker.com/contribute/overview/  ┃
  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
-->

### Proposed changes

Adds a note about what to do if the version codename is not found on Debian derivative distros.

### Related issues (optional)

Closes #17454
