### PR TITLE
style: fix margin for li with children

### DIFF
--- a/assets/css/typography.css
+++ b/assets/css/typography.css
@@ -1,6 +1,9 @@
 .prose {
   li {
-    @apply mt-1 mb-1;
+    @apply my-2;
+    > :last-child, > :first-child {
+      margin: 0;
+    }
   }
   a {
     font-weight: 400;


### PR DESCRIPTION
Fix an issue with element margin for list items with child elements

Before
<img width="376" alt="image" src="https://github.com/docker/docs/assets/35727626/3fc6fe16-14e1-42fc-9d68-167ee4f9ff07">


After
<img width="418" alt="image" src="https://github.com/docker/docs/assets/35727626/7b4bc3d5-8042-46b1-ad80-ab948a54b6b3">