### PR TITLE
desktop: add support for host networking

### DIFF
--- a/content/network/drivers/host.md
+++ b/content/network/drivers/host.md
@@ -31,9 +31,6 @@ Host mode networking can be useful for the following use cases:
 
 This is because it doesn't require network address translation (NAT), and no "userland-proxy" is created for each port.
 
-The host networking driver only works on Linux hosts, and is not supported on
-Docker Desktop for Mac, Docker Desktop for Windows, or Docker EE for Windows Server.
-
 You can also use a `host` network for a swarm service, by passing `--network host`
 to the `docker service create` command. In this case, control traffic (traffic
 related to managing the swarm and the service) is still sent across an overlay

--- a/content/network/network-tutorial-host.md
+++ b/content/network/network-tutorial-host.md
@@ -19,12 +19,9 @@ host.
 
 ## Prerequisites
 
-- This procedure requires port 80 to be available on the Docker host. To make
-  Nginx listen on a different port, see the
-  [documentation for the `nginx` image](https://hub.docker.com/_/nginx/)
-
-- The `host` networking driver only works on Linux hosts, and is not supported
-  on Docker Desktop for Mac, Docker Desktop for Windows, or Docker EE for Windows Server.
+This procedure requires port 80 to be available on the Docker host. To make
+Nginx listen on a different port, see the
+[documentation for the `nginx` image](https://hub.docker.com/_/nginx/)
 
 ## Procedure
 


### PR DESCRIPTION
### Proposed changes

The `host` networking driver will be supported in Docker Desktop from version 4.27
