### PR TITLE
js: improve heading scroll detection

### DIFF
--- a/assets/js/src/toc.js
+++ b/assets/js/src/toc.js
@@ -4,20 +4,19 @@ if (toc) {
   const prose = document.querySelector("article.prose");
   const headings = prose.querySelectorAll("h2, h3");
   // grab all heading anchors on this page
-  const anchorLinks = Array.from(headings)
+  const headingAnchors = Array.from(headings)
     .map((h) => h.previousElementSibling)
-    .map((a) => [a.offsetTop, `${a.name}`])
-    .sort((a, b) => (a[0] > b[0] ? 1 : 0));
+    .map((a) => `${a.name}`);
 
   // find the closest anchor link based on window scrollpos
-  function findClosestHeading(anchorLinks) {
+  function findClosestHeading(headingAnchors) {
     const { innerHeight } = window;
-    for (const anchor of anchorLinks) {
-      const el = document.querySelector(`a[name="${anchor[1]}"]`);
+    for (const anchor of headingAnchors) {
+      const el = document.querySelector(`a[name="${anchor}"]`);
       const { top } = el.getBoundingClientRect();
       // if the heading is visible and within the top 20% of viewport
       if (top > 0 && top < (innerHeight * 0.2)) {
-        return anchor[1];
+        return anchor;
       }
     }
   }
@@ -39,7 +38,7 @@ if (toc) {
       return;
     }
     // grab the anchor id of the closest heading
-    const closestHeading = findClosestHeading(anchorLinks);
+    const closestHeading = findClosestHeading(headingAnchors);
     updateToc(closestHeading);
   }
 

--- a/assets/js/src/toc.js
+++ b/assets/js/src/toc.js
@@ -1,43 +1,48 @@
-const toc = document.querySelector("#TableOfContents")
+const toc = document.querySelector("#TableOfContents");
 
 if (toc) {
-  const prose = document.querySelector("article.prose")
-  const headings = prose.querySelectorAll("h2, h3")
-  // grab the yposition and targets for all anchor links
+  const prose = document.querySelector("article.prose");
+  const headings = prose.querySelectorAll("h2, h3");
+  // grab all heading anchors on this page
   const anchorLinks = Array.from(headings)
     .map((h) => h.previousElementSibling)
-    .map((a) => [a.offsetTop - 64, `#${a.name}`])
-    .sort((a, b) => (a[0] > b[0] ? 1 : 0))
-
-  let closestHeading
+    .map((a) => [a.offsetTop, `${a.name}`])
+    .sort((a, b) => (a[0] > b[0] ? 1 : 0));
 
   // find the closest anchor link based on window scrollpos
-  function findClosestHeading() {
-    yPos = window.scrollY
-    closest = anchorLinks.reduce((prev, curr) => {
-      return Math.abs(curr[0] - yPos) < Math.abs(prev[0] - yPos) &&
-        curr[0] <= yPos
-        ? curr
-        : prev
-    })
-    return closest
+  function findClosestHeading(anchorLinks) {
+    const { innerHeight } = window;
+    for (const anchor of anchorLinks) {
+      const el = document.querySelector(`a[name="${anchor[1]}"]`);
+      const { top } = el.getBoundingClientRect();
+      // if the heading is visible and within the top 20% of viewport
+      if (top > 0 && top < (innerHeight * 0.2)) {
+        return anchor[1];
+      }
+    }
   }
 
-  function updateToc() {
-    const prev = toc.querySelector('a[aria-current="true"]')
-    const next = toc.querySelector(`a[href="${closestHeading[1]}"]`)
-    if (prev) {
-      prev.removeAttribute("aria-current")
+  function updateToc(closestHeading) {
+    const prev = toc.querySelector('a[aria-current="true"]');
+    const next = toc.querySelector(`a[href="#${closestHeading}"]`);
+    console.log(prev, next)
+    if (prev && next) {
+      prev.removeAttribute("aria-current");
     }
     if (next) {
-      next.setAttribute("aria-current", "true")
+      next.setAttribute("aria-current", "true");
     }
   }
 
-  function handleScroll() {
-    closestHeading = findClosestHeading()
-    updateToc()
+  function updateTocHighlight(event) {
+    if (event.type === "click" && !toc.contains(event.target)) {
+      return;
+    }
+    // grab the anchor id of the closest heading
+    const closestHeading = findClosestHeading(anchorLinks);
+    updateToc(closestHeading);
   }
 
-  window.addEventListener("scroll", handleScroll)
+  window.addEventListener("scroll", updateTocHighlight);
+  window.addEventListener("click", updateTocHighlight);
 }


### PR DESCRIPTION
Signed-off-by: David Karlsson <35727626+dvdksn@users.noreply.github.com>

<!--
  Thank you for contributing to Docker documentation!

  Here are a few things to keep in mind:

  - Links between pages should use a relative path
  - Remember to add an alt text for images

  ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
  ┃     Review our contribution guidelines:       ┃
  ┃                                               ┃
  ┃ https://docs.docker.com/contribute/overview/  ┃
  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
-->

### Proposed changes

Previous implementation of detecting scroll position and finding the closest heading did not work well for pages with images. Due to element height for `img` the element positions were offset incorrectly. This implementation uses getBoundingClientRect which seems to fix the problem.