### PR TITLE
Add a missing line to start docker service before running test command in Ubuntu

### DIFF
--- a/content/engine/install/ubuntu.md
+++ b/content/engine/install/ubuntu.md
@@ -165,6 +165,7 @@ Docker from the repository.
    `hello-world` image.
 
    ```console
+   $ sudo service docker start
    $ sudo docker run hello-world
    ```
 


### PR DESCRIPTION
The docker service needs to be started at first before running the command `sudo docker run hello-world` which is missing in the docs (for installation instructions in Ubuntu).

<!--
  Thank you for contributing to Docker documentation!

  Here are a few things to keep in mind:

  - Links between pages should use a relative path
  - Remember to add an alt text for images

  ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
  ┃     Review our contribution guidelines:       ┃
  ┃                                               ┃
  ┃ https://docs.docker.com/contribute/overview/  ┃
  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
-->

### Proposed changes

When installing docker via apt-get in Ubuntu for the first time, the docker service needs to be started before running the test command `sudo docker run hello-world`. Else, `docker` will complain docker daemon is not running.

### Related issues (optional)

<!--
  Refer to related PRs or issues:

  #1234
  Closes #1234
  Closes docker/cli#1234
-->
