### PR TITLE
Added deep link for Descriptor

### DIFF
--- a/registry/notifications.md
+++ b/registry/notifications.md
@@ -71,7 +71,7 @@ Field | Type | Description
 id | string |ID provides a unique identifier for the event.
 timestamp | Time | Timestamp is the time at which the event occurred.
 action |  string |  Action indicates what action encompasses the provided event.
-target | distribution.Descriptor | Target uniquely describes the target of the event.
+target | [Descriptor](https://godoc.org/github.com/docker/distribution#Descriptor) | Target uniquely describes the target of the event.
 length | int | Length in bytes of content. Same as Size field in Descriptor.
 repository | string | Repository identifies the named repository.
 fromRepository | string |  FromRepository identifies the named repository which a blob was mounted from if appropriate.


### PR DESCRIPTION
Added deep link for the Descriptor type in the Docker Registry notifications documentation.

### Proposed changes

It makes it more easy to see what the descriptor contains.