### PR TITLE
engine: remove Ubuntu 18.04 Bionic Beaver LTS, as it reached end of standard support

### DIFF
--- a/compose/compose-file/compose-file-v2.md
+++ b/compose/compose-file/compose-file-v2.md
@@ -856,7 +856,7 @@ a partial image ID.
 image: redis
 ```
 ```yaml
-image: ubuntu:18.04
+image: ubuntu:22.04
 ```
 ```yaml
 image: tutum/influxdb

--- a/compose/compose-file/compose-file-v3.md
+++ b/compose/compose-file/compose-file-v3.md
@@ -805,7 +805,7 @@ services:
       placement:
         constraints:
           - "node.role==manager"
-          - "engine.labels.operatingsystem==ubuntu 18.04"
+          - "engine.labels.operatingsystem==ubuntu 22.04"
         preferences:
           - spread: node.labels.zone
 ```
@@ -1302,7 +1302,7 @@ a partial image ID.
 image: redis
 ```
 ```yaml
-image: ubuntu:18.04
+image: ubuntu:22.04
 ```
 ```yaml
 image: tutum/influxdb

--- a/develop/develop-images/dockerfile_best-practices.md
+++ b/develop/develop-images/dockerfile_best-practices.md
@@ -24,7 +24,8 @@ changes from the previous layer. The following is the contents of an example Doc
 
 ```dockerfile
 # syntax=docker/dockerfile:1
-FROM ubuntu:18.04
+
+FROM ubuntu:22.04
 COPY . /app
 RUN make /app
 CMD python /app/app.py
@@ -32,7 +33,7 @@ CMD python /app/app.py
 
 Each instruction creates one layer:
 
-- `FROM` creates a layer from the `ubuntu:18.04` Docker image.
+- `FROM` creates a layer from the `ubuntu:22.04` Docker image.
 - `COPY` adds files from your Docker client's current directory.
 - `RUN` builds your application with `make`.
 - `CMD` specifies what command to run within the container.
@@ -448,7 +449,8 @@ subsequent `apt-get install` instructions fail. For example, the issue will occu
 
 ```dockerfile
 # syntax=docker/dockerfile:1
-FROM ubuntu:18.04
+
+FROM ubuntu:22.04
 RUN apt-get update
 RUN apt-get install -y curl
 ```
@@ -458,7 +460,8 @@ modify `apt-get install` by adding an extra package as shown in the following Do
 
 ```dockerfile
 # syntax=docker/dockerfile:1
-FROM ubuntu:18.04
+
+FROM ubuntu:22.04
 RUN apt-get update
 RUN apt-get install -y curl nginx
 ```
@@ -890,4 +893,3 @@ These Official Images have exemplary Dockerfiles:
 * [Guidelines for Creating Docker Official Images](../../docker-hub/official_images.md)
 * [Best practices to containerize Node.js web applications with Docker](https://snyk.io/blog/10-best-practices-to-containerize-nodejs-web-applications-with-docker){:target="_blank" rel="noopener" class="_"}
 * [More about Base Images](../../build/building/base-images.md)
-

--- a/engine/install/ubuntu.md
+++ b/engine/install/ubuntu.md
@@ -1,6 +1,6 @@
 ---
 description: Jumpstart your client-side server applications with Docker Engine on Ubuntu. This guide details prerequisites and multiple methods to install.
-keywords: docker install script, ubuntu docker server, ubuntu server docker, install docker engine ubuntu, install docker on ubuntu server, ubuntu 18.04 docker-ce, install docker engine on ubuntu, ubuntu install docker ce, ubuntu install docker engine
+keywords: docker install script, ubuntu docker server, ubuntu server docker, install docker engine ubuntu, install docker on ubuntu server, ubuntu 22.04 docker-ce, install docker engine on ubuntu, ubuntu install docker ce, ubuntu install docker engine
 redirect_from:
   - /ee/docker-ee/ubuntu/
   - /engine/installation/linux/docker-ce/ubuntu/
@@ -38,7 +38,6 @@ versions:
 - Ubuntu Kinetic 22.10
 - Ubuntu Jammy 22.04 (LTS)
 - Ubuntu Focal 20.04 (LTS)
-- Ubuntu Bionic 18.04 (LTS)
 
 Docker Engine is compatible with x86_64 (or amd64), armhf, arm64, and
 s390x architectures.

--- a/storage/storagedriver/index.md
+++ b/storage/storagedriver/index.md
@@ -39,7 +39,8 @@ read-only. Consider the following Dockerfile:
 
 ```dockerfile
 # syntax=docker/dockerfile:1
-FROM ubuntu:18.04
+
+FROM ubuntu:22.04
 LABEL org.opencontainers.image.authors="org@example.com"
 COPY . /app
 RUN make /app
@@ -48,7 +49,7 @@ CMD python /app/app.py
 ```
 
 This Dockerfile contains four commands. Commands that modify the filesystem create
-a layer. The `FROM` statement starts out by creating a layer from the `ubuntu:18.04`
+a layer. The `FROM` statement starts out by creating a layer from the `ubuntu:22.04`
 image. The `LABEL` command only modifies the image's metadata, and does not produce
 a new layer. The `COPY` command adds some files from your Docker client's current
 directory. The first `RUN` command builds your application using the `make` command,
@@ -157,14 +158,15 @@ usually `/var/lib/docker/` on Linux hosts. You can see these layers being pulled
 in this example:
 
 ```console
-$ docker pull ubuntu:18.04
-18.04: Pulling from library/ubuntu
+$ docker pull ubuntu:22.04
+22.04: Pulling from library/ubuntu
 f476d66f5408: Pull complete
 8882c27f669e: Pull complete
 d9af21273955: Pull complete
 f5029279ec12: Pull complete
-Digest: sha256:ab6cb8de3ad7bb33e2534677f865008535427390b117d7939193f8d1a6613e34
-Status: Downloaded newer image for ubuntu:18.04
+Digest: sha256:6120be6a2b7ce665d0cbddc3ce6eae60fe94637c6a66985312d1f02f63cc0bcd
+Status: Downloaded newer image for ubuntu:22.04
+docker.io/library/ubuntu:22.04
 ```
 
 Each of these layers is stored in its own directory inside the Docker host's


### PR DESCRIPTION
Ubuntu 18.04 LTS reached end of standard support. Expanded Security Maintenance
(ESM) is available, but requires a subscription, and we don't provide packages
for those.

- https://wiki.ubuntu.com/Releases
- https://ubuntu.com//blog/18-04-end-of-standard-support

Also removing Ubuntu 18.04 from examples in other places.

<!--
  Thank you for contributing to Docker documentation!

  Here are a few things to keep in mind:

  - Links between pages should use a relative path
  - Remember to add an alt text for images

  ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
  ┃     Review our contribution guidelines:       ┃
  ┃                                               ┃
  ┃ https://docs.docker.com/contribute/overview/  ┃
  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
-->

### Proposed changes

<!-- Tell us what you did and why -->

### Related issues (optional)

<!--
  Refer to related PRs or issues:

  #1234
  Closes #1234
  Closes docker/cli#1234
-->
