### PR TITLE
a11y: add aria-hidden to external link icons

### DIFF
--- a/layouts/_default/_markup/render-link.html
+++ b/layouts/_default/_markup/render-link.html
@@ -7,6 +7,7 @@
     target="_blank"
     rel="noopener"
     >{{ .Text | safeHTML }}<span
+      aria-hidden
       class="select-none ml-1 align-top text-[1em] material-symbols-rounded"
       >open_in_new</span
     ></a

--- a/layouts/partials/github-links.html
+++ b/layouts/partials/github-links.html
@@ -5,7 +5,7 @@
   <span class="material-symbols-rounded">edit</span>
   <a class="link" target="_blank" rel="noopener"
     href="{{ site.Params.repo }}/edit/main/content/{{ .Path }}">{{ T "editPage" }}
-    <span class="material-symbols-rounded align-middle text-base">open_in_new</span>
+    <span aria-hidden class="material-symbols-rounded select-none align-middle text-base">open_in_new</span>
   </a>
 </p>
 {{ end }}
@@ -14,7 +14,7 @@
   <span class="material-symbols-rounded">done</span>
   <a class="link" target="_blank" rel="noopener"
     href="{{ site.Params.repo }}/issues/new?template=doc_issue.yml&location={{ .Permalink }}&labels=status%2Ftriage">{{ T "requestChanges" }}
-    <span class="material-symbols-rounded align-middle text-base">open_in_new</span>
+    <span aria-hidden class="material-symbols-rounded select-none align-middle text-base">open_in_new</span>
   </a>
 </p>
 {{ end }}


### PR DESCRIPTION
Signed-off-by: David Karlsson <35727626+dvdksn@users.noreply.github.com>

Fixes `open_in_new` icon ligature text appearing in e.g. search results

ENGDOCS-1900
