### PR TITLE
fix access token links

### DIFF
--- a/content/language/dotnet/configure-ci-cd.md
+++ b/content/language/dotnet/configure-ci-cd.md
@@ -27,9 +27,7 @@ Create a GitHub repository, configure the Docker Hub secrets, and push your sour
 
 3. Create a new secret named `DOCKER_USERNAME` and your Docker ID as value.
 
-4. Create a new [Personal Access Token
-   (PAT)](/security/for-developers/access-tokens/#create-an-access-token) for Docker Hub. You
-   can name this token `tutorial-docker`.
+4. Create a new [Personal Access Token (PAT)](../../security/for-developers/access-tokens.md/#create-an-access-token) for Docker Hub. You can name this token `tutorial-docker`.
 
 5. Add the PAT as a second secret in your GitHub repository, with the name
    `DOCKERHUB_TOKEN`.

--- a/content/language/python/configure-ci-cd.md
+++ b/content/language/python/configure-ci-cd.md
@@ -27,9 +27,7 @@ Create a GitHub repository, configure the Docker Hub secrets, and push your sour
 
 3. Create a new secret named `DOCKER_USERNAME` and your Docker ID as value.
 
-4. Create a new [Personal Access Token
-   (PAT)](/docker-hub/access-tokens/#create-an-access-token) for Docker Hub. You
-   can name this token `python-docker`.
+4. Create a new [Personal Access Token (PAT)](../../security/for-developers/access-tokens.md/#create-an-access-token) for Docker Hub. You can name this token `python-docker`.
 
 5. Add the PAT as a second secret in your GitHub repository, with the name
    `DOCKERHUB_TOKEN`.


### PR DESCRIPTION
### Proposed changes

https://github.com/docker/docs/pull/18404 and https://github.com/docker/docs/pull/18400 were tested and then some files were moved around before they were merged to main. This caused the links to pass and merge into main, but fail when merging to published.


### Related issues (optional)

<!--
  Refer to related PRs or issues:

  #1234
  Closes #1234
  Closes docker/cli#1234
-->
