### PR TITLE
engine: macvlan is not supported in rootless mode

### DIFF
--- a/content/network/network-tutorial-macvlan.md
+++ b/content/network/network-tutorial-macvlan.md
@@ -31,6 +31,8 @@ container to it.
 - The examples assume your ethernet interface is `eth0`. If your device has a
   different name, use that instead.
 
+- The `macvlan` driver is not supported in rootless mode.
+
 ## Bridge example
 
 In the simple bridge example, your traffic flows through `eth0` and Docker


### PR DESCRIPTION
Signed-off-by: David Karlsson <35727626+dvdksn@users.noreply.github.com>

<!--
  Thank you for contributing to Docker documentation!

  Here are a few things to keep in mind:

  - Links between pages should use a relative path
  - Remember to add an alt text for images

  ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
  ┃     Review our contribution guidelines:       ┃
  ┃                                               ┃
  ┃ https://docs.docker.com/contribute/overview/  ┃
  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
-->

### Proposed changes

Macvlan is not supported in rootless mode

### Related issues (optional)

https://github.com/moby/moby/issues/45779#issuecomment-1599644464
ENGDOCS-1462
