### PR TITLE
fix: redirect for /get-started/hands-on-overview/

### DIFF
--- a/content/get-started/_index.md
+++ b/content/get-started/_index.md
@@ -62,6 +62,7 @@ aliases:
 - /get-started/run-your-own-container/
 - /get-started/run-docker-hub-images/
 - /get-started/publish-your-own-image/
+- /get-started/hands-on-overview/
 ---
 
 This guide contains step-by-step instructions on how to get started with Docker. This guide shows you how to:


### PR DESCRIPTION
Fixes #17995

Signed-off-by: David Karlsson <35727626+dvdksn@users.noreply.github.com>

<!--
  Thank you for contributing to Docker documentation!

  Here are a few things to keep in mind:

  - Links between pages should use a relative path
  - Remember to add an alt text for images

  ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
  ┃     Review our contribution guidelines:       ┃
  ┃                                               ┃
  ┃ https://docs.docker.com/contribute/overview/  ┃
  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
-->

### Proposed changes

<!-- Tell us what you did and why -->

### Related issues (optional)

<!--
  Refer to related PRs or issues:

  #1234
  Closes #1234
  Closes docker/cli#1234
-->
