### PR TITLE
fix: add no-select to external link icon

### DIFF
--- a/layouts/_default/_markup/render-link.html
+++ b/layouts/_default/_markup/render-link.html
@@ -7,7 +7,7 @@
     target="_blank"
     rel="noopener"
     >{{ .Text | safeHTML }}<span
-      class="ml-1 align-top text-[1em] material-symbols-rounded"
+      class="select-none ml-1 align-top text-[1em] material-symbols-rounded"
       >open_in_new</span
     ></a
   >


### PR DESCRIPTION
Prevents users from having the icon ligature text included in
clipboard text when copying text from the docs site.

Signed-off-by: David Karlsson <35727626+dvdksn@users.noreply.github.com>

<!--
  Thank you for contributing to Docker documentation!

  Here are a few things to keep in mind:

  - Links between pages should use a relative path
  - Remember to add an alt text for images

  ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
  ┃     Review our contribution guidelines:       ┃
  ┃                                               ┃
  ┃ https://docs.docker.com/contribute/overview/  ┃
  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
-->

### Proposed changes

<!-- Tell us what you did and why -->

### Related issues (optional)

<!--
  Refer to related PRs or issues:

  #1234
  Closes #1234
  Closes docker/cli#1234
-->
