### PR TITLE
Change Azure AD references to Entra ID

### DIFF
--- a/content/desktop/extensions-sdk/guides/oauth2-flow.md
+++ b/content/desktop/extensions-sdk/guides/oauth2-flow.md
@@ -8,7 +8,7 @@ aliases:
 
 > Note
 >
-> This page assumes that you already have an Identity Provider (IdP), such as Google, Azure AD or Okta, which handles the authentication process and returns an access token.
+> This page assumes that you already have an Identity Provider (IdP), such as Google, Entra ID (formerly Azure AD) or Okta, which handles the authentication process and returns an access token.
 
 Learn how you can let users authenticate from your Docker Extension using OAuth 2.0 via a web browser, and return them back to your Docker extension.
 

--- a/content/docker-hub/release-notes.md
+++ b/content/docker-hub/release-notes.md
@@ -69,7 +69,7 @@ Take a look at the [Docker Public Roadmap](https://github.com/docker/roadmap/pro
 
 ### Bug fixes and enhancements
 
-- SCIM is now available for organizations with a Docker Business subscription using an Azure AD identity provider.
+- SCIM is now available for organizations with a Docker Business subscription using an Entra ID (formerly Azure AD) identity provider.
 
 ## 2022-06-23
 

--- a/content/single-sign-on/faqs.md
+++ b/content/single-sign-on/faqs.md
@@ -10,7 +10,7 @@ Docker Single Sign-on (SSO) is only available with the Docker Business subscript
 
 ### How does Docker SSO work?
 
-Docker Single Sign-on (SSO) allows users to authenticate using their identity providers (IdPs) to access Docker. Docker supports Azure AD and any SAML 2.0 identity providers. When you enable SSO, users are redirected to your provider’s authentication page to authenticate using their email and password.
+Docker Single Sign-on (SSO) allows users to authenticate using their identity providers (IdPs) to access Docker. Docker supports Entra ID (formerly Azure AD) and any SAML 2.0 identity providers. When you enable SSO, users are redirected to your provider’s authentication page to authenticate using their email and password.
 
 ### What SSO flows are supported by Docker?
 

--- a/content/single-sign-on/idp-faqs.md
+++ b/content/single-sign-on/idp-faqs.md
@@ -6,7 +6,7 @@ title: Identity providers
 
 ### Is it possible to use more than one IdP with Docker SSO?
 
-No. You can only configure Docker SSO to work with a single IdP. A domain can only be associated with a single IdP. Docker supports Azure AD and identity providers that support SAML 2.0.
+No. You can only configure Docker SSO to work with a single IdP. A domain can only be associated with a single IdP. Docker supports Entra ID (formerly Azure AD) and identity providers that support SAML 2.0.
 
 ### Is it possible to change my identity provider after configuring SSO?
 
@@ -18,7 +18,7 @@ To enable SSO in Docker, you need the following from your IdP:
 
 * **SAML**: Entity ID, ACS URL, Single Logout URL and the public X.509 certificate
 
-* **Azure AD**: Client ID, Client Secret, AD Domain.
+* **Entra ID (formerly Azure AD)**: Client ID, Client Secret, AD Domain.
 
 ### What happens if my existing certificate expires?
 
@@ -50,8 +50,8 @@ Yes, bot accounts needs a seat, similar to a regular end user, having a non-alia
 
 ### Is it possible to connect Docker Hub directly with a Microsoft Azure Active Directory (AD) Group?
 
-Yes, Azure AD is supported with SSO for Docker Business, both through a direct integration and through SAML.
+Yes, Entra ID (formerly Azure AD) is supported with SSO for Docker Business, both through a direct integration and through SAML.
 
-### My SSO connection with Azure AD isn't working and I receive an error that the application is misconfigured. How can I troubleshoot this?
+### My SSO connection with Entra ID (formerly Azure AD) isn't working and I receive an error that the application is misconfigured. How can I troubleshoot this?
 
-Confirm that you've configured the necessary API permissions in Azure AD for your SSO connection. You need to grant admin consent within your Azure AD tenant. See [Azure AD documentation](https://learn.microsoft.com/en-us/azure/active-directory/manage-apps/grant-admin-consent?pivots=portal#grant-admin-consent-in-app-registrations).
+Confirm that you've configured the necessary API permissions in Entra ID (formerly Azure AD) for your SSO connection. You need to grant admin consent within your Entra ID (formerly Azure AD) tenant. See [Entra ID (formerly Azure AD) documentation](https://learn.microsoft.com/en-us/azure/active-directory/manage-apps/grant-admin-consent?pivots=portal#grant-admin-consent-in-app-registrations).

--- a/content/single-sign-on/idp-faqs.md
+++ b/content/single-sign-on/idp-faqs.md
@@ -48,7 +48,7 @@ We currently do not have any plans to enable IdP initiated logins.
 
 Yes, bot accounts needs a seat, similar to a regular end user, having a non-aliased domain email enabled in the IdP and using a seat in Hub.
 
-### Is it possible to connect Docker Hub directly with a Microsoft Azure Active Directory (AD) Group?
+### Is it possible to connect Docker Hub directly with a Microsoft Entra (formerly Azure AD) group?
 
 Yes, Entra ID (formerly Azure AD) is supported with SSO for Docker Business, both through a direct integration and through SAML.
 

--- a/content/single-sign-on/users-faqs.md
+++ b/content/single-sign-on/users-faqs.md
@@ -53,11 +53,11 @@ For detailed prerequisites and instructions on how to enable SSO, see [Configure
 
 When SSO is enabled and enforced, your users just have to sign in using the email address and password.
 
-### Is Docker SSO fully synced with Active Directory (AD)?
+### Is Docker SSO fully synced with the IdP?
 
-Docker doesn’t currently support a full sync with AD. That's, if a user leaves the organization, administrators must sign in to Docker Hub and manually [remove the user](/docker-hub/members/#remove-a-member-or-invitee) from the organization.
+Docker SSO provides Just In Time (JIT) provisioning by default. This provisioning only happens when a user signs in. If a user leaves the organization, administrators must sign in to Docker Hub and manually [remove the user](/docker-hub/members/#remove-a-member-or-invitee) from the organization. [SCIM](/docker-hub/scim/) is available to provide full synchronization with users and groups.
 
-Additionally, you can use our APIs to complete this process.
+Additionally, you can use the [Docker Hub API](/docker-hub/api/latest/) to complete this process.
 
 ### What's the best way to provision the Docker Subscription without SSO?
 

--- a/content/single-sign-on/users-faqs.md
+++ b/content/single-sign-on/users-faqs.md
@@ -55,7 +55,7 @@ When SSO is enabled and enforced, your users just have to sign in using the emai
 
 ### Is Docker SSO fully synced with the IdP?
 
-Docker SSO provides Just In Time (JIT) provisioning by default. This provisioning only happens when a user signs in. If a user leaves the organization, administrators must sign in to Docker Hub and manually [remove the user](/docker-hub/members/#remove-a-member-or-invitee) from the organization. [SCIM](/docker-hub/scim/) is available to provide full synchronization with users and groups.
+Docker SSO provides Just-In-Time (JIT) provisioning by default. This provisioning only happens when a user signs in. If a user leaves the organization, administrators must sign in to Docker Hub and manually [remove the user](/docker-hub/members/#remove-a-member-or-invitee) from the organization. [SCIM](/docker-hub/scim/) is available to provide full synchronization with users and groups.
 
 Additionally, you can use the [Docker Hub API](/docker-hub/api/latest/) to complete this process.
 

--- a/content/single-sign-on/users-faqs.md
+++ b/content/single-sign-on/users-faqs.md
@@ -61,7 +61,7 @@ Additionally, you can use the [Docker Hub API](/docker-hub/api/latest/) to compl
 
 ### What's the best way to provision the Docker Subscription without SSO?
 
-Company or organisation owners can invite users through Docker Hub UI, by email address (for any user) or by Docker ID (assuming the user has created a user account on Hub already).
+Company or organization owners can invite users through Docker Hub UI, by email address (for any user) or by Docker ID (assuming the user has created a user account on Hub already).
 
 ### If we add a user manually for the first time, can I register in the dashboard and will the user get an invitation link through email?
 

--- a/layouts/shortcodes/admin-group-mapping.html
+++ b/layouts/shortcodes/admin-group-mapping.html
@@ -64,7 +64,7 @@ The following lists the supported group mapping attributes:
 To take advantage of group mapping, follow the instructions provided by your IdP:
 
 - [Okta](https://help.okta.com/en-us/Content/Topics/users-groups-profiles/usgp-enable-group-push.htm)
-- [Azure AD](https://learn.microsoft.com/en-us/azure/active-directory/app-provisioning/customize-application-attributes)
+- [Entra ID (formerly Azure AD)](https://learn.microsoft.com/en-us/azure/active-directory/app-provisioning/customize-application-attributes)
 - [OneLogin](https://developers.onelogin.com/scim/create-app)
 
 Once complete, a user who signs in to Docker through SSO is automatically added to the organizations and teams mapped in the IdP.

--- a/layouts/shortcodes/admin-scim.html
+++ b/layouts/shortcodes/admin-scim.html
@@ -58,7 +58,7 @@ You must make sure you have {{ $sso_link }} before you enable SCIM. Enforcing SS
 Follow the instructions provided by your IdP:
 
 - [Okta](https://help.okta.com/en-us/Content/Topics/Apps/Apps_App_Integration_Wizard_SCIM.htm)
-- [Azure AD](https://learn.microsoft.com/en-us/azure/active-directory/app-provisioning/user-provisioning)
+- [Entra ID (formerly Azure AD)](https://learn.microsoft.com/en-us/azure/active-directory/app-provisioning/user-provisioning)
 - [OneLogin](https://developers.onelogin.com/scim/create-app)
 
 ## Set up role mapping
@@ -84,7 +84,7 @@ The external namespace to use to set up these attributes is `urn:ietf:params:sci
 For how to add these attributes, see the documentation for your IdP:
 
 - [Okta](https://help.okta.com/en-us/Content/Topics/users-groups-profiles/usgp-add-custom-user-attributes.htm)
-- [Azure AD](https://learn.microsoft.com/en-us/azure/active-directory/app-provisioning/customize-application-attributes#provisioning-a-custom-extension-attribute-to-a-scim-compliant-application)
+- [Entra ID (formerly Azure AD)](https://learn.microsoft.com/en-us/azure/active-directory/app-provisioning/customize-application-attributes#provisioning-a-custom-extension-attribute-to-a-scim-compliant-application)
 - [OneLogin](https://onelogin.service-now.com/support?id=kb_article&sys_id=742a000d4740f1909d8dfd1f536d435f&kb_category=566ffd6887332910695f0f66cebb3556#config-info-custom)
 
 ## Disable SCIM

--- a/layouts/shortcodes/admin-sso-config.md
+++ b/layouts/shortcodes/admin-sso-config.md
@@ -40,9 +40,9 @@
 >
 > If your IdP setup requires an Entity ID and the ACS URL, you must select the
 > **SAML** tab in the **Authentication Method** section. For example, if your
-> Azure AD Open ID Connect (OIDC) setup uses SAML configuration within Azure
-> AD, you must select **SAML**. If you are [configuring Open ID Connect with Azure AD](https://docs.microsoft.com/en-us/powerapps/maker/portals/configure/configure-openid-settings) select
-> **Azure AD** as the authentication method. Also, IdP initiated connections
+> Entra ID (formerly Azure AD) Open ID Connect (OIDC) setup uses SAML configuration within Azure
+> AD, you must select **SAML**. If you are [configuring Open ID Connect with Entra ID (formerly Azure AD)](https://docs.microsoft.com/en-us/powerapps/maker/portals/configure/configure-openid-settings) select
+> **Entra ID (formerly Azure AD)** as the authentication method. Also, IdP initiated connections
 > aren't supported at this time.
 { .important}
 
@@ -89,7 +89,7 @@ After you’ve completed the SSO configuration process in Docker, you can test t
 > You can change this on a per-app basis. To prevent auto-provisioning users, you can create a security group in your IdP and configure the SSO app to authenticate and authorize only those users that are in the security group. Follow the instructions provided by your IdP:
 >
 > - [Okta](https://help.okta.com/en-us/Content/Topics/Security/policies/configure-app-signon-policies.htm)
-> - [AzureAD](https://learn.microsoft.com/en-us/azure/active-directory/develop/howto-restrict-your-app-to-a-set-of-users)
+> - [Entra ID (formerly Azure AD)](https://learn.microsoft.com/en-us/azure/active-directory/develop/howto-restrict-your-app-to-a-set-of-users)
 { .important}
 
 The SSO connection is now created. You can continue to set up SCIM without enforcing SSO log-in. For more information about setting up SCIM, see {{ $scim_link }}.

--- a/layouts/shortcodes/admin-sso-management.md
+++ b/layouts/shortcodes/admin-sso-management.md
@@ -73,7 +73,7 @@ When you disable SSO, you can delete the connection to remove the configuration 
 > You can change this on a per-app basis. To prevent auto-provisioning users, you can create a security group in your IdP and configure the SSO app to authenticate and authorize only those users that are in the security group. Follow the instructions provided by your IdP:
 >
 > - [Okta](https://help.okta.com/en-us/Content/Topics/Security/policies/configure-app-signon-policies.htm)
-> - [AzureAD](https://learn.microsoft.com/en-us/azure/active-directory/develop/howto-restrict-your-app-to-a-set-of-users)
+> - [Entra ID (formerly Azure AD)](https://learn.microsoft.com/en-us/azure/active-directory/develop/howto-restrict-your-app-to-a-set-of-users)
 { .important}
 
 ### Add guest users when SSO is enabled


### PR DESCRIPTION
<!--
  Thank you for contributing to Docker documentation!

  Here are a few things to keep in mind:

  - Links between pages should use a relative path
  - Remember to add an alt text for images

  ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
  ┃     Review our contribution guidelines:       ┃
  ┃                                               ┃
  ┃ https://docs.docker.com/contribute/overview/  ┃
  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
-->

### Proposed changes

<!-- Tell us what you did and why -->

Microsoft changed the name of the Azure AD product to Entra ID. This PR replaces Azure AD refs with Entra ID (formerly Azure AD). This is the naming Microsoft is using for now until users learn about the change. The UI in Hub hasn't been updated, so I have left the instructions to still say **Azure AD (OIDC)** because that is what is in UI, but will update in a separate PR once Hub reflects the change.

### Related issues (optional)

<!--
  Refer to related PRs or issues:

  #1234
  Closes #1234
  Closes docker/cli#1234
-->
Closes JIRA https://docker.atlassian.net/browse/ENGDOCS-1679