### PR TITLE
fix lint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,7 @@ RUN hugo --gc --minify -d /out -e $HUGO_ENV -b $DOCS_URL
 FROM scratch as release
 COPY --from=build /out /
 
-FROM davidanson/markdownlint-cli2:next as lint
+FROM davidanson/markdownlint-cli2:v0.10.0 as lint
 USER root
 RUN --mount=type=bind,target=. \
     /usr/local/bin/markdownlint-cli2 content/**/*.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,10 @@ COPY --from=build /out /
 FROM davidanson/markdownlint-cli2:v0.10.0 as lint
 USER root
 RUN --mount=type=bind,target=. \
-    /usr/local/bin/markdownlint-cli2 content/**/*.md
+    /usr/local/bin/markdownlint-cli2 \
+    "content/**/*.md" \
+    "#content/engine/release-notes/*.md" \
+    "#content/desktop/previous-versions/*.md"
 
 FROM wjdp/htmltest:v${HTMLTEST_VERSION} as test
 WORKDIR /test

--- a/content/build/bake/compose-file.md
+++ b/content/build/bake/compose-file.md
@@ -96,7 +96,7 @@ services:
       dockerfile: Dockerfile
 ```
 
-```
+```sh
 # .env
 TAG=v1.1.0
 ```

--- a/content/build/building/context.md
+++ b/content/build/building/context.md
@@ -76,7 +76,7 @@ contents to the `docker build` command. See [Tarballs](#local-tarballs).
 
 Consider the following directory structure:
 
-```
+```text
 .
 ├── index.ts
 ├── src/

--- a/content/build/cache/garbage-collection.md
+++ b/content/build/cache/garbage-collection.md
@@ -61,7 +61,7 @@ For other drivers, garbage collection can be configured using the
 
 Default garbage collection policies apply to all builders if not set:
 
-```
+```text
 GC Policy rule#0:
         All:            false
         Filters:        type==source.local,type==exec.cachemount,type==source.git.checkout

--- a/content/compose/compose-file/compose-file-v3.md
+++ b/content/compose/compose-file/compose-file-v3.md
@@ -1102,12 +1102,14 @@ RACK_ENV=development
 ```
 
 Compose also recognizes inline comments, like in:
-```
+
+```sh
 MY_VAR = value # this is a comment
 ```
 
 To avoid interpreting "#" as an inline comment, use the quotation marks:
-```
+
+```sh
 MY_VAR = "All the # inside are taken as part of the value"
 ```
 
@@ -2412,7 +2414,7 @@ Use the host's networking stack, or no networking. Equivalent to
 `docker stack` commands. If you use the `docker-compose` command,
 use [network_mode](#network_mode) instead.
 
-If you want to use a particular network on a common build, use [network] as
+If you want to use a particular network on a common build, use `network` as
 mentioned in the second yaml file example.
 
 The syntax for using built-in networks such as `host` and `none` is a little

--- a/content/compose/compose-file/compose-versioning.md
+++ b/content/compose/compose-file/compose-versioning.md
@@ -33,6 +33,8 @@ compatibility, and [how to upgrade](#upgrading).
 
 {{< include "content/compose-matrix.md" >}}
 
+<!-- markdownlint-disable reference-links-images -->
+
 > Looking for more detail on Docker and Compose compatibility?
 >
 > We recommend keeping up-to-date with newer releases as much as possible.
@@ -43,6 +45,7 @@ gives details on which versions of Docker Engine are supported, along
 with compatible Compose file format versions. (See also, the discussion in
 [issue #3404]({{% param "repo" %}}/issues/3404).)
 
+<!-- markdownlint-enable reference-links-images -->
 
 For details on versions and how to upgrade, see
 [Versioning](compose-versioning.md#versioning) and

--- a/content/compose/install/linux.md
+++ b/content/compose/install/linux.md
@@ -59,9 +59,11 @@ For Compose standalone, see [Install Compose Standalone](standalone.md).
     ```
 
     Expected output:
-    ```
+
+    ```text
     Docker Compose version vN.N.N
     ```
+
     Where `vN.N.N` is placeholder text standing in for the latest version.
 
 ### Update Compose

--- a/content/compose/install/standalone.md
+++ b/content/compose/install/standalone.md
@@ -18,9 +18,9 @@ On this page you can find instructions on how to install Compose standalone on L
 >For example type `docker-compose up` when using Compose standalone, instead of `docker compose up`.
 
 1. To download and install Compose standalone, run:
-  ```console
-  $ curl -SL https://github.com/docker/compose/releases/download/{{% param "compose_version" %}}/docker-compose-linux-x86_64 -o /usr/local/bin/docker-compose
-  ```
+   ```console
+   $ curl -SL https://github.com/docker/compose/releases/download/{{% param "compose_version" %}}/docker-compose-linux-x86_64 -o /usr/local/bin/docker-compose
+   ```
 2. Apply executable permissions to the standalone binary in the target path for the installation.
 3. Test and execute compose commands using `docker-compose`.
 

--- a/content/config/containers/logging/splunk.md
+++ b/content/config/containers/logging/splunk.md
@@ -46,8 +46,8 @@ configuring Docker using `daemon.json`, see
 To use the `splunk` driver for a specific container, use the commandline flags
 `--log-driver` and `log-opt` with `docker run`:
 
-```
-docker run --log-driver=splunk --log-opt splunk-token=VALUE --log-opt splunk-url=VALUE ...
+```console
+$ docker run --log-driver=splunk --log-opt splunk-token=VALUE --log-opt splunk-url=VALUE ...
 ```
 
 ## Splunk options

--- a/content/contribute/components/accordions.md
+++ b/content/contribute/components/accordions.md
@@ -16,7 +16,7 @@ $ docker run hello-world
 
 ## Markup
 
-````
+````markdown
 {{</* accordion title="Accordion example" */>}}
 
 ```console

--- a/content/contribute/components/tabs.md
+++ b/content/contribute/components/tabs.md
@@ -36,7 +36,7 @@ fmt.Println("hello world")
 
 ## Markup
 
-````
+````markdown
 {{</* tabs */>}}
 {{</* tab name="JavaScript" */>}}
 

--- a/content/desktop/dev-environments/create-dev-env.md
+++ b/content/desktop/dev-environments/create-dev-env.md
@@ -50,7 +50,7 @@ To get started with Dev Environments, you must also install the following tools 
 
 If your WSL 2 distribution doesn't have an `ssh-agent` running, you can append this script at the end of your profile file (that is: ~/.profile, ~/.zshrc, ...).
 
-```
+```bash
 SSH_ENV="$HOME/.ssh/agent-environment"
 function start_agent {
     echo "Initialising new SSH agent..."

--- a/content/desktop/dev-environments/dev-cli.md
+++ b/content/desktop/dev-environments/dev-cli.md
@@ -12,7 +12,7 @@ It is available with [Docker Desktop 4.13.0 and later](../release-notes.md).
 
 ### Usage
 
-```
+```bash
 docker dev [OPTIONS] COMMAND
 ```
 

--- a/content/desktop/extensions-sdk/dev/api/reference/interfaces/Docker.md
+++ b/content/desktop/extensions-sdk/dev/api/reference/interfaces/Docker.md
@@ -91,7 +91,7 @@ const containers = await ddClient.docker.listContainers();
 
 `Promise`<`unknown`\>
 
-___
+---
 
 ### listImages
 
@@ -107,7 +107,7 @@ const images = await ddClient.docker.listImages();
 
 | Name | Type | Description |
 | :------ | :------ | :------ |
-| `options?` | `any` | (Optional). A JSON like `{ "all": true, "filters": JSON.stringify({ dangling: ["true"] }), "digests": true * }` * * For more information about the different properties see [the Docker API endpoint documentation](https://docs.docker.com/engine/api/v1.41/#tag/Image). |
+| `options?` | `any` | (Optional). A JSON like `{ "all": true, "filters": JSON.stringify({ dangling: ["true"] }), "digests": true * }` For more information about the different properties see [the Docker API endpoint documentation](https://docs.docker.com/engine/api/v1.41/#tag/Image). |
 
 #### Returns
 

--- a/content/desktop/extensions-sdk/dev/usage.md
+++ b/content/desktop/extensions-sdk/dev/usage.md
@@ -12,7 +12,7 @@ The Extensions CLI is an extension development tool that is used to manage Docke
 - `docker extension dev` commands for extension development.
 - `docker extension disable` turns off Docker extensions.
 - `docker extension init` creates a new Docker extension.
-- `docker extension install ` installs a Docker extension with the specified image.
+- `docker extension install` installs a Docker extension with the specified image.
 - `docker extension ls` list installed Docker extensions.
 - `docker extension rm` removes a Docker extension.
 - `docker extension update` removes and re-installs a Docker extension.

--- a/content/desktop/extensions-sdk/guides/oauth2-flow.md
+++ b/content/desktop/extensions-sdk/guides/oauth2-flow.md
@@ -69,7 +69,7 @@ Next, you exchange the authorization code for an access token.
 
 The extension must send a `POST` request to the oauth authorization server with the following parameters:
 
-```
+```text
 POST https://authorization-server.com/token
 &client_id=T70hJ3ls5VTYG8ylX3CZsfIu
 &client_secret=YABbyHQShPeO1T3NDQZP8q5m3Jpb_UPNmIzqhLDCScSnRyVG

--- a/content/desktop/extensions/non-marketplace.md
+++ b/content/desktop/extensions/non-marketplace.md
@@ -33,7 +33,7 @@ Go to the Docker Dashboard to see the new extension installed.
 Regardless whether the extension was installed from the Marketplace or manually by using the Extensions CLI, you can use the `docker extension ls` command to display the list of extensions installed.
 As part of the output you'll see the extension ID, the provider, version, the title and whether it runs a backend container or has deployed binaries to the host, for example:
 
-```
+```console
 $ docker extension ls
 ID                  PROVIDER            VERSION             UI                    VM                  HOST
 john/my-extension   John                latest              1 tab(My-Extension)   Running(1)          -

--- a/content/desktop/faqs/macfaqs.md
+++ b/content/desktop/faqs/macfaqs.md
@@ -184,7 +184,7 @@ Desktop `xhyve` virtual machine).
 If you have this directory structure, you do not need to manually add the CA
 certificate to your Mac OS system login:
 
-```
+```text
 /Users/<user>/.docker/certs.d/
 └── <MyRegistry>:<Port>
    ├── ca.crt
@@ -195,7 +195,7 @@ certificate to your Mac OS system login:
 The following further illustrates and explains a configuration with custom
 certificates:
 
-```
+```text
 /etc/docker/certs.d/        <-- Certificate directory
 └── localhost:5000          <-- Hostname:port
    ├── client.cert          <-- Client certificate
@@ -207,7 +207,7 @@ certificates:
 You can also have this directory structure, as long as the CA certificate is
 also in your keychain.
 
-```
+```text
 /Users/<user>/.docker/certs.d/
 └── <MyRegistry>:<Port>
     ├── client.cert

--- a/content/desktop/hardened-desktop/enhanced-container-isolation/_index.md
+++ b/content/desktop/hardened-desktop/enhanced-container-isolation/_index.md
@@ -124,13 +124,13 @@ When Enhanced Container Isolation is enabled, users see:
 
 To check, run:
 
-```
+```console
 $ docker run --rm alpine cat /proc/self/uid_map
 ```
 
 The following output displays:
 
-```
+```text
          0     100000      65536
 ```
 
@@ -144,7 +144,7 @@ further details, see [How Enhanced Container Isolation works](how-eci-works.md).
 
 In contrast, without ECI the Linux user namespace is not used for containers, the following displays:
 
-```
+```text
          0          0 4294967295
 ```
 
@@ -158,7 +158,7 @@ $ docker inspect --format='{{.HostConfig.Runtime}}' my_container
 
 It outputs:
 
-```
+```text
 sysbox-runc
 ```
 

--- a/content/desktop/hardened-desktop/enhanced-container-isolation/features-benefits.md
+++ b/content/desktop/hardened-desktop/enhanced-container-isolation/features-benefits.md
@@ -79,7 +79,7 @@ For example, Enhanced Container Isolation ensures privileged containers can't
 access Docker Desktop network settings in the Linux VM configured via Berkeley
 Packet Filters (BPF):
 
-```
+```console
 $ docker run --privileged djs55/bpftool map show
 Error: can't get next map: Operation not permitted
 ```
@@ -87,7 +87,7 @@ Error: can't get next map: Operation not permitted
 In contrast, without Enhanced Container Isolation, privileged containers
 can easily do this:
 
-```
+```console
 $ docker run --privileged djs55/bpftool map show
 17: ringbuf  name blocked_packets  flags 0x0
         key 0B  value 0B  max_entries 16777216  memlock 0B
@@ -110,22 +110,22 @@ breaks isolation.
 
 For example, sharing the pid namespace fails:
 
-```
+```console
 $ docker run -it --rm --pid=host alpine
 docker: Error response from daemon: failed to create shim task: OCI runtime create failed: error in the container spec: invalid or unsupported container spec: sysbox containers can't share namespaces [pid] with the host (because they use the linux user-namespace for isolation): unknown.
 ```
 
 Similarly sharing the network namespace fails:
 
-```
-docker run -it --rm --network=host alpine
+```console
+$ docker run -it --rm --network=host alpine
 docker: Error response from daemon: failed to create shim task: OCI runtime create failed: error in the container spec: invalid or unsupported container spec: sysbox containers can't share a network namespace with the host (because they use the linux user-namespace for isolation): unknown.
 ```
 
 In addition, the `--userns=host` flag, used to disable the user-namespace on the
 container, is ignored:
 
-```
+```console
 $ docker run -it --rm --userns=host alpine
 / # cat /proc/self/uid_map
          0     100000      65536
@@ -150,7 +150,7 @@ For example, the following bind mount of the Docker Engine's configuration file
 (`/etc/docker/daemon.json` inside the Linux VM) into a container is restricted
 and therefore fails:
 
-```
+```console
 $ docker run -it --rm -v /etc/docker/daemon.json:/mnt/daemon.json alpine
 docker: Error response from daemon: failed to create shim task: OCI runtime create failed: error in the container spec: can't mount /etc/docker/daemon.json because it's configured as a restricted host mount: unknown
 ```
@@ -162,7 +162,7 @@ Of course, bind mounts of host files continue to work as usual. For example,
 assuming a user configures Docker Desktop to file share her $HOME directory,
 she can bind mount it into the container:
 
-```
+```console
 $ docker run -it --rm -v $HOME:/mnt alpine
 / #
 ```
@@ -189,7 +189,7 @@ For example, a container that has `CAP_SYS_ADMIN` (required to execute the
 `mount` system call) can't use that capability to change a read-only bind mount
 into a read-write mount:
 
-```
+```console
 $ docker run -it --rm --cap-add SYS_ADMIN -v $HOME:/mnt:ro alpine
 / # mount -o remount,rw /mnt /mnt
 mount: permission denied (are you root?)
@@ -205,7 +205,7 @@ within the container, and mount them read-only or read-write as needed. Those
 mounts are allowed since they occur within the container, and therefore don't
 breach it's root filesystem:
 
-```
+```text
 / # mkdir /root/tmpfs
 / # mount -t tmpfs tmpfs /root/tmpfs
 / # mount -o remount,ro /root/tmpfs /root/tmpfs
@@ -271,7 +271,7 @@ As a simple example, when Enhanced Container Isolation is enabled the
 `/proc/uptime` file shows the uptime of the container itself, not that of the
 Docker Desktop Linux VM:
 
-```
+```console
 $ docker run -it --rm alpine
 / # cat /proc/uptime
 5.86 5.86

--- a/content/desktop/install/debian.md
+++ b/content/desktop/install/debian.md
@@ -67,7 +67,7 @@ Recommended approach to install Docker Desktop on Debian:
   > At the end of the installation process, `apt` displays an error due to installing a downloaded package. You
   > can ignore this error message.
   >
-  > ```
+  > ```text
   > N: Download is performed unsandboxed as root, as file '/home/user/Downloads/docker-desktop.deb' couldn't be accessed by user '_apt'. - pkgAcquire::Run (13: Permission denied)
   > ```
 

--- a/content/desktop/install/linux-install.md
+++ b/content/desktop/install/linux-install.md
@@ -126,14 +126,14 @@ Make sure you meet the system requirements outlined earlier and follow the distr
 { .important } 
 
 1. Download the correct package for your Linux distribution and install it with the corresponding package manager. 
- - [Install on Debian](debian.md)
- - [Install on Fedora](fedora.md)
- - [Install on Ubuntu](ubuntu.md)
- - [Install on Arch](archlinux.md) 
+   - [Install on Debian](debian.md)
+   - [Install on Fedora](fedora.md)
+   - [Install on Ubuntu](ubuntu.md)
+   - [Install on Arch](archlinux.md) 
 
 2. Open your **Applications** menu in Gnome/KDE Desktop and search for **Docker Desktop**.
 
-    ![Docker app in Applications](images/docker-app-in-apps.png)
+   ![Docker app in Applications](images/docker-app-in-apps.png)
 
 3. Select **Docker Desktop** to start Docker. <br> The Docker menu ({{< inline-image src="images/whale-x.svg" alt="whale menu" >}}) displays the Docker Subscription Service Agreement.
 

--- a/content/desktop/install/ubuntu.md
+++ b/content/desktop/install/ubuntu.md
@@ -67,7 +67,7 @@ Recommended approach to install Docker Desktop on Ubuntu:
    > At the end of the installation process, `apt` displays an error due to installing a downloaded package. You
    > can ignore this error message.
    >
-   > ```
+   > ```text
    > N: Download is performed unsandboxed as root, as file '/home/user/Downloads/docker-desktop.deb' couldn't be accessed by user '_apt'. - pkgAcquire::Run (13: Permission denied)
    > ```
 

--- a/content/desktop/install/windows-install.md
+++ b/content/desktop/install/windows-install.md
@@ -144,7 +144,7 @@ Start-Process 'Docker Desktop Installer.exe' -Wait install
 
 If using the Windows Command Prompt:
 
-```
+```sh
 start /w "" "Docker Desktop Installer.exe" install
 ```
 
@@ -158,9 +158,11 @@ The `install` command accepts the following flags:
 - `--admin-settings`: Automatically creates an `admin-settings.json` file which is used by admins to control certain Docker Desktop settings on client machines within their organization. For more information, see [Settings Management](../hardened-desktop/settings-management/index.md).
   - It must be used together with the `--allowed-org=<org name>` flag. 
   - For example:
-     ```
-     --allowed-org=<org name> --admin-settings="{'configurationFileVersion': 2, 'enhancedContainerIsolation': {'value': true, 'locked': false}}"
-     ```
+
+    ```text
+    --allowed-org=<org name> --admin-settings="{'configurationFileVersion': 2, 'enhancedContainerIsolation': {'value': true, 'locked': false}}"
+    ```
+
 - `--proxy-http-mode=<mode>`: Sets the HTTP Proxy mode, `system` (default) or `manual`
 - `--override-proxy-http=<URL>`: Sets the URL of the HTTP proxy that must be used for outgoing HTTP requests, requires `--proxy-http-mode` to be `manual`
 - `--override-proxy-https=<URL>`: Sets the URL of the HTTP proxy that must be used for outgoing HTTPS requests, requires `--proxy-http-mode` to be `manual`

--- a/content/desktop/wasm/_index.md
+++ b/content/desktop/wasm/_index.md
@@ -187,7 +187,7 @@ This section contains instructions on how to resolve common issues.
 If you try to run a Wasm container before you have opted in to use the
 containerd image store, an error similar to the following displays:
 
-```
+```text
 docker: Error response from daemon: Unknown runtime specified io.containerd.wasmedge.v1.
 ```
 
@@ -199,7 +199,7 @@ in Docker Desktop settings and try again.
 If you use an older version of Docker Desktop that doesn't support running Wasm
 workloads, you will see an error message similar to the following:
 
-```
+```text
 docker: Error response from daemon: failed to start shim: failed to resolve runtime path: runtime "io.containerd.wasmedge.v1" binary not installed "containerd-shim-wasmedge-v1": file does not exist: unknown.
 ```
 

--- a/content/engine/install/centos.md
+++ b/content/engine/install/centos.md
@@ -94,8 +94,8 @@ $ sudo yum-config-manager --add-repo {{% param "download-url-base" %}}/docker-ce
 
 1. Install Docker Engine, containerd, and Docker Compose:
 
-  {{< tabs >}}
-  {{< tab name="Latest" >}}
+   {{< tabs >}}
+   {{< tab name="Latest" >}}
 
    To install the latest version, run:
 
@@ -108,9 +108,9 @@ $ sudo yum-config-manager --add-repo {{% param "download-url-base" %}}/docker-ce
 
    This command installs Docker, but it doesn't start Docker. It also creates a
    `docker` group, however, it doesn't add any users to the group by default.
-  
-  {{< /tab >}}
-  {{< tab name="Specific version" >}}
+   
+   {{< /tab >}}
+   {{< tab name="Specific version" >}}
 
    To install a specific version, start by listing the available versions in
    the repository:
@@ -139,9 +139,9 @@ $ sudo yum-config-manager --add-repo {{% param "download-url-base" %}}/docker-ce
 
    This command installs Docker, but it doesn't start Docker. It also creates a
    `docker` group, however, it doesn't add any users to the group by default.
-  
-  {{< /tab >}}
-  {{< /tabs >}}
+   
+   {{< /tab >}}
+   {{< /tabs >}}
 
 
 2. Start Docker.
@@ -175,6 +175,7 @@ If you can't use Docker's `rpm` repository to install Docker Engine, you can
 download the `.rpm` file for your release and install it manually. You need to
 download a new file each time you want to upgrade Docker Engine.
 
+<!-- markdownlint-disable-next-line -->
 1. Go to [{{% param "download-url-base" %}}/]({{% param "download-url-base" %}}/)
    and choose your version of CentOS. Then browse to `x86_64/stable/Packages/`
    and download the `.rpm` file for the Docker version you want to install.

--- a/content/engine/install/debian.md
+++ b/content/engine/install/debian.md
@@ -184,6 +184,7 @@ If you can't use Docker's `apt` repository to install Docker Engine, you can
 download the `deb` file for your release and install it manually. You need to
 download a new file each time you want to upgrade Docker Engine.
 
+<!-- markdownlint-disable-next-line -->
 1. Go to [`{{% param "download-url-base" %}}/dists/`]({{% param "download-url-base" %}}/dists/).
 
 2. Select your Debian version in the list.

--- a/content/engine/install/fedora.md
+++ b/content/engine/install/fedora.md
@@ -88,9 +88,9 @@ $ sudo dnf config-manager --add-repo {{% param "download-url-base" %}}/docker-ce
 
 1. Install Docker Engine, containerd, and Docker Compose:
 
-  {{< tabs >}}
-  {{< tab name="Latest" >}}
-  
+   {{< tabs >}}
+   {{< tab name="Latest" >}}
+   
    To install the latest version, run:
 
    ```console
@@ -103,8 +103,8 @@ $ sudo dnf config-manager --add-repo {{% param "download-url-base" %}}/docker-ce
    This command installs Docker, but it doesn't start Docker. It also creates a
    `docker` group, however, it doesn't add any users to the group by default.
 
-  {{< /tab >}}
-  {{< tab name="Specific version" >}}
+   {{< /tab >}}
+   {{< tab name="Specific version" >}}
 
    To install a specific version, start by listing the available versions in
    the repository:
@@ -133,9 +133,9 @@ $ sudo dnf config-manager --add-repo {{% param "download-url-base" %}}/docker-ce
 
    This command installs Docker, but it doesn't start Docker. It also creates a
    `docker` group, however, it doesn't add any users to the group by default.
-  
-  {{< /tab >}}
-  {{< /tabs >}}
+   
+   {{< /tab >}}
+   {{< /tabs >}}
 
 2. Start Docker.
 
@@ -168,6 +168,7 @@ If you can't use Docker's `rpm` repository to install Docker Engine, you can
 download the `.rpm` file for your release and install it manually. You need to
 download a new file each time you want to upgrade Docker Engine.
 
+<!-- markdownlint-disable-next-line -->
 1. Go to [{{% param "download-url-base" %}}/]({{% param "download-url-base" %}}/)
    and choose your version of Fedora. Then browse to `x86_64/stable/Packages/`
    and download the `.rpm` file for the Docker version you want to install.

--- a/content/engine/install/raspberry-pi-os.md
+++ b/content/engine/install/raspberry-pi-os.md
@@ -173,6 +173,7 @@ If you can't use Docker's `apt` repository to install Docker Engine, you can
 download the `deb` file for your release and install it manually. You need to
 download a new file each time you want to upgrade Docker Engine.
 
+<!-- markdownlint-disable-next-line -->
 1. Go to [`{{% param "download-url-base" %}}/dists/`]({{% param "download-url-base" %}}/dists/).
 
 2. Select your Raspberry Pi OS version in the list.

--- a/content/engine/install/rhel.md
+++ b/content/engine/install/rhel.md
@@ -105,8 +105,8 @@ $ sudo yum-config-manager --add-repo {{% param "download-url-base" %}}/docker-ce
 
 1. Install Docker Engine, containerd, and Docker Compose:
 
-  {{< tabs >}}
-  {{< tab name="Latest" >}}
+   {{< tabs >}}
+   {{< tab name="Latest" >}}
   
    To install the latest version, run:
 
@@ -120,8 +120,8 @@ $ sudo yum-config-manager --add-repo {{% param "download-url-base" %}}/docker-ce
    This command installs Docker, but it doesn't start Docker. It also creates a
    `docker` group, however, it doesn't add any users to the group by default.
 
-  {{< /tab >}}
-  {{< tab name="Specific version" >}}
+   {{< /tab >}}
+   {{< tab name="Specific version" >}}
 
    To install a specific version, start by listing the available versions in
    the repository:
@@ -151,8 +151,8 @@ $ sudo yum-config-manager --add-repo {{% param "download-url-base" %}}/docker-ce
    This command installs Docker, but it doesn't start Docker. It also creates a
    `docker` group, however, it doesn't add any users to the group by default.
   
-  {{< /tab >}}
-  {{< /tabs >}}
+   {{< /tab >}}
+   {{< /tabs >}}
 
 2. Start Docker.
 
@@ -185,6 +185,7 @@ If you can't use Docker's `rpm` repository to install Docker Engine, you can
 download the `.rpm` file for your release and install it manually. You need to
 download a new file each time you want to upgrade Docker Engine.
 
+<!-- markdownlint-disable-next-line -->
 1. Go to [{{% param "download-url-base" %}}/]({{% param "download-url-base" %}}/)
    and choose your version of RHEL. Then go to `s390x/stable/Packages/`
    and download the `.rpm` file for the Docker version you want to install.

--- a/content/engine/install/sles.md
+++ b/content/engine/install/sles.md
@@ -121,8 +121,8 @@ $ sudo zypper addrepo {{% param "download-url-base" %}}/docker-ce.repo
 
 1. Install Docker Engine, containerd, and Docker Compose:
 
-  {{< tabs >}}
-  {{< tab name="Latest" >}}
+   {{< tabs >}}
+   {{< tab name="Latest" >}}
 
    To install the latest version, run:
 
@@ -136,8 +136,8 @@ $ sudo zypper addrepo {{% param "download-url-base" %}}/docker-ce.repo
    This command installs Docker, but it doesn't start Docker. It also creates a
    `docker` group, however, it doesn't add any users to the group by default.
   
-  {{< /tab >}}
-  {{< tab name="Specific version" >}}
+   {{< /tab >}}
+   {{< tab name="Specific version" >}}
 
    To install a specific version, start by listing the available versions in
    the repository:
@@ -166,8 +166,8 @@ $ sudo zypper addrepo {{% param "download-url-base" %}}/docker-ce.repo
    This command installs Docker, but it doesn't start Docker. It also creates a
    `docker` group, however, it doesn't add any users to the group by default.
   
-  {{< /tab >}}
-  {{< /tabs >}}
+   {{< /tab >}}
+   {{< /tabs >}}
 
 2. Start Docker.
 
@@ -200,6 +200,7 @@ If you can't use Docker's `rpm` repository to install Docker Engine, you can
 download the `.rpm` file for your release and install it manually. You need to
 download a new file each time you want to upgrade Docker Engine.
 
+<!-- markdownlint-disable-next-line -->
 1. Go to [{{% param "download-url-base" %}}/]({{% param "download-url-base" %}}/)
    and choose your version of SLES. Then browse to `s390x/stable/Packages/`
    and download the `.rpm` file for the Docker version you want to install.

--- a/content/engine/install/ubuntu.md
+++ b/content/engine/install/ubuntu.md
@@ -187,6 +187,7 @@ If you can't use Docker's `apt` repository to install Docker Engine, you can
 download the `deb` file for your release and install it manually. You need to
 download a new file each time you want to upgrade Docker Engine.
 
+<!-- markdownlint-disable-next-line -->
 1. Go to [`{{% param "download-url-base" %}}/dists/`]({{% param "download-url-base" %}}/dists/).
 
 2. Select your Ubuntu version in the list.

--- a/content/engine/security/apparmor.md
+++ b/content/engine/security/apparmor.md
@@ -71,7 +71,7 @@ below resources with regard to AppArmor profile syntax.
 In this example, you create a custom AppArmor profile for Nginx. Below is the
 custom profile.
 
-```
+```c
 #include <tunables/global>
 
 
@@ -147,7 +147,7 @@ profile docker-nginx flags=(attach_disconnected,mediate_deleted) {
 ```
 
 1. Save the custom profile to disk in the
-`/etc/apparmor.d/containers/docker-nginx` file.
+   `/etc/apparmor.d/containers/docker-nginx` file.
 
    The file path in this example is not a requirement. In production, you could
    use another.
@@ -208,7 +208,7 @@ regard to AppArmor.
 AppArmor sends quite verbose messaging to `dmesg`. Usually an AppArmor line
 looks like the following:
 
-```
+```text
 [ 5442.864673] audit: type=1400 audit(1453830992.845:37): apparmor="ALLOWED" operation="open" profile="/usr/bin/docker" name="/home/jessie/docker/man/man1/docker-attach.1" pid=10923 comm="docker" requested_mask="r" denied_mask="r" fsuid=1000 ouid=0
 ```
 
@@ -217,7 +217,7 @@ user has the `docker-engine` (Docker Engine Daemon) profile loaded.
 
 Look at another log line:
 
-```
+```text
 [ 3256.689120] type=1400 audit(1405454041.341:73): apparmor="DENIED" operation="ptrace" profile="docker-default" pid=17651 comm="docker" requested_mask="receive" denied_mask="receive"
 ```
 

--- a/content/engine/security/certificates.md
+++ b/content/engine/security/certificates.md
@@ -43,7 +43,7 @@ repository.
 
 The following illustrates a configuration with custom certificates:
 
-```
+```text
     /etc/docker/certs.d/        <-- Certificate directory
     └── localhost:5000          <-- Hostname:port
        ├── client.cert          <-- Client certificate
@@ -79,13 +79,13 @@ as client certificates. If a CA certificate is accidentally given the extension
 `.cert` instead of the correct `.crt` extension, the Docker daemon logs the
 following error message:
 
-```
+```text
 Missing key KEY_NAME for client certificate CERT_NAME. CA certificates should use the extension .crt.
 ```
 
 If the Docker registry is accessed without a port number, do not add the port to the directory name.  The following shows the configuration for a registry on default port 443 which is accessed with `docker login my-https.registry.example.com`:
 
-```
+```text
     /etc/docker/certs.d/
     └── my-https.registry.example.com          <-- Hostname without port
        ├── client.cert

--- a/content/engine/security/protect-access.md
+++ b/content/engine/security/protect-access.md
@@ -69,7 +69,7 @@ $ docker info
 For the best user experience with SSH, configure `~/.ssh/config` as follows to allow
 reusing a SSH connection for multiple invocations of the `docker` CLI:
 
-```
+```text
 ControlMaster     auto
 ControlPath       ~/.ssh/control-%C
 ControlPersist    yes

--- a/content/engine/security/rootless.md
+++ b/content/engine/security/rootless.md
@@ -390,7 +390,7 @@ For example:
 
 ### Errors when starting the Docker daemon
 
-**[rootlesskit:parent] error: failed to start the child: fork/exec /proc/self/exe: operation not permitted**
+**\[rootlesskit:parent\] error: failed to start the child: fork/exec /proc/self/exe: operation not permitted**
 
 This error occurs mostly when the value of `/proc/sys/kernel/unprivileged_userns_clone` is set to 0:
 
@@ -402,7 +402,7 @@ $ cat /proc/sys/kernel/unprivileged_userns_clone
 To fix this issue, add  `kernel.unprivileged_userns_clone=1` to
 `/etc/sysctl.conf` (or `/etc/sysctl.d`) and run `sudo sysctl --system`.
 
-**[rootlesskit:parent] error: failed to start the child: fork/exec /proc/self/exe: no space left on device**
+**\[rootlesskit:parent\] error: failed to start the child: fork/exec /proc/self/exe: no space left on device**
 
 This error occurs mostly when the value of `/proc/sys/user/max_user_namespaces` is too small:
 
@@ -414,7 +414,7 @@ $ cat /proc/sys/user/max_user_namespaces
 To fix this issue, add  `user.max_user_namespaces=28633` to
 `/etc/sysctl.conf` (or `/etc/sysctl.d`) and run `sudo sysctl --system`.
 
-**[rootlesskit:parent] error: failed to setup UID/GID map: failed to compute uid/gid map: No subuid ranges found for user 1001 ("testuser")**
+**\[rootlesskit:parent\] error: failed to setup UID/GID map: failed to compute uid/gid map: No subuid ranges found for user 1001 ("testuser")**
 
 This error occurs when `/etc/subuid` and `/etc/subgid` are not configured. See [Prerequisites](#prerequisites).
 

--- a/content/engine/security/trust/_index.md
+++ b/content/engine/security/trust/_index.md
@@ -39,7 +39,7 @@ chains signing content as part of their release process.
 
 An individual image record has the following identifier:
 
-```
+```text
 [REGISTRY_HOST[:REGISTRY_PORT]/]REPOSITORY[:TAG]
 ```
 

--- a/content/engine/security/trust/trust_delegation.md
+++ b/content/engine/security/trust/trust_delegation.md
@@ -347,20 +347,20 @@ Successfully removed ben from registry.example.com/admin/demo
 #### Troubleshooting
 
 1) If you see an error that there are no usable keys in `targets/releases`, you 
-will need to add additional delegations using `docker trust signer add` before 
-resigning images.
+   will need to add additional delegations using `docker trust signer add` before 
+   resigning images.
 
-```console
-WARN[0000] role targets/releases has fewer keys than its threshold of 1; it will not be usable until keys are added to it
-```
+   ```text
+   WARN[0000] role targets/releases has fewer keys than its threshold of 1; it will not be usable until keys are added to it
+   ```
 
 2) If you have added additional delegations already and are seeing an error 
-message that there are no valid signatures in `targest/releases`, you will need
-to resign the `targets/releases` delegation file with the Notary CLI.
+   message that there are no valid signatures in `targest/releases`, you will need
+   to resign the `targets/releases` delegation file with the Notary CLI.
 
-```console
-WARN[0000] Error getting targets/releases: valid signatures did not meet threshold for targets/releases 
-```
+   ```text
+   WARN[0000] Error getting targets/releases: valid signatures did not meet threshold for targets/releases 
+   ```
 
 Resigning the delegation file is done with the `$ notary witness` command
 
@@ -381,53 +381,53 @@ and the role specific to that signer `targets/<name>`.
 
 1) We will need to grab the Key ID from the Notary Server
 
-```console
-$ notary delegation list registry.example.com/admin/demo
+   ```console
+   $ notary delegation list registry.example.com/admin/demo
 
-ROLE                PATHS             KEY IDS                                                             THRESHOLD
-----                -----             -------                                                             ---------
-targets/jeff        "" <all paths>    8fb597cbaf196f0781628b2f52bff6b3912e4e8075720378fda60d17232bbcf9    1
-                                      1091060d7bfd938dfa5be703fa057974f9322a4faef6f580334f3d6df44c02d1    
-targets/releases    "" <all paths>    8fb597cbaf196f0781628b2f52bff6b3912e4e8075720378fda60d17232bbcf9    1
-                                      1091060d7bfd938dfa5be703fa057974f9322a4faef6f580334f3d6df44c02d1    
-```
+   ROLE                PATHS             KEY IDS                                                             THRESHOLD
+   ----                -----             -------                                                             ---------
+   targets/jeff        "" <all paths>    8fb597cbaf196f0781628b2f52bff6b3912e4e8075720378fda60d17232bbcf9    1
+                                         1091060d7bfd938dfa5be703fa057974f9322a4faef6f580334f3d6df44c02d1    
+   targets/releases    "" <all paths>    8fb597cbaf196f0781628b2f52bff6b3912e4e8075720378fda60d17232bbcf9    1
+                                         1091060d7bfd938dfa5be703fa057974f9322a4faef6f580334f3d6df44c02d1    
+   ```
 
 2) Remove from the `targets/releases` delegation
 
-```console
-$ notary delegation remove registry.example.com/admin/demo targets/releases 1091060d7bfd938dfa5be703fa057974f9322a4faef6f580334f3d6df44c02d1 --publish
-
-Auto-publishing changes to registry.example.com/admin/demo
-Enter username: admin
-Enter password: 
-Enter passphrase for targets key with ID b0014f8: 
-Successfully published changes for repository registry.example.com/admin/demo
-```
+   ```console
+   $ notary delegation remove registry.example.com/admin/demo targets/releases 1091060d7bfd938dfa5be703fa057974f9322a4faef6f580334f3d6df44c02d1 --publish
+   
+   Auto-publishing changes to registry.example.com/admin/demo
+   Enter username: admin
+   Enter password: 
+   Enter passphrase for targets key with ID b0014f8: 
+   Successfully published changes for repository registry.example.com/admin/demo
+   ```
 
 3) Remove from the `targets/<name>` delegation
 
-```console
-$ notary delegation remove registry.example.com/admin/demo targets/jeff 1091060d7bfd938dfa5be703fa057974f9322a4faef6f580334f3d6df44c02d1 --publish
-
-Removal of delegation role targets/jeff with keys [5570b88df0736c468493247a07e235e35cf3641270c944d0e9e8899922fc6f99], to repository "registry.example.com/admin/demo" staged for next publish.
-
-Auto-publishing changes to registry.example.com/admin/demo
-Enter username: admin    
-Enter password: 
-Enter passphrase for targets key with ID b0014f8: 
-Successfully published changes for repository registry.example.com/admin/demo
-```
+   ```console
+   $ notary delegation remove registry.example.com/admin/demo targets/jeff 1091060d7bfd938dfa5be703fa057974f9322a4faef6f580334f3d6df44c02d1 --publish
+   
+   Removal of delegation role targets/jeff with keys [5570b88df0736c468493247a07e235e35cf3641270c944d0e9e8899922fc6f99], to repository "registry.example.com/admin/demo" staged for next publish.
+   
+   Auto-publishing changes to registry.example.com/admin/demo
+   Enter username: admin    
+   Enter password: 
+   Enter passphrase for targets key with ID b0014f8: 
+   Successfully published changes for repository registry.example.com/admin/demo
+   ```
 
 4) Check the remaining delegation list 
 
-```console
-$ notary delegation list registry.example.com/admin/demo
-
-ROLE                PATHS             KEY IDS                                                             THRESHOLD
-----                -----             -------                                                             ---------
-targets/jeff        "" <all paths>    8fb597cbaf196f0781628b2f52bff6b3912e4e8075720378fda60d17232bbcf9    1    
-targets/releases    "" <all paths>    8fb597cbaf196f0781628b2f52bff6b3912e4e8075720378fda60d17232bbcf9    1    
-```
+   ```console
+   $ notary delegation list registry.example.com/admin/demo
+   
+   ROLE                PATHS             KEY IDS                                                             THRESHOLD
+   ----                -----             -------                                                             ---------
+   targets/jeff        "" <all paths>    8fb597cbaf196f0781628b2f52bff6b3912e4e8075720378fda60d17232bbcf9    1    
+   targets/releases    "" <all paths>    8fb597cbaf196f0781628b2f52bff6b3912e4e8075720378fda60d17232bbcf9    1    
+   ```
 
 ### Removing a local Delegation Private Key
 
@@ -437,26 +437,26 @@ the `$ notary key remove` command.
 
 1) We will need to get the Key ID from the local Docker Trust store
 
-```console
-$ notary key list
-
-ROLE       GUN                          KEY ID                                                              LOCATION
-----       ---                          ------                                                              --------
-root                                    f6c6a4b00fefd8751f86194c7d87a3bede444540eb3378c4a11ce10852ab1f96    /home/ubuntu/.docker/trust/private
-admin                                   8fb597cbaf196f0781628b2f52bff6b3912e4e8075720378fda60d17232bbcf9    /home/ubuntu/.docker/trust/private
-jeff                                    1091060d7bfd938dfa5be703fa057974f9322a4faef6f580334f3d6df44c02d1    /home/ubuntu/.docker/trust/private
-targets    ...example.com/admin/demo    c819f2eda8fba2810ec6a7f95f051c90276c87fddfc3039058856fad061c009d    /home/ubuntu/.docker/trust/private
-```
+   ```console
+   $ notary key list
+   
+   ROLE       GUN                          KEY ID                                                              LOCATION
+   ----       ---                          ------                                                              --------
+   root                                    f6c6a4b00fefd8751f86194c7d87a3bede444540eb3378c4a11ce10852ab1f96    /home/ubuntu/.docker/trust/private
+   admin                                   8fb597cbaf196f0781628b2f52bff6b3912e4e8075720378fda60d17232bbcf9    /home/ubuntu/.docker/trust/private
+   jeff                                    1091060d7bfd938dfa5be703fa057974f9322a4faef6f580334f3d6df44c02d1    /home/ubuntu/.docker/trust/private
+   targets    ...example.com/admin/demo    c819f2eda8fba2810ec6a7f95f051c90276c87fddfc3039058856fad061c009d    /home/ubuntu/.docker/trust/private
+   ```
 
 2) Remove the key from the local Docker Trust store
 
-```console
-$ notary key remove 1091060d7bfd938dfa5be703fa057974f9322a4faef6f580334f3d6df44c02d1
-
-Are you sure you want to remove 1091060d7bfd938dfa5be703fa057974f9322a4faef6f580334f3d6df44c02d1 (role jeff) from /home/ubuntu/.docker/trust/private?  (yes/no)  y
-
-Deleted 1091060d7bfd938dfa5be703fa057974f9322a4faef6f580334f3d6df44c02d1 (role jeff) from /home/ubuntu/.docker/trust/private.
-```
+   ```console
+   $ notary key remove 1091060d7bfd938dfa5be703fa057974f9322a4faef6f580334f3d6df44c02d1
+   
+   Are you sure you want to remove 1091060d7bfd938dfa5be703fa057974f9322a4faef6f580334f3d6df44c02d1 (role jeff) from /home/ubuntu/.docker/trust/private?  (yes/no)  y
+   
+   Deleted 1091060d7bfd938dfa5be703fa057974f9322a4faef6f580334f3d6df44c02d1 (role jeff) from /home/ubuntu/.docker/trust/private.
+   ```
 
 ## Removing all trust data from a Repository
 

--- a/content/engine/swarm/swarm-tutorial/_index.md
+++ b/content/engine/swarm/swarm-tutorial/_index.md
@@ -90,7 +90,7 @@ additional hardening is suggested:
 * [Customize the default ingress network](../networking.md) to use encryption
 * Only accept encrypted packets on the Data Path Port:
 
-```
+```bash
 # Example iptables rule (order and other tools may require customization)
 iptables -I INPUT -m udp —-dport 4789 -m policy --dir in --pol none -j DROP
 ```

--- a/content/language/dotnet/containerize.md
+++ b/content/language/dotnet/containerize.md
@@ -79,7 +79,7 @@ Let's get started!
 You should now have the following contents in your `docker-dotnet-sample`
 directory.
 
-```
+```text
 ├── docker-dotnet-sample/
 │ ├── .git/
 │ ├── src/

--- a/content/language/dotnet/develop.md
+++ b/content/language/dotnet/develop.md
@@ -40,7 +40,7 @@ In the `add-db` branch, only the .NET application has been updated. None of the 
 
 You should now have the following in your `docker-dotnet-sample` directory.
 
-```
+```text
 ├── docker-dotnet-sample/
 │ ├── .git/
 │ ├── src/
@@ -128,7 +128,7 @@ You must create this file as it's not included in the source repository.
 In the `docker-dotnet-sample` directory, create a new directory named `db` and
 inside that directory create a file named `password.txt`. Open `password.txt` in an IDE or text editor and add the following password. The password must be on a single line, with no additional lines in the file.
 
-```
+```text
 example
 ```
 
@@ -136,7 +136,7 @@ Save and close the `password.txt` file.
 
 You should now have the following in your `docker-dotnet-sample` directory.
 
-```
+```text
 ├── docker-dotnet-sample/
 │ ├── .git/
 │ ├── db/

--- a/content/language/golang/build-images.md
+++ b/content/language/golang/build-images.md
@@ -106,7 +106,7 @@ $ go run main.go
 This should compile and start the server as a foreground application, outputting
 the banner, as illustrated in the following figure.
 
-```
+```text
    ____    __
   / __/___/ /  ___
  / _// __/ _ \/ _ \
@@ -426,7 +426,7 @@ $ docker image ls
 
 You will see that the tag `v1.0` is no longer in the list of images kept by your Docker instance.
 
-```
+```text
 REPOSITORY                       TAG       IMAGE ID       CREATED         SIZE
 docker-gs-ping                   latest    7f153fbcc0a8   7 minutes ago   1.11GB
 ...
@@ -506,7 +506,7 @@ $ docker build -t docker-gs-ping:multistage -f Dockerfile.multistage .
 Comparing the sizes of `docker-gs-ping:multistage` and `docker-gs-ping:latest`
 you see a few orders-of-magnitude difference.
 
-```
+```console
 $ docker image ls
 REPOSITORY       TAG          IMAGE ID       CREATED              SIZE
 docker-gs-ping   multistage   e3fdde09f172   About a minute ago   28.1MB

--- a/content/language/golang/develop.md
+++ b/content/language/golang/develop.md
@@ -626,7 +626,7 @@ You passed the `--build` flag so Docker will compile your image and then start i
 
 Since your set-up is now run by Docker Compose, it has assigned it a project name, so you get a new volume for your CockroachDB instance. This means that your application will fail to connect to the database, because the database doesn't exist in this new volume. The terminal displays an authentication error for the database:
 
-```
+```text
 # ... omitted output ...
 rest-server             | 2021/05/10 00:54:25 failed to initialise the store: pq: password authentication failed for user totoro
 roach                   | *

--- a/content/language/golang/run-containers.md
+++ b/content/language/golang/run-containers.md
@@ -22,7 +22,7 @@ To run an image inside of a container, you use the `docker run` command. It requ
 $ docker run docker-gs-ping
 ```
 
-```
+```text
    ____    __
   / __/___/ /  ___
  / _// __/ _ \/ _ \

--- a/content/language/java/build-images.md
+++ b/content/language/java/build-images.md
@@ -151,7 +151,7 @@ CMD ["./mvnw", "spring-boot:run"]
 
 To increase the performance of the build, and as a general best practice, Docker recommends that you create a `.dockerignore` file in the same directory as the Dockerfile. For this tutorial, your `.dockerignore` file should contain just one line:
 
-```
+```text
 target
 ```
 

--- a/content/language/nodejs/containerize.md
+++ b/content/language/nodejs/containerize.md
@@ -83,18 +83,18 @@ Let's get started!
 You should now have the following contents in your `docker-nodejs-sample`
 directory.
 
-   ```
-   ├── docker-nodejs-sample/
-   │ ├── spec/
-   │ ├── src/
-   │ ├── .dockerignore
-   │ ├── .gitignore
-   │ ├── compose.yaml
-   │ ├── Dockerfile
-   │ ├── package-lock.json
-   │ ├── package.json
-   │ └── README.md
-   ```
+```text
+├── docker-nodejs-sample/
+│ ├── spec/
+│ ├── src/
+│ ├── .dockerignore
+│ ├── .gitignore
+│ ├── compose.yaml
+│ ├── Dockerfile
+│ ├── package-lock.json
+│ ├── package.json
+│ └── README.md
+```
 
 To learn more about the files that `docker init` added, see the following:
  - [Dockerfile](../../engine/reference/builder.md)

--- a/content/language/nodejs/develop.md
+++ b/content/language/nodejs/develop.md
@@ -93,21 +93,20 @@ In the cloned repository's directory, create a new directory named `db`. Inside 
 You should now have the following contents in your `docker-nodejs-sample`
 directory.
 
-   ```
-   ├── docker-nodejs-sample/
-   │ ├── db/
-   │ │ └── password.txt
-   │ ├── spec/
-   │ ├── src/
-   │ ├── .dockerignore
-   │ ├── .gitignore
-   │ ├── compose.yaml
-   │ ├── Dockerfile
-   │ ├── package-lock.json
-   │ ├── package.json
-   │ └── README.md
-   ```
-
+```text
+├── docker-nodejs-sample/
+│ ├── db/
+│ │ └── password.txt
+│ ├── spec/
+│ ├── src/
+│ ├── .dockerignore
+│ ├── .gitignore
+│ ├── compose.yaml
+│ ├── Dockerfile
+│ ├── package-lock.json
+│ ├── package.json
+│ └── README.md
+```
 
 Run the following command to start your application.
 

--- a/content/language/python/containerize.md
+++ b/content/language/python/containerize.md
@@ -72,15 +72,15 @@ Let's get started!
 You should now have the following contents in your `python-docker`
 directory.
 
-   ```
-   ├── python-docker/
-   │ ├── app.py
-   │ ├── requirements.txt
-   │ ├── .dockerignore
-   │ ├── compose.yaml
-   │ ├── Dockerfile
-   │ └── README.md
-   ```
+```text
+├── python-docker/
+│ ├── app.py
+│ ├── requirements.txt
+│ ├── .dockerignore
+│ ├── compose.yaml
+│ ├── Dockerfile
+│ └── README.md
+```
 
 To learn more about the files that `docker init` added, see the following:
  - [Dockerfile](../../engine/reference/builder.md)

--- a/content/language/python/develop.md
+++ b/content/language/python/develop.md
@@ -100,7 +100,7 @@ Before you run the application using Compose, notice that this Compose file spec
 
 In the cloned repository's directory, create a new directory named `db` and inside that directory create a file named `password.txt` that contains the password for the database. Using your favorite IDE or text editor, add the following contents to the `password.txt` file.
 
-```
+```text
 mysecretpassword
 ```
 
@@ -109,17 +109,17 @@ Save and close the `password.txt` file.
 You should now have the following contents in your `python-docker-dev`
 directory.
 
-   ```
-   ├── python-docker-dev/
-   │ ├── db/
-   │ │ └── password.txt
-   │ ├── app.py
-   │ ├── requirements.txt
-   │ ├── .dockerignore
-   │ ├── compose.yaml
-   │ ├── Dockerfile
-   │ └── README.md
-   ```
+```text
+├── python-docker-dev/
+│ ├── db/
+│ │ └── password.txt
+│ ├── app.py
+│ ├── requirements.txt
+│ ├── .dockerignore
+│ ├── compose.yaml
+│ ├── Dockerfile
+│ └── README.md
+```
 
 Now, run the following `docker compose up` command to start your application.
 

--- a/content/language/rust/develop.md
+++ b/content/language/rust/develop.md
@@ -72,7 +72,7 @@ For the sample application, you'll use a variation of the backend from the react
 
 1. Clone the sample application repository using the following command.
 
-   ```
+   ```console
    $ git clone https://github.com/docker/docker-rust-postgres
    ```
 
@@ -200,7 +200,7 @@ For the sample application, you'll use a variation of the backend from the react
 
    You should get a response like the following.
 
-   ```
+   ```json
    [{"id":1,"login":"root"}]
    ```
 
@@ -282,7 +282,7 @@ Before you run the application using Compose, notice that this Compose file spec
 
 In the cloned repository's directory, create a new directory named `db` and inside that directory create a file named `password.txt` that contains the password for the database. Using your favorite IDE or text editor, add the following contents to the `password.txt` file.
 
-```
+```text
 mysecretpassword
 ```
 
@@ -304,7 +304,7 @@ $ curl http://localhost:8000/users
 
 You should receive the following response:
 
-```
+```json
 [{"id":1,"login":"root"}]
 ```
 

--- a/content/storage/storagedriver/device-mapper-driver.md
+++ b/content/storage/storagedriver/device-mapper-driver.md
@@ -536,33 +536,34 @@ thin pool is 100 GB, and is increased to 200 GB.
 
 5.  Reload the devicemapper thin pool.
 
-    a.  Get the pool name first. The pool name is the first field, delimited by
-        ` :`. This command extracts it.
+    a. Get the pool name first. The pool name is the first field, delimited by
+    `:`. This command extracts it.
 
-            $ sudo dmsetup status | grep ' thin-pool ' | awk -F ': ' {'print $1'}
+    ```console
+    $ sudo dmsetup status | grep ' thin-pool ' | awk -F ': ' {'print $1'}
+    docker-8:1-123141-pool
+    ```
 
-            docker-8:1-123141-pool
+    b. Dump the device mapper table for the thin pool.
 
-    b.  Dump the device mapper table for the thin pool.
+    ```console
+    $ sudo dmsetup table docker-8:1-123141-pool
+    0 209715200 thin-pool 7:1 7:0 128 32768 1 skip_block_zeroing
+    ```
 
-            $ sudo dmsetup table docker-8:1-123141-pool
+    c. Calculate the total sectors of the thin pool using the second field
+    of the output. The number is expressed in 512-k sectors. A 100G file has
+    209715200 512-k sectors. If you double this number to 200G, you get
+    419430400 512-k sectors.
 
-            0 209715200 thin-pool 7:1 7:0 128 32768 1 skip_block_zeroing
+    d. Reload the thin pool with the new sector number, using the following
+    three `dmsetup`  commands.
 
-    c.  Calculate the total sectors of the thin pool using the second field
-        of the output. The number is expressed in 512-k sectors. A 100G file has
-        209715200 512-k sectors. If you double this number to 200G, you get
-        419430400 512-k sectors.
-
-    d.  Reload the thin pool with the new sector number, using the following
-        three `dmsetup`  commands.
-
-            $ sudo dmsetup suspend docker-8:1-123141-pool
-
-            $ sudo dmsetup reload docker-8:1-123141-pool --table '0 419430400 thin-pool 7:1 7:0 128 32768 1 skip_block_zeroing'
-
-            $ sudo dmsetup resume docker-8:1-123141-pool
-
+    ```console
+    $ sudo dmsetup suspend docker-8:1-123141-pool
+    $ sudo dmsetup reload docker-8:1-123141-pool --table '0 419430400 thin-pool 7:1 7:0 128 32768 1 skip_block_zeroing'
+    $ sudo dmsetup resume docker-8:1-123141-pool
+    ```
 
 #### Resize a direct-lvm thin pool
 

--- a/content/storage/storagedriver/select-storage-driver.md
+++ b/content/storage/storagedriver/select-storage-driver.md
@@ -29,11 +29,15 @@ The Docker Engine provides the following storage drivers on Linux:
 | `vfs`              | The `vfs` storage driver is intended for testing purposes, and for situations where no copy-on-write filesystem can be used. Performance of this storage driver is poor, and is not generally recommended for production use.                                                                                                                                                                                   |
 | `devicemapper`     | The `devicemapper` storage driver requires `direct-lvm` for production environments, because `loopback-lvm`, while zero-configuration, has very poor performance. `devicemapper` was the recommended storage driver for CentOS and RHEL, as their kernel version did not support `overlay2`. However, current versions of CentOS and RHEL now have support for `overlay2`, which is now the recommended driver. |
 
+<!-- markdownlint-disable reference-links-images -->
+
 The Docker Engine has a prioritized list of which storage driver to use if no
 storage driver is explicitly configured, assuming that the storage driver meets
 the prerequisites, and automatically selects a compatible storage driver. You
 can see the order in the [source code for Docker Engine {{% param "docker_ce_version" %}}](https://github.com/moby/moby/blob/{{% param "docker_ce_version" %}}/daemon/graphdriver/driver_linux.go#L52-L53).
 { #storage-driver-order }
+
+<!-- markdownlint-enable reference-links-images -->
 
 Some storage drivers require you to use a specific format for the backing filesystem.
 If you have external  requirements to use a specific backing filesystem, this may


### PR DESCRIPTION
- lint: pin markdownlint-cli2 version to v0.10.0
- fix: broken glob path for lint job
  
  Linting was only running on a subset of our Markdown files in `content`.
  This change fixes the glob path, and adds appropriate exclude paths.
  Because the glob pattern was incorrect before, we had lots of files that
  didn't comply with the linting rules. This commit also fixes those
  issues.