### PR TITLE
get-started: remove learning center prereq

### DIFF
--- a/content/language/python/build-images.md
+++ b/content/language/python/build-images.md
@@ -7,7 +7,6 @@ description: Learn how to build an image of your Python application
 ## Prerequisites
 
 * You have installed the latest version of [Docker Desktop](../../get-docker.md).
-* You have completed the walkthroughs in the Docker Desktop [Learning Center](../../desktop/get-started.md) to learn about Docker concepts.
 * You have a [git client](https://git-scm.com/downloads). The examples in this section use a command-line based git client, but you can use any client.
 
 ## Overview

--- a/content/language/rust/build-images.md
+++ b/content/language/rust/build-images.md
@@ -7,7 +7,6 @@ description: Learn how to build your first Rust Docker image
 ## Prerequisites
 
 * You have installed the latest version of [Docker Desktop](../../get-docker.md).
-* You have completed the walkthroughs in the Docker Desktop [Learning Center](../../desktop/get-started.md) to learn about Docker concepts.
 * You have a [git client](https://git-scm.com/downloads). The examples in this section use a command-line based git client, but you can use any client.
 
 ## Overview


### PR DESCRIPTION
### Proposed changes
Remove link to the Desktop get started topic as a prereq in language specific guides.

The Learning Center section no longer exists in the linked topic. As it was never a real prereq, not replacing it.

### Related issues (optional)
ENGDOCS-1638
