### PR TITLE
update titles for language guides

### DIFF
--- a/content/language/golang/_index.md
+++ b/content/language/golang/_index.md
@@ -1,7 +1,7 @@
 ---
 description: Containerize Go apps using Docker
 keywords: docker, getting started, go, golang, language, dockerfile
-title: What will you learn in this module?
+title: Go language-specific guide
 toc_min: 1
 toc_max: 2
 ---

--- a/content/language/golang/configure-ci-cd.md
+++ b/content/language/golang/configure-ci-cd.md
@@ -1,5 +1,5 @@
 ---
-title: Configure CI/CD for your application
+title: Configure CI/CD for your Go application
 keywords: ci, cd, ci/cd, continuous integration, continuous deployment, deployment,
   github, github actions, go, golang, development
 description: Learn how to set up CI/CD pipeline for your application.

--- a/content/language/golang/deploy.md
+++ b/content/language/golang/deploy.md
@@ -1,5 +1,5 @@
 ---
-title: Deploy your app
+title: Deploy your Go app
 keywords: deploy, ACI, ECS, local, development, Go, Golang, cloud, deployment
 description: Learn how to deploy your application
 ---

--- a/content/language/golang/develop.md
+++ b/content/language/golang/develop.md
@@ -1,5 +1,5 @@
 ---
-title: Use containers for development
+title: Use containers for Go development
 keywords: get started, go, golang, local, development
 description: Learn how to develop your application locally.
 aliases:

--- a/content/language/golang/run-containers.md
+++ b/content/language/golang/run-containers.md
@@ -1,5 +1,5 @@
 ---
-title: Run your image as a container
+title: Run your Go image as a container
 keywords: get started, go, golang, run, container
 description: Learn how to run the image as a container.
 aliases:

--- a/content/language/java/_index.md
+++ b/content/language/java/_index.md
@@ -1,5 +1,5 @@
 ---
-title: Getting started with Java
+title: Java language-specific guide
 keywords: Docker, getting started, java, language
 description: Containerize Java apps using Docker
 toc_min: 1

--- a/content/language/java/configure-ci-cd.md
+++ b/content/language/java/configure-ci-cd.md
@@ -1,5 +1,5 @@
 ---
-title: Configure CI/CD for your application
+title: Configure CI/CD for your Java application
 keywords: Java, CI/CD, local, development
 description: Learn how to Configure CI/CD for your application
 ---

--- a/content/language/java/deploy.md
+++ b/content/language/java/deploy.md
@@ -1,5 +1,5 @@
 ---
-title: Deploy your app
+title: Deploy your Java app
 keywords: deploy, ACI, ECS, Java, local, development
 description: Learn how to deploy your application
 ---

--- a/content/language/java/develop.md
+++ b/content/language/java/develop.md
@@ -1,5 +1,5 @@
 ---
-title: Use containers for development
+title: Use containers for Java development
 keywords: Java, local, development, run,
 description: Learn how to develop your application locally.
 ---

--- a/content/language/java/run-containers.md
+++ b/content/language/java/run-containers.md
@@ -1,5 +1,5 @@
 ---
-title: Run your image as a container
+title: Run your Java image as a container
 keywords: Java, run, image, container,
 description: Learn how to run the image as a container.
 ---

--- a/content/language/java/run-tests.md
+++ b/content/language/java/run-tests.md
@@ -1,5 +1,5 @@
 ---
-title: Run your tests
+title: Run your Java tests
 keywords: Java, build, test
 description: How to build and run your Tests
 ---

--- a/content/language/rust/_index.md
+++ b/content/language/rust/_index.md
@@ -1,7 +1,7 @@
 ---
 description: Containerize Rust apps using Docker
 keywords: Docker, getting started, Rust, language
-title: What will you learn in this module?
+title: Rust langauge-specific guide
 toc_min: 1
 toc_max: 2
 ---

--- a/content/language/rust/_index.md
+++ b/content/language/rust/_index.md
@@ -1,7 +1,7 @@
 ---
 description: Containerize Rust apps using Docker
 keywords: Docker, getting started, Rust, language
-title: Rust langauge-specific guide
+title: Rust language-specific guide
 toc_min: 1
 toc_max: 2
 ---

--- a/content/language/rust/configure-ci-cd.md
+++ b/content/language/rust/configure-ci-cd.md
@@ -1,5 +1,5 @@
 ---
-title: Configure CI/CD for your application
+title: Configure CI/CD for your Rust application
 keywords: rust, CI/CD, local, development
 description: Learn how to Configure CI/CD for your application
 ---

--- a/content/language/rust/deploy.md
+++ b/content/language/rust/deploy.md
@@ -1,5 +1,5 @@
 ---
-title: Deploy your app
+title: Deploy your Rust app
 keywords: deploy, ACI, ECS, rust, local, development
 description: Learn how to deploy your application
 ---


### PR DESCRIPTION
### Proposed changes

The language-specific guides use the same titles for multiple topics and it's not great for search.
Some have already been updated or will be updated in pending PRs.

Update titles for the remaining guides: Rust, Java, and Go.

### Related issues (optional)

ENGDOCS-1731