### PR TITLE
Add "-a" flag to "Prune everything" section so it includes all unused images, not just dangling ones

### DIFF
--- a/config/pruning.md
+++ b/config/pruning.md
@@ -158,16 +158,16 @@ WARNING! This will remove:
 Are you sure you want to continue? [y/N] y
 ```
 
-To also prune volumes, add the `--volumes` flag:
+To also prune volumes and unused images, add the `--volumes -a` flag:
 
 ```console
-$ docker system prune --volumes
+$ docker system prune --volumes -a
 
 WARNING! This will remove:
         - all stopped containers
         - all networks not used by at least one container
         - all volumes not used by at least one container
-        - all dangling images
+        - all images without at least one container associated to them
         - all build cache
 Are you sure you want to continue? [y/N] y
 ```


### PR DESCRIPTION


<!--
  Thank you for contributing to Docker documentation!

  Here are a few things to keep in mind:

  - Links between pages should use a relative path
  - Remember to add an alt text for images

  ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
  ┃     Review our contribution guidelines:       ┃
  ┃                                               ┃
  ┃ https://docs.docker.com/contribute/overview/  ┃
  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
-->

### Proposed changes

<!-- Tell us what you did and why -->
"Prune everything" should prune _all_ unnecessary components, including unused images. If someone doesn't want to delete unused images, they can omit the "-a" flag. This way, people who want to clean unused components can attain their purpose.

### Related issues (optional)

<!--
  Refer to related PRs or issues:

  #1234
  Closes #1234
  Closes docker/cli#1234
-->
