### PR TITLE
Clarify adding collaborator permissions

### DIFF
--- a/content/docker-hub/repos/access.md
+++ b/content/docker-hub/repos/access.md
@@ -18,7 +18,7 @@ repository from that repository's **Settings** page.
 > **Note**
 >
 > A collaborator can't add other collaborators. Only the owner of
-> the repository has administrative access.
+> the repository has administrative access. Also, organizations can't add collaborators. Organization owners can control repository access with member roles and teams. See [Roles and permissions](../../security/for-admins/roles-and-permissions.md).
 
 You can also assign more granular collaborator rights ("Read", "Write", or
 "Admin") on Docker Hub by using organizations and teams. For more information

--- a/content/docker-hub/repos/access.md
+++ b/content/docker-hub/repos/access.md
@@ -18,7 +18,7 @@ repository from that repository's **Settings** page.
 > **Note**
 >
 > A collaborator can't add other collaborators. Only the owner of
-> the repository has administrative access. Also, organizations can't add collaborators. Organization owners can control repository access with member roles and teams. See [Roles and permissions](../../security/for-admins/roles-and-permissions.md).
+> the repository has administrative access. Also, you can't add collaborators to organization repositories. Organization owners can control repository access with member roles and teams. See [Roles and permissions](../../security/for-admins/roles-and-permissions.md).
 
 You can also assign more granular collaborator rights ("Read", "Write", or
 "Admin") on Docker Hub by using organizations and teams. For more information


### PR DESCRIPTION
<!--
  Thank you for contributing to Docker documentation!

  Here are a few things to keep in mind:

  - Links between pages should use a relative path
  - Remember to add an alt text for images

  ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
  ┃     Review our contribution guidelines:       ┃
  ┃                                               ┃
  ┃ https://docs.docker.com/contribute/overview/  ┃
  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
-->

### Proposed changes

<!-- Tell us what you did and why -->

This PR clarifies that orgs can't add collaborators to repos, but can grant access with teams and roles instead.

### Related issues (optional)

<!--
  Refer to related PRs or issues:

  #1234
  Closes #1234
  Closes docker/cli#1234
-->
Closes JIRA: https://docker.atlassian.net/browse/ENGDOCS-1888