### PR TITLE
fix for advanced frontend extension example

### DIFF
--- a/desktop/extensions-sdk/build/frontend-extension-tutorial.md
+++ b/desktop/extensions-sdk/build/frontend-extension-tutorial.md
@@ -177,7 +177,7 @@ Now that you have configured the extension, you need to build the extension imag
 install it.
 
 ```bash
-docker build --tag= awesome-inc/my-extension:latest .
+docker build --tag=awesome-inc/my-extension:latest .
 ```
 
 This built an image tagged `awesome-inc/my-extension:latest`, you can run `docker inspect
@@ -365,7 +365,7 @@ If your extension uses `localStorage` to store data, other extensions running in
 Since you have modified the code of the extension, you must build again the extension.
 
 ```console
-$ docker build --tag= awesome-inc/my-extension:latest .
+$ docker build --tag=awesome-inc/my-extension:latest .
 ```
 
 Once built, you need to update it.


### PR DESCRIPTION
### Proposed changes

Quick fix for issue reported by James Spurin:

> For the extension team, space in the example here which breaks it, [link](https://docs.docker.com/desktop/extensions-sdk/build/frontend-extension-tutorial/) for convenience.

![image](https://github.com/docker/docs/assets/108835138/08d71731-540c-4e7d-93e0-d39e4aa818a1)
