### PR TITLE
docker init: update template name in the docs to reflect what's listed in the cli

### DIFF
--- a/content/language/dotnet/containerize.md
+++ b/content/language/dotnet/containerize.md
@@ -1,7 +1,7 @@
 ---
 title: Containerize a .NET application
 keywords: .net, containerize, initialize
-description: Learn how to containerize an  ASP.NET application.
+description: Learn how to containerize an ASP.NET application.
 aliases:
 - /language/dotnet/build-images/
 - /language/dotnet/run-containers/

--- a/data/init-cli/docker_init.yaml
+++ b/data/init-cli/docker_init.yaml
@@ -19,7 +19,7 @@ long: |-
   
   After running `docker init`, you can choose one of the following templates:
     
-    * ASP.NET: Suitable for an ASP.NET application.
+    * ASP.NET Core: Suitable for an ASP.NET Core application.
     * Go: Suitable for a Go server application.
     * Node: Suitable for a Node server application.
     * Python: Suitable for a Python server application.
@@ -70,7 +70,7 @@ examples: |-
   
   ? What application platform does your project use?  [Use arrows to move, type to filter]
   > Go - (detected) suitable for a Go server application
-    ASP.NET - suitable for an ASP.NET application
+    ASP.NET Core - suitable for an ASP.NET Core application
     Python - suitable for a Python server application
     Node - suitable for a Node server application
     Rust - suitable for a Rust server application
@@ -173,12 +173,12 @@ examples: |-
   Your application will be available at http://localhost:8000
   ```
   
-  ### Example of selecting ASP.NET
+  ### Example of selecting ASP.NET Core
   
-  The following example shows the prompts that appear after selecting `ASP.NET` and example input. The ASP.NET template also creates a `README.Docker.md` file with additional information about building and deploying your application.
+  The following example shows the prompts that appear after selecting `ASP.NET Core` and example input. The ASP.NET Core template also creates a `README.Docker.md` file with additional information about building and deploying your application.
   
   ```console
-  ? What application platform does your project use? ASP.NET
+  ? What application platform does your project use? ASP.NET Core
   ? What's the name of your solution's main project? myapp
   ? What version of .NET do you want to use? 6.0
   ? What local port do you want to use to access your server? 8000


### PR DESCRIPTION
<!--
  Thank you for contributing to Docker documentation!

  Here are a few things to keep in mind:

  - Links between pages should use a relative path
  - Remember to add an alt text for images

  ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
  ┃     Review our contribution guidelines:       ┃
  ┃                                               ┃
  ┃ https://docs.docker.com/contribute/overview/  ┃
  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
-->

### Proposed changes

<!-- Tell us what you did and why -->
Docker Init lists the ASP.NET template as "ASP.NET Core," so I've updated a few references to the template in the docs to reflect this.

### Related issues (optional)

<!--
  Refer to related PRs or issues:

  #1234
  Closes #1234
  Closes docker/cli#1234
-->
