### PR TITLE
docs: updates documents to describe default target behaviour 

### DIFF
--- a/_vendor/github.com/docker/buildx/docs/bake-reference.md
+++ b/_vendor/github.com/docker/buildx/docs/bake-reference.md
@@ -733,7 +733,7 @@ target "default" {
 
 ### `target.target`
 
-Set the target build stage to build.
+Set the target build stage to build. If no target is specified, the target will be the last stage defined in the Dockerfile.
 This is the same as the [`--target` flag][target].
 
 ```hcl

--- a/content/build/building/multi-stage.md
+++ b/content/build/building/multi-stage.md
@@ -108,6 +108,11 @@ A few scenarios where this might be useful are:
 - Using a `testing` stage in which your app gets populated with test data, but
   building for production using a different stage which uses real data
 
+> **Note**
+>
+> When no target is specified, the target will be the last stage defined in the
+> Dockerfile.
+
 ## Use an external image as a stage
 
 When using multi-stage builds, you aren't limited to copying from stages you

--- a/data/engine-cli/docker_build.yaml
+++ b/data/engine-cli/docker_build.yaml
@@ -396,7 +396,7 @@ options:
       swarm: false
     - option: target
       value_type: string
-      description: Set the target build stage to build.
+      description: Set the target build stage to build. If no target is specified, the target will be the last stage defined in the Dockerfile.
       details_url: '#target'
       deprecated: false
       hidden: false

--- a/data/engine-cli/docker_builder_build.yaml
+++ b/data/engine-cli/docker_builder_build.yaml
@@ -285,7 +285,7 @@ options:
       swarm: false
     - option: target
       value_type: string
-      description: Set the target build stage to build.
+      description: Set the target build stage to build. If no target is specified, the target will be the last stage defined in the Dockerfile.
       deprecated: false
       hidden: false
       experimental: false

--- a/data/engine-cli/docker_image_build.yaml
+++ b/data/engine-cli/docker_image_build.yaml
@@ -285,7 +285,7 @@ options:
       swarm: false
     - option: target
       value_type: string
-      description: Set the target build stage to build.
+      description: Set the target build stage to build. If no target is specified, the target will be the last stage defined in the Dockerfile.
       deprecated: false
       hidden: false
       experimental: false


### PR DESCRIPTION
<!--
  Thank you for contributing to Docker documentation!

  Here are a few things to keep in mind:

  - Links between pages should use a relative path
  - Remember to add an alt text for images

  ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
  ┃     Review our contribution guidelines:       ┃
  ┃                                               ┃
  ┃ https://docs.docker.com/contribute/overview/  ┃
  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
-->

### Proposed changes

<!-- Tell us what you did and why -->
I updated the reference for --taget in build and bake to describe the default behaviour of the flag.

You can test this by running `docker build -t demo --progress plain .` on any directory with the following image.

```Dockerfile
FROM ubuntu:latest as stagea
RUN echo "stagea"

FROM ubuntu:latest as stageb
RUN echo "stageb"
```

You should see something like this in the logs

```
#6 [stageb 2/2] RUN echo "stageb"
#6 0.097 imageb
#6 DONE 0.2s
```

### Related issues (optional)

https://github.com/docker/cli/pull/4571

<!--
  Refer to related PRs or issues:

  #1234
  Closes #1234
  Closes docker/cli#1234
-->
