### PR TITLE
hugo: fix edge case causing duplicate h1

### DIFF
--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -5,7 +5,9 @@
 {{ define "main" }}
   {{ partial "breadcrumbs-legacy.html" . }}
   <article class="prose max-w-none dark:prose-invert">
-    <h1>{{ .Title }}</h1>
+    {{ with .Title }}
+    <h1>{{ . }}</h1>
+    {{ end }}
     {{ .Content }}
   </article>
 {{ end }}

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -5,7 +5,9 @@
 {{ define "main" }}
   {{ partial "breadcrumbs-legacy.html" . }}
   <article class="prose max-w-none dark:prose-invert">
-    <h1>{{ .Title }}</h1>
+    {{ with .Title }}
+    <h1>{{ . }}</h1>
+    {{ end }}
     {{ .Content }}
   </article>
 {{ end }}


### PR DESCRIPTION
Some documents are missing a `title` front matter,
and instead use an H1 from the document body.
This change introduces a fix to render an external
h1 only if the front matter field is set.

Signed-off-by: David Karlsson <35727626+dvdksn@users.noreply.github.com>

<!--
  Thank you for contributing to Docker documentation!

  Here are a few things to keep in mind:

  - Links between pages should use a relative path
  - Remember to add an alt text for images

  ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
  ┃     Review our contribution guidelines:       ┃
  ┃                                               ┃
  ┃ https://docs.docker.com/contribute/overview/  ┃
  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
-->

### Proposed changes

<!-- Tell us what you did and why -->

### Related issues (optional)

<!--
  Refer to related PRs or issues:

  #1234
  Closes #1234
  Closes docker/cli#1234
-->
