### PR TITLE
engine: clarify arch, os versions for raspberry pi

### DIFF
--- a/content/engine/install/raspberry-pi-os.md
+++ b/content/engine/install/raspberry-pi-os.md
@@ -25,16 +25,14 @@ To get started with Docker Engine on Raspberry Pi OS, make sure you
 
 ### OS requirements
 
-To install Docker Engine, you need the 64-bit version or 32-bit version of one of these Raspberry Pi OS
-versions:
+This installation instruction refers to the 32-bit (armhf) version of Raspberry
+Pi OS. If you're using the 64-bit (arm64) version, follow the instructions for
+[Debian](debian.md).
 
-- Raspberry Pi OS Bookworm 12 (testing)
-- Raspberry Pi OS Bullseye 11 (stable)
-- Raspberry Pi OS Buster 10 (oldstable)
+The following OS versions are supported:
 
-Docker Engine for Raspberry Pi OS is compatible with the armhf architecture.
-
-For the 64-bit version of Raspberry Pi OS follow the instructions for [Debian](debian.md).
+- Raspberry Pi OS Bookworm 12 (stable)
+- Raspberry Pi OS Bullseye 11 (oldstable)
 
 ### Uninstall old versions
 


### PR DESCRIPTION
Signed-off-by: David Karlsson <35727626+dvdksn@users.noreply.github.com>

<!--
  Thank you for contributing to Docker documentation!

  Here are a few things to keep in mind:

  - Links between pages should use a relative path
  - Remember to add an alt text for images

  ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
  ┃     Review our contribution guidelines:       ┃
  ┃                                               ┃
  ┃ https://docs.docker.com/contribute/overview/  ┃
  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
-->

### Proposed changes

This PR makes it clearer that the rPi installation is for armhf only,
and users of arm64 should follow the instruction for Debian instead.

### Related issues (optional)

https://insights.hotjar.com/sites/3169877/feedback/responses/413330?frid=95073028
