### PR TITLE
Update buildx setup instructions to use `install: true`

### DIFF
--- a/content/build/hydrobuild.md
+++ b/content/build/hydrobuild.md
@@ -236,6 +236,7 @@ jobs:
           version: "lab:latest"
           driver: cloud
           endpoint: "<ORG>/default"
+          install: true
       - name: Build and push
         uses: docker/build-push-action@v5
         with:


### PR DESCRIPTION
### Proposed changes

Currently, `install` defaults to false.

Setting `install` to true makes `docker build` use the new builder. I think this is probably the behavior most people want.

