### PR TITLE
remove useless class declaration

### DIFF
--- a/content/build/buildkit/_index.md
+++ b/content/build/buildkit/_index.md
@@ -42,8 +42,7 @@ dependency graph that can be used to put together very complex build
 definitions. It also supports features not exposed in Dockerfiles, like direct
 data mounting and nested invocation.
 
-![Directed acyclic graph (DAG)](../images/buildkit-dag.svg){:class="invertible"
-style="width:60%"}
+![Directed acyclic graph (DAG)](../images/buildkit-dag.svg)
 
 Everything about execution and caching of your builds is defined in LLB. The
 caching model is entirely rewritten compared to the legacy builder. Rather than


### PR DESCRIPTION
### Proposed changes

Removing class declaration on an image of _index.md of BuildKit, it might be a typo or something from old markdown formatter used where we could put class to an image like that. But it didnt work in the actual docs website and is not necessary anyway I think.

```
![Directed acyclic graph (DAG)](../images/buildkit-dag.svg){:class="invertible" style="width:60%"}
```
