### PR TITLE
engine: update gpg keyrings location for ubuntu/debian

### DIFF
--- a/engine/install/debian.md
+++ b/engine/install/debian.md
@@ -106,16 +106,15 @@ Docker from the repository.
 2.  Add Docker's official GPG key:
 
     ```console
-    $ sudo install -m 0755 -d /etc/apt/keyrings
-    $ curl -fsSL {{ download-url-base }}/gpg | sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg
-    $ sudo chmod a+r /etc/apt/keyrings/docker.gpg
+    $ curl -fsSL {{ download-url-base }}/gpg | sudo gpg --dearmor -o /usr/share/keyrings/docker.gpg
+    $ sudo chmod a+r /usr/share/keyrings/docker.gpg
     ```
 
 3.  Use the following command to set up the repository:
 
     ```console
     $ echo \
-      "deb [arch="$(dpkg --print-architecture)" signed-by=/etc/apt/keyrings/docker.gpg] {{ download-url-base }} \
+      "deb [arch="$(dpkg --print-architecture)" signed-by=/usr/share/keyrings/docker.gpg] {{ download-url-base }} \
       "$(. /etc/os-release && echo "$VERSION_CODENAME")" stable" | \
       sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
     ```

--- a/engine/install/raspbian.md
+++ b/engine/install/raspbian.md
@@ -105,16 +105,15 @@ Docker from the repository.
 2.  Add Docker's official GPG key:
 
     ```console
-    $ sudo install -m 0755 -d /etc/apt/keyrings
-    $ curl -fsSL {{ download-url-base }}/gpg | sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg
-    $ sudo chmod a+r /etc/apt/keyrings/docker.gpg
+    $ curl -fsSL {{ download-url-base }}/gpg | sudo gpg --dearmor -o /usr/share/keyrings/docker.gpg
+    $ sudo chmod a+r /usr/share/keyrings/docker.gpg
     ```
 
 3.  Use the following command to set up the repository:
 
     ```console
     $ echo \
-      "deb [arch="$(dpkg --print-architecture)" signed-by=/etc/apt/keyrings/docker.gpg] {{ download-url-base }} \
+      "deb [arch="$(dpkg --print-architecture)" signed-by=/usr/share/keyrings/docker.gpg] {{ download-url-base }} \
       "$(. /etc/os-release && echo "$VERSION_CODENAME")" stable" | \
       sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
     ```

--- a/engine/install/ubuntu.md
+++ b/engine/install/ubuntu.md
@@ -113,16 +113,15 @@ Docker from the repository.
 2.  Add Docker's official GPG key:
 
     ```console
-    $ sudo install -m 0755 -d /etc/apt/keyrings
-    $ curl -fsSL {{ download-url-base }}/gpg | sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg
-    $ sudo chmod a+r /etc/apt/keyrings/docker.gpg
+    $ curl -fsSL {{ download-url-base }}/gpg | sudo gpg --dearmor -o /usr/share/keyrings/docker.gpg
+    $ sudo chmod a+r /usr/share/keyrings/docker.gpg
     ```
 
 3.  Use the following command to set up the repository:
 
     ```console
     $ echo \
-      "deb [arch="$(dpkg --print-architecture)" signed-by=/etc/apt/keyrings/docker.gpg] {{ download-url-base }} \
+      "deb [arch="$(dpkg --print-architecture)" signed-by=/usr/share/keyrings/docker.gpg] {{ download-url-base }} \
       "$(. /etc/os-release && echo "$VERSION_CODENAME")" stable" | \
       sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
     ```


### PR DESCRIPTION
Signed-off-by: David Karlsson <35727626+dvdksn@users.noreply.github.com>

<!--
  Thank you for contributing to Docker documentation!

  Here are a few things to keep in mind:

  - Links between pages should use a relative path
  - Remember to add an alt text for images

  ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
  ┃     Review our contribution guidelines:       ┃
  ┃                                               ┃
  ┃ https://docs.docker.com/contribute/overview/  ┃
  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
-->

### Proposed changes

- Changes the GPG keyrings location from `/etc/apt/keyrings` to `/usr/share/keyrings`
- Removes the `install` command since `/usr/share/keyrings` already exists by default

### Related issues (optional)

Closes #17471
