### PR TITLE
chore: add --rm in docker run hello-world command

### DIFF
--- a/content/engine/install/ubuntu.md
+++ b/content/engine/install/ubuntu.md
@@ -165,7 +165,7 @@ Docker from the repository.
    `hello-world` image.
 
    ```console
-   $ sudo docker run hello-world
+   $ sudo docker run --rm hello-world
    ```
 
    This command downloads a test image and runs it in a container. When the


### PR DESCRIPTION
### Proposed changes

I did add `--rm` in the `sudo docker run hello-world` command. I do that every time and wanted to edit it this time. I do not think people will need the hello-world container later on so I thought we can just make it destroy itself after it is done running.

### Related issues (optional)

None