### PR TITLE
scout: fix links to integrations on dashboard

### DIFF
--- a/content/scout/integrations/registry/ecr.md
+++ b/content/scout/integrations/registry/ecr.md
@@ -63,13 +63,9 @@ Prerequisites:
 
 To create the stack:
 
-1. Go to [ECR integrations](https://scout.docker.com/settings/integrations/ecr)
-   on the Docker Scout Dashboard.
-2. Make sure the correct Docker organization is selected in the Dashboard
-   header.
-
-   If not, switch organizations using the drop-down menu.
-
+1. Go to [Integrations](https://scout.docker.com/settings/integrations/) on the
+   Docker Scout Dashboard.
+2. Select **Integrate** on **Elastic Container Registry**.
 3. Select the **Create on AWS** button.
 
    This opens the **Create stack** wizard in the AWS CloudFormation console in
@@ -87,8 +83,7 @@ To create the stack:
    so you don't need to edit any of the fields.
 
 5. When the resources have been created (the CloudFormation status shows
-   `CREATE_COMPLETE` in the AWS console), return to the
-   [ECR integrations](https://scout.docker.com/settings/integrations/ecr) page
+   `CREATE_COMPLETE` in the AWS console), return to the ECR integrations page
    in the Docker Scout Dashboard.
 
    The **Integrated registries** list shows the account ID and region for the
@@ -106,18 +101,13 @@ Scout, and the analysis results will appear in the Docker Scout Dashboard.
 
 To add additional registries:
 
-1. Go to [ECR integrations](https://scout.docker.com/settings/integrations/ecr)
-   on the Docker Scout Dashboard.
-2. Make sure the correct Docker organization is selected in the Dashboard
-   header.
-
-   If not, switch organizations using the drop-down menu.
-
+1. Go to [Integrations](https://scout.docker.com/settings/integrations/) on the
+   Docker Scout Dashboard.
+2. Select **Manage** on **Elastic Container Registry**.
 3. Select the **Add** button at the top of the list.
 4. Complete the steps for creating the AWS resources.
-5. When the resources have been created, return to the
-   [ECR integrations](https://scout.docker.com/settings/integrations/ecr) page
-   in the Docker Scout Dashboard.
+5. When the resources have been created, return to the ECR integrations page in
+   the Docker Scout Dashboard.
 
    The **Integrated registries** list shows the account ID and region for the
    ECR registry that you just integrated. If successful, the integration status
@@ -131,15 +121,16 @@ Next, activate Docker Scout for the repositories that you want to analyze in
 To remove an integrated ECR registry, you must be an owner of the Docker
 organization.
 
-1. Go to [ECR integrations](https://scout.docker.com/settings/integrations/ecr)
-   on the Docker Scout Dashboard.
-2. Find the registry that you want to remove in the list of integrated
+1. Go to [Integrations](https://scout.docker.com/settings/integrations/) on
+   the Docker Scout Dashboard.
+2. Select **Manage** on **Elastic Container Registry**.
+3. Find the registry that you want to remove in the list of integrated
    registries, and select the remove icon in the **Actions** column.
 
    If the remove icon is disabled, it means that you're lacking the necessary
    permissions in the Docker organization.
 
-3. In the dialog that opens, confirm by selecting **Remove**.
+4. In the dialog that opens, confirm by selecting **Remove**.
 
 > **Important**
 >
@@ -155,8 +146,12 @@ organization.
 
 ### Unable to integrate registry
 
-Check the **Status** of the integration on the
-[ECR integrations](https://scout.docker.com/settings/integrations/ecr) page.
+Check the **Status** of the integration on the ECR integrations page in the
+Docker Scout Dashboard:
+
+1. Go to [Integrations](https://scout.docker.com/settings/integrations/) on the
+   Docker Scout Dashboard.
+2. Select **Manage** on **Elastic Container Registry**.
 
 - If the status is **Pending** for a prolonged period of time, it's an
   indication that the integration was not yet completed on the AWS side. Select
@@ -170,13 +165,13 @@ Check the **Status** of the integration on the
 ### ECR images not showing in the dashboard
 
 If image analysis results for your ECR images aren't showing up in the Docker
-Scout Dashboard, run the following checks:
+Scout Dashboard:
 
 - Ensure that you've activated Docker Scout for the repository. View and manage
-  active repositories in [repository settings](../../dashboard.md#repository-settings).
+  active repositories in [Repository settings](../../dashboard.md#repository-settings).
 
 - Ensure that the AWS account ID and region for your registry is listed on the
-  [ECR integrations](https://scout.docker.com/settings/integrations/ecr) page.
+  ECR integrations page.
 
   The account ID and region are included in the registry hostname:
   `<aws_account_id>.dkr.ecr.<region>.amazonaws.com/<image>`


### PR DESCRIPTION
Signed-off-by: David Karlsson <35727626+dvdksn@users.noreply.github.com>

Org-agnostic deep links to integrations page don't work, so changing the links to point to the top-level integrations landing page instead.

docker/scout-issues#23