### PR TITLE
Fix permission for Scout GHA

### DIFF
--- a/content/scout/integrations/ci/gha.md
+++ b/content/scout/integrations/ci/gha.md
@@ -52,7 +52,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     permissions:
-      pull_request: write
+      pull-requests: write
 
 steps:
   - name: Checkout repository


### PR DESCRIPTION
The permission needed to allow Scout to write back to the PR was incorrect (docs here - https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs)

### Proposed changes

Fixed the permission name
