### PR TITLE
build: fix gha cache scope

### DIFF
--- a/content/build/cache/backends/gha.md
+++ b/content/build/cache/backends/gha.md
@@ -33,13 +33,13 @@ $ docker buildx build --push -t <registry>/<image> \
 The following table describes the available CSV parameters that you can pass to
 `--cache-to` and `--cache-from`.
 
-| Name           | Option                  | Type        | Default                         | Description                                   |
-| -------------- | ----------------------- | ----------- | ------------------------------- | --------------------------------------------- |
-| `url`          | `cache-to`,`cache-from` | String      | `$ACTIONS_CACHE_URL`            | Cache server URL, see [authentication][1].    |
-| `token`        | `cache-to`,`cache-from` | String      | `$ACTIONS_RUNTIME_TOKEN`        | Access token, see [authentication][1].        |
-| `scope`        | `cache-to`,`cache-from` | String      | Name of the current Git branch. | Cache scope, see [scope][2]                   |
-| `mode`         | `cache-to`              | `min`,`max` | `min`                           | Cache layers to export, see [cache mode][3].  |
-| `ignore-error` | `cache-to`              | Boolean     | `false`                         | Ignore errors caused by failed cache exports. |
+| Name           | Option                  | Type        | Default                  | Description                                         |
+|----------------|-------------------------|-------------|--------------------------|-----------------------------------------------------|
+| `url`          | `cache-to`,`cache-from` | String      | `$ACTIONS_CACHE_URL`     | Cache server URL, see [authentication][1].          |
+| `token`        | `cache-to`,`cache-from` | String      | `$ACTIONS_RUNTIME_TOKEN` | Access token, see [authentication][1].              |
+| `scope`        | `cache-to`,`cache-from` | String      | `buildkit`               | Which scope cache object belongs to, see [scope][2] |
+| `mode`         | `cache-to`              | `min`,`max` | `min`                    | Cache layers to export, see [cache mode][3].        |
+| `ignore-error` | `cache-to`              | Boolean     | `false`                  | Ignore errors caused by failed cache exports.       |
 
 [1]: #authentication
 [2]: #scope
@@ -56,23 +56,21 @@ GitHub Action as a helper for exposing the variables.
 
 ## Scope
 
-By default, cache is scoped per Git branch. This ensures a separate cache
-environment for the main branch and each feature branch. If you build multiple
-images on the same branch, each build will overwrite the cache of the previous,
-leaving only the final cache.
+Scope is a key used to identify the cache object. By default, it is set to
+`buildkit`. If you build multiple images, each build will overwrite the cache
+of the previous, leaving only the final cache.
 
-To preserve the cache for multiple builds on the same branch, you can manually
-specify a cache scope name using the `scope` parameter. In the following
-example, the cache is set to a combination of the branch name and the image
-name, to ensure each image gets its own cache):
+To preserve the cache for multiple builds, you can specify this scope attribute
+with a specific name. In the following example, the cache is set to the image
+name, to ensure each image gets its own cache:
 
 ```console
 $ docker buildx build --push -t <registry>/<image> \
-  --cache-to type=gha,url=...,token=...,scope=$GITHUB_REF_NAME-image \
-  --cache-from type=gha,url=...,token=...,scope=$GITHUB_REF_NAME-image .
+  --cache-to type=gha,url=...,token=...,scope=image \
+  --cache-from type=gha,url=...,token=...,scope=image .
 $ docker buildx build --push -t <registry>/<image2> \
-  --cache-to type=gha,url=...,token=...,scope=$GITHUB_REF_NAME-image2 \
-  --cache-from type=gha,url=...,token=...,scope=$GITHUB_REF_NAME-image2 .
+  --cache-to type=gha,url=...,token=...,scope=image2 \
+  --cache-from type=gha,url=...,token=...,scope=image2 .
 ```
 
 GitHub's [cache access restrictions](https://docs.github.com/en/actions/advanced-guides/caching-dependencies-to-speed-up-workflows#restrictions-for-accessing-a-cache),


### PR DESCRIPTION
<!--
  Thank you for contributing to Docker documentation!

  Here are a few things to keep in mind:

  - Links between pages should use a relative path
  - Remember to add an alt text for images

  ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
  ┃     Review our contribution guidelines:       ┃
  ┃                                               ┃
  ┃ https://docs.docker.com/contribute/overview/  ┃
  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
-->

### Proposed changes

<!-- Tell us what you did and why -->

* fixes https://github.com/docker/build-push-action/issues/706

`scope` is an attribute defaulting to `buildkit` (https://github.com/moby/buildkit#github-actions-cache-experimental) while there is also the scope of the JWT token. So you have the token's scope and on top of it the cache scope.

### Related issues (optional)

<!--
  Refer to related PRs or issues:

  #1234
  Closes #1234
  Closes docker/cli#1234
-->
