### PR TITLE
engine: add docs for host-gateway

### DIFF
--- a/_data/engine-cli/docker_build.yaml
+++ b/_data/engine-cli/docker_build.yaml
@@ -707,7 +707,17 @@ examples: |-
     more `--add-host` flags. This example adds a static address for a host named
     `docker`:
 
-        $ docker build --add-host=docker:10.180.0.1 .
+    ```console
+    $ docker build --add-host docker:10.180.0.1 .
+    ```
+
+    If you need your build to connect to services running on the host, you can use
+    the special `host-gateway` value for `--add-host`. In the following example,
+    build containers resolve `host.docker.internal` to the host's gateway IP.
+
+    ```console
+    $ docker build --add-host host.docker.internal:host-gateway .
+    ```
 
     ### Specifying target build stage (--target) {#target}
 

--- a/_data/engine-cli/docker_run.yaml
+++ b/_data/engine-cli/docker_run.yaml
@@ -1703,23 +1703,26 @@ examples: |-
     round-trip min/avg/max = 92.209/92.495/93.052 ms
     ```
 
-    Sometimes you need to connect to the Docker host from within your
-    container. To enable this, pass the Docker host's IP address to
-    the container using the `--add-host` flag. To find the host's address,
-    use the `ip addr show` command.
+    The `--add-host` flag supports a special `host-gateway` value that resolves to
+    the internal IP address of the host. This is useful when you want containers to
+    connect to services running on the host machine.
 
-    The flags you pass to `ip addr show` depend on whether you are
-    using IPv4 or IPv6 networking in your containers. Use the following
-    flags for IPv4 address retrieval for a network device named `eth0`:
+    It's conventional to use `host.docker.internal` as the hostname referring to
+    `host-gateway`. Docker Desktop automatically resolves this hostname, see
+    [Explore networking features](/desktop/networking/#i-want-to-connect-from-a-container-to-a-service-on-the-host).
+
+    The following example creates a simple HTTP server that serves a file from the
+    host to a container.
 
     ```console
-    $ HOSTIP=`ip -4 addr show scope global dev eth0 | grep inet | awk '{print $2}' | cut -d / -f 1 | sed -n 1p`
-    $ docker run  --add-host=docker:${HOSTIP} --rm -it debian
+    $ echo "hello from host!" > ./hello
+    $ python3 -m http.server 8000
+    Serving HTTP on 0.0.0.0 port 8000 (http://0.0.0.0:8000/) ...
+    $ docker run \
+      --add-host host.docker.internal:host-gateway \
+      curlimages/curl -s host.docker.internal:8000/hello
+    hello from host!
     ```
-
-    For IPv6 use the `-6` flag instead of the `-4` flag. For other network
-    devices, replace `eth0` with the correct device name (for example `docker0`
-    for the bridge device).
 
     ### Set ulimits in container (--ulimit) {#ulimit}
 

--- a/config/daemon/prometheus.md
+++ b/config/daemon/prometheus.md
@@ -57,22 +57,11 @@ Docker now exposes Prometheus-compatible metrics on port 9323.
 
 ## Configure and run Prometheus
 
-Prometheus runs as a Docker service on a Docker swarm.
+Prometheus runs as a Docker service on a Swarm.
 
-Copy one of the following configuration files and save it to
-`/tmp/prometheus.yml` (Linux or Mac) or `C:\tmp\prometheus.yml` (Windows). This
-is a stock Prometheus configuration file, except for the addition of the Docker
-job definition at the bottom of the file. Docker Desktop for Mac and Docker Desktop for Windows
-need a slightly different configuration.
-
-<ul class="nav nav-tabs">
-<li class="active"><a data-toggle="tab" data-target="#linux-config" data-group="linux">Docker for Linux</a></li>
-<li><a data-toggle="tab" data-target="#mac-config" data-group="mac">Docker Desktop for Mac</a></li>
-<li><a data-toggle="tab" data-target="#win-config" data-group="win">Docker Desktop for Windows</a></li>
-</ul>
-
-<div class="tab-content">
-<div id="linux-config" class="tab-pane fade in active" markdown="1">
+Copy the following configuration file and save it to a location of your choice,
+for example `/tmp/prometheus.yml`. This is a stock Prometheus configuration file,
+except for the addition of the Docker job definition at the bottom of the file.
 
 ```yml
 # my global config
@@ -101,47 +90,7 @@ scrape_configs:
     # scheme defaults to 'http'.
 
     static_configs:
-      - targets: ['localhost:9090']
-
-  - job_name: 'docker'
-         # metrics_path defaults to '/metrics'
-         # scheme defaults to 'http'.
-
-    static_configs:
-      - targets: ['localhost:9323']
-```
-
-</div><!-- linux -->
-<div id="mac-config" class="tab-pane fade" markdown="1">
-
-```yml
-# my global config
-global:
-  scrape_interval:     15s # Set the scrape interval to every 15 seconds. Default is every 1 minute.
-  evaluation_interval: 15s # Evaluate rules every 15 seconds. The default is every 1 minute.
-  # scrape_timeout is set to the global default (10s).
-
-  # Attach these labels to any time series or alerts when communicating with
-  # external systems (federation, remote storage, Alertmanager).
-  external_labels:
-      monitor: 'codelab-monitor'
-
-# Load rules once and periodically evaluate them according to the global 'evaluation_interval'.
-rule_files:
-  # - "first.rules"
-  # - "second.rules"
-
-# A scrape configuration containing exactly one endpoint to scrape:
-# Here it's Prometheus itself.
-scrape_configs:
-  # The job name is added as a label `job=<job_name>` to any timeseries scraped from this config.
-  - job_name: 'prometheus'
-
-    # metrics_path defaults to '/metrics'
-    # scheme defaults to 'http'.
-
-    static_configs:
-      - targets: ['host.docker.internal:9090'] # Only works on Docker Desktop for Mac
+      - targets: ['host.docker.internal:9090']
 
   - job_name: 'docker'
          # metrics_path defaults to '/metrics'
@@ -150,92 +99,27 @@ scrape_configs:
     static_configs:
       - targets: ['host.docker.internal:9323']
 ```
-
-</div><!-- mac -->
-<div id="win-config" class="tab-pane fade" markdown="1">
-
-```yml
-# my global config
-global:
-  scrape_interval:     15s # Set the scrape interval to every 15 seconds. Default is every 1 minute.
-  evaluation_interval: 15s # Evaluate rules every 15 seconds. The default is every 1 minute.
-  # scrape_timeout is set to the global default (10s).
-
-  # Attach these labels to any time series or alerts when communicating with
-  # external systems (federation, remote storage, Alertmanager).
-  external_labels:
-      monitor: 'codelab-monitor'
-
-# Load rules once and periodically evaluate them according to the global 'evaluation_interval'.
-rule_files:
-  # - "first.rules"
-  # - "second.rules"
-
-# A scrape configuration containing exactly one endpoint to scrape:
-# Here it's Prometheus itself.
-scrape_configs:
-  # The job name is added as a label `job=<job_name>` to any timeseries scraped from this config.
-  - job_name: 'prometheus'
-
-    # metrics_path defaults to '/metrics'
-    # scheme defaults to 'http'.
-
-    static_configs:
-      - targets: ['host.docker.internal:9090'] # Only works on Docker Desktop for Windows
-
-  - job_name: 'docker'
-         # metrics_path defaults to '/metrics'
-         # scheme defaults to 'http'.
-
-    static_configs:
-      - targets: ['host.docker.internal:9323']
-```
-
-</div><!-- windows -->
-</div><!-- tabs -->
-
 
 Next, start a single-replica Prometheus service using this configuration.
 
-<ul class="nav nav-tabs">
-<li class="active"><a data-toggle="tab" data-target="#linux-run" data-group="linux">Docker for Linux</a></li>
-<li><a data-toggle="tab" data-target="#mac-run" data-group="mac">Docker Desktop for Mac</a></li>
-<li><a data-toggle="tab" data-target="#win-run" data-group="win">Docker Desktop for Windows or Windows Server</a></li>
-</ul>
+- If you're using Docker Desktop, run:
 
-<div class="tab-content">
+  ```console
+  $ docker service create --replicas 1 --name my-prometheus \
+      --mount type=bind,source=/tmp/prometheus.yml,destination=/etc/prometheus/prometheus.yml \
+      --publish published=9090,target=9090,protocol=tcp \
+      prom/prometheus
+  ```
 
-<div id="linux-run" class="tab-pane fade in active" markdown="1">
+- If you're using Docker Engine without Docker Desktop, run:
 
-```console
-$ docker service create --replicas 1 --name my-prometheus \
-    --mount type=bind,source=/tmp/prometheus.yml,destination=/etc/prometheus/prometheus.yml \
-    --publish published=9090,target=9090,protocol=tcp \
-    prom/prometheus
-```
-
-</div><!-- linux -->
-<div id="mac-run" class="tab-pane fade" markdown="1">
-
-```console
-$ docker service create --replicas 1 --name my-prometheus \
-    --mount type=bind,source=/tmp/prometheus.yml,destination=/etc/prometheus/prometheus.yml \
-    --publish published=9090,target=9090,protocol=tcp \
-    prom/prometheus
-```
-
-</div><!-- mac -->
-<div id="win-run" class="tab-pane fade" markdown="1">
-
-```powershell
-PS C:\> docker service create --replicas 1 --name my-prometheus
-    --mount type=bind,source=C:/tmp/prometheus.yml,destination=/etc/prometheus/prometheus.yml
-    --publish published=9090,target=9090,protocol=tcp
-    prom/prometheus
-```
-
-</div><!-- windows -->
-</div><!-- tabs -->
+  ```console
+  $ docker service create --replicas 1 --name my-prometheus \
+      --mount type=bind,source=/tmp/prometheus.yml,destination=/etc/prometheus/prometheus.yml \
+      --publish published=9090,target=9090,protocol=tcp \
+      --add-host host.docker.internal:host-gateway \
+      prom/prometheus
+  ```
 
 Verify that the Docker target is listed at http://localhost:9090/targets/.
 

--- a/desktop/faqs/general.md
+++ b/desktop/faqs/general.md
@@ -96,7 +96,9 @@ For details, see [Docker Engine API](../../engine/api/index.md).
 
 ### How do I connect from a container to a service on the host?
 
-Mac, Linux, and Windows have a changing IP address (or none if you have no network access). On both Mac and Windows, we recommend that you connect to the special DNS name `host.docker.internal`, which resolves to the internal IP address used by the host. This is for development purposes and does not work in a production environment outside of Docker Desktop.
+The host has a changing IP address, or none if you have no network access.
+We recommend that you connect to the special DNS name `host.docker.internal`,
+which resolves to the internal IP address used by the host.
 
 For more information and examples, see [how to connect from a container to a service on the host](../networking.md#i-want-to-connect-from-a-container-to-a-service-on-the-host).
 

--- a/desktop/networking.md
+++ b/desktop/networking.md
@@ -108,9 +108,9 @@ However if you are a Windows user, it works with Windows containers.
 
 ### I want to connect from a container to a service on the host
 
-The host has a changing IP address, or none if you have no network access. We recommend that you connect to the special DNS name
-`host.docker.internal` which resolves to the internal IP address used by the
-host. This is for development purpose and does not work in a production environment outside of Docker Desktop.
+The host has a changing IP address, or none if you have no network access.
+We recommend that you connect to the special DNS name `host.docker.internal`,
+which resolves to the internal IP address used by the host.
 
 You can also reach the gateway using `gateway.docker.internal`.
 


### PR DESCRIPTION
- engine/desktop: update references to host.docker.internal
- engine(cli): regenerate --add-host flag reference

<!--
  Thank you for contributing to Docker documentation!

  Here are a few things to keep in mind:

  - Links between pages should use a relative path
  - Remember to add an alt text for images

  ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
  ┃     Review our contribution guidelines:       ┃
  ┃                                               ┃
  ┃ https://docs.docker.com/contribute/overview/  ┃
  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
-->

### Proposed changes

Adds documentation for `host-gateway` with `--add-host`.

### Related issues (optional)

docker/cli#4399
Closes #17597
