### PR TITLE
ci(validate-upstream): allow cleanup of stub files

### DIFF
--- a/.github/workflows/validate-upstream.yml
+++ b/.github/workflows/validate-upstream.yml
@@ -19,6 +19,9 @@ on:
       data-files-placeholder-folder:
         required: false
         type: string
+      data-files-placeholder-prefix:
+        required: false
+        type: string
 
 jobs:
   run:
@@ -70,6 +73,18 @@ jobs:
           if [[ -n "${{ inputs.data-files-folder }}" ]] && [[ -d "./_data/${{ inputs.data-files-folder }}" ]]; then
             rm -rf ./_data/${{ inputs.data-files-folder }}/*
           fi
+      -
+        name: Cleanup stub files
+        if: ${{ inputs.data-files-folder != '' && inputs.data-files-placeholder-prefix != '' }}
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const fs = require('fs');
+            const globber = await glob.create(`${{ inputs.data-files-placeholder-folder }}/${{ inputs.data-files-placeholder-prefix }}*`);
+            for await (const placeholderPath of globber.globGenerator()) {
+              core.info(`removing ${placeholderPath}`);
+              await fs.unlinkSync(placeholderPath);
+            }
       -
         name: Download data files
         uses: actions/download-artifact@v3


### PR DESCRIPTION
<!--
  Thank you for contributing to Docker documentation!

  Here are a few things to keep in mind:

  - Links between pages should use a relative path
  - Remember to add an alt text for images

  ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
  ┃     Review our contribution guidelines:       ┃
  ┃                                               ┃
  ┃ https://docs.docker.com/contribute/overview/  ┃
  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
-->

### Proposed changes

follow-up https://github.com/docker/buildx/pull/2006#issuecomment-1683505890

Adds `data-files-placeholder-prefix` input to handle removal of stub files. This can be useful in case commands on downstream repo are removed.

Tested here: https://github.com/crazy-max/buildx/actions/runs/5909610217/job/16030404526

cc @ktock

### Related issues (optional)

<!--
  Refer to related PRs or issues:

  #1234
  Closes #1234
  Closes docker/cli#1234
-->
