### PR TITLE
Update nodejs langauge guide

### DIFF
--- a/language/nodejs/develop.md
+++ b/language/nodejs/develop.md
@@ -166,7 +166,7 @@ To start our application in debug mode, we need to add a line to our `package.js
 Open the `package.json` file and add the following line to the scripts section:
 
 ```json
-  "debug": "nodemon --inspect=0.0.0.0:9229 server.js"
+  "debug": "nodemon --inspect=0.0.0.0:9229 -L server.js"
 ```
 
 As you can see, we are going to use nodemon. Nodemon starts our server in debug mode and also watches for files that have changed, and restarts our server. Let’s run the following command in a terminal to install nodemon into our project directory.


### PR DESCRIPTION
### Proposed changes

Issue: In the develop section, nodemon may have issues seeing the changes.
Fix: Update nodemon command to use legacy-watch to poll rather than listen.

Issue: In the run tests section, mocha is not found.
Fix: Update Dockerfile to install dev dependencies.

### Related issues (optional)

Fixes #17591
Fixes https://dockercommunity.slack.com/archives/C2V58TASE/p1687979150080119
ENGDOCS-1483
