### PR TITLE
Update 02_our_app.md

### DIFF
--- a/content/get-started/02_our_app.md
+++ b/content/get-started/02_our_app.md
@@ -15,9 +15,10 @@ don't worry. This guide doesn't require any prior experience with JavaScript.
 
 ## Prerequisites
 
-- You have installed the latest version of [Docker Desktop](../get-docker.md).
+- You have installed the latest version of [Docker Desktop](https://www.docker.com/products/docker-desktop).
 - You have installed a [Git client](https://git-scm.com/downloads).
 - You have an IDE or a text editor to edit files. Docker recommends using [Visual Studio Code](https://code.visualstudio.com/).
+
 
 ## Get the app
 


### PR DESCRIPTION
Fixed an issue where open_in_new would show after each link.

<!--
  Thank you for contributing to Docker documentation!

  Here are a few things to keep in mind:

  - Links between pages should use a relative path
  - Remember to add an alt text for images

  ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
  ┃     Review our contribution guidelines:       ┃
  ┃                                               ┃
  ┃ https://docs.docker.com/contribute/overview/  ┃
  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
-->

### Proposed changes

I was going through the Docker documentation and i noticed that the three lines under Prerequisites in the containerise an application page had open_in_new text at the end. I have removed that text so that it looks normal now.

### Related issues (optional)

<!--
  Refer to related PRs or issues:

  #1234
  Closes #1234
  Closes docker/cli#1234
-->
