### PR TITLE
Add example Dockerfile

### DIFF
--- a/content/build/ci/github-actions/cache.md
+++ b/content/build/ci/github-actions/cache.md
@@ -145,20 +145,18 @@ cache mount data with your Docker build steps.
 
 The following example shows how to use this workaround with a Go project.
 
-
 Example Dockerfile in `build/package/Dockerfile`
 ```Dockerfile
 FROM golang:1.21.1-alpine as base-build
 
 WORKDIR /build
-RUN go env -w GOCACHE=/go-cache
-RUN go env -w GOMODCACHE=/gomod-cache
+RUN go env -w GOMODCACHE=/root/.cache/go-build
 
 COPY go.mod go.sum ./
-RUN --mount=type=cache,target=/gomod-cache go mod download
+RUN --mount=type=cache,target=/root/.cache/go-build go mod download
 
 COPY ./src ./
-RUN --mount=type=cache,target=/gomod-cache --mount=type=cache,target=/go-cache && go build -o /bin/app /build/src
+RUN --mount=type=cache,target=/root/.cache/go-build && go build -o /bin/app /build/src
 ```
 
 Example CI action

--- a/content/build/ci/github-actions/cache.md
+++ b/content/build/ci/github-actions/cache.md
@@ -145,6 +145,23 @@ cache mount data with your Docker build steps.
 
 The following example shows how to use this workaround with a Go project.
 
+
+Example Dockerfile in `build/package/Dockerfile`
+```Dockerfile
+FROM golang:1.21.1-alpine as base-build
+
+WORKDIR /build
+RUN go env -w GOCACHE=/go-cache
+RUN go env -w GOMODCACHE=/gomod-cache
+
+COPY go.mod go.sum ./
+RUN --mount=type=cache,target=/gomod-cache go mod download
+
+COPY ./src ./
+RUN --mount=type=cache,target=/gomod-cache --mount=type=cache,target=/go-cache && go build -o /bin/app /build/src
+```
+
+Example CI action
 ```yaml
 name: ci
 on: push

--- a/content/build/ci/github-actions/cache.md
+++ b/content/build/ci/github-actions/cache.md
@@ -157,6 +157,7 @@ RUN --mount=type=cache,target=/root/.cache/go-build go mod download
 
 COPY ./src ./
 RUN --mount=type=cache,target=/root/.cache/go-build && go build -o /bin/app /build/src
+...
 ```
 
 Example CI action


### PR DESCRIPTION
### Proposed changes
The workaround describes the usage of mounted caches in the Dockerfile i.e. `--mount=type=cache`, but the example only shows the action and not how the Dockerfile should look like

### Related issues (optional)

