### PR TITLE
redirects: add redirect for link used in docker init templates

### DIFF
--- a/data/redirects.yml
+++ b/data/redirects.yml
@@ -623,3 +623,7 @@
 # CLI backlinks
 "/config/filter/":
   - /go/filter/
+
+# Docker Init
+"/develop/develop-images/instructions/#user":
+  - /go/dockerfile-user-best-practices/


### PR DESCRIPTION
<!--
  Thank you for contributing to Docker documentation!

  Here are a few things to keep in mind:

  - Links between pages should use a relative path
  - Remember to add an alt text for images

  ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
  ┃     Review our contribution guidelines:       ┃
  ┃                                               ┃
  ┃ https://docs.docker.com/contribute/overview/  ┃
  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
-->

### Proposed changes

<!-- Tell us what you did and why -->
This PR adds a redirect for a link used in templates generated by Docker Init based on a recommendation from @craig-osterhout. 🌟 

### Related issues (optional)

<!--
  Refer to related PRs or issues:

  #1234
  Closes #1234
  Closes docker/cli#1234
-->
