### PR TITLE
Fix typo in _index.md

### DIFF
--- a/content/build/cache/_index.md
+++ b/content/build/cache/_index.md
@@ -167,7 +167,7 @@ a more fine-grained cache between runs. For example, when installing packages,
 you don't always need to fetch all of your packages from the internet each time.
 You only need the ones that have changed.
 
-To solve this problem, you can use `RUN --mount type=cache`. For example, for
+To solve this problem, you can use `RUN --mount=type=cache`. For example, for
 your Debian-based image you might use the following:
 
 ```dockerfile


### PR DESCRIPTION
I think there is a typo in the docs where they talk about use the `--mount` option for the cache.

Changed
`RUN --mount type=cache`
to
`RUN --mount=type=cache`

<!--
  Thank you for contributing to Docker documentation!

  Here are a few things to keep in mind:

  - Links between pages should use a relative path
  - Remember to add an alt text for images

  ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
  ┃     Review our contribution guidelines:       ┃
  ┃                                               ┃
  ┃ https://docs.docker.com/contribute/overview/  ┃
  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
-->

### Proposed changes

<!-- Tell us what you did and why -->

### Related issues (optional)

<!--
  Refer to related PRs or issues:

  #1234
  Closes #1234
  Closes docker/cli#1234
-->
