### PR TITLE
desktop: update 4.23 and 4.22 release notes

### DIFF
--- a/content/desktop/release-notes.md
+++ b/content/desktop/release-notes.md
@@ -34,21 +34,21 @@ For frequently asked questions about Docker Desktop releases, see [FAQs](faqs/re
 - [Compose v2.21.0](https://github.com/docker/compose/releases/tag/v2.21.0)
 - [Docker Engine v24.0.6](https://docs.docker.com/engine/release-notes/24.0/#2406)
 - [Docker Scout CLI v0.24.1](https://github.com/docker/scout-cli/releases/tag/v0.24.1).
-- Wasm runtimes:
+- [Wasm](../desktop/wasm/_index.md) runtimes:
   - wasmtime, wasmedge revision `d0a1a1cd`.
   - slight and spin wasm `v0.9.0`.
 
 ### New
 
 - Added support for new Wasm runtimes: wws and lunatic.
-- `docker init` now supports ASP.NET
+- [`docker init`](../engine/reference/commandline/init.md) now supports ASP.NET
 - Increased performance of exposed ports on macOS, for example with `docker run -p`.
 
 ### Bug fixes and enhancements
 
 #### For all platforms
 
-- With Docker Scout, you can now:
+- With [Docker Scout](../scout/_index.md), you can now:
   - Manage temporary and cached files with `docker scout cache`.
   - Manage environments with `docker scout environment`.
   - Configure the default organization with `docker scout config`.
@@ -130,6 +130,12 @@ For frequently asked questions about Docker Desktop releases, see [FAQs](faqs/re
 - Fixed a bug where turning on Wasm from the UI failed when the system was paused.
 - Bind mounts are now shown when you [inspect a container](use-desktop/container.md).
 - You can now download Wasm runtimes when the containerd image store is enabled.
+- With [Quick Search](../desktop/use-desktop/_index.md/#quick-search), you can now:
+  - Find any container or Compose app residing on your local system. In addition, you can access environment variables and perform essential actions such as starting, stopping, or deleting containers.
+  - Find public Docker Hub images, local images, or images from remote repositories.
+  - Discover more about specific extensions and install them.
+  - Navigate through your volumes and gain insights about the associated containers.
+  - Search and access Docker's documentation.
 
 #### For Mac
 

--- a/content/desktop/release-notes.md
+++ b/content/desktop/release-notes.md
@@ -131,10 +131,14 @@ For frequently asked questions about Docker Desktop releases, see [FAQs](faqs/re
 - Bind mounts are now shown when you [inspect a container](use-desktop/container.md).
 - You can now download Wasm runtimes when the containerd image store is enabled.
 - With [Quick Search](../desktop/use-desktop/_index.md/#quick-search), you can now:
-  - Find any container or Compose app residing on your local system. In addition, you can access environment variables and perform essential actions such as starting, stopping, or deleting containers.
-  - Find public Docker Hub images, local images, or images from remote repositories.
+  - Find any container or Compose app residing on your local system. In
+    addition, you can access environment variables and perform essential actions
+    such as starting, stopping, or deleting containers.
+  - Find public Docker Hub images, local images, or images from remote
+    repositories.
   - Discover more about specific extensions and install them.
-  - Navigate through your volumes and gain insights about the associated containers.
+  - Navigate through your volumes and gain insights about the associated
+    containers.
   - Search and access Docker's documentation.
 
 #### For Mac


### PR DESCRIPTION
### Proposed changes

Issue: Some of the items in the [4.23 blog post](https://www.docker.com/blog/docker-desktop-4-23/) appear to not be in the [4.23 Desktop release notes](https://docs.docker.com/desktop/release-notes/).

Fix:
- Added Quick Search updates to 4.22 release note. Was added in 4.22, but release note was still under consideration. Hence, the mention in the 4.23 blog post.
- Verified that Configuration Integrity Check was in the 4.23 release notes as `Reinstated the health check for macOS that notifies you if there has been a change on your system which might cause problems running Docker binaries`. 

Bonus: Added some links to the features mentioned in 4.23.

### Related issues (optional)

ENGDOCS-1657
