### PR TITLE
Fix small typo on "Containerize an application" in "Start an app container" section

### DIFF
--- a/get-started/02_our_app.md
+++ b/get-started/02_our_app.md
@@ -124,7 +124,7 @@ Now that you have an image, you can run the application in a [container](../get-
    $ docker run -dp 127.0.0.1:3000:3000 getting-started
    ```
 
-   The `-d` flag (short for `--detached`) runs the container in the background.
+   The `-d` flag (short for `--detach`) runs the container in the background.
    The `-p` flag (short for `--publish`) creates a port mapping between the host and the container.
    The `-p` flag take a string value in the format of `HOST:CONTAINER`,
    where `HOST` is the address on the host, and `CONTAINER` is the port on the container.


### PR DESCRIPTION
The `-d` flag is (short for `--detach`). Not `--detached`.

<!--
  Thank you for contributing to Docker documentation!

  Here are a few things to keep in mind:

  - Links between pages should use a relative path
  - Remember to add an alt text for images

  ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
  ┃     Review our contribution guidelines:       ┃
  ┃                                               ┃
  ┃ https://docs.docker.com/contribute/overview/  ┃
  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
-->

### Proposed changes

<!-- Tell us what you did and why -->

### Related issues (optional)

<!--
  Refer to related PRs or issues:

  #1234
  Closes #1234
  Closes docker/cli#1234
-->
