### PR TITLE
engine: clarify the s390x limitation for rhel

### DIFF
--- a/content/engine/install/_index.md
+++ b/content/engine/install/_index.md
@@ -62,16 +62,16 @@ your preferred operating system below.
 Docker provides `.deb` and `.rpm` packages from the following Linux distros
 and architectures:
 
-| Platform                                       | x86_64 / amd64      | arm64 / aarch64     | arm (32-bit)               | ppc64le           | s390x             |
-| :--------------------------------------------- | :------------------ | :------------------ | :------------------------- | :---------------- | :---------------- |
-| [CentOS](centos.md)                            | [✅](centos.md)     | [✅](centos.md)     |                            | [✅](centos.md)   |                   |
-| [Debian](debian.md)                            | [✅](debian.md)     | [✅](debian.md)     | [✅](debian.md)            | [✅](debian.md)   |                   |
-| [Fedora](fedora.md)                            | [✅](fedora.md)     | [✅](fedora.md)     |                            | [✅](fedora.md)   |                   |
-| [Raspberry Pi OS (32-bit)](raspberry-pi-os.md) |                     |                     | [✅](raspberry-pi-os.md)   |                   |                   |
-| [RHEL](rhel.md)                                |                     |                     |                            |                   | [✅](rhel.md)     |
-| [SLES](sles.md)                                |                     |                     |                            |                   | [✅](sles.md)     |
-| [Ubuntu](ubuntu.md)                            | [✅](ubuntu.md)     | [✅](ubuntu.md)     | [✅](ubuntu.md)            | [✅](ubuntu.md)   | [✅](ubuntu.md)   |
-| [Binaries](binaries.md)                        | [✅](binaries.md)   | [✅](binaries.md)   | [✅](binaries.md)          |                   |                   |
+| Platform                                       | x86_64 / amd64    | arm64 / aarch64   | arm (32-bit)             | ppc64le         | s390x           |
+| :--------------------------------------------- | :---------------- | :---------------- | :----------------------- | :-------------- | :-------------- |
+| [CentOS](centos.md)                            | [✅](centos.md)   | [✅](centos.md)   |                          | [✅](centos.md) |                 |
+| [Debian](debian.md)                            | [✅](debian.md)   | [✅](debian.md)   | [✅](debian.md)          | [✅](debian.md) |                 |
+| [Fedora](fedora.md)                            | [✅](fedora.md)   | [✅](fedora.md)   |                          | [✅](fedora.md) |                 |
+| [Raspberry Pi OS (32-bit)](raspberry-pi-os.md) |                   |                   | [✅](raspberry-pi-os.md) |                 |                 |
+| [RHEL (s390x)](rhel.md)                        |                   |                   |                          |                 | [✅](rhel.md)   |
+| [SLES](sles.md)                                |                   |                   |                          |                 | [✅](sles.md)   |
+| [Ubuntu](ubuntu.md)                            | [✅](ubuntu.md)   | [✅](ubuntu.md)   | [✅](ubuntu.md)          | [✅](ubuntu.md) | [✅](ubuntu.md) |
+| [Binaries](binaries.md)                        | [✅](binaries.md) | [✅](binaries.md) | [✅](binaries.md)        |                 |                 |
 
 ### Other Linux distros
 

--- a/content/engine/install/rhel.md
+++ b/content/engine/install/rhel.md
@@ -3,7 +3,7 @@ description: Learn how to install Docker Engine on RHEL. These instructions cove
   the different installation methods, how to uninstall, and next steps.
 keywords: requirements, apt, installation, rhel, rpm, install, install docker engine, uninstall, upgrade,
   update, s390x, ibm-z
-title: Install Docker Engine on RHEL
+title: Install Docker Engine on RHEL (s390x)
 toc_max: 4
 aliases:
 - /ee/docker-ee/rhel/
@@ -17,17 +17,21 @@ aliases:
 download-url-base: https://download.docker.com/linux/rhel
 ---
 
+> **Note**
+>
+> The installation instructions on this page refer to packages for RHEL on the
+> **s390x** architecture (IBM Z). Other architectures, including x86_64, aren't
+> yet supported for RHEL.
+>
+> For other architectures, you may be able to install the CentOS packages.
+> Refer to [Install Docker Engine on CentOS](centos.md).
+{ .warning }
+
 To get started with Docker Engine on RHEL, make sure you
 [meet the prerequisites](#prerequisites), and then follow the
 [installation steps](#installation-methods).
 
 ## Prerequisites
-
-> **Note**
->
-> We currently only provide packages for RHEL on s390x (IBM Z). Other architectures
-> are not yet supported for RHEL, but you may be able to install the CentOS packages
-> on RHEL. Refer to the [Install Docker Engine on CentOS](centos.md) page for details.
 
 ### OS requirements
 

--- a/data/toc.yaml
+++ b/data/toc.yaml
@@ -1406,7 +1406,7 @@ Manuals:
     - path: /engine/install/fedora/
       title: Fedora
     - path: /engine/install/rhel/
-      title: RHEL
+      title: RHEL (s390x)
     - path: /engine/install/sles/
       title: SLES
     - path: /engine/install/ubuntu/


### PR DESCRIPTION
<img width="814" alt="image" src="https://github.com/docker/docs/assets/35727626/10461f92-716a-48f8-a1a9-8d5be40396f9">