### PR TITLE
desktop freshness spillover

### DIFF
--- a/_data/toc.yaml
+++ b/_data/toc.yaml
@@ -1109,7 +1109,7 @@ manuals:
             - path: /desktop/install/archlinux/
               title: Install on Arch
     - path: /desktop/get-started/
-      title: Learning Center and sign in
+      title: Sign in
     - sectiontitle: Explore Docker Desktop
       section:
         - path: /desktop/use-desktop/

--- a/desktop/faqs/general.md
+++ b/desktop/faqs/general.md
@@ -46,7 +46,7 @@ cannot access features that require an active internet
 connection. Additionally, any functionality that requires you to sign won't work while using Docker Desktop offline or in air-gapped environments.
 This includes:
 
-- The resources in the [Learning Center](../get-started.md#learning-center)
+- The resources in the [Learning Center](../use-desktop/index.md)
 - Pulling or pushing an image to Docker Hub
 - [Image Access Management](../../docker-hub/image-access-management.md)
 - [Vulnerability scanning](../../docker-hub/vulnerability-scanning.md)

--- a/desktop/get-started.md
+++ b/desktop/get-started.md
@@ -1,7 +1,7 @@
 ---
 description: Explore the Learning center and understand the benefits of signing in to Docker Desktop
 keywords: Docker Dashboard, manage, containers, gui, dashboard, images, user manual, learning center, guide, sign in
-title: Explore the Learning center and sign in to Docker Desktop
+title: Sign in to Docker Desktop
 redirect_from:
 - /desktop/linux/
 - /desktop/linux/index/
@@ -26,18 +26,6 @@ redirect_from:
 - /winkit/
 - /winkit/getting-started/
 ---
-
-## Learning center
-
-The Learning center helps you get started with quick in-app walkthroughs and other resources for learning about Docker.
-
-To access the Learning center, select the **Learning center** view in Docker
-Desktop.
-
-![Learning Center](images/learning-center.png)
-
-For a more detailed guide about getting started, see
-[Get started](../get-started/index.md).
 
 ## Sign in to Docker Desktop
 
@@ -87,13 +75,13 @@ subrsa3072  2022-03-31 [E] [expires: 2024-03-30]
 To initialize `pass`, run the following command using the public key generated from the previous command:
 
 ```console
-$ pass init <generated gpg-id public key>
+$ pass init <your_generated_gpg-id_public_key>
 ``` 
 The following is an example similar to what you see once you run the previous command:
 
 ```console
 mkdir: created directory '/home/molly/.password-store/'
-Password store initialized for <generated gpg-id public key>
+Password store initialized for <generated_gpg-id_public_key>
 ```
 
 Once you initialize `pass`, you can sign in on the Docker Dashboard and pull your private images.

--- a/desktop/use-desktop/index.md
+++ b/desktop/use-desktop/index.md
@@ -16,6 +16,13 @@ The **Images** view displays a list of your Docker images and allows you to run 
 
 The **Volumes** view displays a list of volumes and allows you to easily create and delete volumes and see which ones are being used. For more information, see [Explore volumes](volumes.md).
 
+The **Learning center** view helps you get started with quick in-app walkthroughs and other resources for learning about Docker. 
+
+For a more detailed guide about getting started, see
+[Get started](../get-started/index.md).
+
+The **Builds** view, currently in beta, lets you inspect your build history and manage builders. By default, it displays a list of all your ongoing and completed builds. [Explore builds](builds.md).
+
 In addition, the Docker Dashboard allows you to:
 
 - Navigate to the **Settings** menu to configure your Docker Desktop settings. Select the **Settings** icon in the Dashboard header.

--- a/desktop/use-desktop/index.md
+++ b/desktop/use-desktop/index.md
@@ -19,7 +19,7 @@ The **Volumes** view displays a list of volumes and allows you to easily create 
 The **Learning center** view helps you get started with quick in-app walkthroughs and other resources for learning about Docker. 
 
 For a more detailed guide about getting started, see
-[Get started](../get-started/index.md).
+[Get started](../../get-started/index.md).
 
 The **Builds** view, currently in beta, lets you inspect your build history and manage builders. By default, it displays a list of all your ongoing and completed builds. [Explore builds](builds.md).
 


### PR DESCRIPTION
Moves the learning center content to the 'explore desktop' section and adds a bit about the build view to keep in line with the rest of the content. 

Also closes https://github.com/docker/docs/issues/17901
