### PR TITLE
doc: comment about async behavior of cli.ImagePull

### DIFF
--- a/content/engine/api/sdk/examples.md
+++ b/content/engine/api/sdk/examples.md
@@ -59,8 +59,9 @@ func main() {
 	}
 
 	defer reader.Close()
-	// cli.ImagePull is asynchronous. The reader needs to be read completely for the pull operation to complete.
-	// If you are not interested in copying to stdout, consider using io.Discard instead of os.Stdout.
+	// cli.ImagePull is asynchronous.
+	// The reader needs to be read completely for the pull operation to complete.
+	// If stdout is not required, consider using io.Discard instead of os.Stdout.
 	io.Copy(os.Stdout, reader)
 
 	resp, err := cli.ContainerCreate(ctx, &container.Config{

--- a/content/engine/api/sdk/examples.md
+++ b/content/engine/api/sdk/examples.md
@@ -59,6 +59,8 @@ func main() {
 	}
 
 	defer reader.Close()
+	// cli.ImagePull is asynchronous. The reader needs to be read completely for the pull operation to complete.
+	// If you are not interested in copying to stdout, consider using io.Discard instead of os.Stdout.
 	io.Copy(os.Stdout, reader)
 
 	resp, err := cli.ContainerCreate(ctx, &container.Config{


### PR DESCRIPTION

<!--
  Thank you for contributing to Docker documentation!

  Here are a few things to keep in mind:

  - Links between pages should use a relative path
  - Remember to add an alt text for images

  ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
  ┃     Review our contribution guidelines:       ┃
  ┃                                               ┃
  ┃ https://docs.docker.com/contribute/overview/  ┃
  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
-->

### Proposed changes

Updated the example for `cli.ImagePull`. This is to educate about the behavior described in this [issue](https://github.com/moby/moby/issues/28646).

### Related issues (optional)
https://github.com/moby/moby/issues/28646
<!--
  Refer to related PRs or issues:

  #1234
  Closes #1234
  Closes docker/cli#1234
-->
