### PR TITLE
fix broken download link in v4.22.1

### DIFF
--- a/content/desktop/release-notes.md
+++ b/content/desktop/release-notes.md
@@ -79,7 +79,7 @@ With Docker Scout, you can now:
 
 {{< release-date date="2023-08-24" >}}
 
-{{< desktop-install all=true version="4.22.1" build_path="/118664" >}}
+{{< desktop-install all=true version="4.22.1" build_path="/118664/" >}}
 
 ### Bug fixes and enhancements
 


### PR DESCRIPTION
### Proposed changes

Fix broken download link in v4.22.1 https://docs.docker.com/desktop/release-notes/#4221

### Related issues (optional)

Related: 
- Closes https://github.com/docker/for-win/issues/13678

<!--
  Refer to related PRs or issues:

  #1234
  Closes #1234
  Closes docker/cli#1234
-->
