### PR TITLE
Update proxy.md

### DIFF
--- a/content/network/proxy.md
+++ b/content/network/proxy.md
@@ -134,7 +134,7 @@ EOF
 
 ### Configure proxy settings per daemon
 
-The `default` key under `proxies` in `daemon.json` configures the proxy
+The `default` key under `proxies` in `~/.docker/config.json` configures the proxy
 settings for all daemons that the client connects to.
 To configure the proxies for individual daemons,
 use the address of the daemon instead of the `default` key.


### PR DESCRIPTION
there is no `default` key under `proxies` in daemon.json at all!, this sentence is misleading, especially for non-english speaker.

I guess the author means 
> The `default` key under `proxies` in `~/.docker/config.json`