### PR TITLE
fix: missing single quote for jq command

### DIFF
--- a/content/build/drivers/remote.md
+++ b/content/build/drivers/remote.md
@@ -188,7 +188,7 @@ through the Kubernetes API. Note that this method only connects to a single pod
 in the deployment.
 
 ```console
-$ kubectl get pods --selector=app=buildkitd -o json | jq -r '.items[].metadata.name
+$ kubectl get pods --selector=app=buildkitd -o json | jq -r '.items[].metadata.name'
 buildkitd-XXXXXXXXXX-xxxxx
 $ docker buildx create \
   --name remote-container \


### PR DESCRIPTION
Signed-off-by: David Karlsson <35727626+dvdksn@users.noreply.github.com>

<!--
  Thank you for contributing to Docker documentation!

  Here are a few things to keep in mind:

  - Links between pages should use a relative path
  - Remember to add an alt text for images

  ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
  ┃     Review our contribution guidelines:       ┃
  ┃                                               ┃
  ┃ https://docs.docker.com/contribute/overview/  ┃
  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
-->

### Proposed changes

<!-- Tell us what you did and why -->

### Related issues (optional)

<!--
  Refer to related PRs or issues:

  #1234
  Closes #1234
  Closes docker/cli#1234
-->
