### PR TITLE
update Compose v2.20.0 release notes to add support of include attribute

### DIFF
--- a/compose/release-notes.md
+++ b/compose/release-notes.md
@@ -39,7 +39,7 @@ For more detailed information, see the [release notes in the Compose repo](https
 ### Bug fixes and enhancements
 * Introduced the `wait` command.
 * Added support of `--builder` and `BUILDX_BUILDER` to the `build` command.
-* Added support for the `attach` attribute from the Compose Specification.
+* Added support for the `include` and `attach` attributes from the Compose Specification.
 * Fixed a DryRun mode issue when initializing CLI client.
 * Fixed a bug with random missing network when a service has more than one.
 * Fixed the Secrets file permission value to comply with the Compose Specification.


### PR DESCRIPTION
<!--
  Thank you for contributing to Docker documentation!

  Here are a few things to keep in mind:

  - Links between pages should use a relative path
  - Remember to add an alt text for images

  ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
  ┃     Review our contribution guidelines:       ┃
  ┃                                               ┃
  ┃ https://docs.docker.com/contribute/overview/  ┃
  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
-->

### Proposed changes
Add missing support of `include` attribute in Compose `v2.20.0` release notes

<!-- Tell us what you did and why -->

### Related issues (optional)

<!--
  Refer to related PRs or issues:

  #1234
  Closes #1234
  Closes docker/cli#1234
-->
