### PR TITLE
Update release-notes.md

### DIFF
--- a/content/desktop/release-notes.md
+++ b/content/desktop/release-notes.md
@@ -28,7 +28,7 @@ For frequently asked questions about Docker Desktop releases, see [FAQs](faqs/re
 
 {{< release-date date="2023-10-12" >}}
 
-{{< desktop-install all=true version="4.24.1" build_path="/124339/" >}}
+{{< desktop-install all=true version="4.24.2" build_path="/124339/" >}}
 
 ### Bug fixes and enhancements
 


### PR DESCRIPTION
Line 31 had 4.24.1 as the version, but it is supposed to be 4.24.2.

<!--
  Thank you for contributing to Docker documentation!

  Here are a few things to keep in mind:

  - Links between pages should use a relative path
  - Remember to add an alt text for images

  ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
  ┃     Review our contribution guidelines:       ┃
  ┃                                               ┃
  ┃ https://docs.docker.com/contribute/overview/  ┃
  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
-->

### Proposed changes

<!-- Tell us what you did and why -->

Current links to GNU/Linux packages are wrong and lead to a page with a 403 Forbidden error. The number of the version is supposed to be 4.24.2, but the links say:
- docker-desktop-4.24.1-amd64.deb
- docker-desktop-4.24.1-x86_64.rpm
- docker-desktop-4.24.1-x86_64.pkg.tar.zst