### PR TITLE
Remove references to Amazon linux

### DIFF
--- a/docker-hub/builds/advanced.md
+++ b/docker-hub/builds/advanced.md
@@ -68,10 +68,10 @@ repository at the same directory level as your Dockerfile. Create a file called
 builder process can execute, such as `docker` and `bash` commands (prefixed
 appropriately with `#!/bin/bash`).
 
-These hooks run on an instance of [Amazon Linux 2](https://aws.amazon.com/amazon-linux-2/){:target="_blank" rel="noopener" class="_"},
-a distro based on Red Hat Enterprise Linux (RHEL), which includes interpreters
+These hooks run on an instance of [Ubuntu](https://releases.ubuntu.com/){:target="_blank" rel="noopener" class="_"},
+which includes interpreters
 such as Perl or Python, and utilities such as `git` or `curl`. Refer to the
-[Amazon Linux 2 documentation](https://aws.amazon.com/amazon-linux-2/faqs/){:target="_blank" rel="noopener" class="_"}
+[Ubuntu documentation](https://ubuntu.com/){:target="_blank" rel="noopener" class="_"}
 for the full list of available interpreters and utilities.
 
 ## Custom build phase hooks


### PR DESCRIPTION
Docs incorrectly state that build hooks run on Amazon Linux. This PR fixes this issue and reinstates that hooks run on Ubuntu.