### PR TITLE
chore: add redirect for old buildx_debug-shell cmd

### DIFF
--- a/content/engine/reference/commandline/buildx_debug.md
+++ b/content/engine/reference/commandline/buildx_debug.md
@@ -3,6 +3,8 @@ datafolder: buildx
 datafile: docker_buildx_debug
 title: docker buildx debug
 layout: cli
+aliases:
+ - /engine/reference/commandline/buildx_debug-shell/
 ---
 
 <!--


### PR DESCRIPTION
Signed-off-by: David Karlsson <35727626+dvdksn@users.noreply.github.com>

<!--
  Thank you for contributing to Docker documentation!

  Here are a few things to keep in mind:

  - Links between pages should use a relative path
  - Remember to add an alt text for images

  ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
  ┃     Review our contribution guidelines:       ┃
  ┃                                               ┃
  ┃ https://docs.docker.com/contribute/overview/  ┃
  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
-->

### Proposed changes

<!-- Tell us what you did and why -->

### Related issues (optional)

<!--
  Refer to related PRs or issues:

  #1234
  Closes #1234
  Closes docker/cli#1234
-->
