### PR TITLE
fix: broken link to docker-hub quickstart

### DIFF
--- a/content/docker-hub/_index.md
+++ b/content/docker-hub/_index.md
@@ -16,7 +16,7 @@ grid:
 - title: Quickstart
   description: Step-by-step instructions on getting started on Docker Hub.
   icon: checklist
-  link: /docker-hub
+  link: /docker-hub/quickstart
 - title: Manage access tokens
   description: Create personal access tokens as an alternative to your password.
   icon: key


### PR DESCRIPTION
Signed-off-by: David Karlsson <35727626+dvdksn@users.noreply.github.com>

<!--
  Thank you for contributing to Docker documentation!

  Here are a few things to keep in mind:

  - Links between pages should use a relative path
  - Remember to add an alt text for images

  ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
  ┃     Review our contribution guidelines:       ┃
  ┃                                               ┃
  ┃ https://docs.docker.com/contribute/overview/  ┃
  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
-->

### Proposed changes

<!-- Tell us what you did and why -->

### Related issues (optional)

<!--
  Refer to related PRs or issues:

  #1234
  Closes #1234
  Closes docker/cli#1234
-->
