### PR TITLE
get-started: remove run sample app without docker

### DIFF
--- a/content/language/dotnet/containerize.md
+++ b/content/language/dotnet/containerize.md
@@ -33,24 +33,6 @@ run the following command to clone the repository.
 $ git clone https://github.com/docker/docker-dotnet-sample
 ```
 
-## Test the simple application without Docker (optional)
-
-You can test the sample application locally without Docker before you continue
-building and running the application with Docker. This section requires you to
-have the .NET SDK version 6.0 installed on your machine. Download and install
-[.NET 6.0 SDK](https://dotnet.microsoft.com/download).
-
-Open a terminal, change directory to the `docker-dotnet-sample/src` directory,
-and run the following command.
-
-```console
-$ dotnet run --urls http://localhost:5000
-```
-
-Open a browser and view the application at [http://localhost:5000](http://localhost:5000). You should see a simple web application.
-
-In the terminal, press `ctrl`+`c` to stop the application.
-
 ## Initialize Docker assets
 
 Now that you have an application, you can use `docker init` to create the

--- a/content/language/golang/build-images.md
+++ b/content/language/golang/build-images.md
@@ -17,7 +17,6 @@ application.
 
 To complete this tutorial, you need the following:
 
-- Go version 1.19 or later. Visit the [download page for Go](https://golang.org/dl/) first and install the toolchain.
 - Docker running locally. Follow the [instructions to download and install Docker](../../desktop/index.md).
 - An IDE or a text editor to edit files. [Visual Studio Code](https://code.visualstudio.com/) is a free and popular choice but you can use anything you feel comfortable with.
 - A Git client. This guide uses a command-line based `git` client, but you are free to use whatever works for you.
@@ -92,44 +91,6 @@ func IntMin(a, b int) int {
 	return b
 }
 ```
-
-## Smoke test the application
-
-Start your application and make sure it’s running. Open your
-terminal and navigate to the directory into which you cloned the project's repository.
-From now on, this guide will refer to this directory as the **project directory**.
-
-```console
-$ go run main.go
-```
-
-This should compile and start the server as a foreground application, outputting
-the banner, as illustrated in the following figure.
-
-```text
-   ____    __
-  / __/___/ /  ___
- / _// __/ _ \/ _ \
-/___/\__/_//_/\___/ v4.10.2
-High performance, minimalist Go web framework
-https://echo.labstack.com
-____________________________________O/_______
-                                    O\
-⇨ http server started on [::]:8080
-```
-
-Run a quick smoke test by accessing the application on `http://localhost:8080`. 
-You can use your favourite web browser, or even a `curl` command in the terminal:
-
-```console
-$ curl http://localhost:8080/
-Hello, Docker! <3
-```
-
-This verifies that the application builds locally and you can start it without an error.
-That's a milestone to celebrate!
-
-Now you're ready to containerize it.
 
 ## Create a Dockerfile for the application
 

--- a/content/language/java/build-images.md
+++ b/content/language/java/build-images.md
@@ -31,44 +31,6 @@ $ git clone https://github.com/spring-projects/spring-petclinic.git
 $ cd spring-petclinic
 ```
 
-## Test the application without Docker (optional)
-
-In this step, you'll test the application locally without Docker, before you
-continue with building and running the application with Docker. This section
-requires you to have Java OpenJDK version 15 or later installed on your machine.
-[Download and install Java](https://jdk.java.net/)
-
-If you prefer to not install Java on your machine, you can skip this step, and
-continue straight to the next section, in which you'll build and run the
-application in Docker. Building or running the application in Docker doesn't
-require you to have Java installed on your machine.
-
-Start your application and make sure it's running. Maven will manage all the project processes (compiling, tests, packaging, etc). The **Spring Pets Clinic** project you cloned earlier contains an embedded version of Maven. Therefore, you don't need to install Maven on your local machine.
-
-Open your terminal and navigate to the working directory you created and run the following command:
-
-```console
-$ ./mvnw spring-boot:run
-```
-
-This downloads the dependencies, builds the project, and starts it.
-
-To test that the application is working, open a new browser and navigate to `http://localhost:8080`.
-
-Switch back to the terminal where your server is running and you should see the following requests in the server logs. The data will be different on your machine.
-
-```console
-o.s.s.petclinic.PetClinicApplication     : Started
-PetClinicApplication in 11.743 seconds (JVM running for 12.364)
-```
-
-Great! You verified that the application works. At this stage, you've completed
-testing the server script locally.
-
-Press `CTRL-c` from within the terminal session where the server is running to stop it.
-
-You'll now continue to build and run the application in Docker.
-
 ## Create a Dockerfile for Java
 
 Create a file named `Dockerfile` in the root of your project folder.

--- a/content/language/nodejs/containerize.md
+++ b/content/language/nodejs/containerize.md
@@ -30,31 +30,6 @@ to clone the repository:
 $ git clone https://github.com/docker/docker-nodejs-sample
 ```
 
-## Test the application without Docker (optional)
-
-You can test the application locally without Docker before you continue building
-and running the application with Docker. This section requires you to have
-Node.js 18 installed on your machine. Download and install
-[Node.js](https://nodejs.org/).
-
-Open a terminal, change directory to the `docker-nodejs-sample` directory, and
-run the following command to install the packages.
-
-```console
-$ npm install
-```
-
-When the packages have finished installing, run the following command to start
-the application.
-
-```console
-$ node src/index.js
-```
-
-Open a browser and view the application at [http://localhost:3000](http://localhost:3000). You should see a simple todo application.
-
-In the terminal, press `ctrl`+`c` to stop the application.
-
 ## Initialize Docker assets
 
 Now that you have an application, you can use `docker init` to create the

--- a/content/language/python/containerize.md
+++ b/content/language/python/containerize.md
@@ -26,28 +26,6 @@ Clone the sample application to use with this guide. Open a terminal, change dir
 $ git clone https://github.com/docker/python-docker
 ```
 
-## Test the application without Docker (optional)
-
-You can test the application locally without Docker before you continue building and running the application with Docker. This section requires you to have Python 3.11 or later installed on your machine. Download and install [Python](https://www.python.org/downloads/).
-
-Open your terminal and navigate to the working directory you created. Create an environment, install the dependencies, and start the application to make sure it’s running.
-
-```console
-$ cd /path/to/python-docker
-$ python3 -m venv .venv
-$ source .venv/bin/activate
-(.venv) $ python3 -m pip install -r requirements.txt
-(.venv) $ python3 -m flask run
-```
-
-To test that the application is working, open a new browser and navigate to `http://localhost:5000`.
-
-Switch back to the terminal where the server is running and you should see the following requests in the server logs. The data and timestamp will be different on your machine.
-
-```shell
-127.0.0.1 - - [22/Sep/2020 11:07:41] "GET / HTTP/1.1" 200 -
-```
-
 ## Initialize Docker assets
 
 Now that you have an application, you can use `docker init` to create the necessary Docker assets to containerize your application. Inside the `python-docker` directory, run the `docker init` command. Refer to the following example to answer the prompts from `docker init`.

--- a/content/language/rust/build-images.md
+++ b/content/language/rust/build-images.md
@@ -23,33 +23,6 @@ Clone the sample application to use with this guide. Open a terminal, change dir
 $ git clone https://github.com/docker/docker-rust-hello
 ```
 
-## Test the application without Docker (optional)
-You can test the application locally without Docker before you continue building and running the application with Docker. This section requires you to have Rust 1.70.0 or later installed on your machine. Download and install [Rust](https://www.rust-lang.org/tools/install).
-
-Open a terminal, change directory to the `docker-rust-hello` directory, and run the following command to run the application:
-
-```console
-$ cargo run
-```
-
-When the application has completed compiling, you should see a line similar to the following:
-
-```console
-Rocket has launched from http://127.0.0.1:8000
-```
-
-Open a new terminal and curl the application.
-
-```console
-$ curl http://localhost:8000
-```
-
-You should see output similar to the following.
-
-```console
-Hello, Docker!
-```
-
 ## Create a Dockerfile for Rust
 
 Now that you have an application, you can use `docker init` to create a Dockerfile for it. Inside the `docker-rust-hello` directory, run the `docker init` command. Refer to the following example to answer the prompts from `docker init`.


### PR DESCRIPTION
### Proposed changes

Remove the optional sections that ask the user to run sample apps without Docker.

Some users may install the tools without realizing they have another version installed, or not realize that it may cause issues to have multiple versions installed. We could put a big warning, but the section is already optional and I think it doesn't really add much value. 

### Related issues (optional)

ENGDOCS-1897
Closes #18689
