### PR TITLE
redirects: add urls used by docker init files

### DIFF
--- a/data/redirects.yml
+++ b/data/redirects.yml
@@ -631,3 +631,13 @@
 # Docker Init
 "/develop/develop-images/instructions/#user":
   - /go/dockerfile-user-best-practices/
+"/develop/develop-images/instructions/#apt-get":
+  - /go/dockerfile-aptget-best-practices/
+"/build/building/context/#dockerignore-files":
+  - /go/build-context-dockerignore/
+"/compose/compose-file":
+  - /go/compose-spec-reference/
+"/engine/reference/builder":
+  - /go/dockerfile-reference/
+"/get-started/04_sharing_app":
+  - /go/get-started-sharing/


### PR DESCRIPTION
<!--
  Thank you for contributing to Docker documentation!

  Here are a few things to keep in mind:

  - Links between pages should use a relative path
  - Remember to add an alt text for images

  ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
  ┃     Review our contribution guidelines:       ┃
  ┃                                               ┃
  ┃ https://docs.docker.com/contribute/overview/  ┃
  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
-->

### Proposed changes

<!-- Tell us what you did and why -->
This PR adds a few more short url redirects for docs pages that are referenced in files generated by Docker Init. If the docs page structure changes in the future, we can change the redirects to point to the current page, while the url that's included in the Init-generated files remains the same.

### Related issues (optional)

<!--
  Refer to related PRs or issues:

  #1234
  Closes #1234
  Closes docker/cli#1234
-->
