### PR TITLE
Define container portability more precisely

### DIFF
--- a/get-started/index.md
+++ b/get-started/index.md
@@ -75,7 +75,7 @@ features that have been in Linux for a long time. Docker has worked to make thes
 
 - Is a runnable instance of an image. You can create, start, stop, move, or delete a container using the DockerAPI or CLI.
 - Can be run on local machines, virtual machines or deployed to the cloud.
-- Is portable (can be run on any OS).
+- Is portable (can be transferred between computers of the same architecture and operating system).
 - Is isolated from other containers and runs its own software, binaries, and configurations.
 
 ## What is a container image?


### PR DESCRIPTION
<!--
  Thank you for contributing to Docker documentation!

  Here are a few things to keep in mind:

  - Links between pages should use a relative path
  - Remember to add an alt text for images

  ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
  ┃     Review our contribution guidelines:       ┃
  ┃                                               ┃
  ┃ https://docs.docker.com/contribute/overview/  ┃
  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
-->

### Proposed changes

The Docker docs overview page states that "[a container] Is portable (can be run on any OS)".
The detail "run on any OS" is not true due to the fact that containers run binary code that is constrained to execution on a specific operating system (mostly Linux, and Windows containers only run on Windows).

Furthermore, the portability of containers is constrained to CPU architectures.

I propose to correct the portability claim to detail the actual constraints of portability.

### Related issues (optional)

<!--
  Refer to related PRs or issues:

  #1234
  Closes #1234
  Closes docker/cli#1234
-->
