### PR TITLE
sso: remove default 'company' team for sso

### DIFF
--- a/layouts/shortcodes/admin-sso-config.md
+++ b/layouts/shortcodes/admin-sso-config.md
@@ -84,7 +84,7 @@ After you’ve completed the SSO configuration process in Docker, you can test t
 
 >**Important**
 >
-> SSO has Just-In-Time (JIT) Provisioning enabled by default. This means your users are auto-provisioned into a team called 'Company' within your organization on Docker Hub.
+> SSO has Just-In-Time (JIT) Provisioning enabled by default. This means your users are auto-provisioned to your organization on Docker Hub.
 >
 > You can change this on a per-app basis. To prevent auto-provisioning users, you can create a security group in your IdP and configure the SSO app to authenticate and authorize only those users that are in the security group. Follow the instructions provided by your IdP:
 >

--- a/layouts/shortcodes/admin-sso-management.md
+++ b/layouts/shortcodes/admin-sso-management.md
@@ -68,7 +68,7 @@ When you disable SSO, you can delete the connection to remove the configuration 
 
 > **Important**
 >
-> SSO has Just-In-Time (JIT) Provisioning enabled by default. This means your users are auto-provisioned into a team called 'Company' within your organization.
+> SSO has Just-In-Time (JIT) Provisioning enabled by default. This means your users are auto-provisioned to your organization.
 >
 > You can change this on a per-app basis. To prevent auto-provisioning users, you can create a security group in your IdP and configure the SSO app to authenticate and authorize only those users that are in the security group. Follow the instructions provided by your IdP:
 >

--- a/layouts/shortcodes/admin-sso.md
+++ b/layouts/shortcodes/admin-sso.md
@@ -28,7 +28,7 @@ Before enabling SSO in Docker, administrators must first configure their IdP to 
 
 After establishing the connection between the IdP server and Docker, administrators sign in to {{ $product_name }} and complete the SSO enablement process.
 
-When you enable SSO for your company, a first-time user can sign in to Docker Hub using their company's domain email address. They're then added to your company and assigned to the company team in the organization.
+When you enable SSO for your company, a first-time user can sign in to Docker Hub using their company's domain email address. They're then added to your company, assigned to an organization, and optionally assigned to a team.
 
 Administrators can then choose to enforce SSO login and effortlessly manage SSO connections for their individual company.
 


### PR DESCRIPTION
### Proposed changes

Remove reference to 'company' team.
Admins can now choose an optional team.

### Related issues (optional)

ENGDOCS-1711
