### PR TITLE
fix: remove excessive quoting in engine/install

### DIFF
--- a/content/engine/install/debian.md
+++ b/content/engine/install/debian.md
@@ -103,8 +103,8 @@ Docker from the repository.
 
    # Add the repository to Apt sources:
    echo \
-     "deb [arch="$(dpkg --print-architecture)" signed-by=/etc/apt/keyrings/docker.gpg] {{% param "download-url-base" %}} \
-     "$(. /etc/os-release && echo "$VERSION_CODENAME")" stable" | \
+     "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] {{% param "download-url-base" %}} \
+     $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | \
      sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
    sudo apt-get update
    ```

--- a/content/engine/install/raspberry-pi-os.md
+++ b/content/engine/install/raspberry-pi-os.md
@@ -102,8 +102,8 @@ Docker from the repository.
 
    # Set up Docker's Apt repository:
    echo \
-     "deb [arch="$(dpkg --print-architecture)" signed-by=/etc/apt/keyrings/docker.gpg] {{% param "download-url-base" %}} \
-     "$(. /etc/os-release && echo "$VERSION_CODENAME")" stable" | \
+     "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] {{% param "download-url-base" %}} \
+     $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | \
      sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
    sudo apt-get update
    ```

--- a/content/engine/install/ubuntu.md
+++ b/content/engine/install/ubuntu.md
@@ -114,8 +114,8 @@ Docker from the repository.
 
    # Add the repository to Apt sources:
    echo \
-     "deb [arch="$(dpkg --print-architecture)" signed-by=/etc/apt/keyrings/docker.gpg] {{% param "download-url-base" %}} \
-     "$(. /etc/os-release && echo "$VERSION_CODENAME")" stable" | \
+     "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] {{% param "download-url-base" %}} \
+     $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | \
      sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
    sudo apt-get update
    ```


### PR DESCRIPTION
The removed quotes cause ShellCheck SC2027 and SC2046 warnings.

<!--
  Thank you for contributing to Docker documentation!

  Here are a few things to keep in mind:

  - Links between pages should use a relative path
  - Remember to add an alt text for images

  ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
  ┃     Review our contribution guidelines:       ┃
  ┃                                               ┃
  ┃ https://docs.docker.com/contribute/overview/  ┃
  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
-->

### Proposed changes

<!-- Tell us what you did and why -->

### Related issues (optional)

<!--
  Refer to related PRs or issues:

  #1234
  Closes #1234
  Closes docker/cli#1234
-->
