### PR TITLE
Update the Resources->Advanced settings for Docker Desktop 4.24

### DIFF
--- a/content/desktop/settings/linux.md
+++ b/content/desktop/settings/linux.md
@@ -53,17 +53,16 @@ On the **Advanced** tab, you can limit resources available to Docker.
 
 Advanced settings are:
 
-- **CPUs**. By default, Docker Desktop is set to use half the number of processors
-  available on the host machine. To increase processing power, set this to a
-  higher number; to decrease, lower the number.
+- **CPU limit**. Specify the maximum number of CPUs to be used by Docker Desktop.
+  By default, Docker Desktop is set to use all the processors available on the host machine.
 
-- **Memory**. By default, Docker Desktop is set to use 25% of your host's
+- **Memory limit**. By default, Docker Desktop is set to use up to 25% of your host's
   memory. To increase the RAM, set this to a higher number; to decrease it,
   lower the number.
 
 - **Swap**. Configure swap file size as needed. The default is 1 GB.
 
-- **Disk image size**. Specify the size of the disk image.
+- **Virtual disk limit**. Specify the maximum size of the disk image.
 
 - **Disk image location**. Specify the location of the Linux volume where containers and images are stored.
 

--- a/content/desktop/settings/mac.md
+++ b/content/desktop/settings/mac.md
@@ -75,17 +75,16 @@ On the **Advanced** tab, you can limit resources available to Docker.
 
 Advanced settings are:
 
-- **CPUs**. By default, Docker Desktop is set to use half the number of processors
-  available on the host machine. To increase processing power, set this to a
-  higher number; to decrease, lower the number.
+- **CPU limit**. Specify the maximum number of CPUs to be used by Docker Desktop.
+  By default, Docker Desktop is set to use all the processors available on the host machine.
 
-- **Memory**. By default, Docker Desktop is set to use `2` GB  of your host's
+- **Memory limit**. By default, Docker Desktop is set to use up to `2` GB of your host's
   memory. To increase the RAM, set this to a higher number; to decrease it,
   lower the number.
 
 - **Swap**. Configure swap file size as needed. The default is 1 GB.
 
-- **Disk image size**. Specify the size of the disk image.
+- **Virtual disk limit**. Specify the maximum size of the disk image.
 
 - **Disk image location**. Specify the location of the Linux volume where containers and images are stored.
 

--- a/content/desktop/settings/mac.md
+++ b/content/desktop/settings/mac.md
@@ -78,7 +78,7 @@ Advanced settings are:
 - **CPU limit**. Specify the maximum number of CPUs to be used by Docker Desktop.
   By default, Docker Desktop is set to use all the processors available on the host machine.
 
-- **Memory limit**. By default, Docker Desktop is set to use up to `2` GB of your host's
+- **Memory limit**. By default, Docker Desktop is set to use up to 50% of your host's
   memory. To increase the RAM, set this to a higher number; to decrease it,
   lower the number.
 

--- a/content/desktop/settings/windows.md
+++ b/content/desktop/settings/windows.md
@@ -65,7 +65,7 @@ containers.
 
 > **Note**
 >
-> The **Advanced** tab is only available in Hyper-V mode, because Windows manages
+> The **Resource allocation** options in the **Advanced** tab are only available in Hyper-V mode, because Windows manages
 > the resources in WSL 2 mode and Windows container mode. In WSL 2
 > mode, you can configure limits on the memory, CPU, and swap size allocated
 > to the [WSL 2 utility VM](https://docs.microsoft.com/en-us/windows/wsl/wsl-config#configure-global-options-with-wslconfig).
@@ -74,17 +74,16 @@ On the **Advanced** tab, you can limit resources available to Docker.
 
 Advanced settings are:
 
-- **CPUs**. By default, Docker Desktop is set to use half the number of processors
-  available on the host machine. To increase processing power, set this to a
-  higher number; to decrease, lower the number.
+- **CPU limit**. Specify the maximum number of CPUs to be used by Docker Desktop.
+  By default, Docker Desktop is set to use all the processors available on the host machine.
 
-- **Memory**. By default, Docker Desktop is set to use `2` GB  of your host's
+- **Memory limit**. By default, Docker Desktop is set to use up to `2` GB of your host's
   memory. To increase the RAM, set this to a higher number; to decrease it,
   lower the number.
 
 - **Swap**. Configure swap file size as needed. The default is 1 GB.
 
-- **Disk image size**. Specify the size of the disk image.
+- **Virtual disk limit**. Specify the maximum size of the disk image.
 
 - **Disk image location**. Specify the location of the Linux volume where containers and images are stored.
 


### PR DESCRIPTION
<!--
  Thank you for contributing to Docker documentation!

  Here are a few things to keep in mind:

  - Links between pages should use a relative path
  - Remember to add an alt text for images

  ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
  ┃     Review our contribution guidelines:       ┃
  ┃                                               ┃
  ┃ https://docs.docker.com/contribute/overview/  ┃
  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
-->

### Proposed changes

- the CPU, memory and disk size are limits, not fixed allocations
- DD is now using all CPU cores by default
- the default allocation on macOS is half of physical memory

### Related issues (optional)

https://github.com/docker/pinata/pull/23894
<!--
  Refer to related PRs or issues:

  #1234
  Closes #1234
  Closes docker/cli#1234
-->
