### PR TITLE
Remove Fedora 36 as it's EOL

### DIFF
--- a/engine/install/fedora.md
+++ b/engine/install/fedora.md
@@ -21,7 +21,6 @@ To get started with Docker Engine on Fedora, make sure you
 To install Docker Engine, you need a maintained version of one of the following
 Fedora versions:
 
-- Fedora 36
 - Fedora 37
 - Fedora 38
 


### PR DESCRIPTION
### Proposed changes
It was already removed from the docker-ce-packaging: https://github.com/docker/docker-ce-packaging/pull/894

### Related issues (optional)


<!--
  Refer to related PRs or issues:

  #1234
  Closes #1234
  Closes docker/cli#1234
-->
