### PR TITLE
Update deactivation docs to include Scout subscriptions

### DIFF
--- a/content/billing/scout-billing.md
+++ b/content/billing/scout-billing.md
@@ -54,7 +54,7 @@ Renewals charge to the original credit card used to buy Docker Scout Team.
 
 ### Cancel your subscription
 
-You can cancel your Docker Scout subscription at anytime. Your subscription features remain available until the end of your billing period.
+You can cancel your Docker Scout subscription at anytime. Your subscription features remain available until the end of your billing cycle.
 
 1. In the billing details portal, find your current plan.
 2. Next to the name of your Docker Scout plan, select **Cancel plan**.
@@ -62,7 +62,7 @@ You can cancel your Docker Scout subscription at anytime. Your subscription feat
 
 ### Renew a canceled subscription
 
-You can renew a plan that you canceled at anytime.
+You can renew a canceled subscription any time before the end of the billing cycle. You can find this date in the billing details portal.
 
 1. Find the canceled plan in the billing details portal.
 2. Next to the name of your canceled Docker Scout plan, select **Renew plan**.

--- a/content/billing/scout-billing.md
+++ b/content/billing/scout-billing.md
@@ -48,7 +48,7 @@ Once your purchase is complete, you receive a confirmation email and a copy of y
 
 ## Manage your subscription
 
-To access your subscription details, go to the **Billing** section for your personal account or organization that's subscribed. In the **Docker Scout Team** section, select **Change plan**. In your billing details portal, you can find your renewal date, invoice history, or cancel your plan.
+To access your subscription details, go to the **Billing** section for your personal account or organization that's subscribed. In the **Docker Scout Team** section, select **Change plan** to go to the billing details portal. In the billing details portal, you can find your renewal date, invoice history, or cancel your plan.
 
 Renewals charge to the original credit card used to buy Docker Scout Team.
 
@@ -62,9 +62,10 @@ You can cancel your Docker Scout subscription at anytime. Your subscription feat
 
 ### Renew a canceled subscription
 
-You can renew a canceled subscription any time before the end of the billing cycle. You can find this date in the billing details portal.
+You can renew a canceled subscription any time before the end of the billing cycle. You can find this date in the details for your current plan.
 
 1. Find the canceled plan in the billing details portal.
-2. Next to the name of your canceled Docker Scout plan, select **Renew plan**.
-3. Review the details for your subscription. Note that you can't edit the number of repositories or the billing information.
-4. Select **Renew plan** to confirm. Renewals charge to the original credit card used to buy your subscription.
+2. Optional: you can update your payment method here before you renew the plan. Otherwise, your renewal charges to the original payment method.
+3. Next to the name of your canceled Docker Scout plan, select **Renew plan**.
+4. Review the details for your subscription. Note that you can't edit the number of repositories or the billing information.
+5. Select **Renew plan** to confirm.

--- a/content/billing/scout-billing.md
+++ b/content/billing/scout-billing.md
@@ -48,6 +48,23 @@ Once your purchase is complete, you receive a confirmation email and a copy of y
 
 ## Manage your subscription
 
-To access your subscription details, go to the **Billing** section for your personal account or organization that's subscribed. In the **Docker Scout Team** section, select **Change plan**. Here you can find your renewal date, invoice history, or cancel your plan.
+To access your subscription details, go to the **Billing** section for your personal account or organization that's subscribed. In the **Docker Scout Team** section, select **Change plan**. In your billing details portal, you can find your renewal date, invoice history, or cancel your plan.
 
 Renewals charge to the original credit card used to buy Docker Scout Team.
+
+### Cancel your subscription
+
+You can cancel your Docker Scout subscription at anytime. Your subscription features remain available until the end of your billing period.
+
+1. In the billing details portal, find your current plan.
+2. Next to the name of your Docker Scout plan, select **Cancel plan**.
+3. Review the details for your subscription, then select **Cancel plan** to confirm.
+
+### Renew a canceled subscription
+
+You can renew a plan that you canceled at anytime.
+
+1. Find the canceled plan in the billing details portal.
+2. Next to the name of your canceled Docker Scout plan, select **Renew plan**.
+3. Review the details for your subscription. Note that you can't edit the number of repositories or the billing information.
+4. Select **Renew plan** to confirm. Renewals charge to the original credit card used to buy your subscription.

--- a/content/docker-hub/deactivate-account.md
+++ b/content/docker-hub/deactivate-account.md
@@ -52,7 +52,9 @@ Before deactivating an organization, complete the following:
 - Download any images and tags you want to keep:
   `docker pull -a <image>:<tag>`.
 
--  If you have an active subscription, [downgrade it to a **Docker Free Team** subscription](../subscription/downgrade.md).
+- If you have an active Docker subscription, [downgrade it to a **Docker Free Team** subscription](../subscription/downgrade.md).
+
+- If you have an active Docker Scout subscription, [cancel your plan](../billing/scout-billing.md#cancel-your-subscription).
 
 - Remove all other members within the organization.
 

--- a/content/docker-hub/deactivate-account.md
+++ b/content/docker-hub/deactivate-account.md
@@ -26,7 +26,9 @@ Before deactivating your Docker account, ensure that you meet the following requ
 
 - If you are the sole owner of an organization, either assign another member of the organization the owner role and then remove yourself from the organization, or deactivate the organization. Similarly, if you are the sole owner of a company, either add someone else as a company owner and then remove yourself, or deactivate the company.
 
-- If you have an active subscription, [downgrade it to a Docker Personal subscription](../subscription/downgrade.md).
+- If you have an active Docker subscription, [downgrade it to a Docker Personal subscription](../subscription/downgrade.md).
+
+- If you have an active Docker Scout subscription, [cancel your plan](../billing/scout-billing.md#cancel-your-subscription).
 
 - Download any images and tags you want to keep. Use `docker pull -a <image>:<tag>`.
 


### PR DESCRIPTION
<!--
  Thank you for contributing to Docker documentation!

  Here are a few things to keep in mind:

  - Links between pages should use a relative path
  - Remember to add an alt text for images

  ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
  ┃     Review our contribution guidelines:       ┃
  ┃                                               ┃
  ┃ https://docs.docker.com/contribute/overview/  ┃
  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
-->

### Proposed changes

<!-- Tell us what you did and why -->

When a user deactivates we recommend they downgrade their Docker subscription. This PR also adds to that list of requirements that they cancel their paid Docker Scout plan before deactivating as well. It also adds the steps to cancel and renew a canceled plan to the Scout billing docs.

- [Docker Scout billing - Manage your subscription](https://deploy-preview-18185--docsdocker.netlify.app/billing/scout-billing/#manage-your-subscription)
- [Deactivate your account or organization](https://deploy-preview-18185--docsdocker.netlify.app/docker-hub/deactivate-account/)

### Related issues (optional)

<!--
  Refer to related PRs or issues:

  #1234
  Closes #1234
  Closes docker/cli#1234
-->
Closes [ENGDOCS-1645](https://docker.atlassian.net/browse/ENGDOCS-1645)

[ENGDOCS-1645]: https://docker.atlassian.net/browse/ENGDOCS-1645?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ