### PR TITLE
fix(healthcheck): extend start_period to 2m to clarify initialization

### DIFF
--- a/content/compose/compose-file/compose-file-v3.md
+++ b/content/compose/compose-file/compose-file-v3.md
@@ -1252,7 +1252,7 @@ healthcheck:
   interval: 1m30s
   timeout: 10s
   retries: 3
-  start_period: 40s
+  start_period: 2m
 ```
 
 `interval`, `timeout` and `start_period` are specified as


### PR DESCRIPTION
### Proposed changes

Revised the start_period in the Docker healthcheck example to 2 minutes to make sure the property's role is clear. This change highlights the intended use of start_period as a grace period for container initialization. Setting start_period to a duration longer than the interval (1 minute and 30 seconds) makes it more evident that health check failures during this initial period will not count towards the retries limit.

### Related issues (optional)
