### PR TITLE
hugo: fix html escape for headings

### DIFF
--- a/layouts/_default/_markup/render-heading.html
+++ b/layouts/_default/_markup/render-heading.html
@@ -1,6 +1,6 @@
 {{ partial "heading.html" (dict
   "level" .Level
-  "text" (plainify .Text)
+  "text" (.Text | plainify | safeHTML)
   "id" (.Attributes.id | default .Anchor)
   "class" .Attributes.class
   )


### PR DESCRIPTION
Signed-off-by: David Karlsson <35727626+dvdksn@users.noreply.github.com>

<!--
  Thank you for contributing to Docker documentation!

  Here are a few things to keep in mind:

  - Links between pages should use a relative path
  - Remember to add an alt text for images

  ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
  ┃     Review our contribution guidelines:       ┃
  ┃                                               ┃
  ┃ https://docs.docker.com/contribute/overview/  ┃
  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
-->

### Proposed changes

Before:
<img width="577" alt="image" src="https://github.com/docker/docs/assets/35727626/b28583f8-e473-4b50-9159-9e831725b00a">


After:
<img width="507" alt="image" src="https://github.com/docker/docs/assets/35727626/4d011118-028c-457d-b3d8-ba79b9c7aa59">
