### PR TITLE
get-started: add walkthrough landing redirect

### DIFF
--- a/content/guides/get-started/_index.md
+++ b/content/guides/get-started/_index.md
@@ -2,6 +2,8 @@
 title: Overview of get started
 keywords: get started, quick start, intro, concepts
 description: Learn how to get started with Docker and Docker Desktop
+aliases:
+- /guides/walkthroughs/
 
 grid:
   - title: "What is a container?"


### PR DESCRIPTION

### Proposed changes

Add a redirect for /guides/walkthroughs/ to /guides/get-started/.

Previously removed the walkthroughs' landing page to use /guides/get-started/ instead, but didn't add a redirect.

### Related issues (optional)

Fixes #18890 
