### PR TITLE
ci: fix validate-upstream workflow

### DIFF
--- a/.github/workflows/validate-upstream.yml
+++ b/.github/workflows/validate-upstream.yml
@@ -1,5 +1,5 @@
 # reusable workflow to validate docs from upstream repository for which pages are remotely fetched
-# - repo: upstream repository (e.g., https://github.com/docker/buildx)
+# - module-name: the name of the module, without github.com prefix (e.g., docker/buildx)
 # - data-files-id: id of the artifact (using actions/upload-artifact) containing the YAML data files to validate (optional)
 # - data-files-folder: folder in _data containing the files to download and copy to (e.g., buildx)
 name: validate-upstream
@@ -7,6 +7,9 @@ name: validate-upstream
 on:
   workflow_call:
     inputs:
+      module-name:
+        required: true
+        type: string
       data-files-id:
         required: false
         type: string
@@ -69,16 +72,18 @@ jobs:
             }
       -
         name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
       -
         name: Validate
-        uses: docker/bake-action@v3
+        uses: docker/bake-action@v4
         with:
           files: |
             docker-bake.hcl
-          targets: validate
+          targets: validate-upstream
           set: |
-            *.args.REPO="github.com/${{ github.repository }}"
-            *.args.HUGO_MODULE_REPLACEMENTS="github.com/${{ github.repository }} -> github.com/${{ github.repository}} ${{ github.ref }}"
             *.cache-from=type=gha,scope=docs-upstream
             *.cache-to=type=gha,scope=docs-upstream,mode=max
+        env:
+          UPSTREAM_MODULE_NAME: ${{ inputs.module-name }}
+          UPSTREAM_REPO: ${{ github.repository }}
+          UPSTREAM_COMMIT: ${{ github.sha }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 # syntax=docker/dockerfile:1
 
 ARG GO_VERSION=1.21
+ARG HTMLTEST_VERSION=0.17.0
 
 FROM golang:${GO_VERSION}-alpine as base
 WORKDIR /src
@@ -19,14 +20,13 @@ RUN go install github.com/gohugoio/hugo@v${HUGO_VERSION}
 FROM base as build-base
 COPY --from=hugo $GOPATH/bin/hugo /bin/hugo
 COPY --from=node /src/node_modules /src/node_modules
+COPY . .
 
 FROM build-base as dev
-COPY . .
 
 FROM build-base as build
 ARG HUGO_ENV
 ARG DOCS_URL
-COPY . .
 RUN hugo --gc --minify -d /out -e $HUGO_ENV -b $DOCS_URL
 
 FROM scratch as release
@@ -37,7 +37,7 @@ USER root
 RUN --mount=type=bind,target=. \
     /usr/local/bin/markdownlint-cli2 content/**/*.md
 
-FROM wjdp/htmltest:v0.17.0 as test
+FROM wjdp/htmltest:v${HTMLTEST_VERSION} as test
 WORKDIR /test
 COPY --from=build /out ./public
 ADD .htmltest.yml .htmltest.yml
@@ -53,3 +53,18 @@ RUN hugo mod vendor
 FROM scratch as vendor
 COPY --from=update-modules /src/_vendor /_vendor
 COPY --from=update-modules /src/go.* /
+
+FROM build-base as build-upstream
+ARG UPSTREAM_MODULE_NAME
+ARG UPSTREAM_REPO
+ARG UPSTREAM_COMMIT
+ENV HUGO_MODULE_REPLACEMENTS="github.com/${UPSTREAM_MODULE_NAME} -> github.com/${UPSTREAM_REPO} ${UPSTREAM_COMMIT}"
+RUN hugo --ignoreVendorPaths "github.com/${UPSTREAM_MODULE_NAME}" -d /out
+
+FROM wjdp/htmltest:v${HTMLTEST_VERSION} as validate-upstream
+WORKDIR /test
+COPY --from=build-upstream /out ./public
+ADD .htmltest.yml .htmltest.yml
+RUN htmltest
+
+FROM dev

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -148,3 +148,23 @@ target "vendor" {
   }
   output = ["."]
 }
+
+variable "UPSTREAM_MODULE_NAME" {
+  default = null
+}
+variable "UPSTREAM_REPO" {
+  default = null
+}
+variable "UPSTREAM_MODULE_NAME" {
+  default = null
+}
+
+target "validate-upstream" {
+  args {
+    UPSTREAM_MODULE_NAME = UPSTREAM_MODULE_NAME
+    UPSTREAM_REPO = UPSTREAM_REPO
+    UPSTREAM_COMMIT = UPSTREAM_COMMIT
+  }
+  target = "validate-upstream"
+  output = ["type=cacheonly"]
+}

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -1,6 +1,6 @@
 title: Docker Docs
 baseURL: https://docs.docker.com
-refLinksErrorLevel: WARNING
+refLinksErrorLevel: ERROR
 enableGitInfo: true
 disablePathToLower: true
 enableInlineShortcodes: true


### PR DESCRIPTION
Signed-off-by: David Karlsson <35727626+dvdksn@users.noreply.github.com>

<!--
  Thank you for contributing to Docker documentation!

  Here are a few things to keep in mind:

  - Links between pages should use a relative path
  - Remember to add an alt text for images

  ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
  ┃     Review our contribution guidelines:       ┃
  ┃                                               ┃
  ┃ https://docs.docker.com/contribute/overview/  ┃
  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
-->

### Proposed changes

Fixes the `validate-upstream` workflow

Tested with:
https://github.com/dvdksn/buildx/commit/cc4427714bc18385400ca056940da3db190d6a76
https://github.com/dvdksn/buildx/actions/runs/6535746411/job/17746006306#step:7:455

htmltest doesnt seem to fail for these links. I changed the hugo config to make these warnings fail the build.

### Related issues (optional)

Fixes #18431