### PR TITLE
hugo: handle multiline flag descriptions

### DIFF
--- a/layouts/_default/cli.html
+++ b/layouts/_default/cli.html
@@ -113,7 +113,8 @@
                   {{ partial "components/badge.html" (dict "color" "blue" "content" "Swarm") }}
                 {{ end }}
                 {{ if .description }}
-                  {{ $.RenderString .description }}
+                  {{/* replace newlines in long desc with break tags */}}
+                  {{ markdownify (strings.Replace .description "\n" "<br>") }}
                 {{ end }}
               </td>
             </tr>


### PR DESCRIPTION
Signed-off-by: David Karlsson <35727626+dvdksn@users.noreply.github.com>

<!--
  Thank you for contributing to Docker documentation!

  Here are a few things to keep in mind:

  - Links between pages should use a relative path
  - Remember to add an alt text for images

  ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
  ┃     Review our contribution guidelines:       ┃
  ┃                                               ┃
  ┃ https://docs.docker.com/contribute/overview/  ┃
  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
-->

### Proposed changes

Some flag descriptions are multi-line. THe cli-docs-tool replaces newlines with <br> tags. This change does the same

I don't love it

#### Before
<img width="814" alt="image" src="https://github.com/docker/docs/assets/35727626/4c9a97ac-6c69-447f-97bc-e5be0e55092c">

#### After
<img width="814" alt="image" src="https://github.com/docker/docs/assets/35727626/d1c9b587-29e1-4b8e-8271-909e9687b97e">
