### PR TITLE
get-started: update .net deployment

### DIFF
--- a/content/language/dotnet/_index.md
+++ b/content/language/dotnet/_index.md
@@ -12,7 +12,7 @@ The .NET getting started guide teaches you how to create a containerized .NET ap
 * Set up a local environment to develop a .NET application using containers
 * Run tests for a .NET application using containers
 * Configure a CI/CD pipeline for a containerized .NET application using GitHub Actions
-* Deploy your application to the cloud
+* Deploy your containerized application locally to Kubernetes to test and debug your deployment
 
 After completing the .NET getting started modules, you should be able to containerize your own .NET application based on the examples and instructions provided in this guide.
 

--- a/content/language/dotnet/configure-ci-cd.md
+++ b/content/language/dotnet/configure-ci-cd.md
@@ -144,6 +144,6 @@ Related information:
 
 ## Next steps
 
-Next, learn how you can deploy your application.
+Next, learn how you can locally test and debug your workloads on Kubernetes before deploying.
 
-{{< button text="Deploy your app" url="./deploy.md" >}}
+{{< button text="Develop using Kubernetes" url="./deploy.md" >}}

--- a/content/language/dotnet/configure-ci-cd.md
+++ b/content/language/dotnet/configure-ci-cd.md
@@ -146,4 +146,4 @@ Related information:
 
 Next, learn how you can locally test and debug your workloads on Kubernetes before deploying.
 
-{{< button text="Develop using Kubernetes" url="./deploy.md" >}}
+{{< button text="Test your deployment" url="./deploy.md" >}}

--- a/content/language/dotnet/deploy.md
+++ b/content/language/dotnet/deploy.md
@@ -137,7 +137,7 @@ In this Kubernetes YAML file, there are four objects, separated by the `---`. In
  - A Deployment, describing a scalable group of identical pods. In this case,
    you'll get just one replica, or copy of your pod. That pod, which is
    described under `template`, has just one container in it. The container is
-    based off of the image built by GitHub Actions in [Configure CI/CD for your
+    created from the image built by GitHub Actions in [Configure CI/CD for your
     .NET application](configure-ci-cd.md).
  - A NodePort service, which will route traffic from port 30001 on your host to
    port 8080 inside the pods it routes to, allowing you to reach your app

--- a/content/language/dotnet/deploy.md
+++ b/content/language/dotnet/deploy.md
@@ -20,7 +20,7 @@ before deploying.
 
 ## Create a Kubernetes YAML file
 
-In your `docker-dotnet-sample` directory, create a file name
+In your `docker-dotnet-sample` directory, create a file named
 `docker-dotnet-kubernetes.yaml`. Open the file in an IDE or text editor and add
 the following contents. Replace `DOCKER_USERNAME/REPO_NAME` with your Docker
 username and the name of the repository that you created in [Configure CI/CD for
@@ -135,9 +135,10 @@ status:
 In this Kubernetes YAML file, there are four objects, separated by the `---`. In addition to a Service and Deployment for the database, the other two objects are:
 
  - A Deployment, describing a scalable group of identical pods. In this case,
-   you'll get just one replica, or copy of your pod, and that pod (which is
-   described under the template: key) has just one container in it, based off of
-    the image built by GitHub Actions in [Configure CI/CD for your .NET application](configure-ci-cd.md).
+   you'll get just one replica, or copy of your pod. That pod, which is
+   described under `template`, has just one container in it. The container is
+    based off of the image built by GitHub Actions in [Configure CI/CD for your
+    .NET application](configure-ci-cd.md).
  - A NodePort service, which will route traffic from port 30001 on your host to
    port 8080 inside the pods it routes to, allowing you to reach your app
    from the network.
@@ -146,7 +147,7 @@ To learn more about Kubernetes objects, see the [Kubernetes documentation](https
 
 ## Deploy and check your application
 
-1. In a terminal, navigate the `docker-dotnet-sample` directory
+1. In a terminal, navigate to the `docker-dotnet-sample` directory
    and deploy your application to Kubernetes.
 
    ```console

--- a/content/language/dotnet/deploy.md
+++ b/content/language/dotnet/deploy.md
@@ -24,7 +24,7 @@ In your `docker-dotnet-sample` directory, create a file name
 `docker-dotnet-kubernetes.yaml`. Open the file in an IDE or text editor and add
 the following contents. Replace `DOCKER_USERNAME/REPO_NAME` with your Docker
 username and the name of the repository that you created in [Configure CI/CD for
-your Node.js application](configure-ci-cd.md).
+your.NET application](configure-ci-cd.md).
 
 ```yaml
 apiVersion: apps/v1
@@ -137,7 +137,7 @@ In this Kubernetes YAML file, there are four objects, separated by the `---`. In
  - A Deployment, describing a scalable group of identical pods. In this case,
    you'll get just one replica, or copy of your pod, and that pod (which is
    described under the template: key) has just one container in it, based off of
-    the image built by GitHub Actions in [Configure CI/CD for your Node.js application](configure-ci-cd.md).
+    the image built by GitHub Actions in [Configure CI/CD for your .NET application](configure-ci-cd.md).
  - A NodePort service, which will route traffic from port 30001 on your host to
    port 8080 inside the pods it routes to, allowing you to reach your app
    from the network.

--- a/content/language/dotnet/deploy.md
+++ b/content/language/dotnet/deploy.md
@@ -1,11 +1,212 @@
 ---
-title: Deploy your app
-keywords: deploy, ACI, ECS, .net, local, development
+title: Test your .NET deployment
+keywords: deploy, .net, local, development
 description: Learn how to deploy your application
 ---
 
-{{< include "deploy.md" >}}
+## Prerequisites
 
-## Feedback
+- Complete all the previous sections of this guide, starting with [Containerize
+  a .NET application](containerize.md).
+- [Turn on Kubernetes](/desktop/kubernetes/#turn-on-kubernetes) in Docker
+  Desktop.
 
-Help us improve this topic by providing your feedback. Let us know what you think by creating an issue in the [Docker Docs](https://github.com/docker/docker.github.io/issues/new?title=[dotnet%20docs%20feedback]) GitHub repository. Alternatively, [create a PR](https://github.com/docker/docker.github.io/pulls) to suggest updates.
+## Overview
+
+In this section, you'll learn how to use Docker Desktop to deploy your
+application to a fully-featured Kubernetes environment on your development
+machine. This allows you to test and debug your workloads on Kubernetes locally
+before deploying.
+
+## Create a Kubernetes YAML file
+
+In your `docker-dotnet-sample` directory, create a file name
+`docker-dotnet-kubernetes.yaml`. Open the file in an IDE or text editor and add
+the following contents. Replace `DOCKER_USERNAME/REPO_NAME` with your Docker
+username and the name of the repository that you created in [Configure CI/CD for
+your Node.js application](configure-ci-cd.md).
+
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    service: server
+  name: server
+  namespace: default
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      service: server
+  strategy: {}
+  template:
+    metadata:
+      labels:
+        service: server
+    spec:
+      initContainers:
+        - name: wait-for-db
+          image: busybox:1.28
+          command: ['sh', '-c', 'until nc -zv db 5432; do echo "waiting for db"; sleep 2; done;']
+      containers:
+        - image: DOCKER_USERNAME/REPO_NAME
+          name: server
+          imagePullPolicy: Always
+          ports:
+            - containerPort: 80
+              hostPort: 8080
+              protocol: TCP
+          resources: {}
+      restartPolicy: Always
+status: {}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    service: db
+  name: db
+  namespace: default
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      service: db
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        service: db
+    spec:
+      containers:
+        - env:
+            - name: POSTGRES_DB
+              value: example
+            - name: POSTGRES_PASSWORD
+              value: example
+          image: postgres
+          name: db
+          ports:
+            - containerPort: 5432
+              protocol: TCP
+          resources: {}
+      restartPolicy: Always
+status: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    service: server
+  name: server
+  namespace: default
+spec:
+  type: NodePort
+  ports:
+    - name: "8080"
+      port: 8080
+      targetPort: 80
+      nodePort: 30001
+  selector:
+    service: server
+status:
+  loadBalancer: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    service: db
+  name: db
+  namespace: default
+spec:
+  ports:
+    - name: "5432"
+      port: 5432
+      targetPort: 5432
+  selector:
+    service: db
+status:
+  loadBalancer: {}
+```
+
+In this Kubernetes YAML file, there are four objects, separated by the `---`. In addition to a Service and Deployment for the database, the other two objects are:
+
+ - A Deployment, describing a scalable group of identical pods. In this case,
+   you'll get just one replica, or copy of your pod, and that pod (which is
+   described under the template: key) has just one container in it, based off of
+    the image built by GitHub Actions in [Configure CI/CD for your Node.js application](configure-ci-cd.md).
+ - A NodePort service, which will route traffic from port 30001 on your host to
+   port 8080 inside the pods it routes to, allowing you to reach your app
+   from the network.
+
+To learn more about Kubernetes objects, see the [Kubernetes documentation](https://kubernetes.io/docs/home/).
+
+## Deploy and check your application
+
+1. In a terminal, navigate the `docker-dotnet-sample` directory
+   and deploy your application to Kubernetes.
+
+   ```console
+   $ kubectl apply -f docker-dotnet-kubernetes.yaml
+   ```
+
+   You should see output that looks like the following, indicating your Kubernetes objects were created successfully.
+
+   ```shell
+   deployment.apps/db created
+   service/db created
+   deployment.apps/server created
+   service/server created
+   ```
+
+2. Make sure everything worked by listing your deployments.
+
+   ```console
+   $ kubectl get deployments
+   ```
+
+   Your deployment should be listed as follows:
+
+   ```shell
+   NAME     READY   UP-TO-DATE   AVAILABLE   AGE
+   db       1/1     1            1           76s
+   server   1/1     1            1           76s
+   ```
+
+   This indicates all of the pods are up and running. Do the same check for your services.
+
+   ```console
+   $ kubectl get services
+   ```
+
+   You should get output like the following.
+
+   ```shell
+   NAME         TYPE        CLUSTER-IP      EXTERNAL-IP   PORT(S)          AGE
+   db           ClusterIP   10.96.156.90    <none>        5432/TCP         2m8s
+   kubernetes   ClusterIP   10.96.0.1       <none>        443/TCP          164m
+   server       NodePort    10.102.94.225   <none>        8080:30001/TCP   2m8s
+   ```
+
+   In addition to the default `kubernetes` service, you can see your `server` service and `db` service. The `server` service is accepting traffic on port 30001/TCP.
+
+3. Open a browser and visit your app at `localhost:30001`. You should see your
+   application.
+
+4. Run the following command to tear down your application.
+
+   ```console
+   $ kubectl delete -f docker-dotnet-kubernetes.yaml
+   ```
+
+## Summary
+
+In this section, you learned how to use Docker Desktop to deploy your application to a fully-featured Kubernetes environment on your development machine.
+
+Related information:
+   - [Kubernetes documentation](https://kubernetes.io/docs/home/)
+   - [Deploy on Kubernetes with Docker Desktop](../../desktop/kubernetes.md)
+   - [Swarm mode overview](../../engine/swarm/_index.md)

--- a/data/toc.yaml
+++ b/data/toc.yaml
@@ -101,7 +101,7 @@ Guides:
       path: /language/dotnet/run-tests/
     - title: "Configure CI/CD"
       path: /language/dotnet/configure-ci-cd/
-    - title: "Deploy your app"
+    - title: "Test your deployment"
       path: /language/dotnet/deploy/
   - sectiontitle: Rust
     section:


### PR DESCRIPTION
### Proposed changes

Update the Deployment section in the .NET guide to be like the Node.js guide.
 - Remove cloud integrations
 - Update the topic to use the sample app

https://deploy-preview-18400--docsdocker.netlify.app/language/dotnet/deploy/

### Related issues (optional)

ENGDOCS-1713
