### PR TITLE
Dockerfile: fix duplicate WORKDIR, and source COPY for update-modules…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,8 +48,6 @@ RUN htmltest
 
 FROM build-base as update-modules
 ARG MODULE="-u"
-WORKDIR /src
-COPY . .
 RUN hugo mod get ${MODULE}
 RUN hugo mod vendor
 


### PR DESCRIPTION
… stage

I noticed that building the "vendor" target was copying the source twice; once in the "build-base" stage, and once in the "update-modules" stage:

    docker buildx bake --set vendor.args.MODULE=github.com/docker/cli vendor
    ...
    => [build-base 1/3] COPY --from=hugo /go/bin/hugo /bin/hugo                 0.2s
    => [build-base 2/3] COPY --from=node /src/node_modules /src/node_modules    1.6s
    => [build-base 3/3] COPY . .                                                3.1s
    => [update-modules 1/4] WORKDIR /src                                        0.0s
    => [update-modules 2/4] COPY . .                                            5.0s
    => [update-modules 3/4] RUN hugo mod get -u                                14.1s
    => [update-modules 4/4] RUN hugo mod vendor                                17.3s

<!--
  Thank you for contributing to Docker documentation!

  Here are a few things to keep in mind:

  - Links between pages should use a relative path
  - Remember to add an alt text for images

  ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
  ┃     Review our contribution guidelines:       ┃
  ┃                                               ┃
  ┃ https://docs.docker.com/contribute/overview/  ┃
  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
-->

### Proposed changes

<!-- Tell us what you did and why -->

### Related issues (optional)

<!--
  Refer to related PRs or issues:

  #1234
  Closes #1234
  Closes docker/cli#1234
-->
