### PR TITLE
remove /compose/extends

### DIFF
--- a/_data/toc.yaml
+++ b/_data/toc.yaml
@@ -1862,8 +1862,6 @@ manuals:
       title: Include
   - path: /compose/gpu-support/
     title: GPU support in Compose
-  - path: /compose/extends/
-    title: Extend services in Compose
   - path: /compose/networking/
     title: Networking in Compose
   - path: /compose/file-watch/

--- a/compose/multiple-compose-files/extends.md
+++ b/compose/multiple-compose-files/extends.md
@@ -2,7 +2,7 @@
 description: How to use Docker Compose's extends keyword to share configuration between files and projects
 keywords: fig, composition, compose, docker, orchestration, documentation, docs
 title: Extend your Compose file
-redirect: 
+redirect_from:
  - /compose/extends/
 ---
 


### PR DESCRIPTION
https://github.com/docker/docs/pull/17713 relocated /compose/extends to a new section and forgot to remove this TOC entry

<!--
  Thank you for contributing to Docker documentation!

  Here are a few things to keep in mind:

  - Links between pages should use a relative path
  - Remember to add an alt text for images

  ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
  ┃     Review our contribution guidelines:       ┃
  ┃                                               ┃
  ┃ https://docs.docker.com/contribute/overview/  ┃
  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
-->

### Proposed changes

The `/compose/extends` entry was relocated under https://github.com/docker/docs/pull/17713 but the original entry wasn't removed.

<!-- Tell us what you did and why -->

### Related issues (optional)

Closes #17789
Closes #17786
Closes #17783
Closes #17775
Closes #17767
Closes #17801
Closes #17784
Closes #17790

<!--
  Refer to related PRs or issues:

  #1234
  Closes #1234
  Closes docker/cli#1234
-->
