### PR TITLE
fix(multi-stage): fix outdated stage name reference

### DIFF
--- a/build/building/multi-stage.md
+++ b/build/building/multi-stage.md
@@ -92,7 +92,7 @@ CMD ["/bin/hello"]
 When you build your image, you don't necessarily need to build the entire
 Dockerfile including every stage. You can specify a target build stage. The
 following command assumes you are using the previous `Dockerfile` but stops at
-the stage named `builder`:
+the stage named `build`:
 
 ```console
 $ docker build --target build -t hello .


### PR DESCRIPTION
fixes https://github.com/docker/docs/issues/17921
closes https://github.com/docker/docs/pull/17922

<!--
  Thank you for contributing to Docker documentation!

  Here are a few things to keep in mind:

  - Links between pages should use a relative path
  - Remember to add an alt text for images

  ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
  ┃     Review our contribution guidelines:       ┃
  ┃                                               ┃
  ┃ https://docs.docker.com/contribute/overview/  ┃
  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
-->

### Proposed changes

![image](https://github.com/docker/docs/assets/20135478/0d39af90-97d8-4fa5-b4c1-cce5bba931fd)


In commit 2a6f7eac80, the Dockerfile under the section "Name your build stages" was updated, the build stage was renamed from "builder" to "build". However, the next section was still using the old build stage name.

Fixes: 2a6f7eac80 ("freshness: update top pages in the build section")

### Related issues (optional)

<!--
  Refer to related PRs or issues:

  #1234
  Closes #1234
  Closes docker/cli#1234
-->
