### PR TITLE
fix: broken link to build cloud subscription

### DIFF
--- a/content/build/cloud/_index.md
+++ b/content/build/cloud/_index.md
@@ -60,7 +60,7 @@ Once you've signed up and created a builder, continue by [setting up the
 builder in your local environment](./setup.md).
 
 For more information about the available subscription plans, see [Docker Build Cloud
-subscriptions and features](/subscriptions/build-details).
+subscriptions and features](../../subscription/build-details.md).
 
 ## Frequently asked questions
 


### PR DESCRIPTION
Signed-off-by: David Karlsson <35727626+dvdksn@users.noreply.github.com>

<!--
  Thank you for contributing to Docker documentation!

  Here are a few things to keep in mind:

  - Links between pages should use a relative path
  - Remember to add an alt text for images

  ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
  ┃     Review our contribution guidelines:       ┃
  ┃                                               ┃
  ┃ https://docs.docker.com/contribute/overview/  ┃
  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
-->

### Proposed changes

<!-- Tell us what you did and why -->

### Related issues (optional)

<!--
  Refer to related PRs or issues:

  #1234
  Closes #1234
  Closes docker/cli#1234
-->
