### PR TITLE
Change 'Rust' to 'Python' in Python docs

### DIFF
--- a/content/language/python/run-containers.md
+++ b/content/language/python/run-containers.md
@@ -183,6 +183,6 @@ Related information:
 
 ## Next steps
 
-In the next section, you’ll learn how to run a database in a container and connect it to a Rust application.
+In the next section, you’ll learn how to run a database in a container and connect it to a Python application.
 
 {{< button text="How to develop your application" url="develop.md" >}}


### PR DESCRIPTION
<!--
  Thank you for contributing to Docker documentation!

  Here are a few things to keep in mind:

  - Links between pages should use a relative path
  - Remember to add an alt text for images

  ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
  ┃     Review our contribution guidelines:       ┃
  ┃                                               ┃
  ┃ https://docs.docker.com/contribute/overview/  ┃
  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
-->

### Proposed changes
In the `Run your image as a container` Python document under [`Next Steps`](https://docs.docker.com/language/python/run-containers/#next-steps), there is a reference to a `Rust` Application in the next section. The next section, however, involves a Python app. This PR changes this document to refer to a `Python` application instead.

### Related issues (optional)

<!--
  Refer to related PRs or issues:

  #1234
  Closes #1234
  Closes docker/cli#1234
-->
