### PR TITLE
add COMPOSE_ANSI and COMPOSE_STATUS_STDOUT env variables to Compose E…

### DIFF
--- a/compose/environment-variables/envvars.md
+++ b/compose/environment-variables/envvars.md
@@ -133,8 +133,8 @@ Specifies when to print ANSI control characters.
 
 ### COMPOSE\_STATUS\_STDOUT
 
-When enabled, Compose switches the output stream, with status and progress messages sent to `stdout` instead of `stderr`.
-The default value is false to use Posix `stderr` in order to easily separate Compose output stream 
+When enabled, Compose writes its internal status and progress messages to `stdout` instead of `stderr`. 
+The default value is false to clearly separate the output streams between Compose messages and your container's logs.
 and containers output (on `stdout` by default)
 
 * Supported values:

--- a/compose/environment-variables/envvars.md
+++ b/compose/environment-variables/envvars.md
@@ -19,6 +19,8 @@ This page contains information on how you can change the following pre-defined e
 - `COMPOSE_IGNORE_ORPHANS`
 - `COMPOSE_REMOVE_ORPHANS`
 - `COMPOSE_PATH_SEPARATOR`
+- `COMPOSE_ANSI`
+- `COMPOSE_STATUS_STDOUT`
 
 Compose also inherits common Docker CLI environment variables, such as `DOCKER_HOST` and `DOCKER_CONTEXT`. See [Docker CLI environment variable reference](/engine/reference/commandline/cli/#environment-variables) for details.
 
@@ -118,6 +120,27 @@ When enabled, Compose doesn't try to detect orphaned containers for the project.
 ### COMPOSE\_PARALLEL\_LIMIT
 
 Specifies the maximum level of parallelism for concurrent engine calls.
+
+### COMPOSE\_ANSI
+
+Specifies when to print ANSI control characters. 
+
+* Supported values:
+  * `auto`, Compose detect if TTY mode can be use otherwise use plain text mode,
+  * `never`, use plain text mode.
+  * `always` or `0`, use TTY mode.
+* Defaults to: `auto`.
+
+### COMPOSE\_STATUS\_STDOUT
+
+When enabled, Compose will switch the output stream, with status and progress messages, to `stdout` instead of `stderr`.
+The default value is false to use Posix `stderr` in order to easily separate Compose output stream 
+and containers output (on `stdout` by default)
+
+* Supported values:
+  * `true` or `1`, to enable,
+  * `false` or `0`, to disable.
+* Defaults to: `0`.
 
 ## Unsupported in Compose V2
 

--- a/compose/environment-variables/envvars.md
+++ b/compose/environment-variables/envvars.md
@@ -135,7 +135,6 @@ Specifies when to print ANSI control characters.
 
 When enabled, Compose writes its internal status and progress messages to `stdout` instead of `stderr`. 
 The default value is false to clearly separate the output streams between Compose messages and your container's logs.
-and containers output (on `stdout` by default)
 
 * Supported values:
   * `true` or `1`, to enable,

--- a/compose/environment-variables/envvars.md
+++ b/compose/environment-variables/envvars.md
@@ -126,14 +126,14 @@ Specifies the maximum level of parallelism for concurrent engine calls.
 Specifies when to print ANSI control characters. 
 
 * Supported values:
-  * `auto`, Compose detect if TTY mode can be use otherwise use plain text mode,
+  * `auto`, Compose detects if TTY mode can be used. Otherwise, use plain text mode.
   * `never`, use plain text mode.
   * `always` or `0`, use TTY mode.
 * Defaults to: `auto`.
 
 ### COMPOSE\_STATUS\_STDOUT
 
-When enabled, Compose will switch the output stream, with status and progress messages, to `stdout` instead of `stderr`.
+When enabled, Compose switches the output stream, with status and progress messages sent to `stdout` instead of `stderr`.
 The default value is false to use Posix `stderr` in order to easily separate Compose output stream 
 and containers output (on `stdout` by default)
 


### PR DESCRIPTION
<!--
  Thank you for contributing to Docker documentation!

  Here are a few things to keep in mind:

  - Links between pages should use a relative path
  - Remember to add an alt text for images

  ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
  ┃     Review our contribution guidelines:       ┃
  ┃                                               ┃
  ┃ https://docs.docker.com/contribute/overview/  ┃
  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
-->

### Proposed changes
Add definition of `COMPOSE_ANSI` and `COMPOSE_STATUS_STDOUT` env vars to Compose environment variables page
<!-- Tell us what you did and why -->

### Related issues (optional)

<!--
  Refer to related PRs or issues:

  #1234
  Closes #1234
  Closes docker/cli#1234
-->
Closes #17653