### PR TITLE
Modifying pip3 install to python3 -m pip install for consistency across guide modules

### DIFF
--- a/language/python/develop.md
+++ b/language/python/develop.md
@@ -139,7 +139,7 @@ First, let’s add the `mysql-connector-python` module to our application using 
 
 ```console
 $ python3 -m pip install mysql-connector-python
-$ python3 -m pip | grep mysql-connector-python >> requirements.txt
+$ python3 -m pip freeze | grep mysql-connector-python >> requirements.txt
 ```
 
 Now we can build our image.

--- a/language/python/develop.md
+++ b/language/python/develop.md
@@ -138,8 +138,8 @@ We’ve added the MySQL module and updated the code to connect to the database s
 First, let’s add the `mysql-connector-python` module to our application using pip.
 
 ```console
-$ pip3 install mysql-connector-python
-$ pip3 freeze | grep mysql-connector-python >> requirements.txt
+$ python3 -m pip install mysql-connector-python
+$ python3 -m pip | grep mysql-connector-python >> requirements.txt
 ```
 
 Now we can build our image.


### PR DESCRIPTION


<!--
  Thank you for contributing to Docker documentation!

  Here are a few things to keep in mind:

  - Links between pages should use a relative path
  - Remember to add an alt text for images

  ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
  ┃     Review our contribution guidelines:       ┃
  ┃                                               ┃
  ┃ https://docs.docker.com/contribute/overview/  ┃
  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
-->

### Proposed changes

In the other pages of the guide python3 -m pip install is used instead of pip3 install, the former being the better practice as well. Therefore, replacing the use of pip3 install commands with the recommended one. This would also maintain consistency across the language guide pages.

### Related issues (optional)

<!--
  Refer to related PRs or issues:

  #1234
  Closes #1234
  Closes docker/cli#1234
-->
