### PR TITLE
fix(docs-cache-mount): invalid go build with cache command

### DIFF
--- a/content/build/ci/github-actions/cache.md
+++ b/content/build/ci/github-actions/cache.md
@@ -156,7 +156,7 @@ COPY go.mod go.sum ./
 RUN --mount=type=cache,target=/root/.cache/go-build go mod download
 
 COPY ./src ./
-RUN --mount=type=cache,target=/root/.cache/go-build && go build -o /bin/app /build/src
+RUN --mount=type=cache,target=/root/.cache/go-build go build -o /bin/app /build/src
 ...
 ```
 


### PR DESCRIPTION
<!--
  Thank you for contributing to Docker documentation!

  Here are a few things to keep in mind:

  - Links between pages should use a relative path
  - Remember to add an alt text for images

  ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
  ┃     Review our contribution guidelines:       ┃
  ┃                                               ┃
  ┃ https://docs.docker.com/contribute/overview/  ┃
  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
-->

### Proposed changes

Wrong command of example cache mount in Dockerfile

screenshot:
![image](https://github.com/docker/docs/assets/12433101/43f8f8e4-dc65-4cec-9129-d27edfaae10e)
