### PR TITLE
Add tip to group mapping docs and update Hub release notes

### DIFF
--- a/content/docker-hub/release-notes.md
+++ b/content/docker-hub/release-notes.md
@@ -12,6 +12,10 @@ known issues for each Docker Hub release.
 
 Take a look at the [Docker Public Roadmap](https://github.com/docker/roadmap/projects/1) to see what's coming next.
 
+## 2023-08-28
+
+- Organizations with SSO enabled can assign members to roles, organizations, and teams with[SCIM role mapping](scim.md#set-up-role-mapping). 
+
 ## 2023-07-26
 
 ### New

--- a/content/docker-hub/release-notes.md
+++ b/content/docker-hub/release-notes.md
@@ -14,7 +14,7 @@ Take a look at the [Docker Public Roadmap](https://github.com/docker/roadmap/pro
 
 ## 2023-08-28
 
-- Organizations with SSO enabled can assign members to roles, organizations, and teams with[SCIM role mapping](scim.md#set-up-role-mapping). 
+- Organizations with SSO enabled can assign members to roles, organizations, and teams with [SCIM role mapping](scim.md#set-up-role-mapping). 
 
 ## 2023-07-26
 

--- a/layouts/shortcodes/admin-group-mapping.html
+++ b/layouts/shortcodes/admin-group-mapping.html
@@ -12,6 +12,11 @@
 
 With directory group-to-team provisioning from your IdP, user updates will automatically sync with your Docker organizations and teams.
 
+> **Tip**
+>
+> Group mapping is ideal for adding a user to multiple organizations. If you don't need to set up multi-organization assignment, you can use {{ $mapping_link }}.
+{ .tip }
+
 ## How group mapping works
 
 IdPs share with Docker the main attributes of every authorized user through SSO, such as email address, name, surname, and groups. These attributes are used by Just-In-Time (JIT) Provisioning to create or update the user’s Docker profile and their associations with organizations and teams on Docker Hub.
@@ -55,11 +60,6 @@ The following lists the supported group mapping attributes:
 | displayName | Name of the group following the group mapping format: `organization:team`. |
 | members | A list of users that are members of this group. |
 | members[x].value | Unique ID of the user that is a member of this group. Members are referenced by ID. |
-
-> **Tip**
->
-> Group mapping is ideal for adding a user to multiple organizations. If you don't need to set up multi-organization assignment, you can use {{ $mapping_link }}.
-{ .tip }
 
 To take advantage of group mapping, follow the instructions provided by your IdP:
 

--- a/layouts/shortcodes/admin-group-mapping.html
+++ b/layouts/shortcodes/admin-group-mapping.html
@@ -1,9 +1,12 @@
 {{ $scim_link := "[Enable SCIM](/docker-hub/scim/)" }}
+{{ $mapping_link := "[user-level attributes](docker-hub/scim.md#set-up-role-mapping)"}}
 
 {{ if eq (.Get "product") "admin" }}
-{{ $scim_link = "[Enable SCIM](/admin/company/settings/scim/)" }}
-{{ if eq (.Get "layer") "company" }}
 {{ $scim_link = "[Enable SCIM](/admin/organization/security-settings/scim/)" }}
+{{ $mapping_link = "[user-level attributes](admin/organization/security-settings/scim.md#set-up-role-mapping)"}}
+{{ if eq (.Get "layer") "company" }}
+{{ $scim_link = "[Enable SCIM](/admin/company/settings/scim/)" }}
+{{ $mapping_link = "[user-level attributes](admin/company/settings/scim.md#set-up-role-mapping)"}}
 {{ end }}
 {{ end }}
 
@@ -52,6 +55,11 @@ The following lists the supported group mapping attributes:
 | displayName | Name of the group following the group mapping format: `organization:team`. |
 | members | A list of users that are members of this group. |
 | members[x].value | Unique ID of the user that is a member of this group. Members are referenced by ID. |
+
+> **Tip**
+>
+> Group mapping is ideal for adding a user to multiple organizations. If you don't need to set up multi-organization assignment, you can use {{ $mapping_link }}.
+{ .tip }
 
 To take advantage of group mapping, follow the instructions provided by your IdP:
 

--- a/layouts/shortcodes/admin-group-mapping.html
+++ b/layouts/shortcodes/admin-group-mapping.html
@@ -14,7 +14,7 @@ With directory group-to-team provisioning from your IdP, user updates will autom
 
 > **Tip**
 >
-> Group mapping is ideal for adding a user to multiple organizations. If you don't need to set up multi-organization assignment, you can use {{ $mapping_link }}.
+> Group mapping is ideal for adding a user to multiple organizations or multiple teams within one organization. If you don't need to set up multi-organization or multi-team assignment, you can use {{ $mapping_link }}.
 { .tip }
 
 ## How group mapping works


### PR DESCRIPTION
<!--
  Thank you for contributing to Docker documentation!

  Here are a few things to keep in mind:

  - Links between pages should use a relative path
  - Remember to add an alt text for images

  ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
  ┃     Review our contribution guidelines:       ┃
  ┃                                               ┃
  ┃ https://docs.docker.com/contribute/overview/  ┃
  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
-->

### Proposed changes

<!-- Tell us what you did and why -->

This PR adds a tip callout to the group mapping docs to highlight when to use group mapping vs user attributes. There's also a fix for org vs company links in the group mapping doc, and an update to the Hub release notes for this feature.

- [Group mapping](https://deploy-preview-18156--docsdocker.netlify.app/docker-hub/group-mapping/) - also in the Admin > Company and Admin > Organization sections
- [Release notes](https://deploy-preview-18156--docsdocker.netlify.app/docker-hub/release-notes/)

### Related issues (optional)

<!--
  Refer to related PRs or issues:

  #1234
  Closes #1234
  Closes docker/cli#1234
-->
Related JIRA tickets:
- Closes [ENGDOCS-1647](https://docker.atlassian.net/browse/ENGDOCS-1647)
- Closes [ENGDOCS-1648](https://docker.atlassian.net/browse/ENGDOCS-1648)

[ENGDOCS-1647]: https://docker.atlassian.net/browse/ENGDOCS-1647?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ENGDOCS-1648]: https://docker.atlassian.net/browse/ENGDOCS-1648?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ