### PR TITLE
Removed output from console text

### DIFF
--- a/content/compose/install/linux.md
+++ b/content/compose/install/linux.md
@@ -56,10 +56,13 @@ For Compose standalone, see [Install Compose Standalone](standalone.md).
 
     ```console
     $ docker compose version
-    Docker Compose version vN.N.N
     ```
 
-   Where `vN.N.N` is placeholder text standing in for the latest version.
+    Expected output:
+    ```
+    Docker Compose version vN.N.N
+    ```
+    Where `vN.N.N` is placeholder text standing in for the latest version.
 
 ### Update Compose
 


### PR DESCRIPTION
When someone is copying everything in the console section in this instance, they are also copying the output. This is unnecessary and potentially confusing.

<!--
  Thank you for contributing to Docker documentation!

  Here are a few things to keep in mind:

  - Links between pages should use a relative path
  - Remember to add an alt text for images

  ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
  ┃     Review our contribution guidelines:       ┃
  ┃                                               ┃
  ┃ https://docs.docker.com/contribute/overview/  ┃
  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
-->

### Proposed changes

<!-- Tell us what you did and why -->

### Related issues (optional)

<!--
  Refer to related PRs or issues:

  #1234
  Closes #1234
  Closes docker/cli#1234
-->
