### PR TITLE
fix: use links with leading slash as-is

### DIFF
--- a/layouts/_default/_markup/render-link.html
+++ b/layouts/_default/_markup/render-link.html
@@ -12,8 +12,8 @@
     ></a
   >
 {{- else if (strings.HasPrefix $url "/") -}}
-  {{/* absolute link, use absURL */}}
-  <a class="link" href="{{ absURL $url }}">{{ .Text | safeHTML }}</a>
+  {{/* absolute link, use url as-is */}}
+  <a class="link" href="{{ $url }}">{{ .Text | safeHTML }}</a>
 {{- else -}}
   {{/* check if the file links to index.md */}}
   {{- if (strings.FindRE `([^_]|^)index.md` $url 1) -}}


### PR DESCRIPTION
Links that started with a slash were being prepended the URL hostname
and rendered as absolute links before. This caused our link checker to
miss broken links that contained a leading slash.

This change fixes this issue by rendering links with a leading slash as-is,
without modification.

Signed-off-by: David Karlsson <35727626+dvdksn@users.noreply.github.com>

<!--
  Thank you for contributing to Docker documentation!

  Here are a few things to keep in mind:

  - Links between pages should use a relative path
  - Remember to add an alt text for images

  ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
  ┃     Review our contribution guidelines:       ┃
  ┃                                               ┃
  ┃ https://docs.docker.com/contribute/overview/  ┃
  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
-->

### Proposed changes

<!-- Tell us what you did and why -->

### Related issues (optional)

<!--
  Refer to related PRs or issues:

  #1234
  Closes #1234
  Closes docker/cli#1234
-->
