### PR TITLE
Correct capitalzation and pluralization of GitHub Actions in `ci.md`

### DIFF
--- a/scout/ci.md
+++ b/scout/ci.md
@@ -22,7 +22,7 @@ First, set up the rest of the workflow. There's a lot that's not specific to Doc
 Scout but needed to create the images to compare. For more details on those actions and using GitHub Actions 
 with Docker in general, see [the GitHub Actions documentation](../build/ci/github-actions/index.md).
 
-Add the following to a GitHub action YAML file:
+Add the following to a GitHub Actions YAML file:
 
 {% raw %}
 ```yaml


### PR DESCRIPTION
### Proposed changes

This PR corrects a small typo in the name of the CI system "GitHub Actions".

### Related issues (optional)

None.