### PR TITLE
scout: auto-ingest images after enabling scout

### DIFF
--- a/content/scout/image-analysis.md
+++ b/content/scout/image-analysis.md
@@ -31,6 +31,11 @@ repositories per Docker organization. You can update your Docker Scout plan if
 you need additional repositories, see [Docker Scout
 billing](../billing/scout-billing.md).
 
+Before you can activate image analysis for a repository, ensure that the
+registry is integrated with Docker Scout. Docker Hub is integrated by default.
+For information about integrating Docker Scout with registries and other
+systems, see [Integrating Docker Scout](./integrations/_index.md)
+
 > **Note**
 >
 > You must have the **Editor** or **Owner** role in the Docker organization to
@@ -45,18 +50,14 @@ To activate image analysis:
 5. Select the repositories that you want to enable.
 6. Select **Enable image analysis**.
 
+If your repositories already contain images, Docker Scout pulls and analyzes
+the latest images automatically.
+
 ## Analyze registry images
 
-To trigger image analysis for an image in a registry, push the image to a registry that's
-integrated with Docker Scout, to a repository where image analysis is
-activated.
-
-Prerequisites:
-
-- The registry must be integrated with Docker Scout. Docker Hub is integrated
-  by default.
-- You must [activate Docker Scout](#activate-image-analysis) for the
-  repository, before pushing the image.
+To trigger image analysis for an image in a registry, push the image to a
+registry that's integrated with Docker Scout, to a repository where image
+analysis is activated.
 
 1. Sign in with your Docker ID, either using the `docker login` command or the
    **Sign in** button in Docker Desktop.

--- a/content/scout/integrations/registry/ecr.md
+++ b/content/scout/integrations/registry/ecr.md
@@ -95,8 +95,10 @@ The ECR integration is now active. For Docker Scout to start analyzing images
 in the registry, you need to activate it for each repository. Refer to
 [repository settings](../../dashboard.md#repository-settings).
 
-After activating repositories, images that you push will be analyzed by Docker
-Scout, and the analysis results will appear in the Docker Scout Dashboard.
+After activating repositories, images that you push are analyzed by Docker
+Scout. The analysis results appear in the Docker Scout Dashboard.
+If your repository already contains images, Docker Scout pulls and analyzes the
+latest image version automatically.
 
 ## Integrate additional registries
 
@@ -176,13 +178,3 @@ Scout Dashboard:
 
   The account ID and region are included in the registry hostname:
   `<aws_account_id>.dkr.ecr.<region>.amazonaws.com/<image>`
-
-- Docker Scout only analyzes images that were pushed _after_ the integration
-  was created. If you want to analyze images created before the registry was
-  integrated, you can push the images to the registry again.
-
-  ```console
-  $ docker login <aws_account_id>.dkr.ecr.<region>.amazonaws.com/<image>
-  $ docker pull <aws_account_id>.dkr.ecr.<region>.amazonaws.com/<image>
-  $ docker push <aws_account_id>.dkr.ecr.<region>.amazonaws.com/<image>
-  ```


### PR DESCRIPTION
Docker Scout now automatically ingests the latest image when you enable
a repository.

Signed-off-by: David Karlsson <35727626+dvdksn@users.noreply.github.com>

<!--
  Thank you for contributing to Docker documentation!

  Here are a few things to keep in mind:

  - Links between pages should use a relative path
  - Remember to add an alt text for images

  ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
  ┃     Review our contribution guidelines:       ┃
  ┃                                               ┃
  ┃ https://docs.docker.com/contribute/overview/  ┃
  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
-->

### Proposed changes

<!-- Tell us what you did and why -->

### Related issues (optional)

<!--
  Refer to related PRs or issues:

  #1234
  Closes #1234
  Closes docker/cli#1234
-->
