### PR TITLE
add "go" redirect for deprecated image formats

### DIFF
--- a/_redirects.yml
+++ b/_redirects.yml
@@ -96,6 +96,16 @@
   # used in warnings printed by the Docker Engine, and in the installation script
   # at "get.docker.com"
   - /go/attack-surface/
+"/registry/spec/deprecated-schema-v1/":
+  # Details about deprecated image manifest formats. This redirect is currently
+  # used in warnings printed by the Docker Engine when pulling deprecated image
+  # formats:
+  #
+  #   - Docker Image Specification v1.0.0 (https://github.com/moby/moby/blob/v24.0.0/image/spec/v1.md)
+  #   - Docker Image manifest version 2, schema 1 (https://github.com/distribution/distribution/blob/ff2bce27319a0a0bca924820c353fae3b9046e91/docs/spec/manifest-v2-1.md)
+  #
+  # TODO(thaJeztah) We need a better page describing the image formats (and deprecated ones)
+  - /go/deprecated-image-specs/
 "/build/buildkit/#getting-started":
   - /go/buildkit/
 "/build/architecture/#install-buildx":


### PR DESCRIPTION
We currently print the full URL in warnings, and we may want to create a better page for this at some point;

    docker pull docker:1.0.1
    1.0.1: Pulling from library/docker
    Image docker.io/library/docker:1.0.1 uses outdated schema1 manifest format. Please upgrade to a schema2 image for better future compatibility. More information at https://docs.docker.com/registry/spec/deprecated-schema-v1/

Adding a new "/go/" redirect, so that we can point it to the relevant content as we go. I tried to keep the URl  somewhat short, so didn't include "deprecated", but naming is hard, so input welcome.

### Related issues (optional)

<!--
  Refer to related PRs or issues:

  #1234
  Closes #1234
  Closes docker/cli#1234
-->
