### PR TITLE
Update access token docs and clarify where to use PATs

### DIFF
--- a/content/security/for-developers/access-tokens.md
+++ b/content/security/for-developers/access-tokens.md
@@ -7,8 +7,7 @@ aliases:
 - /docker-hub/access-tokens/
 ---
 
-If you are using the [Docker Hub CLI](https://github.com/docker/hub-tool#readme)
-tool (currently experimental) to access Hub images from the Docker CLI, you can create personal access tokens (PAT) as alternatives to your password.
+You can create personal access tokens (PAT) to use as alternatives to your password for Docker CLI authentication.
 
 Compared to passwords, personal access tokens provide the following advantages:
 
@@ -49,12 +48,15 @@ any time.
 
 ## Use an access token
 
-You can use an access token anywhere that requires your Docker Hub
-password.
+You can use an access token in place of your password when you log in using Docker CLI.
 
-When logging in from your Docker CLI client (`docker login --username <username>`),
-omit the password in the login command. Instead, enter your token when asked for
-a password.
+Log in from your Docker CLI client with the following command, replacing `YOUR_USERNAME` with your Docker ID:
+
+```console
+$ docker login --username <YOUR_USERNAME>
+```
+
+When prompted for a password, enter your personal access token instead of a password.
 
 > **Note**
 >


### PR DESCRIPTION
<!--
  Thank you for contributing to Docker documentation!

  Here are a few things to keep in mind:

  - Links between pages should use a relative path
  - Remember to add an alt text for images

  ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
  ┃     Review our contribution guidelines:       ┃
  ┃                                               ┃
  ┃ https://docs.docker.com/contribute/overview/  ┃
  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
-->

### Proposed changes

<!-- Tell us what you did and why -->

New PR to accommodate security IA update! This PR:

- Removes reference to Hub CLI tool to simplify the intro
- Clarifies that you can use your PAT to log in to the CLI

### Related issues (optional)

<!--
  Refer to related PRs or issues:

  #1234
  Closes #1234
  Closes docker/cli#1234
-->
Closes JIRA https://docker.atlassian.net/browse/ENGDOCS-1732