### PR TITLE
Fix typo: /Volume -> /Volumes

### DIFF
--- a/content/desktop/settings/mac.md
+++ b/content/desktop/settings/mac.md
@@ -125,7 +125,7 @@ Use File sharing to allow local directories on your machine to be shared with
 Linux containers. This is especially useful for editing source code in an IDE on
 the host while running and testing the code in a container.
 
-By default the `/Users`, `/Volume`, `/private`, `/tmp` and `/var/folders` directory are shared.
+By default the `/Users`, `/Volumes`, `/private`, `/tmp` and `/var/folders` directory are shared.
 If your project is outside this directory then it must be added to the list,
 otherwise you may get `Mounts denied` or `cannot start service` errors at runtime.
 


### PR DESCRIPTION
### Proposed changes
The file sharing directory defaults for Mac had a typo (`/Volume` instead of `/Volumes`). This PR corrects the typo.

### Related issues (optional)
N/A