### PR TITLE
desktop: remove BuildKit feature from daemon config

### DIFF
--- a/desktop/settings/linux.md
+++ b/desktop/settings/linux.md
@@ -136,10 +136,7 @@ You configure the daemon using a JSON configuration file. Here's what the file m
       "enabled": true
     }
   },
-  "experimental": false,
-  "features": {
-    "buildkit": true
-  }
+  "experimental": false
 }
 ```
 

--- a/desktop/settings/mac.md
+++ b/desktop/settings/mac.md
@@ -189,10 +189,7 @@ You configure the daemon using a JSON configuration file. Here's what the file m
       "enabled": true
     }
   },
-  "experimental": false,
-  "features": {
-    "buildkit": true
-  }
+  "experimental": false
 }
 ```
 

--- a/desktop/settings/windows.md
+++ b/desktop/settings/windows.md
@@ -223,10 +223,7 @@ You configure the daemon using a JSON configuration file. Here's what the file m
       "enabled": true
     }
   },
-  "experimental": false,
-  "features": {
-    "buildkit": true
-  }
+  "experimental": false
 }
 ```
 


### PR DESCRIPTION
<!--
  Thank you for contributing to Docker documentation!

  Here are a few things to keep in mind:

  - Links between pages should use a relative path
  - Remember to add an alt text for images

  ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
  ┃     Review our contribution guidelines:       ┃
  ┃                                               ┃
  ┃ https://docs.docker.com/contribute/overview/  ┃
  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
-->

### Proposed changes

This is a follow-up of a future change in Docker Desktop:

> 
> Since Docker 23, `docker build` command is forwarded to `docker buildx build` which always enables BuildKit. If user tries to set `buildkit` to `false` in the daemon config it will have no effect. Only setting the env var `DOCKER_BUILDKIT=0` client side makes it use the legacy builder when using the `docker build` command.
> 
> So better to remove the BuildKit feature from the daemon config to avoid any confusion.

### Related issues (optional)

* https://github.com/docker/for-win/issues/13548