### PR TITLE
hub-admin: update export members

### DIFF
--- a/layouts/shortcodes/admin-users.html
+++ b/layouts/shortcodes/admin-users.html
@@ -11,7 +11,7 @@
 * **Email**: The user's email address.
 * **Type**: The type of user. For example, **Invitee** for users who have not accepted the organization's invite,
   or **User** for users who are members of the organization.
-* **Role**: The user's role in the organization . For example, **Member** or **Owner**.
+* **Role**: The user's role in the organization. For example, **Member** or **Owner**.
 * **Teams**: The teams where the user is a member. A team is not listed for invitees.
 * **Date Joined**: The time and date when the user was invited to the organization.` }}
 

--- a/layouts/shortcodes/admin-users.html
+++ b/layouts/shortcodes/admin-users.html
@@ -5,6 +5,15 @@
 {{ $product_link := "[Docker Hub](https://hub.docker.com)" }}
 {{ $update_role := "Select the role you want to assign, then select **Save**." }}
 {{ $role_mapping_link := "[SCIM for role mapping](docker-hub/scim.md#set-up-role-mapping)" }}
+{{ $export_fields := `The CSV file for an organization contains the following fields:
+* **Name**: The user's name.
+* **Username**: The user's Docker ID.
+* **Email**: The user's email address.
+* **Type**: The type of user. For example, **Invitee** for users who have not accepted the organization's invite,
+  or **User** for users who are members of the organization.
+* **Role**: The user's role in the organization . For example, **Member** or **Owner**.
+* **Teams**: The teams where the user is a member. A team is not listed for invitees.
+* **Date Joined**: The time and date when the user was invited to the organization.` }}
 
 {{ if eq (.Get "product") "admin" }}
 {{ $invite_button = "**Invite**" }}
@@ -14,6 +23,13 @@
 {{ $product_link = "[Docker Admin](https://admin.docker.com)" }}
 {{ $role_mapping_link = "[SCIM for role mapping](admin/organization/security-settings/scim.md#set-up-role-mapping)" }}
 {{ if eq (.Get "layer") "company" }}
+{{ $export_fields = `The CSV file for a company contains the following fields:
+* **Name**: The user's name.
+* **Username**: The user's Docker ID.
+* **Email**: The user's email address.
+* **Member of Organizations**: All organizations the user is a member of within a company.
+* **Invited to Organizations**: All organizations the user is an invitee of within a company.
+* **Account Created**: The time and date when the user account was created.` }}
 {{ $member_navigation = "Select your company in the left navigation drop-down menu, and then select **Users**." }}
 {{ $remove_button = "**Remove user**" }}
 {{ $update_role = "Select their organization, select the role you want to assign, and then select **Save**." }}
@@ -153,19 +169,7 @@ To update a member role:
 ## Export members
 
 Owners can export a CSV file containing all members.
-The CSV file may contain the following fields:
-
-* **Name**: The user's name.
-* **Username**: The user's Docker ID.
-* **Email**: The user's email address.
-* **Type**: The type of user. For example, **Invitee** for users who have not accepted the organization's invite,
-  or **User** for users who are members of the organization.
-* **Permission**: The user's organization permissions. For example, **Member** or **Owner**.
-* **Teams**: The teams where the user is a member. A team is not listed for invitees.
-* **Date Joined**: The time and date when the user was invited to the organization.
-* **Member of Organizations**: All organizations the user is a member of within a company.
-* **Invited to Organizations**: All organizations the user is an invitee of within a company.
-* **Account Created**: The time and date when the user account was created.
+{{ $export_fields }}
 
 To export a CSV file of the members:
 


### PR DESCRIPTION
### Proposed changes

Update "Permission" heading to "Role".

Separate the fields exported for a company and for an organization, rather than using "may contain" and adding everything in a single list.

https://deploy-preview-18414--docsdocker.netlify.app/admin/company/users/#export-members
https://deploy-preview-18414--docsdocker.netlify.app/admin/organization/members/#export-members
https://deploy-preview-18414--docsdocker.netlify.app/docker-hub/members/#export-members

### Related issues (optional)

ENGDOCS-1725
