### PR TITLE
hugo: clip overflowing card titles

### DIFF
--- a/layouts/partials/components/card.html
+++ b/layouts/partials/components/card.html
@@ -1,4 +1,4 @@
-<div class="not-prose">
+<div class="not-prose overflow-x-hidden">
   {{ if .link }}
     <a class="h-full" href="{{ .link }}">
   {{ end }}


### PR DESCRIPTION
Signed-off-by: David Karlsson <35727626+dvdksn@users.noreply.github.com>

See https://www.notion.so/dockerinc/Fix-text-overflow-on-card-components-dc68fe41e3e145beb49a24daf3fa25de?pvs=4