### PR TITLE
Compose note

### DIFF
--- a/compose/compose-file/index.md
+++ b/compose/compose-file/index.md
@@ -13,8 +13,6 @@ toc_min: 1
 > Find more information about the [key features and use cases of Docker Compose](../features-uses.md) or [try the get started guide](../gettingstarted.md).
 {: .tip}
 
-Use the following links to navigate key sections of the Compose Specification. 
-
 The [Compose Specification](https://github.com/compose-spec/compose-spec/blob/master/spec.md) is the latest and recommended version of the Compose file format. It helps you define a [Compose file](03-compose-file.md) which is used to configure your Docker application’s services, networks, volumes, and more.
 
 Legacy versions 2.x and 3.x of the Compose file format were merged into the Compose Specification. It is  implemented in versions 1.27.0 and above (also known as Compose V2) of the Docker Compose CLI.
@@ -26,6 +24,7 @@ Legacy versions 2.x and 3.x of the Compose file format were merged into the Comp
 > Compose V2 is included with all currently supported versions of Docker Desktop.
 > For more information, see [Migrate to Compose V2](/compose/migrate).
 
+Use the following links to navigate key sections of the Compose Specification. 
 
 <div class="component-container">
   <!--start row-->

--- a/compose/compose-file/index.md
+++ b/compose/compose-file/index.md
@@ -9,9 +9,9 @@ toc_max: 4
 toc_min: 1
 ---
 
-Use a [Compose file](03-compose-file.md) to configure your Docker application’s services, networks, volumes, and more.
+The [Compose Specification](https://github.com/compose-spec/compose-spec/blob/master/spec.md) is the latest and recommended version of the Compose file format. It helps you define a [Compose file](03-compose-file.md) which is used to configure your Docker application’s services, networks, volumes, and more.
 
-The [Compose Specification](https://github.com/compose-spec/compose-spec/blob/master/spec.md) is the latest and recommended version of the Compose file format. It merges the legacy 2.x and 3.x versions and is implemented by Docker Compose CLI version 1.27.0.
+Legacy versions 2.x and 3.x of the Compose file format were merged into the Compose Specification. It was first implemented in version 1.27.0 of the Docker Compose CLI.
 
 Use the following links to navigate key sections of the Compose Specification. 
 

--- a/compose/compose-file/index.md
+++ b/compose/compose-file/index.md
@@ -14,8 +14,8 @@ The Compose file is a [YAML](https://yaml.org){: target="_blank" rel="noopener" 
 networks, and volumes for a Docker application. The latest and recommended
 version of the Compose file format is defined by the [Compose
 Specification](https://github.com/compose-spec/compose-spec/blob/master/spec.md){:
-target="_blank" rel="noopener" class="_"}. The Compose spec merges the legacy
-2.x and 3.x versions, aggregating properties across these formats and is implemented by **Compose 1.27.0+**.
+target="_blank" rel="noopener" class="_"}. The Compose Specification merges the legacy
+2.x and 3.x versions (also known as Compose V1), aggregating properties across these formats and is implemented by **Compose 1.27.0+**.
 
 Use the links below to navigate key sections of the Compose Specification. 
 

--- a/compose/compose-file/index.md
+++ b/compose/compose-file/index.md
@@ -8,16 +8,17 @@ title: Overview
 toc_max: 4
 toc_min: 1
 ---
-{% include compose-eol.md %}
 
-The Compose file is a [YAML](https://yaml.org){: target="_blank" rel="noopener" class="_"} file defining services,
-networks, and volumes for a Docker application. The latest and recommended
-version of the Compose file format is defined by the [Compose
-Specification](https://github.com/compose-spec/compose-spec/blob/master/spec.md){:
-target="_blank" rel="noopener" class="_"}. The Compose Specification merges the legacy
-2.x and 3.x versions (also known as Compose V1), aggregating properties across these formats and is implemented by **Compose 1.27.0+**.
+Use a [Compose file](03-compose-file.md) to configure your Docker application’s services, networks, volumes, and more.
 
-Use the links below to navigate key sections of the Compose Specification. 
+The [Compose Specification](https://github.com/compose-spec/compose-spec/blob/master/spec.md) is the latest and recommended version of the Compose file format. It merges the legacy 2.x and 3.x versions and is implemented by Docker Compose CLI version 1.27.0.
+
+Use the following links to navigate key sections of the Compose Specification. 
+
+>**New to Compose?**
+>
+> Find more information about the [key features and use cases of Docker Compose](../features-uses.md) or [try the get started guide](../gettingstarted.md).
+{: .tip}
 
 <div class="component-container">
   <!--start row-->

--- a/compose/compose-file/index.md
+++ b/compose/compose-file/index.md
@@ -8,17 +8,24 @@ title: Overview
 toc_max: 4
 toc_min: 1
 ---
-
-The [Compose Specification](https://github.com/compose-spec/compose-spec/blob/master/spec.md) is the latest and recommended version of the Compose file format. It helps you define a [Compose file](03-compose-file.md) which is used to configure your Docker application’s services, networks, volumes, and more.
-
-Legacy versions 2.x and 3.x of the Compose file format were merged into the Compose Specification. It was first implemented in version 1.27.0 of the Docker Compose CLI.
-
-Use the following links to navigate key sections of the Compose Specification. 
-
 >**New to Compose?**
 >
 > Find more information about the [key features and use cases of Docker Compose](../features-uses.md) or [try the get started guide](../gettingstarted.md).
 {: .tip}
+
+Use the following links to navigate key sections of the Compose Specification. 
+
+The [Compose Specification](https://github.com/compose-spec/compose-spec/blob/master/spec.md) is the latest and recommended version of the Compose file format. It helps you define a [Compose file](03-compose-file.md) which is used to configure your Docker application’s services, networks, volumes, and more.
+
+Legacy versions 2.x and 3.x of the Compose file format were merged into the Compose Specification. It is  implemented in versions 1.27.0 and above (also known as Compose V2) of the Docker Compose CLI.
+
+> **Note**
+>
+> Compose V1 no longer receives updates and will not be available in new releases of Docker Desktop after June 2023.
+>
+> Compose V2 is included with all currently supported versions of Docker Desktop.
+> For more information, see [Migrate to Compose V2](/compose/migrate).
+
 
 <div class="component-container">
   <!--start row-->


### PR DESCRIPTION
This PR makes the landing page for the compose spec a bit more user friendly - it tidies up the paragraph and moves the 'important' banner . It also adds a tip for beginners to direct them to better pages in the docs so they don't dive into the deep end with the spec
