### PR TITLE
Add filtering section on docker system prune

### DIFF
--- a/content/config/pruning.md
+++ b/content/config/pruning.md
@@ -175,3 +175,15 @@ Are you sure you want to continue? [y/N] y
 
 By default, you are prompted to continue. To bypass the prompt, use the `-f` or
 `--force` flag.
+
+By default, all unused containers, networks, images (both dangling and unreferenced)
+are removed. If you are using docker {{< badge color=blue text="API 1.28+" >}}, you can limit the scope using the 
+`--filter` flag. For instance, the following command removes items older than 24 hours:
+
+```console
+$ docker system prune --filter "until=24h"
+```
+
+Other filtering expressions are available. See the
+[`docker system prune` reference](../engine/reference/commandline/system_prune.md)
+for more examples.

--- a/content/config/pruning.md
+++ b/content/config/pruning.md
@@ -177,7 +177,7 @@ By default, you are prompted to continue. To bypass the prompt, use the `-f` or
 `--force` flag.
 
 By default, all unused containers, networks, images (both dangling and unreferenced)
-are removed. If you are using docker {{< badge color=blue text="API 1.28+" >}}, you can limit the scope using the 
+are removed. You can limit the scope using the 
 `--filter` flag. For instance, the following command removes items older than 24 hours:
 
 ```console


### PR DESCRIPTION
Docker system prune is allowed for API 1.28+, as shown in the doc https://docs.docker.com/engine/reference/commandline/system_prune/, but this is not shown in the Prune unused objects page.

<!--
  Thank you for contributing to Docker documentation!

  Here are a few things to keep in mind:

  - Links between pages should use a relative path
  - Remember to add an alt text for images

  ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
  ┃     Review our contribution guidelines:       ┃
  ┃                                               ┃
  ┃ https://docs.docker.com/contribute/overview/  ┃
  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
-->

### Proposed changes

Copied and pasted the "filtering" section from an above prune command and modified to make it accurate for system prune. Also noted that API 1.28+ is required.

### Related issues (optional)

Closes #18518
<!--
  Refer to related PRs or issues:

  #1234
  Closes #1234
  Closes docker/cli#1234
-->
