### PR TITLE
hugo: remove edit page link for upstream pages

### DIFF
--- a/layouts/partials/github-links.html
+++ b/layouts/partials/github-links.html
@@ -1,14 +1,20 @@
 {{ if hugo.IsProduction }}
-{{ if .File }}
+{{ with .File }}
+{{ if not (in .Filename "/_vendor/") }}
 <p class="flex items-center gap-2">
-  <span class="material-symbols-rounded">edit</span><a class="link"
-    href="{{ site.Params.repo }}/edit/main/content/{{ .File.Path }}">{{ T "editPage" }}
-    <span class="material-symbols-rounded align-middle text-base">open_in_new</span></a>
-</p>
-<p class="flex items-center gap-2">
-  <span class="material-symbols-rounded">done</span><a class="link" target="_blank" rel="noopener"
-    href="{{ site.Params.repo }}/issues/new?template=doc_issue.yml&location={{ .Permalink }}&labels=status%2Ftriage"
-    >{{ T "requestChanges" }}<span class="material-symbols-rounded align-middle text-base">open_in_new</span></a>
+  <span class="material-symbols-rounded">edit</span>
+  <a class="link" target="_blank" rel="noopener"
+    href="{{ site.Params.repo }}/edit/main/content/{{ .Path }}">{{ T "editPage" }}
+    <span class="material-symbols-rounded align-middle text-base">open_in_new</span>
+  </a>
 </p>
 {{ end }}
+{{ end }}
+<p class="flex items-center gap-2">
+  <span class="material-symbols-rounded">done</span>
+  <a class="link" target="_blank" rel="noopener"
+    href="{{ site.Params.repo }}/issues/new?template=doc_issue.yml&location={{ .Permalink }}&labels=status%2Ftriage">{{ T "requestChanges" }}
+    <span class="material-symbols-rounded align-middle text-base">open_in_new</span>
+  </a>
+</p>
 {{ end }}


### PR DESCRIPTION
Signed-off-by: David Karlsson <35727626+dvdksn@users.noreply.github.com>

<!--
  Thank you for contributing to Docker documentation!

  Here are a few things to keep in mind:

  - Links between pages should use a relative path
  - Remember to add an alt text for images

  ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
  ┃     Review our contribution guidelines:       ┃
  ┃                                               ┃
  ┃ https://docs.docker.com/contribute/overview/  ┃
  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
-->

### Proposed changes

This removes the (currently broken) "edit this page" links from pages that we mount from upstream repositories.

