### PR TITLE
Fix typo for repeating word in SSO overview

### DIFF
--- a/_includes/admin-sso.md
+++ b/_includes/admin-sso.md
@@ -24,7 +24,7 @@ The following diagram shows how SSO operates and is managed in Docker Hub and Do
 
 Before enabling SSO in Docker, administrators must first configure their IdP to work with Docker. Docker provides the Assertion Consumer Service (ACS) URL and the Entity ID. Administrators use this information to establish a connection between their IdP server and Docker Hub.
 
-After establishing the connection between the IdP server and Docker, administrators sign in to Docker {{ product_name }} and complete the SSO enablement process.
+After establishing the connection between the IdP server and Docker, administrators sign in to {{ product_name }} and complete the SSO enablement process.
 
 When you enable SSO for your company, a first-time user can sign in to Docker Hub using their company's domain email address. They're then added to your company and assigned to the company team in the organization.
 


### PR DESCRIPTION
<!--
  Thank you for contributing to Docker documentation!

  Here are a few things to keep in mind:

  - Links between pages should use a relative path
  - Remember to add an alt text for images

  ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
  ┃     Review our contribution guidelines:       ┃
  ┃                                               ┃
  ┃ https://docs.docker.com/contribute/overview/  ┃
  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
-->

### Proposed changes

Fix for a small typo in the SSO overview section of a repeating word with the new approach to using templates for admin docs.

Deploy previews:
- [SSO overview](https://deploy-preview-17769--docsdocker.netlify.app/single-sign-on/)
- [Admin company SSO overview](https://deploy-preview-17769--docsdocker.netlify.app/admin/company/settings/sso/)
- [Admin org SSO overview](https://deploy-preview-17769--docsdocker.netlify.app/admin/organization/security-settings/sso/)

### Related issues (optional)

<!--
  Refer to related PRs or issues:

  #1234
  Closes #1234
  Closes docker/cli#1234
-->

N/A
