### PR TITLE
Fix invalid use of em dash in a CLI command

### DIFF
--- a/content/engine/swarm/swarm-tutorial/_index.md
+++ b/content/engine/swarm/swarm-tutorial/_index.md
@@ -92,7 +92,7 @@ additional hardening is suggested:
 
 ```bash
 # Example iptables rule (order and other tools may require customization)
-iptables -I INPUT -m udp —-dport 4789 -m policy --dir in --pol none -j DROP
+iptables -I INPUT -m udp --dport 4789 -m policy --dir in --pol none -j DROP
 ```
 
 ## What's next?


### PR DESCRIPTION
### Proposed changes

Replace the invalid em dash (U+2014) character with the hyphen (U+002D).

The current command results in an error, which is hard to fix unless you notice that the two dashes are different.

```log
Bad argument `—-dport'
```


