### PR TITLE
css: improve table display

### DIFF
--- a/assets/css/tables.css
+++ b/assets/css/tables.css
@@ -1,5 +1,5 @@
 .prose table {
-  @apply block overflow-x-auto text-base;
+  @apply table w-full text-base sm:block overflow-x-auto;
   thead tr {
     @apply bg-gray-light-300 dark:bg-gray-dark-300
   }


### PR DESCRIPTION
- Use full reading col width for tables on large screens
- Use `display: block; overflow-x: scroll;` on small screens

Signed-off-by: David Karlsson <35727626+dvdksn@users.noreply.github.com>

## Before
<img width="1012" alt="image" src="https://github.com/docker/docs/assets/35727626/e547a7a4-3e78-42fd-8961-a170c54426db">

## After
<img width="935" alt="image" src="https://github.com/docker/docs/assets/35727626/6a60b9bd-ee6a-49e4-9598-c64268b19723">
