### PR TITLE
fix: "hte" to "the" in "Create an advanced frontend extension" documentation page

### DIFF
--- a/content/desktop/extensions-sdk/build/frontend-extension-tutorial.md
+++ b/content/desktop/extensions-sdk/build/frontend-extension-tutorial.md
@@ -153,7 +153,7 @@ The `root` property is the path to the frontend application in the extension's c
 system to deploy it on the host.
 The `src` property is the path to the HTML entry point of the frontend application within the `root` folder.
 
-For more information on the `ui` section of hte `metadata.json`, see [Metadata](../architecture/metadata.md#ui-section).
+For more information on the `ui` section of the `metadata.json`, see [Metadata](../architecture/metadata.md#ui-section).
 
 ## Build the extension and install it
 


### PR DESCRIPTION


### Proposed changes

It's just a typo fix :)
"hte" to "the".

