### PR TITLE
Update profiles.md

### DIFF
--- a/content/compose/profiles.md
+++ b/content/compose/profiles.md
@@ -170,7 +170,7 @@ db:
   profiles: ["debug", "dev"]
 ```
 
-or start a profile of `db` explicitly:
+or start the `dev` profile explicitly:
 
 ```console
 # Profiles "debug" is started automatically by targeting phpmyadmin


### PR DESCRIPTION


<!--
  Thank you for contributing to Docker documentation!

  Here are a few things to keep in mind:

  - Links between pages should use a relative path
  - Remember to add an alt text for images

  ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
  ┃     Review our contribution guidelines:       ┃
  ┃                                               ┃
  ┃ https://docs.docker.com/contribute/overview/  ┃
  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
-->

### Proposed changes

Was reading the docs and I noticed this passage. I believe that it should say start `dev` profile explicitly rather than `db` profile, as `db` is the service container in this case and `dev` is the profile that service `db` requires.
