### PR TITLE
fix watch

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -6,7 +6,7 @@ services:
     ports:
       - "1313:1313"
     entrypoint: ["hugo", "server", "--bind", "0.0.0.0"]
-    x-develop:
+    develop:
       watch:
         - action: sync
           path: .

--- a/content/contribute/contribute-guide.md
+++ b/content/contribute/contribute-guide.md
@@ -75,8 +75,7 @@ $ cd docs
 Then, build and run the documentation using [Docker Compose](../compose/index.md):
 
 ```console
-$ docker compose up -d --build
-$ docker compose alpha watch
+$ docker compose watch
 ```
 
 > **Note**
@@ -85,7 +84,7 @@ $ docker compose alpha watch
 
 When the container is built and running, visit [http://localhost:1313](http://localhost:1313) in your web browser to view the docs.
 
-The [Docker Compose `watch`](../compose/file-watch.md) feature causes your
+[Compose `watch`](../compose/file-watch.md) causes your
 running container to rebuild itself automatically when you make changes to your
 content files.
 


### PR DESCRIPTION
Compose Watch is now GA and now means you only have to run one command. This PR fixes the contribute section to reflect the changes and updates the compose.yaml file as well. 

![Screenshot 2023-09-26 at 14 40 29](https://github.com/docker/docs/assets/102604716/38b89fbe-38c7-4944-aebf-e22bcdce746c)
