### PR TITLE
docs: fix typos

### DIFF
--- a/_includes/landing-page/docker-pricing.html
+++ b/_includes/landing-page/docker-pricing.html
@@ -6,7 +6,7 @@
           Docker updates subscription model to deliver scale, speed, and security
         </h2>
         <h5>
-        The updated Docker subscription tiers deliver the productivity and collaboration developers rely on, paired with the security and trust businesses demand. Docker subscription tiers now include Personal, Pro, Team, and Buisness.
+        The updated Docker subscription tiers deliver the productivity and collaboration developers rely on, paired with the security and trust businesses demand. Docker subscription tiers now include Personal, Pro, Team, and Business.
         </h5>
       </div>
       <div class="col-xs-12 col-md-6 col-lg-4 text-center">

--- a/billing/details.md
+++ b/billing/details.md
@@ -6,7 +6,7 @@ keywords: payments, billing, subscription
 
 Find information on how to update the billing information for your personal account or for an organization. 
 
-The billing information provided appears on all your billing invoices. The email address provided is where Docker sends all invoices and other billing-related communication. For more information on the billing emails you recieve, see [FAQs](faqs.md#what-billing-related-emails-will-i-receive-from-docker-hub)
+The billing information provided appears on all your billing invoices. The email address provided is where Docker sends all invoices and other billing-related communication. For more information on the billing emails you receive, see [FAQs](faqs.md#what-billing-related-emails-will-i-receive-from-docker-hub)
 
 ## Personal account
 

--- a/compose/release-notes.md
+++ b/compose/release-notes.md
@@ -812,7 +812,7 @@ For the full change log or additional information, check the [Compose repository
 - Fixed typo in `--ssh` flag description. Related to [#7025](https://github.com/docker/compose/issues/7025){:target="_blank" rel="noopener" class="_"}.
 - Pinned Kubernetes dependencies to the same version as in buildx.
 - Passed the interactive flag from the Compose CLI to the Docker one to run exec command.
-- Fixed race condition on start-stop end-to-end tests running in parrallel.
+- Fixed race condition on start-stop end-to-end tests running in parallel.
 - Removed code regarding an obsolete warning.
 - Vendor: github.com/containerd/containerd v1.6.2. Includes a fix for CVE-2022-24769 (doesn't affect our codebase).
 

--- a/desktop/hardened-desktop/registry-access-management.md
+++ b/desktop/hardened-desktop/registry-access-management.md
@@ -1,6 +1,6 @@
 ---
 description: What Registry Access Management is and how to use it
-keywords: registry access managment, Hardened Docker Desktop, Docker Desktop, images, Docker Hub
+keywords: registry access management, Hardened Docker Desktop, Docker Desktop, images, Docker Hub
 title: Registry Access Management
 redirect_from: 
 - /docker-hub/registry-access-management/

--- a/desktop/previous-versions/archive-windows.md
+++ b/desktop/previous-versions/archive-windows.md
@@ -138,7 +138,7 @@ This page contains release notes for older versions of Docker Desktop for Window
 * Bug fixes and minor changes
   - Fix Windows Containers port forwarding on Windows 10 build 16299 post KB4074588. Fixes [docker/for-win#1707](https://github.com/docker/for-win/issues/1707), [docker/for-win#1737](https://github.com/docker/for-win/issues/1737)
   - Fix daemon not starting properly when setting TLS-related options.
-  - DNS name `host.docker.internal` shoud be used for host resolution from containers. Older aliases (still valid) are deprecated in favor of this one. (See https://tools.ietf.org/html/draft-west-let-localhost-be-localhost-06).
+  - DNS name `host.docker.internal` should be used for host resolution from containers. Older aliases (still valid) are deprecated in favor of this one. (See https://tools.ietf.org/html/draft-west-let-localhost-be-localhost-06).
   - Fix for the HTTP/S transparent proxy when using "localhost" names (for example, `host.docker.internal`). Fixes [docker/for-win#1130](https://github.com/docker/for-win/issues/1130)
   - Fix Linuxkit start on Windows RS4 Insider. Fixes [docker/for-win#1458](https://github.com/docker/for-win/issues/1458), [docker/for-win#1514](https://github.com/docker/for-win/issues/1514), [docker/for-win#1640](https://github.com/docker/for-win/issues/1640)
   - Fix risk of privilege escalation. (https://www.tenable.com/sc-report-templates/microsoft-windows-unquoted-service-path-vulnerability)

--- a/desktop/previous-versions/edge-releases-windows.md
+++ b/desktop/previous-versions/edge-releases-windows.md
@@ -1321,7 +1321,7 @@ This release contains a Kubernetes upgrade. Note that your local Kubernetes clus
   - Allow users to activate Windows container during installation (avoid vm disk creation and vm boot when working only on win containers). See [docker/for-win#217](https://github.com/docker/for-win/issues/217).
 
 * Bug fixes and minor changes
-  - DNS name `host.docker.internal` shoud be used for host resolution from containers. Older aliases (still valid) are deprecated in favor of this one. (See https://tools.ietf.org/html/draft-west-let-localhost-be-localhost-06).
+  - DNS name `host.docker.internal` should be used for host resolution from containers. Older aliases (still valid) are deprecated in favor of this one. (See https://tools.ietf.org/html/draft-west-let-localhost-be-localhost-06).
   - Fix Linuxkit start on Windows Insider. Fixes [docker/for-win#1458](https://github.com/docker/for-win/issues/1458), [docker/for-win#1514](https://github.com/docker/for-win/issues/1514), [docker/for-win#1640](https://github.com/docker/for-win/issues/1640)
   - Fix risk of privilege escalation. (https://www.tenable.com/sc-report-templates/microsoft-windows-unquoted-service-path-vulnerability)
   - All users present in the docker-users group are now able to use docker. Fixes [docker/for-win#1732](https://github.com/docker/for-win/issues/1732)

--- a/desktop/troubleshoot/topics.md
+++ b/desktop/troubleshoot/topics.md
@@ -201,7 +201,7 @@ $ docker run --rm -ti -v /$(pwd):/work alpine
 ```
 
 Portability of the scripts is not affected as Linux treats multiple `/` as a single entry.
-Each occurence of paths on a single line must be neutralized.
+Each occurrence of paths on a single line must be neutralized.
 
 ```console
 $ docker run --rm -ti -v /$(pwd):/work alpine ls /work
@@ -278,7 +278,7 @@ To enable nested virtualisation, see [Run Docker Desktop for Windows in a VM or 
 If you have completed the steps described above and are still experiencing
 Docker Desktop startup issues, this could be because the Hypervisor is installed,
 but not launched during Windows startup. Some tools (such as older versions of 
-Virtual Box) and video game installers disable hypervisor on boot. To reenable it:
+Virtual Box) and video game installers disable hypervisor on boot. To re-enable it:
 
 1. Open an administrative console prompt.
 2. Run `bcdedit /set hypervisorlaunchtype auto`.

--- a/engine/release-notes/23.0.md
+++ b/engine/release-notes/23.0.md
@@ -190,7 +190,7 @@ For a full list of pull requests and changes in this release, refer to the relev
 - Fix an issue where `ipvlan` networks created prior to upgrading would prevent the daemon from starting. [moby/moby#44937](https://github.com/moby/moby/pull/44937)
 - Fix the `overlay2` storage driver failing early in `metacopy` testing when initialized on an unsupported backing filesystem. [moby/moby#44922](https://github.com/moby/moby/pull/44922)
 - Fix `exec` exit events being misinterpreted as container exits under some runtimes, such as Kata Containers. [moby/moby#44892](https://github.com/moby/moby/pull/44892)
-- Improve the error message returned by the CLI when recieving a truncated JSON response caused by the API hanging up mid-request. [docker/cli#4004](https://github.com/docker/cli/pull/4004)
+- Improve the error message returned by the CLI when receiving a truncated JSON response caused by the API hanging up mid-request. [docker/cli#4004](https://github.com/docker/cli/pull/4004)
 - Fix an incorrect CLI exit code when attempting to execute a directory with a `runc` compiled using Go 1.20. [docker/cli#4004](https://github.com/docker/cli/pull/4004)
 - Fix mishandling the size argument to `--device-write-bps` as a path. [docker/cli#4004](https://github.com/docker/cli/pull/4004)
 

--- a/engine/release-notes/24.0.md
+++ b/engine/release-notes/24.0.md
@@ -61,7 +61,7 @@ For a full list of pull requests and changes in this release, refer to the relev
 * Fix running containers restoring with a zero (successful) exit status when the daemon is unexpectedly terminated. [moby/moby#45801](https://github.com/moby/moby/pull/45801)
 * Fix a potential panic while executing healthcheck probes. [moby/moby#45798](https://github.com/moby/moby/pull/45798)
 * Fix a panic caused by a race condition in container exec start. [moby/moby#45794](https://github.com/moby/moby/pull/45794)
-* Fix an exception caused by attaching a terminal to an exec with a non-existant command. [moby/moby#45643](https://github.com/moby/moby/pull/45643)
+* Fix an exception caused by attaching a terminal to an exec with a non-existent command. [moby/moby#45643](https://github.com/moby/moby/pull/45643)
 * Fix `host-gateway` with BuildKit by passing the IP as a label (also requires [docker/buildx#1894](https://github.com/docker/buildx/pull/1894)). [moby/moby#45790](https://github.com/moby/moby/pull/45790)
 * Fix an issue where `POST /containers/{id}/stop` would forcefully terminate the container when the request was canceled, instead of waiting until the specified timeout for a 'graceful' stop. [moby/moby#45774](https://github.com/moby/moby/pull/45774)
 * Fix an issue where `docker cp -a` from the root (`/`) directory would fail. [moby/moby#45748](https://github.com/moby/moby/pull/45748)

--- a/engine/release-notes/prior-releases.md
+++ b/engine/release-notes/prior-releases.md
@@ -2705,7 +2705,7 @@ With the ongoing changes to the networking and execution subsystems of docker te
 - Replace deprecated upgrading reference to docker-latest.tgz, which hasn't been updated since 0.5.3
 * Update Gentoo installation documentation now that we're in the portage tree proper
 * Cleanup and reorganize docs and tooling for contributors and maintainers
-- Minor spelling correction of protocoll -> protocol
+- Minor spelling correction of protocol -> protocol
 
 ### Contrib
 

--- a/engine/release-notes/prior-releases.md
+++ b/engine/release-notes/prior-releases.md
@@ -2705,7 +2705,7 @@ With the ongoing changes to the networking and execution subsystems of docker te
 - Replace deprecated upgrading reference to docker-latest.tgz, which hasn't been updated since 0.5.3
 * Update Gentoo installation documentation now that we're in the portage tree proper
 * Cleanup and reorganize docs and tooling for contributors and maintainers
-- Minor spelling correction of protocol -> protocol
+- Minor spelling correction of protocoll -> protocol
 
 ### Contrib
 

--- a/get-started/06_bind_mounts.md
+++ b/get-started/06_bind_mounts.md
@@ -113,7 +113,7 @@ work.
    │ ├── Dockerfile
    │ ├── myfile.txt
    │ ├── node_modules/
-   │ ├── pacakge.json
+   │ ├── package.json
    │ ├── spec/
    │ ├── src/
    │ └── yarn.lock

--- a/language/java/run-tests.md
+++ b/language/java/run-tests.md
@@ -140,7 +140,7 @@ $ docker build -t java-docker --target test .
 => => naming to docker.io/library/java-docker
 ```
 
-The build output is truncated for simplicity, but you can see that our tests ran succesfully and passed. Let’s break one of the tests and observe the output when our tests fail.
+The build output is truncated for simplicity, but you can see that our tests ran successfully and passed. Let’s break one of the tests and observe the output when our tests fail.
 
 Open the `src/test/java/org/springframework/samples/petclinic/model/ValidatorTests.java` file and change the assertion 
 

--- a/language/nodejs/build-images.md
+++ b/language/nodejs/build-images.md
@@ -135,7 +135,7 @@ Before we can run `npm install`, we need to get our `package.json` and `package-
  COPY ["<src>", "<dest>"]
  ```
 
-You can specify multiple `src` resources seperated by a comma. For example, `COPY ["<src1>", "<src2>",..., "<dest>"]`.
+You can specify multiple `src` resources separated by a comma. For example, `COPY ["<src1>", "<src2>",..., "<dest>"]`.
 We’ll copy the `package.json` and the `package-lock.json` file into our working directory `/app`.
 
 ```dockerfile


### PR DESCRIPTION
Hey :wave:,

This PR will fix :

1 typo in `_includes/landing-page/docker-pricing.html`
1 typo in `billing/details.md`
1 typo in `compose/release-notes.md`
1 typo in `desktop/hardened-desktop/registry-access-management.md`
1 typo in `desktop/previous-versions/archive-windows.md`
1 typo in `desktop/previous-versions/edge-releases-windows.md`
2 typos in `desktop/troubleshoot/topics.md`
1 typo in `engine/release-notes/23.0.md`
1 typo in `engine/release-notes/24.0.md`
1 typo in `engine/release-notes/prior-releases.md`
1 typo in `get-started/06_bind_mounts.md`
1 typo in `language/java/run-tests.md`
1 typo in `language/nodejs/build-images.md`


Best!