### PR TITLE
fix: li margin issue

### DIFF
--- a/assets/css/typography.css
+++ b/assets/css/typography.css
@@ -1,9 +1,6 @@
 .prose {
   li {
     @apply mt-1 mb-1;
-    & > :first-child, & > :last-child {
-      @apply m-0;
-    }
   }
   a {
     font-weight: 400;


### PR DESCRIPTION
List item margins were incorrectly set to 0.

<img width="851" alt="image" src="https://github.com/docker/docs/assets/35727626/2ff9ae56-5308-4d8b-9cea-56fd67896edd">
