### PR TITLE
engine: fix link to engine install from get-docker

### DIFF
--- a/content/get-docker.md
+++ b/content/get-docker.md
@@ -47,4 +47,4 @@ section and choose the best installation path for you.
 
 > **Note**
 >
-> If you're looking for information on how to install Docker Engine, see [Docker Engine installation overview](/engine/install/index.md).
+> If you're looking for information on how to install Docker Engine, see [Docker Engine installation overview](/engine/install/).


### PR DESCRIPTION
Signed-off-by: David Karlsson <35727626+dvdksn@users.noreply.github.com>

<!--
  Thank you for contributing to Docker documentation!

  Here are a few things to keep in mind:

  - Links between pages should use a relative path
  - Remember to add an alt text for images

  ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
  ┃     Review our contribution guidelines:       ┃
  ┃                                               ┃
  ┃ https://docs.docker.com/contribute/overview/  ┃
  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
-->

### Proposed changes

<!-- Tell us what you did and why -->

### Related issues (optional)

<!--
  Refer to related PRs or issues:

  #1234
  Closes #1234
  Closes docker/cli#1234
-->
