### PR TITLE
update dotnet guide

### DIFF
--- a/content/language/dotnet/develop.md
+++ b/content/language/dotnet/develop.md
@@ -182,15 +182,35 @@ cb36e310aa7e   docker-dotnet-server   "dotnet myWebApp.dll"    About a minute ag
 39fdcf0aff7b   postgres               "docker-entrypoint.s…"   About a minute ago   Up About a minute (healthy)   5432/tcp               docker-dotnet-db-1
 ```
 
-In the previous example, the container ID is `39fdcf0aff7b`. Run the following command to run the `psql` command inside your database container and insert a record into the database. Replace the container ID with your own container ID.
+In the previous example, the container ID is `39fdcf0aff7b`. Run the following command to start a bash shell in the postgres container. Replace the container ID with your own container ID.
 
 ```console
-$ docker exec 39fdcf0aff7b psql -d example -U postgres -c "INSERT INTO \"Students\" (\"ID\", \"LastName\", \"FirstMidName\", \"EnrollmentDate\") VALUES (DEFAULT, 'Whale', 'Moby', '2013-03-20');"
+$ docker exec -it 39fdcf0aff7b bash
 ```
+
+Then run the following command to connect to the database.
+
+```console
+postgres@39fdcf0aff7b:/$ psql -d example -U postgres
+```
+
+And finally, insert a record into the database.
+
+```console
+example=# INSERT INTO "Students" ("ID", "LastName", "FirstMidName", "EnrollmentDate") VALUES (DEFAULT, 'Whale', 'Moby', '2013-03-20');
+```
+
 You should see output like the following.
 
 ```console
 INSERT 0 1
+```
+
+Exit the container shell by running `exit` twice.
+
+```console
+example=# exit
+postgres@39fdcf0aff7b:/$ exit
 ```
 
 ## Verify that data persists in the database

--- a/content/language/dotnet/develop.md
+++ b/content/language/dotnet/develop.md
@@ -206,7 +206,7 @@ You should see output like the following.
 INSERT 0 1
 ```
 
-Exit the container shell by running `exit` twice.
+Close the database connection and exit the container shell by running `exit` twice.
 
 ```console
 example=# exit


### PR DESCRIPTION
### Proposed changes

Update the `docker exec` command in the .net guide to use an interactive shell.

A user reported that the escaped double quotes (`\"`) may not work on some terminals.
The escaped double double quotes (`\""`) seem to be the more robust solution that works on more terminals.
The command is already pretty gnarly and gets worse with the escaped double double quotes. Breaking it down and running it in an interactive shell seems like a good workaround to simplify it, although not copy-paste friendly if showing the prompt states.
 
### Related issues (optional)
ENGDOCS-1807

https://deploy-preview-18810--docsdocker.netlify.app/language/dotnet/develop/#add-records-to-the-database
