### PR TITLE
Add info on specific build that is targeted

### DIFF
--- a/build/building/multi-stage.md
+++ b/build/building/multi-stage.md
@@ -98,6 +98,14 @@ the stage named `builder`:
 $ docker build --target build -t hello .
 ```
 
+The builder targeted here is actually the first stage build responsible for building the Go application
+
+```dockerfile
+FROM golang:1.21 as build
+WORKDIR /src
+COPY <<EOF /src/main.go
+```
+
 A few scenarios where this might be useful are:
 
 - Debugging a specific build stage


### PR DESCRIPTION
<!--
  Thank you for contributing to Docker documentation!

  Here are a few things to keep in mind:

  - Links between pages should use a relative path
  - Remember to add an alt text for images

  ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
  ┃     Review our contribution guidelines:       ┃
  ┃                                               ┃
  ┃ https://docs.docker.com/contribute/overview/  ┃
  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
-->

### Proposed changes

Added an extra explanation that breaks down which build stage is targeted by the multi-stage build command;

`docker build --target build -t hello .`

### Related issues

[Issue 17921](https://github.com/docker/docs/issues/17921)
