### PR TITLE
Fix "scope" default value for GHA cache options

### DIFF
--- a/build/cache/backends/gha.md
+++ b/build/cache/backends/gha.md
@@ -43,7 +43,7 @@ The following table describes the available CSV parameters that you can pass to
 | -------------- | ----------------------- | ----------- | ------------------------------- | --------------------------------------------- |
 | `url`          | `cache-to`,`cache-from` | String      | `$ACTIONS_CACHE_URL`            | Cache server URL, see [authentication][1].    |
 | `token`        | `cache-to`,`cache-from` | String      | `$ACTIONS_RUNTIME_TOKEN`        | Access token, see [authentication][1].        |
-| `scope`        | `cache-to`,`cache-from` | String      | Name of the current Git branch. | Cache scope, see [scope][2]                   |
+| `scope`        | `cache-to`,`cache-from` | String      | `buildkit`                      | Cache scope, see [scope][2]                   |
 | `mode`         | `cache-to`              | `min`,`max` | `min`                           | Cache layers to export, see [cache mode][3].  |
 | `ignore-error` | `cache-to`              | Boolean     | `false`                         | Ignore errors caused by failed cache exports. |
 


### PR DESCRIPTION
Update the `cache-to` and `cache-from` `scope` config value to the correct default of `buildkit`.

### Proposed changes

The documentation for the GitHub Action cache is incorrect in listing that the branch name is the default scope value. The correct value is `buildkit`, which is also listed as the default value in the buildkit docs [here](https://github.com/moby/buildkit#github-actions-cache-experimental).

### Related issues (optional)

N/A
