### PR TITLE
chore: add vendor target for bake

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,3 +39,14 @@ WORKDIR /test
 COPY --from=build /out ./public
 ADD .htmltest.yml .htmltest.yml
 RUN htmltest
+
+FROM build-base as update-modules
+ARG MODULE="-u"
+WORKDIR /src
+COPY . .
+RUN hugo mod get ${MODULE}
+RUN hugo mod vendor
+
+FROM scratch as vendor
+COPY --from=update-modules /src/_vendor /_vendor
+COPY --from=update-modules /src/go.* /

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -140,3 +140,11 @@ target "aws-cloudfront-update" {
   no-cache-filter = ["aws-cloudfront-update"]
   output = ["type=cacheonly"]
 }
+
+target "vendor" {
+  target = "vendor"
+  args = {
+    MODULE = null
+  }
+  output = ["."]
+}


### PR DESCRIPTION
Signed-off-by: David Karlsson <35727626+dvdksn@users.noreply.github.com>

<!--
  Thank you for contributing to Docker documentation!

  Here are a few things to keep in mind:

  - Links between pages should use a relative path
  - Remember to add an alt text for images

  ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
  ┃     Review our contribution guidelines:       ┃
  ┃                                               ┃
  ┃ https://docs.docker.com/contribute/overview/  ┃
  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
-->

### Proposed changes

This adds a bake target for updating and vendoring Go modules

By default, updates all direct dependencies to the latest version.

`docker buildx bake vendor` is equivalent to `hugo mod get -u && hugo mod vendor`

It's possible to set a build-arg to define the module, e.g. `docker buildx bake vendor --set "*.args.MODULE=github.com/docker/scout-cli@v0.20.0"`
