### PR TITLE
build: remove beta callouts for builds view

### DIFF
--- a/content/build/builders/_index.md
+++ b/content/build/builders/_index.md
@@ -1,7 +1,7 @@
 ---
 title: Builders
 keywords: build, buildx, builders, buildkit, drivers, backend
-description: null
+description: Learn about builders and how to manage them
 ---
 
 A builder is a BuildKit daemon that you can use to run your builds. BuildKit
@@ -10,13 +10,6 @@ container image or other artifacts.
 
 You can create and manage builders, inspect them, and even connect to builders
 running remotely. You interact with builders using the Docker CLI.
-
-> **Builds in Docker Desktop**
->
-> The [Docker Desktop Builds view](../../desktop/use-desktop/builds.md)
-> is a [Beta](../../release-lifecycle.md#beta) feature that lets you
-> view and manage builders using Docker Desktop.
-{ .experimental }
 
 ## Default builder
 

--- a/content/desktop/use-desktop/_index.md
+++ b/content/desktop/use-desktop/_index.md
@@ -22,7 +22,7 @@ The **Learning center** view helps you get started with quick in-app walkthrough
 For a more detailed guide about getting started, see
 [Get started](../../get-started/index.md).
 
-The **Builds** view, currently in beta, lets you inspect your build history and manage builders. By default, it displays a list of all your ongoing and completed builds. [Explore builds](builds.md).
+The **Builds** view lets you inspect your build history and manage builders. By default, it displays a list of all your ongoing and completed builds. [Explore builds](builds.md).
 
 In addition, the Docker Dashboard allows you to:
 

--- a/content/desktop/use-desktop/builds.md
+++ b/content/desktop/use-desktop/builds.md
@@ -10,22 +10,6 @@ The **Builds** view is a simple interface that lets you inspect your build
 history and manage builders using Docker Desktop. By default, it
 displays a list of all your ongoing and completed builds.
 
-> **Beta feature**
->
-> The **Builds** view is currently in [Beta](../../release-lifecycle.md/#beta).
-> This feature may change or be removed from future releases.
-{ .experimental }
-
-## Turn on the Builds view
-
-1. Navigate to **Settings**.
-2. Select **Features in development**.
-3. In the **Beta features** tab, select the **Display Builds view** checkbox.
-4. Select **Apply & restart** for the changes to take effect.
-
-After the restart, the **Builds** view and the **Builders** settings menu
-appear.
-
 ## Show build list
 
 Select the **Builds** view in the Docker Dashboard to open the build list.


### PR DESCRIPTION
Signed-off-by: David Karlsson <35727626+dvdksn@users.noreply.github.com>

These beta callouts had been overlooked for the GA release of the builds view in Docker Desktop
