### PR TITLE
fix: ignore empty default values for cli flags

### DIFF
--- a/layouts/_default/cli.html
+++ b/layouts/_default/cli.html
@@ -85,7 +85,12 @@
             <tr>
               <td>{{ with .option }}<code>--{{ . }}</code>{{ end }}</td>
               <td>{{ with .shorthand }}<code>-{{ . }}</code>{{ end }}</td>
-              <td>{{ with .default_value }}<code>{{ . }}</code>{{ end }}</td>
+              {{ $skipDefault := `[],map[],false,0,0s,default,'',""` }}
+              <td>
+                {{ with .default_value }}
+                  {{ cond (in $skipDefault .) "" (printf "<code>%s</code>" . | safeHTML) }}
+                {{ end }}
+              </td>
               <td>
                 {{ with .min_api_version }}
                   {{ partial "components/badge.html" (dict "color" "blue" "content" (printf "API %s+" .)) }}


### PR DESCRIPTION
Signed-off-by: David Karlsson <35727626+dvdksn@users.noreply.github.com>

<!--
  Thank you for contributing to Docker documentation!

  Here are a few things to keep in mind:

  - Links between pages should use a relative path
  - Remember to add an alt text for images

  ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
  ┃     Review our contribution guidelines:       ┃
  ┃                                               ┃
  ┃ https://docs.docker.com/contribute/overview/  ┃
  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
-->

### Proposed changes

<!-- Tell us what you did and why -->

### Related issues (optional)

<!--
  Refer to related PRs or issues:

  #1234
  Closes #1234
  Closes docker/cli#1234
-->
