### PR TITLE
docker-ce 24.0.7 release

### DIFF
--- a/content/engine/release-notes/24.0.md
+++ b/content/engine/release-notes/24.0.md
@@ -20,6 +20,48 @@ For more information about:
 - Deprecated and removed features, see [Deprecated Engine Features](../deprecated.md).
 - Changes to the Engine API, see [Engine API version history](../api/version-history.md).
 
+## 24.0.7
+
+{{< release-date date="2023-10-27" >}}
+
+For a full list of pull requests and changes in this release, refer to the relevant GitHub milestones:
+
+- [docker/cli, 24.0.7 milestone](https://github.com/docker/cli/issues?q=is%3Aclosed+milestone%3A24.0.7)
+- [moby/moby, 24.0.7 milestone](https://github.com/moby/moby/issues?q=is%3Aclosed+milestone%3A24.0.7)
+
+### Bug fixes and enhancements
+
+* Ensure that overlay2 layer metadata is correct. [moby/moby#46703](https://github.com/moby/moby/pull/46703)
+* Fix "Rootful-in-Rootless" Docker-in-Docker on systemd versions 250 and later. [moby/moby#46626](https://github.com/moby/moby/pull/46626)
+* Fix `docker.socket` not getting disabled when uninstalling the `docker-ce` RPM package. [docker/docker-ce-packaging#852](https://github.com/docker/docker-ce-packaging/pull/852)
+* Fix `dockerd-rootless-setuptools.sh` when username contains a backslash. [moby/moby#46407](https://github.com/moby/moby/pull/46407)
+* Fix a bug that would prevent network sandboxes to be fully deleted when stopping containers with no network attachments and when `dockerd --bridge=none` is used. [moby/moby#46702](https://github.com/moby/moby/pull/46702)
+* Fix a bug where context cancellation could interrupt container restart. [moby/moby#46697](https://github.com/moby/moby/pull/46697)
+* Fix an issue where containers would fail to start when providing `--ip-range` with a mask larger than its parent subnet. [docker/for-mac#6870](https://github.com/docker/for-mac/issues/6870)
+* Fix data corruption with zstd output. [moby/moby#46709](https://github.com/moby/moby/pull/46709)
+* Fix the conditions under which the container's MAC address is applied. [moby/moby#46478](https://github.com/moby/moby/pull/46478)
+* Improve the performance of the stats collector. [moby/moby#46448](https://github.com/moby/moby/pull/46448)
+* Fix an issue with source policy rules ending up in the wrong order. [moby/moby#46441](https://github.com/moby/moby/pull/46441)
+
+### Packaging updates
+
+* Add support for Fedora 39 and Ubuntu 23.10. [docker/docker-ce-packaging#940](https://github.com/docker/docker-ce-packaging/pull/940), [docker/docker-ce-packaging#955](https://github.com/docker/docker-ce-packaging/pull/955)
+* Upgrade Go to `go1.20.10`. [docker/docker-ce-packaging#951](https://github.com/docker/docker-ce-packaging/pull/951)
+* Upgrade containerd to `v1.7.6` (static binaries only). [moby/moby#46103](https://github.com/moby/moby/pull/46103)
+* Upgrade the `containerd.io` package to [`v1.6.24`](https://github.com/containerd/containerd/releases/tag/v1.6.24).
+
+### Security
+
+* Deny containers access to `/sys/devices/virtual/powercap` by default. This change hardens against
+  [CVE-2020-8694](https://scout.docker.com/v/CVE-2020-8694),
+  [CVE-2020-8695](https://scout.docker.com/v/CVE-2020-8695), and
+  [CVE-2020-12912](https://scout.docker.com/v/CVE-2020-12912),
+  and an attack known as [the PLATYPUS attack](https://platypusattack.com/).
+
+  For more details, see
+  [advisory](https://github.com/moby/moby/security/advisories/GHSA-jq35-85cj-fj4p),
+  [commit](https://github.com/moby/moby/commit/c9ccbfad11a60e703e91b6cca4f48927828c7e35).
+
 ## 24.0.6
 
 {{< release-date date="2023-09-05" >}}

--- a/content/engine/release-notes/24.0.md
+++ b/content/engine/release-notes/24.0.md
@@ -31,13 +31,12 @@ For a full list of pull requests and changes in this release, refer to the relev
 
 ### Bug fixes and enhancements
 
-* Ensure that overlay2 layer metadata is correct. [moby/moby#46703](https://github.com/moby/moby/pull/46703)
-* Fix "Rootful-in-Rootless" Docker-in-Docker on systemd versions 250 and later. [moby/moby#46626](https://github.com/moby/moby/pull/46626)
-* Fix `docker.socket` not getting disabled when uninstalling the `docker-ce` RPM package. [docker/docker-ce-packaging#852](https://github.com/docker/docker-ce-packaging/pull/852)
+* Write overlay2 layer metadata atomically. [moby/moby#46703](https://github.com/moby/moby/pull/46703)
+* Fix "Rootful-in-Rootless" Docker-in-Docker on systemd version 250 and later. [moby/moby#46626](https://github.com/moby/moby/pull/46626)
 * Fix `dockerd-rootless-setuptools.sh` when username contains a backslash. [moby/moby#46407](https://github.com/moby/moby/pull/46407)
 * Fix a bug that would prevent network sandboxes to be fully deleted when stopping containers with no network attachments and when `dockerd --bridge=none` is used. [moby/moby#46702](https://github.com/moby/moby/pull/46702)
-* Fix a bug where context cancellation could interrupt container restart. [moby/moby#46697](https://github.com/moby/moby/pull/46697)
-* Fix an issue where containers would fail to start when providing `--ip-range` with a mask larger than its parent subnet. [docker/for-mac#6870](https://github.com/docker/for-mac/issues/6870)
+* Fix a bug where cancelling an API request could interrupt container restart. [moby/moby#46697](https://github.com/moby/moby/pull/46697)
+* Fix an issue where containers would fail to start when providing `--ip-range` with a range larger than the subnet. [docker/for-mac#6870](https://github.com/docker/for-mac/issues/6870)
 * Fix data corruption with zstd output. [moby/moby#46709](https://github.com/moby/moby/pull/46709)
 * Fix the conditions under which the container's MAC address is applied. [moby/moby#46478](https://github.com/moby/moby/pull/46478)
 * Improve the performance of the stats collector. [moby/moby#46448](https://github.com/moby/moby/pull/46448)
@@ -46,6 +45,7 @@ For a full list of pull requests and changes in this release, refer to the relev
 ### Packaging updates
 
 * Add support for Fedora 39 and Ubuntu 23.10. [docker/docker-ce-packaging#940](https://github.com/docker/docker-ce-packaging/pull/940), [docker/docker-ce-packaging#955](https://github.com/docker/docker-ce-packaging/pull/955)
+* Fix `docker.socket` not getting disabled when uninstalling the `docker-ce` RPM package. [docker/docker-ce-packaging#852](https://github.com/docker/docker-ce-packaging/pull/852)
 * Upgrade Go to `go1.20.10`. [docker/docker-ce-packaging#951](https://github.com/docker/docker-ce-packaging/pull/951)
 * Upgrade containerd to `v1.7.6` (static binaries only). [moby/moby#46103](https://github.com/moby/moby/pull/46103)
 * Upgrade the `containerd.io` package to [`v1.6.24`](https://github.com/containerd/containerd/releases/tag/v1.6.24).

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -91,7 +91,7 @@ params:
   docs_url: https://docs.docker.com
 
   latest_engine_api_version: "1.43"
-  docker_ce_version: "24.0.6"
+  docker_ce_version: "24.0.7"
   compose_version: "v2.23.0"
   compose_file_v3: "3.8"
   compose_file_v2: "2.4"


### PR DESCRIPTION
- engine: add 24.0.7 release notes
- config: update docker_ce_version to 24.0.7

https://deploy-preview-18528--docsdocker.netlify.app/engine/release-notes/24.0/#2407