### PR TITLE
engine: fix ipv6 example for Compose

### DIFF
--- a/content/config/daemon/ipv6.md
+++ b/content/config/daemon/ipv6.md
@@ -54,10 +54,12 @@ The following steps show you how to create a Docker network that uses IPv6.
    - Using a Docker Compose file:
 
      ```yaml
-     networks:
-       ip6net:
-         enable_ipv6: true
-         subnet: 2001:0DB8::/112
+      networks:
+        ip6net:
+          enable_ipv6: true
+          ipam:
+            config:
+              - subnet: 2001:0DB8::/112
      ```
 
 You can now run containers that attach to the `ip6net` network.


### PR DESCRIPTION
### Proposed changes
Fixed the example for creating an IPv6 network in Compose YAML.

See https://github.com/compose-spec/compose-spec/blob/796804a634e4a1fd48a70f0b0b0e02f1a3a97890/06-networks.md#L168-L196

(Note: there's a typo there too, which is being fixed as well. The indentation is wrong, but the description of the fields/hierarchy is correct.)
 
### Related issues (optional)
* compose-spec/compose-spec#417
* docker/compose#10978