### PR TITLE
cli: use the new add-host separator

### DIFF
--- a/content/config/daemon/prometheus.md
+++ b/content/config/daemon/prometheus.md
@@ -102,7 +102,7 @@ Next, start a Prometheus container using this configuration.
 $ docker run --name my-prometheus \
     --mount type=bind,source=/tmp/prometheus.yml,destination=/etc/prometheus/prometheus.yml \
     -p 9090:9090 \
-    --add-host host.docker.internal:host-gateway \
+    --add-host host.docker.internal=host-gateway \
     prom/prometheus
 ```
 


### PR DESCRIPTION
Use the preferred `=` separator instead of `:`

(available in moby 25.0)

- relates to https://github.com/docker/cli/pull/4663
- replaces #18950

ENGDOCS-1908
