### PR TITLE
js: fix copy function for multiline code blocks

### DIFF
--- a/layouts/_default/_markup/render-codeblock.html
+++ b/layouts/_default/_markup/render-codeblock.html
@@ -1,6 +1,6 @@
 <div class="group relative">
   <button
-    x-data="{ code: '{{ strings.ReplaceRE `(?sm)\s*^\$\s+` `` .Inner | base64Encode }}' }"
+    x-data="{ code: '{{ strings.ReplaceRE `(?sm)^\$\s+` "" .Inner | base64Encode }}' }"
     class="material-symbols-rounded hidden group-hover:block absolute top-3 right-3 text-gray-light-300 dark:text-gray-dark-600"
     title="Copy"
     @click="window.navigator.clipboard.writeText(atob(code));


### PR DESCRIPTION
Signed-off-by: David Karlsson <35727626+dvdksn@users.noreply.github.com>

<!--
  Thank you for contributing to Docker documentation!

  Here are a few things to keep in mind:

  - Links between pages should use a relative path
  - Remember to add an alt text for images

  ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
  ┃     Review our contribution guidelines:       ┃
  ┃                                               ┃
  ┃ https://docs.docker.com/contribute/overview/  ┃
  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
-->

### Proposed changes

The previous regex was greedy for consuming whitespace, which caused it to collapse line breaks in the code that was copied (the regex is multiline)

This removes the unnecessary whitespace munge at the start of the line. I think I added it there in case code block was indented, but this was not needed. The `.Inner` content is deindented in the render hook context.