### PR TITLE
Update EXPERIMENTAL_BUILDKIT_SOURCE_POLICY

### DIFF
--- a/build/building/env-vars.md
+++ b/build/building/env-vars.md
@@ -116,7 +116,7 @@ Example:
     {
       "action": "DENY",
       "selector": {
-          "identifier": "docker-image://docker.io/library/golang*"
+        "identifier": "docker-image://docker.io/library/golang*"
       }
     }
   ]

--- a/build/building/env-vars.md
+++ b/build/building/env-vars.md
@@ -22,7 +22,7 @@ the behavior of features related to building:
 | [BUILDX_GIT_LABELS](#buildx_git_labels)                                     | String \| Boolean | Add Git provenance labels to images.                 |
 | [BUILDX_NO_DEFAULT_ATTESTATIONS](#buildx_no_default_attestations)           | Boolean           | Turn off default provenance attestations.            |
 | [BUILDX_NO_DEFAULT_LOAD](#buildx_no_default_load)                           | Boolean           | Turn off loading images to image store by default.   |
-| [EXPERIMENTAL_BUILDKIT_SOURCE_POLICY](#experimental_builkit_source_policy)  | String            | Specify a BuildKit source policy file.               |
+| [EXPERIMENTAL_BUILDKIT_SOURCE_POLICY](#experimental_buildkit_source_policy)  | String           | Specify a BuildKit source policy file.               |
 
 See also
 [BuildKit built-in build args](../../engine/reference/builder.md#buildkit-built-in-build-args).

--- a/build/building/env-vars.md
+++ b/build/building/env-vars.md
@@ -14,7 +14,6 @@ the behavior of features related to building:
 | [BUILDKIT_COLORS](#buildkit_colors)                                         | String            | Configure text color for the terminal output.        |
 | [BUILDKIT_HOST](#buildkit_host)                                             | String            | Specify host to use for remote builders.             |
 | [BUILDKIT_PROGRESS](#buildkit_progress)                                     | String            | Configure type of progress output.                   |
-| [BUILDKIT_EXPERIMENTAL_SOURCE_POLICY](#buildkit_experimental_source_policy) | String            | Specify a BuildKit source policy file.               |
 | [BUILDX_BUILDER](#buildx_builder)                                           | String            | Specify the builder instance to use.                 |
 | [BUILDX_CONFIG](#buildx_config)                                             | String            | Specify location for configuration, state, and logs. |
 | [BUILDX_EXPERIMENTAL](#buildx_experimental)                                 | Boolean           | Turn on experimental features.                       |
@@ -23,6 +22,7 @@ the behavior of features related to building:
 | [BUILDX_GIT_LABELS](#buildx_git_labels)                                     | String \| Boolean | Add Git provenance labels to images.                 |
 | [BUILDX_NO_DEFAULT_ATTESTATIONS](#buildx_no_default_attestations)           | Boolean           | Turn off default provenance attestations.            |
 | [BUILDX_NO_DEFAULT_LOAD](#buildx_no_default_load)                           | Boolean           | Turn off loading images to image store by default.   |
+| [EXPERIMENTAL_BUILDKIT_SOURCE_POLICY](#experimental_builkit_source_policy)  | String            | Specify a BuildKit source policy file.               |
 
 See also
 [BuildKit built-in build args](../../engine/reference/builder.md#buildkit-built-in-build-args).
@@ -80,14 +80,47 @@ Usage:
 $ export BUILDKIT_PROGRESS=plain
 ```
 
-## BUILDKIT_EXPERIMENTAL_SOURCE_POLICY
+## EXPERIMENTAL_BUILDKIT_SOURCE_POLICY
 
 Lets you specify a
 [BuildKit source policy](https://github.com/moby/buildkit/blob/master/docs/build-repro.md#reproducing-the-pinned-dependencies)
 file for creating reproducible builds with pinned dependencies.
 
 ```console
-$ export BUILDKIT_EXPERIMENTAL_SOURCE_POLICY=./policy.json
+$ export EXPERIMENTAL_BUILDKIT_SOURCE_POLICY=./policy.json
+```
+
+Example:
+
+```json
+{
+  "rules": [
+    {
+      "action": "CONVERT",
+      "selector": {
+        "identifier": "docker-image://docker.io/library/alpine:latest"
+      },
+      "updates": {
+        "identifier": "docker-image://docker.io/library/alpine:latest@sha256:4edbd2beb5f78b1014028f4fbb99f3237d9561100b6881aabbf5acce2c4f9454"
+      }
+    },
+    {
+      "action": "CONVERT",
+      "selector": {
+        "identifier": "https://raw.githubusercontent.com/moby/buildkit/v0.10.1/README.md"
+      },
+      "updates": {
+        "attrs": {"http.checksum": "sha256:6e4b94fc270e708e1068be28bd3551dc6917a4fc5a61293d51bb36e6b75c4b53"}
+      }
+    },
+    {
+        "action": "DENY",
+        "selector": {
+            "identifier": "docker-image://docker.io/library/golang*"
+        }
+    }
+  ]
+}
 ```
 
 ## BUILDX_BUILDER

--- a/build/building/env-vars.md
+++ b/build/building/env-vars.md
@@ -114,10 +114,10 @@ Example:
       }
     },
     {
-        "action": "DENY",
-        "selector": {
-            "identifier": "docker-image://docker.io/library/golang*"
-        }
+      "action": "DENY",
+      "selector": {
+          "identifier": "docker-image://docker.io/library/golang*"
+      }
     }
   ]
 }

--- a/build/release-notes.md
+++ b/build/release-notes.md
@@ -62,7 +62,7 @@ The full release note for this release is available
   that lets you start a debug session in your builds.
   [docker/buildx#1626](https://github.com/docker/buildx/pull/1626){:target="blank" rel="noopener"},
   [docker/buildx#1640](https://github.com/docker/buildx/pull/1640){:target="blank" rel="noopener"}
-- New [`EXPERIMENTAL_BUILDKIT_SOURCE_POLICY` environment variable](./building/env-vars.md#buildkit_experimental_source_policy)
+- New [`EXPERIMENTAL_BUILDKIT_SOURCE_POLICY` environment variable](./building/env-vars.md#experimental_buildkit_source_policy)
   for applying a BuildKit source policy file.
   [docker/buildx#1628](https://github.com/docker/buildx/pull/1628){:target="blank" rel="noopener"}
 


### PR DESCRIPTION
<!--
  Thank you for contributing to Docker documentation!

  Here are a few things to keep in mind:

  - Links between pages should use a relative path
  - Remember to add an alt text for images

  ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
  ┃     Review our contribution guidelines:       ┃
  ┃                                               ┃
  ┃ https://docs.docker.com/contribute/overview/  ┃
  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
-->

### Proposed changes

- `EXPERIMENTAL_BUILDKIT_SOURCE_POLICY` flag is not correct in the docs
- Added an example 

It is correct in release notes: https://docs.docker.com/build/release-notes/#new
PR: https://github.com/docker/buildx/pull/1628/files#diff-7fdd319c657fbde54b83a5dfa233c5c2c417b291739ff75c05dc5d83ee7a9d24R1672


### Related issues (optional)

<!--
  Refer to related PRs or issues:

  #1234
  Closes #1234
  Closes docker/cli#1234
-->
