### PR TITLE
Clarification for build hooks

### DIFF
--- a/content/docker-hub/builds/advanced.md
+++ b/content/docker-hub/builds/advanced.md
@@ -68,6 +68,9 @@ repository at the same directory level as your Dockerfile. Create a file called
 builder process can execute, such as `docker` and `bash` commands (prefixed
 appropriately with `#!/bin/bash`).
 
+Please note that the current working directory for your hooks is the directory of 
+your dockerfile location ( `DOCKERFILE_PATH` ) and NOT your build context. 
+
 These hooks run on an instance of [Ubuntu](https://releases.ubuntu.com/),
 which includes interpreters
 such as Perl or Python, and utilities such as `git` or `curl`. Refer to the


### PR DESCRIPTION

### Proposed changes

Add clarification to documentation for build hooks, to make people aware that hooks are executed from the working directory of the dockerfile and a specified build context is ignored for hooks. The build context is also not available as environment variable and hook scripts need to be adapted to cater for this.

Example:

If you are having a repository which is list Dockerfiles in a subdirectory `dockerfiles/DockerfileABC` , with a build context `/` you will most likely setup the automated build as: "Dockerfile location=dockerfiles/DockerfileABC" and "Build Context=/".

Locally this could be represented as:

`docker build --file ./dockerfiles/DockerfileABC ./` 

but within a hook it needs to be adapted like:

`docker build --file ./DockerfileABC ../` 


