### PR TITLE
poc: scalar api reference

### DIFF
--- a/_vendor/github.com/moby/moby/docs/api/v1.43.yaml
+++ b/_vendor/github.com/moby/moby/docs/api/v1.43.yaml
@@ -9,17 +9,10 @@
 # - There is no maximum line length, for ease of editing and pretty diffs.
 # - operationIds are in the format "NounVerb", with a singular noun.
 
-swagger: "2.0"
-schemes:
-  - "http"
-  - "https"
-produces:
-  - "application/json"
-  - "text/plain"
-consumes:
-  - "application/json"
-  - "text/plain"
-basePath: "/v1.43"
+openapi: 3.0.0
+servers:
+  - url: http://localhost/v1.43
+
 info:
   title: "Docker Engine API"
   version: "1.43"

--- a/layouts/_default/engine-api-baseof.html
+++ b/layouts/_default/engine-api-baseof.html
@@ -1,38 +1,25 @@
 <!DOCTYPE html>
 <html lang="en">
-
-<head>
+  <head>
     <title>Docker Engine API {{ .File.BaseFileName }} Reference</title>
-    <!-- needed for adaptive design -->
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <meta name="description"
-        content="Reference documentation and Swagger (OpenAPI) specification for the {{ .File.BaseFileName }} version of the API served by Docker Engine." />
     <meta charset="utf-8" />
-    <!-- favicon -->
-    <meta name="msapplication-TileImage" content="{{ site.BaseURL }}/assets/favicons/docs@2x.ico" />
-    <meta property="og:image" content="{{ site.BaseURL }}/assets/favicons/docs@2x.ico" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1" />
     <link rel="apple-touch-icon" type="image/x-icon" href="{{ site.BaseURL }}/assets/favicons/docs@2x.ico"
         sizes="129x128" />
     <link rel="icon" type="image/x-icon" href="{{ site.BaseURL }}/assets/favicons/docs@2x.ico" sizes="129x128" />
-    <!-- make the latest API version the canonical page as that's what we want users to be using mostly -->
-    <link rel="canonical" href="{{ site.BaseURL }}/engine/api/v{{ site.Params.latest_engine_api_version }}/" />
     <style>
-        body {
-            margin: 0;
-            padding: 0;
-        }
-
-        .menu-content>div:first-child {
-            background-color: #086dd7;
-            padding: 16px;
-        }
+      body {
+        margin: 0;
+      }
     </style>
-</head>
-
-<body>
-    <redoc spec-url="/reference/engine/{{ .File.BaseFileName }}.yaml" hide-hostname="true" suppress-warnings="true"
-        lazy-rendering></redoc>
-    <script src="https://cdn.redoc.ly/redoc/latest/bundles/redoc.standalone.js"></script>
-</body>
-
+  </head>
+  <body>
+    <script
+      id="api-reference"
+      data-url="/reference/engine/{{ .File.BaseFileName }}.yaml"
+      data-proxy-url="https://api.scalar.com/request-proxy"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@scalar/api-reference"></script>
+  </body>
 </html>


### PR DESCRIPTION
Trying out an alternative api reference template for rendering openapi
specs

Signed-off-by: David Karlsson <35727626+dvdksn@users.noreply.github.com>

@netlify /engine/api/v1.43/
