### PR TITLE
build: set missing frontmatter for remote pages

### DIFF
--- a/data/frontmatter.yaml
+++ b/data/frontmatter.yaml
@@ -9,6 +9,28 @@
 # relative to the content directory. For upstream
 # page files, that's the target of the file mount.
 
+build/attestations/attestation-storage.md:
+  description: |
+    How SBOM and provenance attestations are stored for images.
+  keywords: |
+    build, attestations, sbom, provenance, storage, manifest
+
+build/attestations/slsa-definitions.md:
+  description: |
+    How BuildKit populates the fields in the SLSA provenance attestations.
+  keywords: |
+    build, attestations, provenance, slsa, definitions, reference
+
+build/bake/reference.md:
+  description: |
+    Learn about the syntax and available commands for the Buildx Bake file.
+  keywords: |
+    build, reference, buildx, bake, hcl
+
+build/buildkit/toml-configuration.md:
+  keywords: |
+    build, buildkit, configuration
+
 engine/reference/builder.md:
   description: |
     Find all the available commands you can use in a Dockerfile


### PR DESCRIPTION
<!--
  Thank you for contributing to Docker documentation!

  Here are a few things to keep in mind:

  - Links between pages should use a relative path
  - Remember to add an alt text for images

  ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
  ┃     Review our contribution guidelines:       ┃
  ┃                                               ┃
  ┃ https://docs.docker.com/contribute/overview/  ┃
  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
-->

### Proposed changes

follow-up https://github.com/docker/docs/pull/18473

Set missing frontmatter for remote pages. Values transposed from lab branch: https://github.com/docker/docs/blob/lab/build

### Related issues (optional)

<!--
  Refer to related PRs or issues:

  #1234
  Closes #1234
  Closes docker/cli#1234
-->
