### PR TITLE
Proxy settings for multiple daemons are stored in config.json

### DIFF
--- a/network/proxy.md
+++ b/network/proxy.md
@@ -134,7 +134,7 @@ EOF
 
 ### Configure proxy settings per daemon
 
-The `default` key under `proxies` in `daemon.json` configures the proxy
+The `default` key under `proxies` in `~/.docker/config.json` configures the proxy
 settings for all daemons that the client connects to.
 To configure the proxies for individual daemons,
 use the address of the daemon instead of the `default` key.


### PR DESCRIPTION
Proxy settings for multiple daemons are stored in ~/.docker/config.json and not in daemon.json

### Proposed changes

The [daemon docs](https://docs.docker.com/config/daemon/) state that proxy configurations can not be done through `daemon.json`. I think the right place is `config.json` instead. 

In this PR I simply corrected `daemon.json` with `~/.docker/config.json` 

### Related issues (optional)
n/a
