### PR TITLE
remove dead external link

### DIFF
--- a/content/get-started/09_image_best.md
+++ b/content/get-started/09_image_best.md
@@ -95,9 +95,6 @@ dependencies if there was a change to the `package.json`.
     [here](../build/building/context.md#dockerignore-files).
     In this case, the `node_modules` folder should be omitted in the second `COPY` step because otherwise,
     it would possibly overwrite files which were created by the command in the `RUN` step.
-    For further details on why this is recommended for Node.js applications and other best practices,
-    have a look at their guide on
-    [Dockerizing a Node.js web app](https://nodejs.org/en/docs/guides/nodejs-docker-webapp/).
 
 3. Build a new image using `docker build`.
 


### PR DESCRIPTION
### Proposed changes

The guide in the node.js docs no longer exists. Remove link.

### Related issues (optional)

Close #18570
