### PR TITLE
fix: add scroll margin for h1s

### DIFF
--- a/layouts/_default/cli.html
+++ b/layouts/_default/cli.html
@@ -14,7 +14,7 @@
   {{ partial "breadcrumbs.html" . }}
   <article class="DocSearch-content prose max-w-none dark:prose-invert">
     {{ with .Title }}
-    <h1 id="{{ anchorize . }}">{{ . }}</h1>
+    <h1 id="{{ anchorize . }}" class="scroll-mt-36">{{ . }}</h1>
     {{ end }}
     {{ $data.short | .RenderString (dict "display" "block") }}
     {{ if $data.deprecated }}

--- a/layouts/_default/glossary.html
+++ b/layouts/_default/glossary.html
@@ -6,7 +6,7 @@
   {{ partial "breadcrumbs.html" . }}
   <article class="DocSearch-content prose max-w-none dark:prose-invert">
     {{ with .Title }}
-    <h1 id="{{ anchorize . }}">{{ . }}</h1>
+    <h1 id="{{ anchorize . }}" class="scroll-mt-36">{{ . }}</h1>
     {{ end }}
     <table>
       <thead>

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -6,7 +6,7 @@
   {{ partial "breadcrumbs.html" . }}
   <article class="DocSearch-content prose max-w-none dark:prose-invert">
     {{ with .Title }}
-    <h1 id="{{ anchorize . }}">{{ . }}</h1>
+    <h1 id="{{ anchorize . }}" class="scroll-mt-36">{{ . }}</h1>
     {{ end }}
     {{ .Content }}
   </article>

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -6,7 +6,7 @@
   {{ partial "breadcrumbs.html" . }}
   <article class="DocSearch-content prose max-w-none dark:prose-invert">
     {{ with .Title }}
-    <h1 id="{{ anchorize . }}">{{ . }}</h1>
+    <h1 id="{{ anchorize . }}" class="scroll-mt-36">{{ . }}</h1>
     {{ end }}
     {{ .Content }}
   </article>

--- a/layouts/samples/single.html
+++ b/layouts/samples/single.html
@@ -6,7 +6,7 @@
   {{ partial "breadcrumbs.html" . }}
   <article class="DocSearch-content prose max-w-none dark:prose-invert">
     {{ with .Title }}
-    <h1 id="{{ anchorize . }}">{{ . }}</h1>
+    <h1 id="{{ anchorize . }}" class="scroll-mt-36">{{ . }}</h1>
     {{ end }}
     <blockquote>
       <p><strong>Note</strong></p>


### PR DESCRIPTION
h1 elements with IDs need a scroll margin to account for the header and
margin height. These anchors are linked automatically by Algolia.

Signed-off-by: David Karlsson <35727626+dvdksn@users.noreply.github.com>

<!--
  Thank you for contributing to Docker documentation!

  Here are a few things to keep in mind:

  - Links between pages should use a relative path
  - Remember to add an alt text for images

  ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
  ┃     Review our contribution guidelines:       ┃
  ┃                                               ┃
  ┃ https://docs.docker.com/contribute/overview/  ┃
  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
-->

### Proposed changes

<!-- Tell us what you did and why -->

### Related issues (optional)

<!--
  Refer to related PRs or issues:

  #1234
  Closes #1234
  Closes docker/cli#1234
-->
