### PR TITLE
build: resource constraint driver opts

### DIFF
--- a/content/build/drivers/docker-container.md
+++ b/content/build/drivers/docker-container.md
@@ -33,12 +33,22 @@ container
 The following table describes the available driver-specific options that you can
 pass to `--driver-opt`:
 
-| Parameter       | Type   | Default          | Description                                                                                |
-| --------------- | ------ | ---------------- | ------------------------------------------------------------------------------------------ |
-| `image`         | String |                  | Sets the image to use for running BuildKit.                                                |
-| `network`       | String |                  | Sets the network mode for running the BuildKit container.                                  |
-| `cgroup-parent` | String | `/docker/buildx` | Sets the cgroup parent of the BuildKit container if Docker is using the `cgroupfs` driver. |
-| `env.<key>`     | String |                  | Sets the environment variable `key` to the specified `value` in the BuildKit container.    |
+| Parameter       | Type   | Default          | Description                                                                       |
+| --------------- | ------ | ---------------- | --------------------------------------------------------------------------------- |
+| `image`         | String |                  | Sets the BuildKit image to use for the container.                                 |
+| `memory`        | String |                  | Sets the amount of memory the container can use.                                  |
+| `memory-swap`   | String |                  | Sets the memory swap limit for the container.                                     |
+| `cpu-quota`     | String |                  | Imposes a CPU CFS quota on the container.                                         |
+| `cpu-period`    | String |                  | Sets the CPU CFS scheduler period for the container.                              |
+| `cpu-shares`    | String |                  | Configures CPU shares (relative weight) of the container.                         |
+| `cpuset-cpus`   | String |                  | Limits the set of CPU cores the container can use.                                |
+| `cpuset-mems`   | String |                  | Limits the set of CPU memory nodes the container can use.                         |
+| `network`       | String |                  | Sets the network mode for the container.                                          |
+| `cgroup-parent` | String | `/docker/buildx` | Sets the cgroup parent of the container if Docker is using the "cgroupfs" driver. |
+| `env.<key>`     | String |                  | Sets the environment variable `key` to the specified `value` in the container.    |
+
+Before you configure the resource limits for the container,
+read about [configuring runtime resource constraints for containers](../../config/containers/resource_constraints/).
 
 ## Usage
 


### PR DESCRIPTION
Signed-off-by: David Karlsson <35727626+dvdksn@users.noreply.github.com>

<!--
  Thank you for contributing to Docker documentation!

  Here are a few things to keep in mind:

  - Links between pages should use a relative path
  - Remember to add an alt text for images

  ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
  ┃     Review our contribution guidelines:       ┃
  ┃                                               ┃
  ┃ https://docs.docker.com/contribute/overview/  ┃
  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
-->

### Proposed changes

Adds resource constraint configuration for `docker-container` worker

### Related issues (optional)

- Follow-up of docker/buildx#2048
