### PR TITLE
Update _index.md

### DIFF
--- a/content/engine/api/sdk/_index.md
+++ b/content/engine/api/sdk/_index.md
@@ -205,6 +205,7 @@ file them with the library maintainers.
 | Perl                  | [Eixo::Docker](https://github.com/alambike/eixo-docker)                     |
 | PHP                   | [Docker-PHP](https://github.com/docker-php/docker-php)                      |
 | Ruby                  | [docker-api](https://github.com/swipely/docker-api)                         |
+| Rust                  | [bollard](https://github.com/fussybeaver/bollard)                           |
 | Rust                  | [docker-rust](https://github.com/abh1nav/docker-rust)                       |
 | Rust                  | [shiplift](https://github.com/softprops/shiplift)                           |
 | Scala                 | [tugboat](https://github.com/softprops/tugboat)                             |


### PR DESCRIPTION
Add bollard as Rust SDK.

Bollard is currently the most actively maintained docker SDK in the Rust programming language, so it should be mentioned on this page.

<!--
  Thank you for contributing to Docker documentation!

  Here are a few things to keep in mind:

  - Links between pages should use a relative path
  - Remember to add an alt text for images

  ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
  ┃     Review our contribution guidelines:       ┃
  ┃                                               ┃
  ┃ https://docs.docker.com/contribute/overview/  ┃
  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
-->

### Proposed changes

<!-- Tell us what you did and why -->

### Related issues (optional)

<!--
  Refer to related PRs or issues:

  #1234
  Closes #1234
  Closes docker/cli#1234
-->
