### PR TITLE
Remove capabilities message about swarm mode

### DIFF
--- a/content/compose/compose-file/compose-file-v3.md
+++ b/content/compose/compose-file/compose-file-v3.md
@@ -415,12 +415,6 @@ cap_drop:
   - SYS_ADMIN
 ```
 
-> Note when using docker stack deploy
->
-> The `cap_add` and `cap_drop` options are ignored when
-> [deploying a stack in swarm mode](../../engine/reference/commandline/stack_deploy.md)
-{ .important }
-
 ### cgroup_parent
 
 Specify an optional parent cgroup for the container.


### PR DESCRIPTION
### Proposed changes
Remove message about capabilities not being supported in swarm mode, since the capabilities feature was added in [20.10.0](https://docs.docker.com/engine/release-notes/20.10/#swarm-4).