### PR TITLE
Fix reference to UI name

### DIFF
--- a/layouts/shortcodes/admin-sso-config.md
+++ b/layouts/shortcodes/admin-sso-config.md
@@ -42,7 +42,7 @@
 > **SAML** tab in the **Authentication Method** section. For example, if your
 > Entra ID (formerly Azure AD) Open ID Connect (OIDC) setup uses SAML configuration within Azure
 > AD, you must select **SAML**. If you are [configuring Open ID Connect with Entra ID (formerly Azure AD)](https://docs.microsoft.com/en-us/powerapps/maker/portals/configure/configure-openid-settings) select
-> **Entra ID (formerly Azure AD)** as the authentication method. Also, IdP initiated connections
+> **Azure AD (OIDC)** as the authentication method. Also, IdP initiated connections
 > aren't supported at this time.
 { .important}
 


### PR DESCRIPTION
<!--
  Thank you for contributing to Docker documentation!

  Here are a few things to keep in mind:

  - Links between pages should use a relative path
  - Remember to add an alt text for images

  ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
  ┃     Review our contribution guidelines:       ┃
  ┃                                               ┃
  ┃ https://docs.docker.com/contribute/overview/  ┃
  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
-->

### Proposed changes

<!-- Tell us what you did and why -->

I realized this callout still needs to use the **Azure AD (OIDC)** name to match the UI. Although the product has changed names, the UI hasn't been updated yet.
