### PR TITLE
develop: Update multi-stage example to use go mod

### DIFF
--- a/develop/develop-images/dockerfile_best-practices.md
+++ b/develop/develop-images/dockerfile_best-practices.md
@@ -237,19 +237,18 @@ A Dockerfile for a Go application could look like:
 
 ```dockerfile
 # syntax=docker/dockerfile:1
-FROM golang:1.16-alpine AS build
+FROM golang:{{site.example_go_version}}-alpine AS build
 
 # Install tools required for project
 # Run `docker build --no-cache .` to update dependencies
 RUN apk add --no-cache git
-RUN go get github.com/golang/dep/cmd/dep
 
-# List project dependencies with Gopkg.toml and Gopkg.lock
+# List project dependencies with go.mod and go.sum
 # These layers are only re-built when Gopkg files are updated
-COPY Gopkg.lock Gopkg.toml /go/src/project/
 WORKDIR /go/src/project/
+COPY go.mod go.sum /go/src/project/
 # Install library dependencies
-RUN dep ensure -vendor-only
+RUN go mod download
 
 # Copy the entire project and build it
 # This layer is rebuilt when a file changes in the project directory


### PR DESCRIPTION
<!--
  Thank you for contributing to Docker documentation!

  Here are a few things to keep in mind:

  - Links between pages should use a relative path
  - Remember to add an alt text for images

  ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
  ┃     Review our contribution guidelines:       ┃
  ┃                                               ┃
  ┃ https://docs.docker.com/contribute/overview/  ┃
  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
-->

### Proposed changes

Updated [an example of a multi-stage Go build](https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#use-multi-stage-builds) to use `go mod` as [`dep`](https://github.com/golang/dep) is no longer maintained.

<!-- Tell us what you did and why -->


<!--
  Refer to related PRs or issues:

  #1234
  Closes #1234
  Closes docker/cli#1234
-->
