### PR TITLE
Inverting dpkg install order

### DIFF
--- a/content/engine/install/ubuntu.md
+++ b/content/engine/install/ubuntu.md
@@ -215,8 +215,8 @@ download a new file each time you want to upgrade Docker Engine.
    and Docker Compose packages:
 
    - `containerd.io_<version>_<arch>.deb`
-   - `docker-ce_<version>_<arch>.deb`
    - `docker-ce-cli_<version>_<arch>.deb`
+   - `docker-ce_<version>_<arch>.deb`
    - `docker-buildx-plugin_<version>_<arch>.deb`
    - `docker-compose-plugin_<version>_<arch>.deb`
 
@@ -225,8 +225,8 @@ download a new file each time you want to upgrade Docker Engine.
 
    ```console
    $ sudo dpkg -i ./containerd.io_<version>_<arch>.deb \
-     ./docker-ce_<version>_<arch>.deb \
      ./docker-ce-cli_<version>_<arch>.deb \
+     ./docker-ce_<version>_<arch>.deb \
      ./docker-buildx-plugin_<version>_<arch>.deb \
      ./docker-compose-plugin_<version>_<arch>.deb
    ```


### PR DESCRIPTION
### Proposed changes

Installing the `docker-ce.deb` package before the `docker-ce-cli.deb` package causes a dpkg error.

This PR just inverts the dpkg arguments for these packages.

```bash
$ dpkg -i ./docker-ce_24.0.5-1~ubuntu.22.04~jammy_amd64.deb
Selecting previously unselected package docker-ce.
(Reading database ... 64311 files and directories currently installed.)
Preparing to unpack .../docker-ce_24.0.5-1~ubuntu.22.04~jammy_amd64.deb ...
Unpacking docker-ce (5:24.0.5-1~ubuntu.22.04~jammy) ...
dpkg: dependency problems prevent configuration of docker-ce:
 docker-ce depends on docker-ce-cli; however:
  Package docker-ce-cli is not installed.

dpkg: error processing package docker-ce (--install):
 dependency problems - leaving unconfigured
Errors were encountered while processing:
 docker-ce
```