### PR TITLE
fix dotnet aliases typo

### DIFF
--- a/content/language/dotnet/containerize.md
+++ b/content/language/dotnet/containerize.md
@@ -3,8 +3,8 @@ title: Containerize a .NET application
 keywords: .net, containerize, initialize
 description: Learn how to containerize an  ASP.NET application.
 aliases:
-- /langauage/dotnet/build-images/
-- /langauage/dotnet/run-containers/
+- /language/dotnet/build-images/
+- /language/dotnet/run-containers/
 ---
 
 ## Prerequisites


### PR DESCRIPTION
### Proposed changes

Fix a typo in the redirects for the old dotnet pages.

### Related issues (optional)

Fixes #18386
