### PR TITLE
Fixing the wasmtime path in alternative-runtimes.md

### DIFF
--- a/content/engine/alternative-runtimes.md
+++ b/content/engine/alternative-runtimes.md
@@ -115,7 +115,7 @@ The following examples show you how to set up and use alternative container
 runtimes with Docker Engine.
 
 - [youki](#youki)
-- [Wasmtime](#youki)
+- [Wasmtime](#wasmtime)
 
 ### youki
 


### PR DESCRIPTION
Fixing the wasmtime path in alternative-runtimes.md

<!--
  Thank you for contributing to Docker documentation!

  Here are a few things to keep in mind:

  - Links between pages should use a relative path
  - Remember to add an alt text for images

  ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
  ┃     Review our contribution guidelines:       ┃
  ┃                                               ┃
  ┃ https://docs.docker.com/contribute/overview/  ┃
  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
-->

### Proposed changes

Wasmtime path in [example](https://docs.docker.com/engine/alternative-runtimes/#examples) is incorrect. Fixing the path in alternative-runtimes.md.

### Related issues (optional)


Closes #18672 

<!--
  Refer to related PRs or issues:

  #1234
  Closes #1234
  Closes docker/cli#1234
-->
