### PR TITLE
Add docker-compose-v2 to list of unofficial Ubuntu packages

### DIFF
--- a/content/engine/install/ubuntu.md
+++ b/content/engine/install/ubuntu.md
@@ -59,6 +59,7 @@ The unofficial packages to uninstall are:
 
 - `docker.io`
 - `docker-compose`
+- `docker-compose-v2`
 - `docker-doc`
 - `podman-docker`
 
@@ -70,7 +71,7 @@ conflicts with the versions bundled with Docker Engine.
 Run the following command to uninstall all conflicting packages:
 
 ```console
-$ for pkg in docker.io docker-doc docker-compose podman-docker containerd runc; do sudo apt-get remove $pkg; done
+$ for pkg in docker.io docker-doc docker-compose docker-compose-v2 podman-docker containerd runc; do sudo apt-get remove $pkg; done
 ```
 
 `apt-get` might report that you have none of these packages installed.


### PR DESCRIPTION
### Proposed changes

Ubuntu has a package called `docker-compose-v2` that should be installed when installing from the official Docker repo.

https://packages.ubuntu.com/mantic/docker-compose-v2

### Related issues (optional)
N/A