### PR TITLE
Revert "search: add a stronger main content identifier"

### DIFF
--- a/layouts/_default/cli.html
+++ b/layouts/_default/cli.html
@@ -12,7 +12,7 @@
   {{ .Scratch.Set "headings" slice }}
   {{ .Scratch.Set "subheadings" slice }}
   {{ partial "breadcrumbs.html" . }}
-  <article id="content" class="prose max-w-none dark:prose-invert">
+  <article class="prose max-w-none dark:prose-invert">
     <h1>{{ .Title }}</h1>
     {{ $data.short | .RenderString (dict "display" "block") }}
     {{ if $data.deprecated }}

--- a/layouts/_default/glossary.html
+++ b/layouts/_default/glossary.html
@@ -4,7 +4,7 @@
 
 {{ define "main" }}
   {{ partial "breadcrumbs.html" . }}
-  <article id="content" class="prose max-w-none dark:prose-invert">
+  <article class="prose max-w-none dark:prose-invert">
     <h1>{{ .Title }}</h1>
     <table>
       <thead>

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -4,7 +4,7 @@
 
 {{ define "main" }}
   {{ partial "breadcrumbs.html" . }}
-  <article id="content" class="prose max-w-none dark:prose-invert">
+  <article class="prose max-w-none dark:prose-invert">
     {{ with .Title }}
     <h1>{{ . }}</h1>
     {{ end }}

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -4,7 +4,7 @@
 
 {{ define "main" }}
   {{ partial "breadcrumbs.html" . }}
-  <article id="content" class="prose max-w-none dark:prose-invert">
+  <article class="prose max-w-none dark:prose-invert">
     {{ with .Title }}
     <h1>{{ . }}</h1>
     {{ end }}

--- a/layouts/samples/single.html
+++ b/layouts/samples/single.html
@@ -4,7 +4,7 @@
 
 {{ define "main" }}
   {{ partial "breadcrumbs.html" . }}
-  <article id="content" class="prose max-w-none dark:prose-invert">
+  <article class="prose max-w-none dark:prose-invert">
     <h1>{{ .Title }}</h1>
     <blockquote>
       <p><strong>Note</strong></p>


### PR DESCRIPTION
Reverts docker/docs#18627

Turns out that adding a content ID messes up the search results urls. I think the "algolia way" might be to use class names instead, but that seems semantically incorrect and not guaranteed to be a unique identifier.

For now, let's remove this content ID