### PR TITLE
Update reset password link

### DIFF
--- a/content/docker-id/_index.md
+++ b/content/docker-id/_index.md
@@ -50,7 +50,7 @@ stored in your home directory in `.docker/config.json`. The password is base64-e
 
 ## Troubleshooting
 
-If you run into trouble with your Docker ID account, know that we're here to help! If you want to retrieve or reset your password, [enter your email address](https://id.docker.com/reset-password/) for additional instructions.
+If you run into trouble with your Docker ID account, know that we're here to help! If you want to retrieve or reset your password, [enter your email address](https://login.docker.com/u/login) for additional instructions.
 
 You can use the [Docker forums](https://forums.docker.com/) to ask questions amongst other Docker community members, while our [hub-feedback GitHub repository](https://github.com/docker/hub-feedback) allows you to provide feedback on how we can better improve the experience with Docker Hub.
 


### PR DESCRIPTION
<!--
  Thank you for contributing to Docker documentation!

  Here are a few things to keep in mind:

  - Links between pages should use a relative path
  - Remember to add an alt text for images

  ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
  ┃     Review our contribution guidelines:       ┃
  ┃                                               ┃
  ┃ https://docs.docker.com/contribute/overview/  ┃
  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
-->

### Proposed changes

<!-- Tell us what you did and why -->

This PR updates the link to the login page instead of the id page to direct users to where to go to reset their password. 

- [Create account](https://deploy-preview-18170--docsdocker.netlify.app/docker-id/#troubleshooting)

### Related issues (optional)

<!--
  Refer to related PRs or issues:

  #1234
  Closes #1234
  Closes docker/cli#1234
-->
Closes: [JIRA ticket](https://docker.atlassian.net/browse/ENGDOCS-1650)