### PR TITLE
fix: remove references to openjdk doi

### DIFF
--- a/build/cache/index.md
+++ b/build/cache/index.md
@@ -201,7 +201,7 @@ layers to a minimum.
 
 Docker provides over 170 pre-built [official images](https://hub.docker.com/search?q=&image_filter=official){:target="blank" rel="noopener" class=""}
 for almost every common development scenario. For example, if you're building a
-Java web server, use a dedicated image such as [`openjdk`](https://hub.docker.com/_/openjdk/){:target="blank" rel="noopener" class=""}.
+Java web server, use a dedicated image such as [`eclipse-temurin`](https://hub.docker.com/_/eclipse-temurin/){:target="blank" rel="noopener" class=""}.
 Even when there's not an official image for what you might want, Docker provides
 images from [verified publishers](https://hub.docker.com/search?q=&image_filter=store){:target="blank" rel="noopener" class=""}
 and [open source partners](https://hub.docker.com/search?q=&image_filter=open_source){:target="blank" rel="noopener" class=""}

--- a/develop/dev-best-practices.md
+++ b/develop/dev-best-practices.md
@@ -16,9 +16,8 @@ memory when starting containers or services. There are a few rules of thumb to
 keep image size small:
 
 - Start with an appropriate base image. For instance, if you need a JDK,
-  consider basing your image on the official `openjdk` image, rather than
-  starting with a generic `ubuntu` image and installing `openjdk` as part of the
-  Dockerfile.
+  consider basing your image on a Docker Official Image which includes OpenJDK,
+  such as `eclipse-temurin`, rather than building your own image from scratch.
 
 - [Use multistage builds](../build/building/multi-stage.md). For
   instance, you can use the `maven` image to build your Java application, then


### PR DESCRIPTION
Signed-off-by: David Karlsson <35727626+dvdksn@users.noreply.github.com>

<!--
  Thank you for contributing to Docker documentation!

  Here are a few things to keep in mind:

  - Links between pages should use a relative path
  - Remember to add an alt text for images

  ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
  ┃     Review our contribution guidelines:       ┃
  ┃                                               ┃
  ┃ https://docs.docker.com/contribute/overview/  ┃
  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
-->

### Proposed changes

Removes references to the deprecated `openjdk` DOI, replaces with `eclipse-temurin`

See https://github.com/docker-library/docs/blob/master/openjdk/README.md#deprecation-notice

### Related issues (optional)

Closes #17500
