### PR TITLE
Update Settings Management docs with added support for extensions

### DIFF
--- a/desktop/hardened-desktop/settings-management/configure.md
+++ b/desktop/hardened-desktop/settings-management/configure.md
@@ -104,6 +104,10 @@ The following `admin-settings.json` code and table provides an example of the re
   "analyticsEnabled": {
     "locked": false,
     "value": true
+  },
+  "extensionsEnabled": {
+    "value": false,
+    "locked": true
   }
 }
 ```
@@ -124,6 +128,7 @@ The following `admin-settings.json` code and table provides an example of the re
 | &nbsp; &nbsp; &nbsp; &nbsp;`dockerDaemonOptions` |  | Overrides the options in the linux daemon config file. See the [Docker Engine reference](/engine/reference/commandline/dockerd/#daemon-configuration-file).|                                |
 |`disableUpdate`|  |If `value` is set to true, checking for and notifications about Docker Desktop updates is disabled.|
 |`analyticsEnabled`|  |If `value` is set to false, Docker Desktop doesn't send usage statistics to Docker. |
+|`extensionsEnabled`|  |If `value` is set to false, Docker extensions are disabled. |
 
 ### Step three: Re-launch Docker Desktop
 >**Note**

--- a/desktop/hardened-desktop/settings-management/index.md
+++ b/desktop/hardened-desktop/settings-management/index.md
@@ -36,6 +36,7 @@ Using the `admin-settings.json` file, admins can:
 - Enforce the use of WSL2 based engine or Hyper-V
 - Configure Docker Engine
 - Turn off Docker Desktop's ability to checks for updates
+- Disable Docker Extensions
 
 For more details on the syntax and options admins can set, see [Configure Settings Management](configure.md).
 

--- a/desktop/hardened-desktop/settings-management/index.md
+++ b/desktop/hardened-desktop/settings-management/index.md
@@ -36,7 +36,7 @@ Using the `admin-settings.json` file, admins can:
 - Enforce the use of WSL2 based engine or Hyper-V
 - Configure Docker Engine
 - Turn off Docker Desktop's ability to checks for updates
-- Disable Docker Extensions
+- Turn off Docker Extensions
 
 For more details on the syntax and options admins can set, see [Configure Settings Management](configure.md).
 


### PR DESCRIPTION
<!--
  Thank you for contributing to Docker documentation!

  Here are a few things to keep in mind:

  - Links between pages should use a relative path
  - Remember to add an alt text for images

  ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
  ┃     Review our contribution guidelines:       ┃
  ┃                                               ┃
  ┃ https://docs.docker.com/contribute/overview/  ┃
  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
-->

### Proposed changes

<!-- Tell us what you did and why -->

Added support for extensions in Settings Management in Docker Desktop 4.22

### Related issues (optional)

<!--
  Refer to related PRs or issues:

  #1234
  Closes #1234
  Closes docker/cli#1234
-->

[pinata/22153](https://github.com/docker/pinata/pull/22152)
