### PR TITLE
update java language-specific guide

### DIFF
--- a/content/language/java/_index.md
+++ b/content/language/java/_index.md
@@ -14,7 +14,7 @@ The Java getting started guide teaches you how to create a containerized Spring 
 * Set up a local development environment to connect a database to the container
 * Use Docker Compose to run the Spring Boot application
 * Configure a CI/CD pipeline for your application using GitHub Actions
-* Deploy your application to the cloud
+* Deploy your containerized application locally to Kubernetes to test and debug your deployment
 
 After completing the Java getting started modules, you should be able to containerize your own Java application based on the examples and instructions provided in this guide.
 

--- a/content/language/java/configure-ci-cd.md
+++ b/content/language/java/configure-ci-cd.md
@@ -1,7 +1,7 @@
 ---
 title: Configure CI/CD for your Java application
 keywords: java, CI/CD, local, development
-description: Learn how to Configure CI/CD for Java your application
+description: Learn how to Configure CI/CD for your Java application
 ---
 
 ## Prerequisites

--- a/content/language/java/configure-ci-cd.md
+++ b/content/language/java/configure-ci-cd.md
@@ -1,17 +1,142 @@
 ---
 title: Configure CI/CD for your Java application
-keywords: Java, CI/CD, local, development
-description: Learn how to Configure CI/CD for your application
+keywords: java, CI/CD, local, development
+description: Learn how to Configure CI/CD for Java your application
 ---
 
-## Get started with GitHub Actions
+## Prerequisites
 
-{{< include "gha-tutorial.md" >}}
+Complete the previous sections of this guide, starting with [Build your Java image](build-images.md). You must have a [GitHub](https://github.com/signup) account and a [Docker](https://hub.docker.com/signup) account to complete this section.
+
+## Overview
+
+In this section, you'll learn how to set up and use GitHub Actions to build and push your Docker image to Docker Hub. You will complete the following steps:
+
+1. Create a new repository on GitHub.
+2. Define the GitHub Actions workflow.
+3. Run the workflow.
+
+## Step one: Create the repository
+
+Create a GitHub repository, configure the Docker Hub secrets, and push your source code.
+
+1. [Create a new repository](https://github.com/new) on GitHub.
+
+2. Open the repository **Settings**, and go to **Secrets and variables** >
+   **Actions**.
+
+3. Create a new secret named `DOCKER_USERNAME` and your Docker ID as value.
+
+4. Create a new [Personal Access Token (PAT)](../../security/for-developers/access-tokens.md/#create-an-access-token) for Docker Hub. You can name this token `docker-tutorial`.
+
+5. Add the PAT as a second secret in your GitHub repository, with the name
+   `DOCKERHUB_TOKEN`.
+
+6. In your local repository on your machine, run the following command to change
+   the origin to the repository you just created. Make sure you change
+   `your-username` to your GitHub username and `your-repository` to the name of
+   the repository you created.
+
+   ```console
+   $ git remote set-url origin https://github.com/your-username/your-repository.git
+   ```
+
+7. Run the following commands to stage, commit, and push your local repository to GitHub.
+
+   ```console
+   $ git add -A
+   $ git commit -m "my commit"
+   $ git push -u origin main
+   ```
+
+## Step two: Set up the workflow
+
+Set up your GitHub Actions workflow for building, testing, and pushing the image
+to Docker Hub.
+
+1. Go to your repository on GitHub and then select the **Actions** tab.
+   The project already has the `maven-build` workflow to build and test your Java application with Maven. If you want, you can optionally disable this workflow because you won't use it in this guide. You'll create a new, alternate workflow to build, test, and push your image.
+
+2. Select **New workflow**.
+
+3. Select **set up a workflow yourself**.
+
+   This takes you to a page for creating a new GitHub actions workflow file in
+   your repository, under `.github/workflows/main.yml` by default.
+
+4. In the editor window, copy and paste the following YAML configuration.
+
+   ```yaml
+   name: ci
+   
+   on:
+     push:
+       branches:
+         - main
+   
+   jobs:
+     build:
+       runs-on: ubuntu-latest
+       steps:
+         -
+           name: Checkout
+           uses: actions/checkout@v4
+         -
+           name: Login to Docker Hub
+           uses: docker/login-action@v3
+           with:
+             username: ${{ secrets.DOCKER_USERNAME }}
+             password: ${{ secrets.DOCKERHUB_TOKEN }}
+         -
+           name: Set up Docker Buildx
+           uses: docker/setup-buildx-action@v3
+         -
+           name: Build and test
+           uses: docker/build-push-action@v5
+           with:
+             context: .
+             target: test
+             load: true
+         -
+           name: Build and push
+           uses: docker/build-push-action@v5
+           with:
+             context: .
+             push: true
+             target: production
+             tags: ${{ secrets.DOCKER_USERNAME }}/${{ github.event.repository.name }}:latest
+   ```
+
+   For more information about the YAML syntax used here, see [Workflow syntax for GitHub Actions](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions).
+
+## Step three: Run the workflow
+
+Save the workflow file and run the job.
+
+1. Select **Commit changes...** and push the changes to the `main` branch.
+
+   After pushing the commit, the workflow starts automatically.
+
+2. Go to the **Actions** tab. It displays the workflow.
+
+   Selecting the workflow shows you the breakdown of all the steps.
+
+3. When the workflow is complete, go to your
+   [repositories on Docker Hub](https://hub.docker.com/repositories).
+
+   If you see the new repository in that list, it means the GitHub Actions
+   successfully pushed the image to Docker Hub.
+
+## Summary
+
+In this section, you learned how to set up a GitHub Actions workflow for your application.
+
+Related information:
+ - [Introduction to GitHub Actions](../../build/ci/github-actions/index.md)
+ - [Workflow syntax for GitHub Actions](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions)
 
 ## Next steps
 
-In this module, you have learned how to set up GitHub Actions workflow to an existing Docker project, optimize your workflow to improve build times, and reduce the number of pull requests. Finally, you learned how to push only specific versions to Docker Hub. You can also set up nightly tests against the latest tag, test each PR, or do something more elegant with the tags you're using and make use of the Git tag for the same tag in your image.
+Next, learn how you can locally test and debug your workloads on Kubernetes before deploying.
 
-You can also consider deploying your application.
-
-{{< button text="Deploy your application" url="deploy.md" >}}
+{{< button text="Test your deployment" url="./deploy.md" >}}

--- a/content/language/java/deploy.md
+++ b/content/language/java/deploy.md
@@ -1,7 +1,148 @@
 ---
-title: Deploy your Java app
-keywords: deploy, ACI, ECS, Java, local, development
-description: Learn how to deploy your application
+title: Test your Java deployment
+keywords: deploy, kubernetes, java
+description: Learn how to develop locally using Kubernetes
 ---
 
-{{< include "deploy.md" >}}
+## Prerequisites
+
+- Complete all the previous sections of this guide, starting with [Build your Java image](build-images.md).
+- [Turn on Kubernetes](/desktop/kubernetes/#turn-on-kubernetes) in Docker Desktop.
+
+## Overview
+
+In this section, you'll learn how to use Docker Desktop to deploy your
+application to a fully-featured Kubernetes environment on your development
+machine. This lets you to test and debug your workloads on Kubernetes locally
+before deploying.
+
+## Create a Kubernetes YAML file
+
+In your `spring-petclinic` directory, create a file named
+`docker-java-kubernetes.yaml`. Open the file in an IDE or text editor and add
+the following contents. Replace `DOCKER_USERNAME/REPO_NAME` with your Docker
+username and the name of the repository that you created in [Configure CI/CD for
+your Java application](configure-ci-cd.md).
+
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: docker-java-demo
+  namespace: default
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      service: server
+  template:
+    metadata:
+      labels:
+        service: server
+    spec:
+      containers:
+       - name: server-service
+         image: DOCKER_USERNAME/REPO_NAME
+         imagePullPolicy: Always
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: service-entrypoint
+  namespace: default
+spec:
+  type: NodePort
+  selector:
+    service: server
+  ports:
+  - port: 8080
+    targetPort: 8080
+    nodePort: 30001
+```
+
+In this Kubernetes YAML file, there are two objects, separated by the `---`:
+
+ - A Deployment, describing a scalable group of identical pods. In this case,
+   you'll get just one replica, or copy of your pod. That pod, which is
+   described under `template`, has just one container in it. The
+    container is created from the image built by GitHub Actions in [Configure CI/CD for
+    your Java application](configure-ci-cd.md).
+ - A NodePort service, which will route traffic from port 30001 on your host to
+   port 5000 inside the pods it routes to, allowing you to reach your app
+   from the network.
+
+To learn more about Kubernetes objects, see the [Kubernetes documentation](https://kubernetes.io/docs/home/).
+
+## Deploy and check your application
+
+1. In a terminal, navigate to `spring-petclinic` and deploy your application to
+   Kubernetes.
+
+   ```console
+   $ kubectl apply -f docker-java-kubernetes.yaml
+   ```
+
+   You should see output that looks like the following, indicating your Kubernetes objects were created successfully.
+
+   ```shell
+   deployment.apps/docker-java-demo created
+   service/service-entrypoint created
+   ```
+
+2. Make sure everything worked by listing your deployments.
+
+   ```console
+   $ kubectl get deployments
+   ```
+
+   Your deployment should be listed as follows:
+
+   ```shell
+   NAME                 READY   UP-TO-DATE   AVAILABLE   AGE
+   docker-java-demo     1/1     1            1           15s
+   ```
+
+   This indicates all one of the pods you asked for in your YAML are up and running. Do the same check for your services.
+
+   ```console
+   $ kubectl get services
+   ```
+
+   You should get output like the following.
+
+   ```shell
+   NAME                 TYPE        CLUSTER-IP      EXTERNAL-IP   PORT(S)          AGE
+   kubernetes           ClusterIP   10.96.0.1       <none>        443/TCP          23h
+   service-entrypoint   NodePort    10.99.128.230   <none>        8080:30001/TCP   75s
+   ```
+
+   In addition to the default `kubernetes` service, you can see your `service-entrypoint` service, accepting traffic on port 30001/TCP.
+
+3. In a terminal, curl the service. Note that a database wasn't deployed in
+   this example.
+
+   ```console
+   $ curl --request GET \
+     --url http://localhost:30001/actuator/health \
+     --header 'content-type: application/json'
+   ```
+
+   You should get output like the following.
+   ```console
+   {"status":"UP","groups":["liveness","readiness"]}
+   ```
+
+4. Run the following command to tear down your application.
+
+   ```console
+   $ kubectl delete -f docker-java-kubernetes.yaml
+   ```
+
+## Summary
+
+In this section, you learned how to use Docker Desktop to deploy your application to a fully-featured Kubernetes environment on your development machine.
+
+Related information:
+   - [Kubernetes documentation](https://kubernetes.io/docs/home/)
+   - [Deploy on Kubernetes with Docker Desktop](../../desktop/kubernetes.md)
+   - [Swarm mode overview](../../engine/swarm/_index.md)

--- a/content/language/java/deploy.md
+++ b/content/language/java/deploy.md
@@ -68,7 +68,7 @@ In this Kubernetes YAML file, there are two objects, separated by the `---`:
     container is created from the image built by GitHub Actions in [Configure CI/CD for
     your Java application](configure-ci-cd.md).
  - A NodePort service, which will route traffic from port 30001 on your host to
-   port 5000 inside the pods it routes to, allowing you to reach your app
+   port 8080 inside the pods it routes to, allowing you to reach your app
    from the network.
 
 To learn more about Kubernetes objects, see the [Kubernetes documentation](https://kubernetes.io/docs/home/).

--- a/content/language/java/deploy.md
+++ b/content/language/java/deploy.md
@@ -13,7 +13,7 @@ description: Learn how to develop locally using Kubernetes
 
 In this section, you'll learn how to use Docker Desktop to deploy your
 application to a fully-featured Kubernetes environment on your development
-machine. This lets you to test and debug your workloads on Kubernetes locally
+machine. This lets you test and debug your workloads on Kubernetes locally
 before deploying.
 
 ## Create a Kubernetes YAML file

--- a/data/toc.yaml
+++ b/data/toc.yaml
@@ -69,7 +69,7 @@ Guides:
       path: /language/java/run-tests/
     - title: "Configure CI/CD"
       path: /language/java/configure-ci-cd/
-    - title: "Deploy your app"
+    - title: "Test your deployment"
       path: /language/java/deploy/
   - sectiontitle: Go
     section:


### PR DESCRIPTION
### Proposed changes

Update Java language-specific guide.
- Remove cloud integrations from Deployment and replace with steps to run app locally in Kubernetes.
- Update CI/CD based on sample app.

### Related issues (optional)

ENGDOCS-1494
