### PR TITLE
registry: remove protocol from insecure-registries config

### DIFF
--- a/registry/insecure.md
+++ b/registry/insecure.md
@@ -33,7 +33,7 @@ isolated testing or in a tightly controlled, air-gapped environment.
 
     ```json
     {
-      "insecure-registries" : ["http://myregistrydomain.com:5000"]
+      "insecure-registries" : ["myregistrydomain.com:5000"]
     }
     ```
 


### PR DESCRIPTION
Using a protocol here is meaningless, and is ignored by the daemon (and will even produce a warning in the logs).

Code reference for the curious: https://github.com/moby/moby/blob/75d7e053dc9496a0b6d653c25f470453f230753b/registry/config.go#L199-L207

<!--
  Thank you for contributing to Docker documentation!

  Here are a few things to keep in mind:

  - Links between pages should use a relative path
  - Remember to add an alt text for images

  ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
  ┃     Review our contribution guidelines:       ┃
  ┃                                               ┃
  ┃ https://docs.docker.com/contribute/overview/  ┃
  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
-->

### Proposed changes

<!-- Tell us what you did and why -->

### Related issues (optional)

- https://github.com/docker/buildx/issues/1642
- https://github.com/moby/moby/pull/29988
