### PR TITLE
Leading space typo in a few console commands

### DIFF
--- a/_vendor/github.com/docker/scout-cli/docs/scout_sbom.md
+++ b/_vendor/github.com/docker/scout-cli/docs/scout_sbom.md
@@ -52,7 +52,7 @@ $ docker scout sbom --format list alpine
 ### Only display packages of a specific type
 
 ```console
- $ docker scout sbom --format list --only-package-type apk alpine
+$ docker scout sbom --format list --only-package-type apk alpine
 ```
 
 ### Display the full SBOM as json

--- a/content/config/daemon/remote-access.md
+++ b/content/config/daemon/remote-access.md
@@ -54,7 +54,7 @@ you can use the `daemon.json` file, if your distribution doesn't use systemd.
 4. Reload the `systemctl` configuration.
 
    ```console
-    $ sudo systemctl daemon-reload
+   $ sudo systemctl daemon-reload
    ```
 
 5. Restart Docker.

--- a/content/engine/install/debian.md
+++ b/content/engine/install/debian.md
@@ -145,7 +145,7 @@ Docker from the repository.
    To install the latest version, run:
 
    ```console
-    $ sudo apt-get install docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+   $ sudo apt-get install docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
    ```
   
   {{< /tab >}}

--- a/content/engine/install/raspberry-pi-os.md
+++ b/content/engine/install/raspberry-pi-os.md
@@ -137,7 +137,7 @@ Docker from the repository.
    To install the latest version, run:
 
    ```console
-    $ sudo apt-get install docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+   $ sudo apt-get install docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
    ```
   
   {{< /tab >}}

--- a/content/engine/install/ubuntu.md
+++ b/content/engine/install/ubuntu.md
@@ -151,7 +151,7 @@ Docker from the repository.
    To install the latest version, run:
 
    ```console
-    $ sudo apt-get install docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+   $ sudo apt-get install docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
    ```
   
   {{< /tab >}}


### PR DESCRIPTION
### Proposed changes

I noticed an instance where one too many leading spaces was before the "$" in a console command, causing the "$" to be included when you click the copy button for the command. So I wrote a quick script to find any other places this occurred and fix them.