### PR TITLE
get-started: move app repo

### DIFF
--- a/get-started/02_our_app.md
+++ b/get-started/02_our_app.md
@@ -24,22 +24,28 @@ To complete this guide, you'll need the following:
 
 Before you can run the application, you need to get the application source code onto your machine.
 
-1. Clone the [getting-started repository](https://github.com/docker/getting-started/tree/master){:target="_blank" rel="noopener" class="_"} using the following command:
+1. Clone the [getting-started-app repository](https://github.com/docker/getting-started-app/tree/main){:target="_blank" rel="noopener" class="_"} using the following command:
 
    ```console
-   $ git clone https://github.com/docker/getting-started.git
+   $ git clone https://github.com/docker/getting-started-app.git
    ```
 
-2. View the contents of the cloned repository. Inside the `getting-started/app` directory you should see `package.json` and two subdirectories (`src` and `spec`).
+2. View the contents of the cloned repository. You should see the following files and subdirectories.
 
-    ![Screenshot of Visual Studio Code opened with the app loaded](images/ide-screenshot.png){: style="width:650px;margin-top:20px;"}
-    {: .text-center }
+   ```
+   ├── getting-started-app/
+   │ ├── pacakge.json
+   │ ├── README.md
+   │ ├── spec/
+   │ ├── src/
+   │ └── yarn.lock
+   ```
 
 ## Build the app's container image
 
 To build the [container image](../get-started/overview.md/#docker-objects){:target="_blank" rel="noopener" class="_"}, you'll need to use a `Dockerfile`. A Dockerfile is simply a text-based file with no file extension that contains a script of instructions. Docker uses this script to build a container image.
 
-1. In the `app` directory, the same location as the `package.json` file, create a file named `Dockerfile`. You can use the following commands below to create a Dockerfile based on your operating system.
+1. In the `getting-started-app` directory, the same location as the `package.json` file, create a file named `Dockerfile`. You can use the following commands below to create a Dockerfile based on your operating system.
 
    <ul class="nav nav-tabs">
      <li class="active"><a data-toggle="tab" data-target="#mac-linux">Mac / Linux</a></li>
@@ -50,9 +56,9 @@ To build the [container image](../get-started/overview.md/#docker-objects){:targ
 
     In the terminal, run the following commands listed below.
 
-    Change directory to the `app` directory. Replace `/path/to/app` with the path to your `getting-started/app` directory.
+    Change directory to the `getting-started-app` directory. Replace `/path/to/getting-started-app` with the path to your `getting-started-app` directory.
     ```console
-    $ cd /path/to/app
+    $ cd /path/to/getting-started-app
     ```
     Create an empty file named `Dockerfile`.
     ```console
@@ -65,9 +71,9 @@ To build the [container image](../get-started/overview.md/#docker-objects){:targ
 
     In the Windows Command Prompt, run the following commands listed below.
 
-    Change directory to the `app` directory. Replace `\path\to\app` with the path to your `getting-started\app` directory.
+    Change directory to the `getting-started-app` directory. Replace `\path\to\getting-started-app` with the path to your `getting-started-app` directory.
     ```console
-    $ cd \path\to\app
+    $ cd \path\to\getting-started-app
     ```
     Create an empty file named `Dockerfile`.
     ```console
@@ -95,10 +101,10 @@ To build the [container image](../get-started/overview.md/#docker-objects){:targ
 
 3. Build the container image using the following commands:
 
-   In the terminal, change directory to the `getting-started/app` directory. Replace `/path/to/app` with the path to your `getting-started/app` directory.
+   In the terminal, change directory to the `getting-started-app` directory. Replace `/path/to/getting-started-app` with the path to your `getting-started-app` directory.
 
    ```console
-   $ cd /path/to/app
+   $ cd /path/to/getting-started-app
    ```
 
    Build the container image.
@@ -126,7 +132,7 @@ Now that you have an image, you can run the application in a [container](../get-
 
    The `-d` flag (short for `--detach`) runs the container in the background.
    The `-p` flag (short for `--publish`) creates a port mapping between the host and the container.
-   The `-p` flag take a string value in the format of `HOST:CONTAINER`,
+   The `-p` flag takes a string value in the format of `HOST:CONTAINER`,
    where `HOST` is the address on the host, and `CONTAINER` is the port on the container.
    The command shown here publishes the container's port 3000 to `127.0.0.1:3000` (`localhost:3000`) on the host.
    Without the port mapping, you wouldn't be able to access the application from the host.

--- a/get-started/02_our_app.md
+++ b/get-started/02_our_app.md
@@ -30,22 +30,22 @@ Before you can run the application, you need to get the application source code 
    $ git clone https://github.com/docker/getting-started-app.git
    ```
 
-2. View the contents of the cloned repository. You should see the following files and subdirectories.
+2. View the contents of the cloned repository. You should see the following files and sub-directories.
 
    ```
    ├── getting-started-app/
-   │ ├── pacakge.json
+   │ ├── pacakage.json
    │ ├── README.md
    │ ├── spec/
    │ ├── src/
    │ └── yarn.lock
-   ```
+```
 
 ## Build the app's container image
 
 To build the [container image](../get-started/overview.md/#docker-objects){:target="_blank" rel="noopener" class="_"}, you'll need to use a `Dockerfile`. A Dockerfile is simply a text-based file with no file extension that contains a script of instructions. Docker uses this script to build a container image.
 
-1. In the `getting-started-app` directory, the same location as the `package.json` file, create a file named `Dockerfile`. You can use the following commands below to create a Dockerfile based on your operating system.
+1. In the `getting-started-app` directory, the same location as the `package.json` file, create a file named `Dockerfile`. You can use the following commands to create a Dockerfile based on your operating system.
 
    <ul class="nav nav-tabs">
      <li class="active"><a data-toggle="tab" data-target="#mac-linux">Mac / Linux</a></li>
@@ -56,7 +56,7 @@ To build the [container image](../get-started/overview.md/#docker-objects){:targ
 
     In the terminal, run the following commands listed below.
 
-    Change directory to the `getting-started-app` directory. Replace `/path/to/getting-started-app` with the path to your `getting-started-app` directory.
+    Make sure you're in the `getting-started-app` directory. Replace `/path/to/getting-started-app` with the path to your `getting-started-app` directory.
     ```console
     $ cd /path/to/getting-started-app
     ```
@@ -71,7 +71,7 @@ To build the [container image](../get-started/overview.md/#docker-objects){:targ
 
     In the Windows Command Prompt, run the following commands listed below.
 
-    Change directory to the `getting-started-app` directory. Replace `\path\to\getting-started-app` with the path to your `getting-started-app` directory.
+    Make sure you're in the `getting-started-app` directory. Replace `\path\to\getting-started-app` with the path to your `getting-started-app` directory.
     ```console
     $ cd \path\to\getting-started-app
     ```
@@ -101,7 +101,7 @@ To build the [container image](../get-started/overview.md/#docker-objects){:targ
 
 3. Build the container image using the following commands:
 
-   In the terminal, change directory to the `getting-started-app` directory. Replace `/path/to/getting-started-app` with the path to your `getting-started-app` directory.
+   In the terminal, make sure you're in the `getting-started-app` directory. Replace `/path/to/getting-started-app` with the path to your `getting-started-app` directory.
 
    ```console
    $ cd /path/to/getting-started-app
@@ -132,7 +132,7 @@ Now that you have an image, you can run the application in a [container](../get-
 
    The `-d` flag (short for `--detach`) runs the container in the background.
    The `-p` flag (short for `--publish`) creates a port mapping between the host and the container.
-   The `-p` flag takes a string value in the format of `HOST:CONTAINER`,
+   The `-p` flag take a string value in the format of `HOST:CONTAINER`,
    where `HOST` is the address on the host, and `CONTAINER` is the port on the container.
    The command shown here publishes the container's port 3000 to `127.0.0.1:3000` (`localhost:3000`) on the host.
    Without the port mapping, you wouldn't be able to access the application from the host.

--- a/get-started/02_our_app.md
+++ b/get-started/02_our_app.md
@@ -132,7 +132,7 @@ Now that you have an image, you can run the application in a [container](../get-
 
    The `-d` flag (short for `--detach`) runs the container in the background.
    The `-p` flag (short for `--publish`) creates a port mapping between the host and the container.
-   The `-p` flag take a string value in the format of `HOST:CONTAINER`,
+   The `-p` flag takes a string value in the format of `HOST:CONTAINER`,
    where `HOST` is the address on the host, and `CONTAINER` is the port on the container.
    The command shown here publishes the container's port 3000 to `127.0.0.1:3000` (`localhost:3000`) on the host.
    Without the port mapping, you wouldn't be able to access the application from the host.

--- a/get-started/02_our_app.md
+++ b/get-started/02_our_app.md
@@ -34,7 +34,7 @@ Before you can run the application, you need to get the application source code 
 
    ```
    ├── getting-started-app/
-   │ ├── pacakage.json
+   │ ├── package.json
    │ ├── README.md
    │ ├── spec/
    │ ├── src/

--- a/get-started/06_bind_mounts.md
+++ b/get-started/06_bind_mounts.md
@@ -41,8 +41,8 @@ Before looking at how you can use bind mounts for developing your application,
 you can run a quick experiment to get a practical understanding of how bind mounts
 work.
 
-1. Open a terminal and change directory to the `app`
-   directory of the getting started repository.
+1. Open a terminal and change directory to the `getting-started-app`
+   directory.
 
 2. Run the following command to start `bash` in an `ubuntu` container with a
    bind mount.
@@ -71,7 +71,7 @@ work.
    </div>
 
    The `--mount` option tells Docker to create a bind mount, where `src` is the
-   current working directory on your host machine (`getting-started/app`), and
+   current working directory on your host machine (`getting-started-app`), and
    `target` is where that directory should appear inside the container (`/src`).
 
 3. After running the command, Docker starts an interactive `bash` session in the
@@ -89,7 +89,7 @@ work.
 
    This is the directory that you mounted when starting the container. Listing
    the contents of this directory displays the same files as in the
-   `getting-started/app` directory on your host machine.
+   `getting-started-app` directory on your host machine.
 
    ```console
    root@ac1237fad8db:/# cd src
@@ -105,11 +105,11 @@ work.
    Dockerfile  myfile.txt  node_modules  package.json  spec  src  yarn.lock
    ```
 
-6. Open the `app` directory on the host and observe that the `myfile.txt` file
-   is in the directory.
+6. Open the `getting-started-app` directory on the host and observe that the
+   `myfile.txt` file is in the directory.
 
    ```
-   ├── app/
+   ├── getting-started-app/
    │ ├── Dockerfile
    │ ├── myfile.txt
    │ ├── node_modules/
@@ -158,7 +158,7 @@ You can use the CLI or Docker Desktop to run your container with a bind mount.
 
 1. Make sure you don't have any `getting-started` containers currently running.
 
-2. Run the following command from the `getting-started/app` directory.
+2. Run the following command from the `getting-started-app` directory.
 
    <ul class="nav nav-tabs">
      <li class="active"><a data-toggle="tab" data-target="#mac-linux2">Mac / Linux</a></li>
@@ -253,7 +253,7 @@ You can use the CLI or Docker Desktop to run your container with a bind mount.
      >  Use the search filter to filter images and only show **Local images**.
    4. Select your image and then select **Run**.
    5. Select **Optional settings**.
-   6. In **Host path**, specify the path to the `app` directory on your host machine.
+   6. In **Host path**, specify the path to the `getting-started-app` directory on your host machine.
    7. In **Container path**, specify `/app`.
    8. Select **Run**.
 

--- a/get-started/07_multi_container.md
+++ b/get-started/07_multi_container.md
@@ -195,7 +195,7 @@ The todo app supports the setting of a few environment variables to specify MySQ
 
 You can now start your dev-ready container.
 
-1. Specify each of the environment variables above, as well as connect the container to your app network. Make sure that you are in the `getting-started/app` directory when you run this command.
+1. Specify each of the environment variables above, as well as connect the container to your app network. Make sure that you are in the `getting-started-app` directory when you run this command.
 
     <ul class="nav nav-tabs">
     <li class="active"><a data-toggle="tab" data-target="#mac-linux2">Mac / Linux</a></li>

--- a/get-started/08_using_compose.md
+++ b/get-started/08_using_compose.md
@@ -30,7 +30,7 @@ $ docker compose version
 
 ## Create the Compose file
 
-1. At the root of the `/getting-started/app` folder, create a file named `docker-compose.yml`.
+1. At the root of the `/getting-started-app` folder, create a file named `docker-compose.yml`.
 
 2. In the compose file, we'll start off by defining the list of services (or containers) we want to run as part of our application.
 


### PR DESCRIPTION
### Proposed changes

Issue: The sample app is inside the getting-started tutorial repo. There have been several issues related to users running the commands or creating files in the wrong directory, and being confused by the Dockerfile in the repo root.

Fix: Create a new standalone repo for the sample app.

### Related issues (optional)
ENGDOCS-1510
Fixes #17837

