### PR TITLE
typo in the content

### DIFF
--- a/content/desktop/use-desktop/images.md
+++ b/content/desktop/use-desktop/images.md
@@ -103,7 +103,7 @@ For more information about supported integrations, see
 
 ### Hub
 
-Switching to the **Hub** tab prompts you to sign in to your Docke Hub account, if you're not already signed in.
+Switching to the **Hub** tab prompts you to sign in to your Docker Hub account, if you're not already signed in.
 When signed in, it shows you a list of images in Docker Hub organizations and repositories that you have access to.
 
 Select an organization from the drop-down to view a list of repositories for that organization.


### PR DESCRIPTION
"Docker hub" was written as "docke hub", which is not a word.

<!--
  Thank you for contributing to Docker documentation!

  Here are a few things to keep in mind:

  - Links between pages should use a relative path
  - Remember to add an alt text for images

  ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
  ┃     Review our contribution guidelines:       ┃
  ┃                                               ┃
  ┃ https://docs.docker.com/contribute/overview/  ┃
  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
-->

### Proposed changes
"Docker hub" was written as "docke hub", which is not a word.
<!-- Tell us what you did and why -->
I have corrected the spelling mistake in the documentation.
I did the changes because I was revisiting docker basics and found it.
### Related issues (optional)

<!--
  Refer to related PRs or issues:

  #1234
  Closes #1234
  Closes docker/cli#1234
-->
