### PR TITLE
fix: Spelling mistake for Hyper-V

### DIFF
--- a/content/desktop/install/windows-install.md
+++ b/content/desktop/install/windows-install.md
@@ -50,7 +50,7 @@ _For checksums, see [Release notes](../release-notes.md)_
     [Virtualization](../troubleshoot/topics.md#virtualization).
 
 {{< /tab >}}
-{{< tab name="Hypver-V backend and Windows containers" >}}
+{{< tab name="Hyper-V backend and Windows containers" >}}
 
 - Windows 11 64-bit: Pro version 21H2 or higher, or Enterprise or Education version 21H2 or higher.
 - Windows 10 64-bit: Pro 21H2 (build 19044) or higher, or Enterprise or Education 21H2 (build 19044) or higher.


### PR DESCRIPTION
<!--
  Thank you for contributing to Docker documentation!

  Here are a few things to keep in mind:

  - Links between pages should use a relative path
  - Remember to add an alt text for images

  ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
  ┃     Review our contribution guidelines:       ┃
  ┃                                               ┃
  ┃ https://docs.docker.com/contribute/overview/  ┃
  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
-->

### Proposed changes

<!-- Tell us what you did and why -->

At the moment HyperV is spelt `Hypver-V` and has an additional `v` in the Hyper header.
### Related issues (optional)

<!--
  Refer to related PRs or issues:

  #1234
  Closes #1234
  Closes docker/cli#1234
-->
