### PR TITLE
Update nvidia/cuda image tag

### DIFF
--- a/content/compose/gpu-support.md
+++ b/content/compose/gpu-support.md
@@ -36,7 +36,7 @@ For more information on these properties, see the `deploy` section in the [Compo
 ```yaml
 services:
   test:
-    image: nvidia/cuda:10.2-base
+    image: nvidia/cuda:12.3.1-base-ubuntu20.04
     command: nvidia-smi
     deploy:
       resources:


### PR DESCRIPTION


<!--
  Thank you for contributing to Docker documentation!

  Here are a few things to keep in mind:

  - Links between pages should use a relative path
  - Remember to add an alt text for images

  ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
  ┃     Review our contribution guidelines:       ┃
  ┃                                               ┃
  ┃ https://docs.docker.com/contribute/overview/  ┃
  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
-->

### Proposed changes

<!-- Tell us what you did and why -->

Image tag `10.2-base` is no longer present in the image registry so it should be replaced by a newer image tag which is present in the image registry

### Related issues (optional)

<!--
  Refer to related PRs or issues:

  #1234
  Closes #1234
  Closes docker/cli#1234
-->
