### PR TITLE
Update search.css

### DIFF
--- a/assets/css/search.css
+++ b/assets/css/search.css
@@ -89,6 +89,7 @@ html.dark {
 .DocSearch-Button-Keys {
   display: flex;
   min-width: calc(40px + 0.8em);
+  margin-top: 3px
 }
 .DocSearch-Button-Key {
   align-items: center;


### PR DESCRIPTION
Centered the CTRL K icons in the search bar.

<!--
  Thank you for contributing to Docker documentation!

  Here are a few things to keep in mind:

  - Links between pages should use a relative path
  - Remember to add an alt text for images

  ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
  ┃     Review our contribution guidelines:       ┃
  ┃                                               ┃
  ┃ https://docs.docker.com/contribute/overview/  ┃
  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
-->

### Proposed changes

I  noticed in the search bar for docker docs that the CTRL K icon was not centered properly so i have fixed it so it becomes center and hopefully looks better now.
