### PR TITLE
fix: handle trailing slash mismatch for redirects

### DIFF
--- a/_releaser/cloudfront-lambda-redirects.js
+++ b/_releaser/cloudfront-lambda-redirects.js
@@ -3,13 +3,15 @@
 exports.handler = (event, context, callback) => {
     //console.log("event", JSON.stringify(event));
     const request = event.Records[0].cf.request;
+    const requestUrl = request.uri.replace(/\/$/, "")
 
     const redirects = JSON.parse(`{{.RedirectsJSON}}`);
     for (let key in redirects) {
-        if (key !== request.uri) {
+        const redirectTarget = key.replace(/\/$/, "")
+        if (redirectTarget !== requestUrl) {
             continue;
         }
-        //console.log(`redirect: ${request.uri} to ${redirects[key]}`);
+        //console.log(`redirect: ${requestUrl} to ${redirects[key]}`);
         const response = {
             status: '301',
             statusDescription: 'Moved Permanently',


### PR DESCRIPTION
Signed-off-by: David Karlsson <35727626+dvdksn@users.noreply.github.com>

<!--
  Thank you for contributing to Docker documentation!

  Here are a few things to keep in mind:

  - Links between pages should use a relative path
  - Remember to add an alt text for images

  ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
  ┃     Review our contribution guidelines:       ┃
  ┃                                               ┃
  ┃ https://docs.docker.com/contribute/overview/  ┃
  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
-->

### Proposed changes

Before this change, request.uri had to match the redirect key exactly.

This change normalizes trailing slashes.

### Related issues (optional)

Closes #18014
Closes #18015
