### PR TITLE
Update zfs-driver.md (remove section "Limit a container's writable storage quota")

### DIFF
--- a/storage/storagedriver/zfs-driver.md
+++ b/storage/storagedriver/zfs-driver.md
@@ -118,26 +118,6 @@ the Docker host, and then add it to the `zpool` using the `zpool add` command:
 $ sudo zpool add zpool-docker /dev/xvdh
 ```
 
-### Limit a container's writable storage quota
-
-If you want to implement a quota on a per-image/dataset basis, you can set the
-`size` storage option to limit the amount of space a single container can use
-for its writable layer.
-
-Edit `/etc/docker/daemon.json` and add the following:
-
-```json
-{
-  "storage-driver": "zfs",
-  "storage-opts": ["size=256M"]
-}
-```
-
-See all storage options for each storage driver in the
-[daemon reference documentation](/engine/reference/commandline/dockerd/#daemon-storage-driver)
-
-Save and close the file, and restart Docker.
-
 ## How the `zfs` storage driver works
 
 ZFS uses the following objects:


### PR DESCRIPTION
Instruction how to limit container's size has been removed because this option doesn't work and prevent the docker service from starting up.

See https://github.com/moby/moby/issues/33847 for bug description

<!--
  Thank you for contributing to Docker documentation!

  Here are a few things to keep in mind:

  - Links between pages should use a relative path
  - Remember to add an alt text for images

  ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
  ┃     Review our contribution guidelines:       ┃
  ┃                                               ┃
  ┃ https://docs.docker.com/contribute/overview/  ┃
  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
-->

### Proposed changes

<!-- Tell us what you did and why -->

I've removed the section of docker documentation since it contains wrong instruction.

### Related issues (optional)
(https://github.com/moby/moby/issues/33847)

