### PR TITLE
Typo in debian.md console command

### DIFF
--- a/content/engine/install/debian.md
+++ b/content/engine/install/debian.md
@@ -145,7 +145,7 @@ Docker from the repository.
    To install the latest version, run:
 
    ```console
-    $ sudo apt-get install docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+   $ sudo apt-get install docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
    ```
   
   {{< /tab >}}


### PR DESCRIPTION
### Proposed changes

Leading space in console command caused "$" to be copied when clicking the copy button for the command. So I removed the leading space.