### PR TITLE
Update docker_tag.yaml

### DIFF
--- a/data/engine-cli/docker_tag.yaml
+++ b/data/engine-cli/docker_tag.yaml
@@ -13,7 +13,7 @@ long: |-
     canonical reference for Docker's public registry.
     - `PORT_NUMBER`: If a hostname is present, it may optionally be followed by a
     registry port number in the format `:8080`.
-    - `PATH`: The path consists consists of slash-separated components. Each
+    - `PATH`: The path consists of slash-separated components. Each
     component may contain lowercase letters, digits and separators. A separator is
     defined as a period, one or two underscores, or one or more hyphens. A component
     may not start or end with a separator. While the


### PR DESCRIPTION
Removing extra "consists"

### Proposed changes

I noticed that [this page](https://docs.docker.com/engine/reference/commandline/tag/) contains the sentence "The path consists consists of slash-separated components." This PR is just to correct that minor error.

### Related issues (optional)

n/a