### PR TITLE
Update style guide word recommendations

### DIFF
--- a/.github/vale/Docker/Substitute.yml
+++ b/.github/vale/Docker/Substitute.yml
@@ -46,7 +46,6 @@ swap:
   repo: repository
   scroll: navigate
   (?:sign on|log on|log in|logon|login): sign in
-  sign up: register
   tb: TB
   vs: versus
   wish: want

--- a/contribute/style/recommended-words.md
+++ b/contribute/style/recommended-words.md
@@ -120,7 +120,7 @@ Don't use `please` in the normal course of explaining how to use a product, even
 
 #### register
 
-Use `register` instead of sign up when talking about creating an account.
+Use `sign up` instead of register when talking about creating an account.
 
 #### repo
 
@@ -142,7 +142,7 @@ Use `sign in to` instead of `sign into`.
 
 #### sign up
 
-Use `register` or `create account` instead of `sign up` when talking about creating an account.
+Use `sign up` or `create account` instead of `register` when talking about creating an account.
 
 #### tab versus view
 


### PR DESCRIPTION
<!--
  Thank you for contributing to Docker documentation!

  Here are a few things to keep in mind:

  - Links between pages should use a relative path
  - Remember to add an alt text for images

  ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
  ┃     Review our contribution guidelines:       ┃
  ┃                                               ┃
  ┃ https://docs.docker.com/contribute/overview/  ┃
  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
-->

### Proposed changes

<!-- Tell us what you did and why -->

The UI copy in Hub has changed from `register` to `sign up`. This PR updates the docs style guide to align with this change, and removes the vale recommendation to use register instead of sign up. Since register is used throughout the docs in other contexts besides account creation, I removed instead of swapping (i.e. recommend sign up for register).

### Related issues (optional)

<!--
  Refer to related PRs or issues:

  #1234
  Closes #1234
  Closes docker/cli#1234
-->
Closes ENGDOCS-1582