### PR TITLE
Remove wrong statement from fluentd logging driver

### DIFF
--- a/content/config/containers/logging/fluentd.md
+++ b/content/config/containers/logging/fluentd.md
@@ -24,7 +24,6 @@ driver sends the following metadata in the structured log message:
 | `source`         | `stdout` or `stderr`                                                                                                                                   |
 | `log`            | The container log                                                                                                                                      |
 
-The `docker logs` command isn't available for this logging driver.
 
 ## Usage
 


### PR DESCRIPTION
Since docker 20.10 dual logging is supported which enables logging drivers to use the `docker logs` command.
This is already stated in the following section: https://docs.docker.com/config/containers/logging/configure/#supported-logging-drivers

This PR just removes the 'wrong' line from the fluentd logging driver documentation.