### PR TITLE
Modify "stop" to "stop and remove" to avoid container name conflict error

### DIFF
--- a/language/python/develop.md
+++ b/language/python/develop.md
@@ -148,7 +148,7 @@ Now we can build our image.
 $ docker build --tag python-docker-dev .
 ```
 
-If you have any containers running from the previous sections using the name `rest-server` or port 8000, [stop](./run-containers.md/#stop-start-and-name-containers) them now.
+If you have any containers running from the previous sections using the name `rest-server` or port 8000, [stop and remove](./run-containers.md/#stop-start-and-name-containers) them now.
 
 Now, let’s add the container to the database network and then run our container. This allows us to access the database by its container name.
 


### PR DESCRIPTION


<!--
  Thank you for contributing to Docker documentation!

  Here are a few things to keep in mind:

  - Links between pages should use a relative path
  - Remember to add an alt text for images

  ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
  ┃     Review our contribution guidelines:       ┃
  ┃                                               ┃
  ┃ https://docs.docker.com/contribute/overview/  ┃
  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
-->

### Proposed changes

Added instruction to remove the container along with stopping it to avoid error - 
```
docker: Error response from daemon: Conflict. The container name "/rest-server" is already in use by container "abc". 
You have to remove (or rename) that container to be able to reuse that name.
```

### Related issues (optional)

<!--
  Refer to related PRs or issues:

  #1234
  Closes #1234
  Closes docker/cli#1234
-->
