### PR TITLE
ci: fix excludepaths in labeler

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -15,14 +15,20 @@ area/compose:
   - _vendor/github.com/compose-spec/compose-spec/**
 
 area/desktop:
-  - content/desktop/**
-  - '!content/desktop/extensions/**'
-  - '!content/desktop/extensions-sdk/**'
+  - any:
+      [
+        content/desktop/**,
+        "!content/desktop/extensions/**",
+        "!content/desktop/extensions-sdk/**",
+      ]
 
 area/engine:
-  - content/engine/**
-  - content/config/**
-  - '!content/engine/reference/commandline/*'
+  - any:
+      [
+        content/engine/**,
+        content/config/**,
+        "!content/engine/reference/commandline/*",
+      ]
 
 area/install:
   - content/desktop/install/**


### PR DESCRIPTION
Added the `any` key where label globs included an exclude path to
prevent the exclude path from acting as a catch-all

Signed-off-by: David Karlsson <35727626+dvdksn@users.noreply.github.com>

<!--
  Thank you for contributing to Docker documentation!

  Here are a few things to keep in mind:

  - Links between pages should use a relative path
  - Remember to add an alt text for images

  ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
  ┃     Review our contribution guidelines:       ┃
  ┃                                               ┃
  ┃ https://docs.docker.com/contribute/overview/  ┃
  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
-->

### Proposed changes

<!-- Tell us what you did and why -->

### Related issues (optional)

<!--
  Refer to related PRs or issues:

  #1234
  Closes #1234
  Closes docker/cli#1234
-->
