### PR TITLE
Update containerize.md - correction of path to ../activate

### DIFF
--- a/content/language/python/containerize.md
+++ b/content/language/python/containerize.md
@@ -32,6 +32,15 @@ You can test the application locally without Docker before you continue building
 
 Open your terminal and navigate to the working directory you created. Create an environment, install the dependencies, and start the application to make sure it’s running.
 
+Linux:
+```console
+$ cd /path/to/python-docker
+$ python3 -m venv .venv
+$ source .venv/bin/activate
+(.venv) $ python3 -m pip install -r requirements.txt
+(.venv) $ python3 -m flask run
+```
+Windows:
 ```console
 $ cd /path/to/python-docker
 $ python3 -m venv .venv

--- a/content/language/python/containerize.md
+++ b/content/language/python/containerize.md
@@ -35,7 +35,7 @@ Open your terminal and navigate to the working directory you created. Create an 
 ```console
 $ cd /path/to/python-docker
 $ python3 -m venv .venv
-$ source .venv/bin/activate
+$ source .venv/Scripts/activate
 (.venv) $ python3 -m pip install -r requirements.txt
 (.venv) $ python3 -m flask run
 ```


### PR DESCRIPTION
The path to .//activate was incorrect. ( .venv/bin/activate). I There is no bin folder in this repo. I've corrected it to source .venv/Scripts/activate that is the existing path.

<!--
  Thank you for contributing to Docker documentation!

  Here are a few things to keep in mind:

  - Links between pages should use a relative path
  - Remember to add an alt text for images

  ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
  ┃     Review our contribution guidelines:       ┃
  ┃                                               ┃
  ┃ https://docs.docker.com/contribute/overview/  ┃
  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
-->

### Proposed changes

<!-- Tell us what you did and why -->

### Related issues (optional)

<!--
  Refer to related PRs or issues:

  #1234
  Closes #1234
  Closes docker/cli#1234
-->
