### PR TITLE
Fix typo in create company docs

### DIFF
--- a/docker-hub/new-company.md
+++ b/docker-hub/new-company.md
@@ -21,7 +21,7 @@ To create a new company:
 > You must be a company owner to add an organization to a company.
 {: .important}
 
-There is no limit to the number of organizations you can have under a company layer. All organizations must have Business subscription.
+There is no limit to the number of organizations you can have under a company layer. All organizations must have a Business subscription.
 
 1. In Docker Hub, select **Organizations**.
 2. Select your company.


### PR DESCRIPTION
<!--
  Thank you for contributing to Docker documentation!

  Here are a few things to keep in mind:

  - Links between pages should use a relative path
  - Remember to add an alt text for images

  ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
  ┃     Review our contribution guidelines:       ┃
  ┃                                               ┃
  ┃ https://docs.docker.com/contribute/overview/  ┃
  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
-->

### Proposed changes

This PR fixes a tiny typo in the **Create a company** page to be consistent with the updated section based on this docs that is found in the Docker admin docs #17640 

### Related issues (optional)

<!--
  Refer to related PRs or issues:

  #1234
  Closes #1234
  Closes docker/cli#1234
-->
See proposed changes

@netlify /docker-hub/new-company/