### PR TITLE
Update filter.md - fix description inconsistency and grammar errors

### DIFF
--- a/content/config/filter.md
+++ b/content/config/filter.md
@@ -39,7 +39,7 @@ alpine       3.16      a8cbb8c69ee7   40 minutes ago   8.67MB
 alpine       latest    7144f7bab3d4   40 minutes ago   11.7MB
 ```
 
-The available fields (`reference` in this case) depends on the command you run.
+The available fields (`reference` in this case) depend on the command you run.
 Some filters expect an exact match. Others handle partial matches. Some filters
 let you use regular expressions.
 
@@ -49,8 +49,8 @@ about the supported filtering capabilities for each command.
 ## Combining filters
 
 You can combine multiple filters by passing multiple `--filter` flags. The
-following example shows how to print all images that don't match
-`alpine:latest` or `busybox` - a logical `OR`.
+following example shows how to print all images that match `alpine:latest` or
+`busybox` - a logical `OR`.
 
 ```console
 $ docker images
@@ -71,17 +71,17 @@ busybox      glibc     7338d0c72c65   2 hours ago   6.09MB
 ### Multiple negated filters
 
 Some commands support negated filters on [labels](./labels-custom-metadata.md).
-Negated filters only consider results don't match the specified patterns. The
-following command prunes all containers that aren't labeled `foo`.
+Negated filters only consider results that don't match the specified patterns.
+The following command prunes all containers that aren't labeled `foo`.
 
 ```console
 $ docker container prune --filter "label!=foo"
 ```
 
 There's a catch in combining multiple negated label filters. Multiple negated
-filters a single negative constraint - a logical `AND`. The following command
-prunes all containers except those labeled both `foo` and `bar`. Containers
-labeled either `foo` or `bar`, but not both, will be pruned.
+filters create a single negative constraint - a logical `AND`. The following 
+command prunes all containers except those labeled both `foo` and `bar`.
+Containers labeled either `foo` or `bar`, but not both, will be pruned.
 
 ```console
 $ docker container prune --filter "label!=foo" --filter "label!=bar"


### PR DESCRIPTION
### Proposed changes

* Update the command description in the "Combining filters" section of the ["Filter commands"](https://docs.docker.com/config/filter/) page to match the behavior of the provided example (by removing the word "don't" - L52-53)
* Fix grammar errors

<!--
  Thank you for contributing to Docker documentation!

  Here are a few things to keep in mind:

  - Links between pages should use a relative path
  - Remember to add an alt text for images

  ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
  ┃     Review our contribution guidelines:       ┃
  ┃                                               ┃
  ┃ https://docs.docker.com/contribute/overview/  ┃
  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
-->



<!-- Tell us what you did and why -->

### Related issues (optional)

N/A
