### PR TITLE
ENGDOCS-1875

### DIFF
--- a/content/desktop/hardened-desktop/settings-management/_index.md
+++ b/content/desktop/hardened-desktop/settings-management/_index.md
@@ -40,6 +40,7 @@ Using the `admin-settings.json` file, admins can:
 - Turn off Docker Desktop's ability to checks for updates
 - Turn off Docker Extensions
 - Turn off Docker Scout SBOM indexing
+- Turn off beta and experimental features
 
 For more details on the syntax and options admins can set, see [Configure Settings Management](configure.md).
 

--- a/content/desktop/hardened-desktop/settings-management/configure.md
+++ b/content/desktop/hardened-desktop/settings-management/configure.md
@@ -147,9 +147,9 @@ The following `admin-settings.json` code and table provides an example of the re
 |`analyticsEnabled`|  |If `value` is set to false, Docker Desktop doesn't send usage statistics to Docker. |
 |`extensionsEnabled`|  |If `value` is set to false, Docker extensions are disabled. |
 |`scout`|| Setting `useBackgroundIndexing` to `false` disables automatic indexing of images loaded to the image store. Setting `sbomIndexing` to `false` prevents the manual indexing triggered by inspecting an image in Docker Desktop.<br><br>**Note**: Users can still use the `docker scout` CLI commands to index images, even if indexing is disabled in Settings Management. |
-| `allowExperimentalFeatures`| If `locked` is set to `true`, users are no longer able to access or use experimental features.|
-| `allowBetaFeatures`| If `locked` is set to `true`, users are no longer able to access or use beta features.|
-| `blockDockerLoad` | If `value` is set to `true`, users are no longer able to run [`docker load`](../../../engine/reference/commandline/load.md).|
+| `allowExperimentalFeatures`| | If `locked` is set to `true`, users are no longer able to access or use experimental features.|
+| `allowBetaFeatures`| | If `locked` is set to `true`, users are no longer able to access or use beta features.|
+| `blockDockerLoad` | | If `value` is set to `true`, users are no longer able to run [`docker load`](../../../engine/reference/commandline/load.md).|
 
 ### Step three: Re-launch Docker Desktop
 >**Note**

--- a/content/desktop/hardened-desktop/settings-management/configure.md
+++ b/content/desktop/hardened-desktop/settings-management/configure.md
@@ -121,6 +121,10 @@ The following `admin-settings.json` code and table provides an example of the re
   "allowBetaFeatures": {
     "locked": true,
     "value": true
+  },
+  "blockDockerLoad": {
+    "value": true,
+    "locked": true
   }
 }
 ```
@@ -145,7 +149,7 @@ The following `admin-settings.json` code and table provides an example of the re
 |`scout`|| Setting `useBackgroundIndexing` to `false` disables automatic indexing of images loaded to the image store. Setting `sbomIndexing` to `false` prevents the manual indexing triggered by inspecting an image in Docker Desktop.<br><br>**Note**: Users can still use the `docker scout` CLI commands to index images, even if indexing is disabled in Settings Management. |
 | `allowExperimentalFeatures`| If `locked` is set to `true`, users are no longer able to access or use experimental features.|
 | `allowBetaFeatures`| If `locked` is set to `true`, users are no longer able to access or use beta features.|
-
+| `blockDockerLoad` | If `value` is set to `true`, users are no longer able to run [`docker load`](../../../engine/reference/commandline/load.md).|
 
 ### Step three: Re-launch Docker Desktop
 >**Note**

--- a/content/desktop/hardened-desktop/settings-management/configure.md
+++ b/content/desktop/hardened-desktop/settings-management/configure.md
@@ -113,6 +113,14 @@ The following `admin-settings.json` code and table provides an example of the re
     "locked": false,
     "sbomIndexing": true,
     "useBackgroundIndexing": true
+  },
+  "allowExperimentalFeatures": {
+    "locked": true,
+    "value": true
+  },
+  "allowBetaFeatures": {
+    "locked": true,
+    "value": true
   }
 }
 ```
@@ -135,6 +143,9 @@ The following `admin-settings.json` code and table provides an example of the re
 |`analyticsEnabled`|  |If `value` is set to false, Docker Desktop doesn't send usage statistics to Docker. |
 |`extensionsEnabled`|  |If `value` is set to false, Docker extensions are disabled. |
 |`scout`|| Setting `useBackgroundIndexing` to `false` disables automatic indexing of images loaded to the image store. Setting `sbomIndexing` to `false` prevents the manual indexing triggered by inspecting an image in Docker Desktop.<br><br>**Note**: Users can still use the `docker scout` CLI commands to index images, even if indexing is disabled in Settings Management. |
+| `allowExperimentalFeatures`| If `locked` is set to `true`, users are no longer able to access or use experimental features.|
+| `allowBetaFeatures`| If `locked` is set to `true`, users are no longer able to access or use beta features.|
+
 
 ### Step three: Re-launch Docker Desktop
 >**Note**

--- a/content/desktop/hardened-desktop/settings-management/configure.md
+++ b/content/desktop/hardened-desktop/settings-management/configure.md
@@ -106,8 +106,8 @@ The following `admin-settings.json` code and table provides an example of the re
     "value": true
   },
   "extensionsEnabled": {
-    "value": false,
-    "locked": true
+    "locked": true,
+    "value": false    
   },
   "scout": {
     "locked": false,
@@ -115,16 +115,16 @@ The following `admin-settings.json` code and table provides an example of the re
     "useBackgroundIndexing": true
   },
   "allowExperimentalFeatures": {
-    "locked": true,
-    "value": true
+    "locked": false,
+    "value": false
   },
   "allowBetaFeatures": {
-    "locked": true,
-    "value": true
+    "locked": false,
+    "value": false
   },
   "blockDockerLoad": {
-    "value": true,
-    "locked": true
+    "locked": false,
+    "value": true    
   }
 }
 ```
@@ -147,9 +147,9 @@ The following `admin-settings.json` code and table provides an example of the re
 |`analyticsEnabled`|  |If `value` is set to false, Docker Desktop doesn't send usage statistics to Docker. |
 |`extensionsEnabled`|  |If `value` is set to false, Docker extensions are disabled. |
 |`scout`|| Setting `useBackgroundIndexing` to `false` disables automatic indexing of images loaded to the image store. Setting `sbomIndexing` to `false` prevents the manual indexing triggered by inspecting an image in Docker Desktop.<br><br>**Note**: Users can still use the `docker scout` CLI commands to index images, even if indexing is disabled in Settings Management. |
-| `allowExperimentalFeatures`| | If `locked` is set to `true`, users are no longer able to access or use experimental features.|
-| `allowBetaFeatures`| | If `locked` is set to `true`, users are no longer able to access or use beta features.|
-| `blockDockerLoad` | | If `value` is set to `true`, users are no longer able to run [`docker load`](../../../engine/reference/commandline/load.md).|
+| `allowExperimentalFeatures`| | If `value` is set to `false`, experimental features are disabled.|
+| `allowBetaFeatures`| | If `value` is set to `false`, beta features are disabled.|
+| `blockDockerLoad` | | If `value` is set to `true`, users are no longer able to run [`docker load`](../../../engine/reference/commandline/load.md) and receive an error if they try to.|
 
 ### Step three: Re-launch Docker Desktop
 >**Note**

--- a/content/desktop/settings/linux.md
+++ b/content/desktop/settings/linux.md
@@ -18,10 +18,13 @@ You can also locate the `settings.json` file at `~/.docker/desktop/settings.json
 
 On the **General** tab, you can configure when to start Docker and specify other settings:
 
-- **Start Docker Desktop when you log in**. Select to automatically start Docker
+- **Start Docker Desktop when you sign in**. Select to automatically start Docker
   Desktop when you sign in to your machine.
 
-- **Choose Theme for Docker Desktop**. Choose whether you want to apply a **Light** or **Dark** theme to Docker Desktop. Alternatively you can set Docker Desktop to **Use System Settings**.
+- **Open Docker Dashboard when Docker Desktop starts**. Select to automatically open the
+  dashboard when starting Docker Desktop.
+
+- **Choose theme for Docker Desktop**. Choose whether you want to apply a **Light** or **Dark** theme to Docker Desktop. Alternatively you can set Docker Desktop to **Use System Settings**.
 
 - **Choose container terminal**. Determines which terminal is launched when opening the terminal from a container.
 If you choose the integrated terminal, you can run commands in a running container straight from the Docker Dashboard. For more information, see [Explore containers](../use-desktop/container.md).
@@ -33,9 +36,6 @@ If you choose the integrated terminal, you can run commands in a running contain
 
 - **Show weekly tips**. Select to display useful advice and suggestions about
   using Docker.
-
-- **Open Docker Desktop dashboard at startup**. Select to automatically open the
-  dashboard when starting Docker Desktop.
 
 - **Use Enhanced Container Isolation**. Select to enhance security by preventing containers from breaching the Linux VM. For more information, see [Enhanced Container Isolation](../hardened-desktop/enhanced-container-isolation/index.md)
     >**Note**

--- a/content/desktop/settings/mac.md
+++ b/content/desktop/settings/mac.md
@@ -23,10 +23,13 @@ You can also locate the `settings.json` file at `~/Library/Group Containers/grou
 
 On the **General** tab, you can configure when to start Docker and specify other settings:
 
-- **Start Docker Desktop when you log in**. Select to automatically start Docker
+- **Start Docker Desktop when you sign in**. Select to automatically start Docker
   Desktop when you sign in to your machine.
 
-- **Choose Theme for Docker Desktop**. Choose whether you want to apply a **Light** or **Dark** theme to Docker Desktop. Alternatively you can set Docker Desktop to **Use System Settings**.
+- **Open Docker Dashboard when Docker Desktop starts**. Select to automatically open the
+  dashboard when starting Docker Desktop.
+
+- **Choose theme for Docker Desktop**. Choose whether you want to apply a **Light** or **Dark** theme to Docker Desktop. Alternatively you can set Docker Desktop to **Use System Settings**.
 
 - **Choose container terminal**. Determines which terminal is launched when opening the terminal from a container.
 If you choose the integrated terminal, you can run commands in a running container straight from the Docker Dashboard. For more information, see [Explore containers](../use-desktop/container.md).
@@ -46,7 +49,6 @@ If you choose the integrated terminal, you can run commands in a running contain
     > Use VirtioFS for speedy file sharing. VirtioFS has reduced the time taken to complete filesystem operations by [up to 98%](https://github.com/docker/roadmap/issues/7#issuecomment-1044452206)
     { .tip }
 
-
 - **Use Rosetta for x86/AMD64 emulation on Apple Silicon**. Turns on Rosetta to accelerate x86/AMD64 binary emulation on Apple Silicon. This option is only available if you have turned on **Virtualization framework** in the **General** settings tab. You must also be on macOS Ventura or later. 
 
 - **Send usage statistics**. Select so Docker Desktop sends diagnostics,
@@ -56,9 +58,6 @@ If you choose the integrated terminal, you can run commands in a running contain
 
 - **Show weekly tips**. Select to display useful advice and suggestions about
   using Docker.
-
-- **Open Docker Desktop dashboard at startup**. Select to automatically open the
-  dashboard when starting Docker Desktop.
 
 - **Use Enhanced Container Isolation**. Select to enhance security by preventing containers from breaching the Linux VM. For more information, see [Enhanced Container Isolation](../hardened-desktop/enhanced-container-isolation/index.md).
     >**Note**
@@ -198,6 +197,8 @@ The HTTPS proxy settings used for scanning images are set using the `HTTPS_PROXY
 ### Network
 
 {{< include "desktop-network-setting.md" >}}
+
+You can also select **Use kernel networking for UDP**. This lets you use a more efficient kernel networking path for UDP by changing the value of `kernelForUDP` in the `settings.json` file.
 
 ## Docker Engine
 

--- a/content/desktop/settings/windows.md
+++ b/content/desktop/settings/windows.md
@@ -18,12 +18,16 @@ You can also locate the `settings.json` file at `C:\Users\[USERNAME]\AppData\Roa
 
 On the **General** tab, you can configure when to start Docker and specify other settings:
 
-- **Start Docker Desktop when you log in**. Select to automatically start Docker
+- **Start Docker Desktop when you sign in**. Select to automatically start Docker
   Desktop when you sign in to your machine.
 
-- **Choose Theme for Docker Desktop**. Choose whether you want to apply a **Light** or **Dark** theme to Docker Desktop. Alternatively you can set Docker Desktop to **Use System Settings**.
+- **Open Docker Dashboard when Docker Desktop starts**. Select to automatically open the
+  dashboard when starting Docker Desktop.
 
-- **Use integrated container terminal**. Select to execute commands in a running container straight from the Docker Dashboard. For more information, see [Explore containers](../use-desktop/container.md).
+- **Choose theme for Docker Desktop**. Choose whether you want to apply a **Light** or **Dark** theme to Docker Desktop. Alternatively you can set Docker Desktop to **Use System Settings**.
+
+- **Choose container terminal**. Determines which terminal is launched when opening the terminal from a container.
+If you choose the integrated terminal, you can run commands in a running container straight from the Docker Dashboard. For more information, see [Explore containers](../use-desktop/container.md).
 
 - **Expose daemon on tcp://localhost:2375 without TLS**. Check this option to
   enable legacy clients to connect to the Docker daemon. You must use this option
@@ -42,9 +46,6 @@ On the **General** tab, you can configure when to start Docker and specify other
 
 - **Show weekly tips**. Select to display useful advice and suggestions about
   using Docker.
-
-- **Open Docker Desktop dashboard at startup**. Select to automatically open the
-  dashboard when starting Docker Desktop.
 
 - **Use Enhanced Container Isolation**. Select to enhance security by preventing containers from breaching the Linux VM. For more information, see [Enhanced Container Isolation](../hardened-desktop/enhanced-container-isolation/index.md)
     >**Note**

--- a/content/desktop/use-desktop/builds.md
+++ b/content/desktop/use-desktop/builds.md
@@ -1,5 +1,5 @@
 ---
-title: Explore Builds (Beta)
+title: Explore Builds
 description: Understand how to use the Builds view in Docker Desktop
 keywords: Docker Dashboard, manage, gui, dashboard, builders, builds
 ---

--- a/data/toc.yaml
+++ b/data/toc.yaml
@@ -1255,6 +1255,8 @@ Manuals:
           title: Manage non-Marketplace extensions
         - path: /desktop/extensions/settings-feedback/
           title: Change settings and give feedback
+        - path: /desktop/extensions/private-marketplace/
+          title: Configure a private marketplace (Beta)
     - sectiontitle: Extensions SDK
       section:
         - path: /desktop/extensions-sdk/

--- a/data/toc.yaml
+++ b/data/toc.yaml
@@ -1141,7 +1141,7 @@ Manuals:
         - path: /desktop/use-desktop/volumes/
           title: Explore Volumes
         - path: /desktop/use-desktop/builds/
-          title: Explore Builds (Beta)
+          title: Explore Builds 
         - path: /desktop/use-desktop/resource-saver/
           title: Resource Saver mode
         - path: /desktop/use-desktop/pause/


### PR DESCRIPTION
This PR adds all of the content updates for DD 4.26:

- Admins can set experimental and beta tabs on or off with Settings Management (Desktop Stability)
- minor reordering and rewording of settings (Desktop Stability)

- extension private marketplace visibility in toc (Publisher)

- kernelUDP setting (POS)
- Add admin setting for blocking 'docker load' (POS)

- Removes beta label from the 'Explore Builds' content
