### PR TITLE
Set correct default value for fluentd-buffer-limit

### DIFF
--- a/content/config/containers/logging/fluentd.md
+++ b/content/config/containers/logging/fluentd.md
@@ -119,7 +119,7 @@ connection is established. Defaults to `false`.
 
 Sets the number of events buffered on the memory. Records will be stored in memory
 up to this number. If the buffer is full, the call to record logs will fail.
-The default is 8192.
+The default is 1048576.
 (https://github.com/fluent/fluent-logger-golang/tree/master#bufferlimit)
 
 ### fluentd-retry-wait


### PR DESCRIPTION
Docker is setting a higher (1048576) default buffer limit than the fluent logger library (8192). 

Here is the relevant code in the latest docker release:
https://github.com/moby/moby/blob/v24.0.6/daemon/logger/fluentd/fluentd.go#L39

