### PR TITLE
Remove docs for already-removed workflow input

### DIFF
--- a/.github/workflows/validate-upstream.yml
+++ b/.github/workflows/validate-upstream.yml
@@ -1,5 +1,4 @@
 # reusable workflow to validate docs from upstream repository for which pages are remotely fetched
-# - repo: upstream repository (e.g., https://github.com/docker/buildx)
 # - data-files-id: id of the artifact (using actions/upload-artifact) containing the YAML data files to validate (optional)
 # - data-files-folder: folder in _data containing the files to download and copy to (e.g., buildx)
 name: validate-upstream


### PR DESCRIPTION
<!--
  Thank you for contributing to Docker documentation!

  Here are a few things to keep in mind:

  - Links between pages should use a relative path
  - Remember to add an alt text for images

  ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
  ┃     Review our contribution guidelines:       ┃
  ┃                                               ┃
  ┃ https://docs.docker.com/contribute/overview/  ┃
  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
-->

### Proposed changes

I removed the documentation of the `repo` parameter from the validate-upstream workflow.

### Related issues (optional)

#17427 removed the `repo` parameter, but left the docs behind.