### PR TITLE
Change "database service" to "application service"

### DIFF
--- a/content/get-started/08_using_compose.md
+++ b/content/get-started/08_using_compose.md
@@ -31,7 +31,7 @@ In the `getting-started-app` directory, create a file named `compose.yaml`.
 
 ## Define the app service
 
-In [part 7](./07_multi_container.md), you used the following command to start the database service.
+In [part 7](./07_multi_container.md), you used the following command to start the application service.
 
 ```console
 $ docker run -dp 127.0.0.1:3000:3000 \


### PR DESCRIPTION
Hello, in this part of the documentation the explanation is talking about the application service not the database service.