### PR TITLE
Improve volumes.md 

### DIFF
--- a/storage/volumes.md
+++ b/storage/volumes.md
@@ -576,7 +576,7 @@ The filesystem support of your system depends on the version of the Linux kernel
 1. Create a file and allocate some space to it:
 
    ```console
-   $ fallocate -f 1G disk.raw
+   $ fallocate -l 1G disk.raw
    ```
 
 2. Build a filesystem onto the `disk.raw` file:


### PR DESCRIPTION
I was reading the docker volume [documentation](https://docs.docker.com/storage/volumes/) and I noticed something is wrong in it. here [here](https://docs.docker.com/storage/volumes/#block-storage-devices) discussed about how mount a block device to a container.
the `fallocate`  does not have -f option at all.
so the correct way of using this command is like this:
`fallocate -l 1G disk.raw`