### PR TITLE
ux: enable search for non-prod deploys

### DIFF
--- a/assets/js/src/search.js
+++ b/assets/js/src/search.js
@@ -1,11 +1,17 @@
-import docsearch from '@docsearch/js';
-import * as params from '@params'; // hugo dict
+import docsearch from "@docsearch/js";
+import * as params from "@params"; // hugo dict
 
-const { appid, apikey, indexname } = params
+const { appid, apikey, indexname } = params;
 
 docsearch({
-  container: '#docsearch',
+  container: "#docsearch",
   appId: appid,
   apiKey: apikey,
   indexName: indexname,
+  transformItems(items) {
+    return items.map((item) => ({
+      ...item,
+      url: item.url.replace("https://docs.docker.com", ""),
+    }));
+  },
 });


### PR DESCRIPTION
Signed-off-by: David Karlsson <35727626+dvdksn@users.noreply.github.com>

<!--
  Thank you for contributing to Docker documentation!

  Here are a few things to keep in mind:

  - Links between pages should use a relative path
  - Remember to add an alt text for images

  ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
  ┃     Review our contribution guidelines:       ┃
  ┃                                               ┃
  ┃ https://docs.docker.com/contribute/overview/  ┃
  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
-->

### Proposed changes

Search results include the hostname by default.
This change strips the hostname which makes it
possible to search when the site is deployed on
other domains, such as netlify and localhost.

