### PR TITLE
engine/inst/debian-like: clarify commands should be discretely entered

### DIFF
--- a/content/engine/install/debian.md
+++ b/content/engine/install/debian.md
@@ -93,20 +93,20 @@ Docker from the repository.
 
 1. Set up Docker's `apt` repository.
 
-   ```bash
+   ```console
    # Add Docker's official GPG key:
-   sudo apt-get update
-   sudo apt-get install ca-certificates curl gnupg
-   sudo install -m 0755 -d /etc/apt/keyrings
-   curl -fsSL {{% param "download-url-base" %}}/gpg | sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg
-   sudo chmod a+r /etc/apt/keyrings/docker.gpg
+   $ sudo apt-get update
+   $ sudo apt-get install ca-certificates curl gnupg
+   $ sudo install -m 0755 -d /etc/apt/keyrings
+   $ curl -fsSL {{% param "download-url-base" %}}/gpg | sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg
+   $ sudo chmod a+r /etc/apt/keyrings/docker.gpg
 
    # Add the repository to Apt sources:
-   echo \
+   $ echo \
      "deb [arch="$(dpkg --print-architecture)" signed-by=/etc/apt/keyrings/docker.gpg] {{% param "download-url-base" %}} \
      "$(. /etc/os-release && echo "$VERSION_CODENAME")" stable" | \
      sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
-   sudo apt-get update
+   $ sudo apt-get update
    ```
 
    > **Note**
@@ -116,7 +116,7 @@ Docker from the repository.
    > print the version codename:
    >
    > ```console
-   > $(. /etc/os-release && echo "$VERSION_CODENAME")
+   > $ $(. /etc/os-release && echo "$VERSION_CODENAME")
    > ```
    >
    > Replace this part with the codename of the corresponding Debian release,

--- a/content/engine/install/raspberry-pi-os.md
+++ b/content/engine/install/raspberry-pi-os.md
@@ -95,20 +95,20 @@ Docker from the repository.
 
 1. Set up Docker's `apt` repository.
 
-   ```bash
+   ```console
    # Add Docker's official GPG key:
-   sudo apt-get update
-   sudo apt-get install ca-certificates curl gnupg
-   sudo install -m 0755 -d /etc/apt/keyrings
-   curl -fsSL {{% param "download-url-base" %}}/gpg | sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg
-   sudo chmod a+r /etc/apt/keyrings/docker.gpg
+   $ sudo apt-get update
+   $ sudo apt-get install ca-certificates curl gnupg
+   $ sudo install -m 0755 -d /etc/apt/keyrings
+   $ curl -fsSL {{% param "download-url-base" %}}/gpg | sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg
+   $ sudo chmod a+r /etc/apt/keyrings/docker.gpg
 
    # Set up Docker's APT repository:
-   echo \
+   $ echo \
      "deb [arch="$(dpkg --print-architecture)" signed-by=/etc/apt/keyrings/docker.gpg] {{% param "download-url-base" %}} \
      "$(. /etc/os-release && echo "$VERSION_CODENAME")" stable" | \
      sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
-   sudo apt-get update
+   $ sudo apt-get update
    ```
 
 2. Install the Docker packages.

--- a/content/engine/install/ubuntu.md
+++ b/content/engine/install/ubuntu.md
@@ -104,20 +104,20 @@ Docker from the repository.
 
 1. Set up Docker's `apt` repository.
 
-   ```bash
+   ```console
    # Add Docker's official GPG key:
-   sudo apt-get update
-   sudo apt-get install ca-certificates curl gnupg
-   sudo install -m 0755 -d /etc/apt/keyrings
-   curl -fsSL {{% param "download-url-base" %}}/gpg | sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg
-   sudo chmod a+r /etc/apt/keyrings/docker.gpg
+   $ sudo apt-get update
+   $ sudo apt-get install ca-certificates curl gnupg
+   $ sudo install -m 0755 -d /etc/apt/keyrings
+   $ curl -fsSL {{% param "download-url-base" %}}/gpg | sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg
+   $ sudo chmod a+r /etc/apt/keyrings/docker.gpg
 
    # Add the repository to Apt sources:
-   echo \
+   $ echo \
      "deb [arch="$(dpkg --print-architecture)" signed-by=/etc/apt/keyrings/docker.gpg] {{% param "download-url-base" %}} \
      "$(. /etc/os-release && echo "$VERSION_CODENAME")" stable" | \
      sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
-   sudo apt-get update
+   $ sudo apt-get update
    ```
 
    > **Note**


### PR DESCRIPTION
### Proposed changes

Clarify that these commands should be entered separately, as this block is not written as a script and various issues can result from a lack of bracketed paste/early-lexing.
