### PR TITLE
Fixed referencing to the wrong brach /s/master/main

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ We've made it easy for you to file new issues.
 
 We value your contribution. We want to make it as easy as possible to submit
 your contributions to the Docker docs repository. Changes to the docs are
-handled through pull requests against the `master` branch. To learn how to
+handled through pull requests against the `main` branch. To learn how to
 contribute, see our [Contribute section](https://docs.docker.com/contribute/overview/).
 
 ## Copyright and license


### PR DESCRIPTION
In the README.md there is still a reference to the `master` branch. Renamed this into main.