### PR TITLE
Fix typo on "Create an advanced frontend extension" page

### DIFF
--- a/desktop/extensions-sdk/build/frontend-extension-tutorial.md
+++ b/desktop/extensions-sdk/build/frontend-extension-tutorial.md
@@ -21,7 +21,7 @@ The quickest way to create a new extension is to run `docker extension init my-e
 > **Tip**
 >
 > The `docker extension init` generates a React based extension. But you can still use it as a starting point for
-> your own extension and use any other frontend framework, like Vue, Angular, Svelte, etc. or event stay with
+> your own extension and use any other frontend framework, like Vue, Angular, Svelte, etc. or even stay with
 > vanilla Javascript.
 {: .tip }
 


### PR DESCRIPTION
### Proposed changes

Fix typo on the [Create an advanced frontend extension](https://docs.docker.com/desktop/extensions-sdk/build/frontend-extension-tutorial/) page of the docs. ("event" should be "even").

**Current:**
> The `docker extension init` generates a React based extension. But you can still use it as a starting point for your own extension and use any other frontend framework, like Vue, Angular, Svelte, etc. or **event** stay with vanilla Javascript.

**Fix:**
> The `docker extension init` generates a React based extension. But you can still use it as a starting point for your own extension and use any other frontend framework, like Vue, Angular, Svelte, etc. or **even** stay with vanilla Javascript.
