### PR TITLE
Fix capitalization error in sentence by adding an uppercase letter at…

### DIFF
--- a/_data/compose-cli/docker_compose_run.yaml
+++ b/_data/compose-cli/docker_compose_run.yaml
@@ -3,7 +3,7 @@ short: Run a one-off command on a service.
 long: |-
     Runs a one-time command against a service.
 
-    the following command starts the `web` service and runs `bash` as its command:
+    The following command starts the `web` service and runs `bash` as its command:
 
     ```console
     $ docker compose run web bash


### PR DESCRIPTION


<!--
  Thank you for contributing to Docker documentation!

  Here are a few things to keep in mind:

  - Links between pages should use a relative path
  - Remember to add an alt text for images

  ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
  ┃     Review our contribution guidelines:       ┃
  ┃                                               ┃
  ┃ https://docs.docker.com/contribute/overview/  ┃
  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
-->

### Proposed changes
I made a documentation change to fix a missing uppercase letter at the beginning of a sentence. The specific fix is as follows:

Change in the original documentation:
From: "the following command starts the web service and runs bash as its command:"
To: "The following command starts the web service and runs bash as its command:"
The purpose of this change is to ensure proper capitalization and improve the readability and consistency of the documentation.
<!-- Tell us what you did and why -->


### Related issues (optional)
  Closes #17520 
<!--
  Refer to related PRs or issues:

  #1234
  Closes #1234
  Closes docker/cli#1234
-->
