### PR TITLE
Add missing file extension to create admin-settings.json

### DIFF
--- a/content/desktop/hardened-desktop/settings-management/configure.md
+++ b/content/desktop/hardened-desktop/settings-management/configure.md
@@ -22,7 +22,7 @@ Settings Management is designed specifically for organizations who don’t give 
 You can either use the `--admin-settings` installer flag on [macOS](../../install/mac-install.md#install-from-the-command-line) or [Windows](../../install/windows-install.md#install-from-the-command-line) to automatically create the `admin-settings.json` and save it in the correct location, or set it up manually.
 
 To set it up manually:
-1. Create a new, empty JSON file and name it `admin-settings`.
+1. Create a new, empty JSON file and name it `admin-settings.json`.
 2. Save the `admin-settings.json` file on your developers' machines in the following locations:
 
     - Mac: `/Library/Application\ Support/com.docker.docker/admin-settings.json`


### PR DESCRIPTION
<!--
  Thank you for contributing to Docker documentation!

  Here are a few things to keep in mind:

  - Links between pages should use a relative path
  - Remember to add an alt text for images

  ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
  ┃     Review our contribution guidelines:       ┃
  ┃                                               ┃
  ┃ https://docs.docker.com/contribute/overview/  ┃
  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
-->

### Proposed changes

<!-- Tell us what you did and why -->

During a customer interview we noticed that they created the file without the `.json` extension wich makes Docker Deskotp not work.

### Related issues (optional)

<!--
  Refer to related PRs or issues:

  #1234
  Closes #1234
  Closes docker/cli#1234
-->
