### PR TITLE
engine: restructure toc

### DIFF
--- a/data/toc.yaml
+++ b/data/toc.yaml
@@ -259,585 +259,578 @@ Guides:
 Reference:
 - path: /reference/
   title: Reference documentation
-- sectiontitle: Command-line reference
+- sectiontitle: CLI reference
   section:
-  - sectiontitle: Docker CLI (docker)
+  - path: /engine/reference/commandline/docker/
+    title: docker (base command)
+  - path: /engine/reference/commandline/attach/
+    title: docker attach
+  - path: /engine/reference/commandline/build/
+    title: docker build
+  - sectiontitle: docker builder
     section:
-    - path: /engine/reference/run/
-      title: Docker run reference
-    - path: /engine/reference/commandline/cli/
-      title: Use the Docker command line
-    - path: /engine/reference/commandline/docker/
-      title: docker (base command)
-    - path: /engine/reference/commandline/attach/
-      title: docker attach
-    - path: /engine/reference/commandline/build/
-      title: docker build
-    - sectiontitle: docker builder
-      section:
-        - path: /engine/reference/commandline/builder/
-          title: docker builder
-        - path: /engine/reference/commandline/builder_build/
-          title: docker builder build
-        - path: /engine/reference/commandline/builder_prune/
-          title: docker builder prune
-    - sectiontitle: docker buildx
-      section:
-        - path: /engine/reference/commandline/buildx/
-          title: docker buildx
-        - path: /engine/reference/commandline/buildx_bake/
-          title: docker buildx bake
-        - path: /engine/reference/commandline/buildx_build/
-          title: docker buildx build
-        - path: /engine/reference/commandline/buildx_create/
-          title: docker buildx create
-        - path: /engine/reference/commandline/buildx_debug/
-          title: docker buildx debug
-        - path: /engine/reference/commandline/buildx_debug_build/
-          title: docker buildx debug build
-        - path: /engine/reference/commandline/buildx_du/
-          title: docker buildx du
-        - path: /engine/reference/commandline/buildx_imagetools/
-          title: docker buildx imagetools
-        - path: /engine/reference/commandline/buildx_imagetools_create/
-          title: docker buildx imagetools create
-        - path: /engine/reference/commandline/buildx_imagetools_inspect/
-          title: docker buildx imagetools inspect
-        - path: /engine/reference/commandline/buildx_inspect/
-          title: docker buildx inspect
-        - path: /engine/reference/commandline/buildx_ls/
-          title: docker buildx ls
-        - path: /engine/reference/commandline/buildx_prune/
-          title: docker buildx prune
-        - path: /engine/reference/commandline/buildx_rm/
-          title: docker buildx rm
-        - path: /engine/reference/commandline/buildx_stop/
-          title: docker buildx stop
-        - path: /engine/reference/commandline/buildx_use/
-          title: docker buildx use
-        - path: /engine/reference/commandline/buildx_version/
-          title: docker buildx version
-    - sectiontitle: docker checkpoint
-      section:
-      - path: /engine/reference/commandline/checkpoint/
-        title: docker checkpoint
-      - path: /engine/reference/commandline/checkpoint_create/
-        title: docker checkpoint create
-      - path: /engine/reference/commandline/checkpoint_ls/
-        title: docker checkpoint ls
-      - path: /engine/reference/commandline/checkpoint_rm/
-        title: docker checkpoint rm
-    - path: /engine/reference/commandline/commit/
-      title: docker commit
-    - sectiontitle: docker compose
-      section:
-        - path: /compose/reference/
-          title: overview
-        - path: /compose/environment-variables/envvars/
-          title: environment variables
-        - path: /engine/reference/commandline/compose_alpha/
-          title: docker compose alpha
-        - path: /engine/reference/commandline/compose_alpha_dry-run/
-          title: docker compose alpha dry-run
-        - path: /engine/reference/commandline/compose_alpha_publish/
-          title: docker compose alpha publish
-        - path: /engine/reference/commandline/compose_alpha_scale/
-          title: docker compose alpha scale
-        - path: /engine/reference/commandline/compose_alpha_viz/
-          title: docker compose alpha viz
-        - path: /engine/reference/commandline/compose/
-          title: docker compose
-        - path: /engine/reference/commandline/compose_build/
-          title: docker compose build
-        - path: /engine/reference/commandline/compose_config/
-          title: docker compose config
-        - path: /engine/reference/commandline/compose_cp/
-          title: docker compose cp
-        - path: /engine/reference/commandline/compose_create/
-          title: docker compose create
-        - path: /engine/reference/commandline/compose_down/
-          title: docker compose down
-        - path: /engine/reference/commandline/compose_events/
-          title: docker compose events
-        - path: /engine/reference/commandline/compose_exec/
-          title: docker compose exec
-        - path: /engine/reference/commandline/compose_images/
-          title: docker compose images
-        - path: /engine/reference/commandline/compose_kill/
-          title: docker compose kill
-        - path: /engine/reference/commandline/compose_logs/
-          title: docker compose logs
-        - path: /engine/reference/commandline/compose_ls/
-          title: docker compose ls
-        - path: /engine/reference/commandline/compose_pause/
-          title: docker compose pause
-        - path: /engine/reference/commandline/compose_port/
-          title: docker compose port
-        - path: /engine/reference/commandline/compose_ps/
-          title: docker compose ps
-        - path: /engine/reference/commandline/compose_pull/
-          title: docker compose pull
-        - path: /engine/reference/commandline/compose_push/
-          title: docker compose push
-        - path: /engine/reference/commandline/compose_restart/
-          title: docker compose restart
-        - path: /engine/reference/commandline/compose_rm/
-          title: docker compose rm
-        - path: /engine/reference/commandline/compose_run/
-          title: docker compose run
-        - path: /engine/reference/commandline/compose_start/
-          title: docker compose start
-        - path: /engine/reference/commandline/compose_stop/
-          title: docker compose stop
-        - path: /engine/reference/commandline/compose_top/
-          title: docker compose top
-        - path: /engine/reference/commandline/compose_unpause/
-          title: docker compose unpause
-        - path: /engine/reference/commandline/compose_up/
-          title: docker compose up
-        - path: /engine/reference/commandline/compose_version/
-          title: docker compose version
-        - path: /engine/reference/commandline/compose_wait/
-          title: docker compose wait
-        - path: /engine/reference/commandline/compose_watch/
-          title: docker compose watch
-    - sectiontitle: docker config
-      section:
-      - path: /engine/reference/commandline/config/
-        title: docker config
-      - path: /engine/reference/commandline/config_create/
-        title: docker config create
-      - path: /engine/reference/commandline/config_inspect/
-        title: docker config inspect
-      - path: /engine/reference/commandline/config_ls/
-        title: docker config ls
-      - path: /engine/reference/commandline/config_rm/
-        title: docker config rm
-    - sectiontitle: docker container
-      section:
-      - path: /engine/reference/commandline/container/
-        title: docker container
-      - path: /engine/reference/commandline/container_attach/
-        title: docker container attach
-      - path: /engine/reference/commandline/container_commit/
-        title: docker container commit
-      - path: /engine/reference/commandline/container_cp/
-        title: docker container cp
-      - path: /engine/reference/commandline/container_create/
-        title: docker container create
-      - path: /engine/reference/commandline/container_diff/
-        title: docker container diff
-      - path: /engine/reference/commandline/container_exec/
-        title: docker container exec
-      - path: /engine/reference/commandline/container_export/
-        title: docker container export
-      - path: /engine/reference/commandline/container_inspect/
-        title: docker container inspect
-      - path: /engine/reference/commandline/container_kill/
-        title: docker container kill
-      - path: /engine/reference/commandline/container_logs/
-        title: docker container logs
-      - path: /engine/reference/commandline/container_ls/
-        title: docker container ls
-      - path: /engine/reference/commandline/container_pause/
-        title: docker container pause
-      - path: /engine/reference/commandline/container_port/
-        title: docker container port
-      - path: /engine/reference/commandline/container_prune/
-        title: docker container prune
-      - path: /engine/reference/commandline/container_rename/
-        title: docker container rename
-      - path: /engine/reference/commandline/container_restart/
-        title: docker container restart
-      - path: /engine/reference/commandline/container_rm/
-        title: docker container rm
-      - path: /engine/reference/commandline/container_run/
-        title: docker container run
-      - path: /engine/reference/commandline/container_start/
-        title: docker container start
-      - path: /engine/reference/commandline/container_stats/
-        title: docker container stats
-      - path: /engine/reference/commandline/container_stop/
-        title: docker container stop
-      - path: /engine/reference/commandline/container_top/
-        title: docker container top
-      - path: /engine/reference/commandline/container_unpause/
-        title: docker container unpause
-      - path: /engine/reference/commandline/container_update/
-        title: docker container update
-      - path: /engine/reference/commandline/container_wait/
-        title: docker container wait
-    - sectiontitle: docker context
-      section:
-        - path: /engine/reference/commandline/context/
-          title: docker context
-        - path: /engine/reference/commandline/context_create/
-          title: docker context create
-        - path: /engine/reference/commandline/context_export/
-          title: docker context export
-        - path: /engine/reference/commandline/context_import/
-          title: docker context import
-        - path: /engine/reference/commandline/context_inspect/
-          title: docker context inspect
-        - path: /engine/reference/commandline/context_ls/
-          title: docker context ls
-        - path: /engine/reference/commandline/context_rm/
-          title: docker context rm
-        - path: /engine/reference/commandline/context_show/
-          title: docker context show
-        - path: /engine/reference/commandline/context_update/
-          title: docker context update
-        - path: /engine/reference/commandline/context_use/
-          title: docker context use
-    - path: /engine/reference/commandline/cp/
-      title: docker cp
-    - path: /engine/reference/commandline/create/
-      title: docker create
-    - path: /engine/reference/commandline/diff/
-      title: docker diff
-    - path: /engine/reference/commandline/events/
-      title: docker events
-    - path: /engine/reference/commandline/exec/
-      title: docker exec
-    - path: /engine/reference/commandline/export/
-      title: docker export
-    - path: /engine/reference/commandline/history/
-      title: docker history
-    - sectiontitle: docker image
-      section:
-      - path: /engine/reference/commandline/image/
-        title: docker image
-      - path: /engine/reference/commandline/image_build/
-        title: docker image build
-      - path: /engine/reference/commandline/image_history/
-        title: docker image history
-      - path: /engine/reference/commandline/image_import/
-        title: docker image import
-      - path: /engine/reference/commandline/image_inspect/
-        title: docker image inspect
-      - path: /engine/reference/commandline/image_load/
-        title: docker image load
-      - path: /engine/reference/commandline/image_ls/
-        title: docker image ls
-      - path: /engine/reference/commandline/image_prune/
-        title: docker image prune
-      - path: /engine/reference/commandline/image_pull/
-        title: docker image pull
-      - path: /engine/reference/commandline/image_push/
-        title: docker image push
-      - path: /engine/reference/commandline/image_rm/
-        title: docker image rm
-      - path: /engine/reference/commandline/image_save/
-        title: docker image save
-      - path: /engine/reference/commandline/image_tag/
-        title: docker image tag
-    - path: /engine/reference/commandline/images/
-      title: docker images
-    - path: /engine/reference/commandline/import/
-      title: docker import
-    - path: /engine/reference/commandline/info/
-      title: docker info
-    - path: /engine/reference/commandline/init/
-      title: docker init (Beta)
-    - path: /engine/reference/commandline/inspect/
-      title: docker inspect
-    - path: /engine/reference/commandline/kill/
-      title: docker kill
-    - path: /engine/reference/commandline/load/
-      title: docker load
-    - path: /engine/reference/commandline/login/
-      title: docker login
-    - path: /engine/reference/commandline/logout/
-      title: docker logout
-    - path: /engine/reference/commandline/logs/
-      title: docker logs
-    - sectiontitle: docker manifest
-      section:
-      - path: /engine/reference/commandline/manifest/
-        title: docker manifest
-      - path: /engine/reference/commandline/manifest_annotate/
-        title: docker manifest annotate
-      - path: /engine/reference/commandline/manifest_create/
-        title: docker manifest create
-      - path: /engine/reference/commandline/manifest_inspect/
-        title: docker manifest inspect
-      - path: /engine/reference/commandline/manifest_push/
-        title: docker manifest push
-      - path: /engine/reference/commandline/manifest_rm/
-        title: docker manifest rm
-    - sectiontitle: docker network
-      section:
-      - path: /engine/reference/commandline/network/
-        title: docker network
-      - path: /engine/reference/commandline/network_connect/
-        title: docker network connect
-      - path: /engine/reference/commandline/network_create/
-        title: docker network create
-      - path: /engine/reference/commandline/network_disconnect/
-        title: docker network disconnect
-      - path: /engine/reference/commandline/network_inspect/
-        title: docker network inspect
-      - path: /engine/reference/commandline/network_ls/
-        title: docker network ls
-      - path: /engine/reference/commandline/network_prune/
-        title: docker network prune
-      - path: /engine/reference/commandline/network_rm/
-        title: docker network rm
-    - sectiontitle: docker node
-      section:
-      - path: /engine/reference/commandline/node/
-        title: docker node
-      - path: /engine/reference/commandline/node_demote/
-        title: docker node demote
-      - path: /engine/reference/commandline/node_inspect/
-        title: docker node inspect
-      - path: /engine/reference/commandline/node_ls/
-        title: docker node ls
-      - path: /engine/reference/commandline/node_promote/
-        title: docker node promote
-      - path: /engine/reference/commandline/node_ps/
-        title: docker node ps
-      - path: /engine/reference/commandline/node_rm/
-        title: docker node rm
-      - path: /engine/reference/commandline/node_update/
-        title: docker node update
-    - path: /engine/reference/commandline/pause/
-      title: docker pause
-    - sectiontitle: docker plugin
-      section:
-      - path: /engine/reference/commandline/plugin/
-        title: docker plugin
-      - path: /engine/reference/commandline/plugin_create/
-        title: docker plugin create
-      - path: /engine/reference/commandline/plugin_disable/
-        title: docker plugin disable
-      - path: /engine/reference/commandline/plugin_enable/
-        title: docker plugin enable
-      - path: /engine/reference/commandline/plugin_inspect/
-        title: docker plugin inspect
-      - path: /engine/reference/commandline/plugin_install/
-        title: docker plugin install
-      - path: /engine/reference/commandline/plugin_ls/
-        title: docker plugin ls
-      - path: /engine/reference/commandline/plugin_rm/
-        title: docker plugin rm
-      - path: /engine/reference/commandline/plugin_set/
-        title: docker plugin set
-      - path: /engine/reference/commandline/plugin_upgrade/
-        title: docker plugin upgrade
-    - path: /engine/reference/commandline/port/
-      title: docker port
-    - path: /engine/reference/commandline/ps/
-      title: docker ps
-    - path: /engine/reference/commandline/pull/
-      title: docker pull
-    - path: /engine/reference/commandline/push/
-      title: docker push
-    - path: /engine/reference/commandline/rename/
-      title: docker rename
-    - path: /engine/reference/commandline/restart/
-      title: docker restart
-    - path: /engine/reference/commandline/rm/
-      title: docker rm
-    - path: /engine/reference/commandline/rmi/
-      title: docker rmi
-    - path: /engine/reference/commandline/run/
-      title: docker run
-    - path: /engine/reference/commandline/save/
-      title: docker save
-    - sectiontitle: docker scout
-      section:
-      - path: /engine/reference/commandline/scout/
-        title: docker scout
-      - path: /engine/reference/commandline/scout_cache/
-        title: docker scout cache
-      - path: /engine/reference/commandline/scout_cache_df/
-        title: docker scout cache df
-      - path: /engine/reference/commandline/scout_cache_prune/
-        title: docker scout cache prune
-      - path: /engine/reference/commandline/scout_compare/
-        title: docker scout compare
-      - path: /engine/reference/commandline/scout_config/
-        title: docker scout config
-      - path: /engine/reference/commandline/scout_cves/
-        title: docker scout cves
-      - path: /engine/reference/commandline/scout_enroll/
-        title: docker scout enroll
-      - path: /engine/reference/commandline/scout_environment/
-        title: docker scout environment
-      - path: /engine/reference/commandline/scout_integration/
-        title: docker scout integration
-      - path: /engine/reference/commandline/scout_integration_configure/
-        title: docker scout integration configure
-      - path: /engine/reference/commandline/scout_integration_delete/
-        title: docker scout integration delete
-      - path: /engine/reference/commandline/scout_integration_list/
-        title: docker scout integration list
-      - path: /engine/reference/commandline/scout_policy/
-        title: docker scout policy
-      - path: /engine/reference/commandline/scout_quickview/
-        title: docker scout quickview
-      - path: /engine/reference/commandline/scout_recommendations/
-        title: docker scout recommendations
-      - path: /engine/reference/commandline/scout_repo/
-        title: docker scout repo
-      - path: /engine/reference/commandline/scout_repo_disable/
-        title: docker scout repo disable
-      - path: /engine/reference/commandline/scout_repo_enable/
-        title: docker scout repo enable
-      - path: /engine/reference/commandline/scout_repo_list/
-        title: docker scout repo list
-      - path: /engine/reference/commandline/scout_sbom/
-        title: docker scout sbom
-      - path: /engine/reference/commandline/scout_stream/
-        title: docker scout stream
-      - path: /engine/reference/commandline/scout_version/
-        title: docker scout version
-      - path: /engine/reference/commandline/scout_watch/
-        title: docker scout watch
-    - path: /engine/reference/commandline/search/
-      title: docker search
-    - sectiontitle: docker secret
-      section:
-      - path: /engine/reference/commandline/secret/
-        title: docker secret
-      - path: /engine/reference/commandline/secret_create/
-        title: docker secret create
-      - path: /engine/reference/commandline/secret_inspect/
-        title: docker secret inspect
-      - path: /engine/reference/commandline/secret_ls/
-        title: docker secret ls
-      - path: /engine/reference/commandline/secret_rm/
-        title: docker secret rm
-    - sectiontitle: docker service
-      section:
-      - path: /engine/reference/commandline/service/
-        title: docker service
-      - path: /engine/reference/commandline/service_create/
-        title: docker service create
-      - path: /engine/reference/commandline/service_inspect/
-        title: docker service inspect
-      - path: /engine/reference/commandline/service_logs/
-        title: docker service logs
-      - path: /engine/reference/commandline/service_ls/
-        title: docker service ls
-      - path: /engine/reference/commandline/service_ps/
-        title: docker service ps
-      - path: /engine/reference/commandline/service_rollback/
-        title: docker service rollback
-      - path: /engine/reference/commandline/service_rm/
-        title: docker service rm
-      - path: /engine/reference/commandline/service_scale/
-        title: docker service scale
-      - path: /engine/reference/commandline/service_update/
-        title: docker service update
-    - sectiontitle: docker stack
-      section:
-      - path: /engine/reference/commandline/stack/
-        title: docker stack
-      - path: /engine/reference/commandline/stack_config/
-        title: docker stack config
-      - path: /engine/reference/commandline/stack_deploy/
-        title: docker stack deploy
-      - path: /engine/reference/commandline/stack_ls/
-        title: docker stack ls
-      - path: /engine/reference/commandline/stack_ps/
-        title: docker stack ps
-      - path: /engine/reference/commandline/stack_rm/
-        title: docker stack rm
-      - path: /engine/reference/commandline/stack_services/
-        title: docker stack services
-    - path: /engine/reference/commandline/start/
-      title: docker start
-    - path: /engine/reference/commandline/stats/
-      title: docker stats
-    - path: /engine/reference/commandline/stop/
-      title: docker stop
-    - sectiontitle: docker swarm
-      section:
-      - path: /engine/reference/commandline/swarm/
-        title: docker swarm
-      - path: /engine/reference/commandline/swarm_ca/
-        title: docker swarm ca
-      - path: /engine/reference/commandline/swarm_init/
-        title: docker swarm init
-      - path: /engine/reference/commandline/swarm_join-token/
-        title: docker swarm join-token
-      - path: /engine/reference/commandline/swarm_join/
-        title: docker swarm join
-      - path: /engine/reference/commandline/swarm_leave/
-        title: docker swarm leave
-      - path: /engine/reference/commandline/swarm_unlock-key/
-        title: docker swarm unlock-key
-      - path: /engine/reference/commandline/swarm_unlock/
-        title: docker swarm unlock
-      - path: /engine/reference/commandline/swarm_update/
-        title: docker swarm update
-    - sectiontitle: docker system
-      section:
-      - path: /engine/reference/commandline/system/
-        title: docker system
-      - path: /engine/reference/commandline/system_df/
-        title: docker system df
-      - path: /engine/reference/commandline/system_events/
-        title: docker system events
-      - path: /engine/reference/commandline/system_info/
-        title: docker system info
-      - path: /engine/reference/commandline/system_prune/
-        title: docker system prune
-    - path: /engine/reference/commandline/tag/
-      title: docker tag
-    - path: /engine/reference/commandline/top/
-      title: docker top
-    - sectiontitle: docker trust
-      section:
-      - path: /engine/reference/commandline/trust/
-        title: docker trust
-      - path: /engine/reference/commandline/trust_inspect/
-        title: docker trust inspect
-      - path: /engine/reference/commandline/trust_key/
-        title: docker trust key
-      - path: /engine/reference/commandline/trust_key_generate/
-        title: docker trust key generate
-      - path: /engine/reference/commandline/trust_key_load/
-        title: docker trust key load
-      - path: /engine/reference/commandline/trust_revoke/
-        title: docker trust revoke
-      - path: /engine/reference/commandline/trust_sign/
-        title: docker trust sign
-      - path: /engine/reference/commandline/trust_signer/
-        title: docker trust signer
-      - path: /engine/reference/commandline/trust_signer_add/
-        title: docker trust signer add
-      - path: /engine/reference/commandline/trust_signer_remove/
-        title: docker trust signer remove
-    - path: /engine/reference/commandline/unpause/
-      title: docker unpause
-    - path: /engine/reference/commandline/update/
-      title: docker update
-    - path: /engine/reference/commandline/version/
-      title: docker version
-    - sectiontitle: docker volume
-      section:
-      - path: /engine/reference/commandline/volume_create/
-        title: docker volume create
-      - path: /engine/reference/commandline/volume_inspect/
-        title: docker volume inspect
-      - path: /engine/reference/commandline/volume_ls/
-        title: docker volume ls
-      - path: /engine/reference/commandline/volume_prune/
-        title: docker volume prune
-      - path: /engine/reference/commandline/volume_rm/
-        title: docker volume rm
-      - path: /engine/reference/commandline/volume_update/
-        title: docker volume update
-    - path: /engine/reference/commandline/wait/
-      title: docker wait
-  - title: Docker Compose CLI reference
-    # using old URL that redirects to the new location
-    path: /compose/reference/overview/
-  - title: Daemon CLI (dockerd)
-    path: /engine/reference/commandline/dockerd/
+      - path: /engine/reference/commandline/builder/
+        title: docker builder
+      - path: /engine/reference/commandline/builder_build/
+        title: docker builder build
+      - path: /engine/reference/commandline/builder_prune/
+        title: docker builder prune
+  - sectiontitle: docker buildx
+    section:
+      - path: /engine/reference/commandline/buildx/
+        title: docker buildx
+      - path: /engine/reference/commandline/buildx_bake/
+        title: docker buildx bake
+      - path: /engine/reference/commandline/buildx_build/
+        title: docker buildx build
+      - path: /engine/reference/commandline/buildx_create/
+        title: docker buildx create
+      - path: /engine/reference/commandline/buildx_debug/
+        title: docker buildx debug
+      - path: /engine/reference/commandline/buildx_debug_build/
+        title: docker buildx debug build
+      - path: /engine/reference/commandline/buildx_du/
+        title: docker buildx du
+      - path: /engine/reference/commandline/buildx_imagetools/
+        title: docker buildx imagetools
+      - path: /engine/reference/commandline/buildx_imagetools_create/
+        title: docker buildx imagetools create
+      - path: /engine/reference/commandline/buildx_imagetools_inspect/
+        title: docker buildx imagetools inspect
+      - path: /engine/reference/commandline/buildx_inspect/
+        title: docker buildx inspect
+      - path: /engine/reference/commandline/buildx_ls/
+        title: docker buildx ls
+      - path: /engine/reference/commandline/buildx_prune/
+        title: docker buildx prune
+      - path: /engine/reference/commandline/buildx_rm/
+        title: docker buildx rm
+      - path: /engine/reference/commandline/buildx_stop/
+        title: docker buildx stop
+      - path: /engine/reference/commandline/buildx_use/
+        title: docker buildx use
+      - path: /engine/reference/commandline/buildx_version/
+        title: docker buildx version
+  - sectiontitle: docker checkpoint
+    section:
+    - path: /engine/reference/commandline/checkpoint/
+      title: docker checkpoint
+    - path: /engine/reference/commandline/checkpoint_create/
+      title: docker checkpoint create
+    - path: /engine/reference/commandline/checkpoint_ls/
+      title: docker checkpoint ls
+    - path: /engine/reference/commandline/checkpoint_rm/
+      title: docker checkpoint rm
+  - path: /engine/reference/commandline/commit/
+    title: docker commit
+  - sectiontitle: docker compose
+    section:
+      - path: /compose/reference/
+        title: overview
+      - path: /compose/environment-variables/envvars/
+        title: environment variables
+      - path: /engine/reference/commandline/compose_alpha/
+        title: docker compose alpha
+      - path: /engine/reference/commandline/compose_alpha_dry-run/
+        title: docker compose alpha dry-run
+      - path: /engine/reference/commandline/compose_alpha_publish/
+        title: docker compose alpha publish
+      - path: /engine/reference/commandline/compose_alpha_scale/
+        title: docker compose alpha scale
+      - path: /engine/reference/commandline/compose_alpha_viz/
+        title: docker compose alpha viz
+      - path: /engine/reference/commandline/compose/
+        title: docker compose
+      - path: /engine/reference/commandline/compose_build/
+        title: docker compose build
+      - path: /engine/reference/commandline/compose_config/
+        title: docker compose config
+      - path: /engine/reference/commandline/compose_cp/
+        title: docker compose cp
+      - path: /engine/reference/commandline/compose_create/
+        title: docker compose create
+      - path: /engine/reference/commandline/compose_down/
+        title: docker compose down
+      - path: /engine/reference/commandline/compose_events/
+        title: docker compose events
+      - path: /engine/reference/commandline/compose_exec/
+        title: docker compose exec
+      - path: /engine/reference/commandline/compose_images/
+        title: docker compose images
+      - path: /engine/reference/commandline/compose_kill/
+        title: docker compose kill
+      - path: /engine/reference/commandline/compose_logs/
+        title: docker compose logs
+      - path: /engine/reference/commandline/compose_ls/
+        title: docker compose ls
+      - path: /engine/reference/commandline/compose_pause/
+        title: docker compose pause
+      - path: /engine/reference/commandline/compose_port/
+        title: docker compose port
+      - path: /engine/reference/commandline/compose_ps/
+        title: docker compose ps
+      - path: /engine/reference/commandline/compose_pull/
+        title: docker compose pull
+      - path: /engine/reference/commandline/compose_push/
+        title: docker compose push
+      - path: /engine/reference/commandline/compose_restart/
+        title: docker compose restart
+      - path: /engine/reference/commandline/compose_rm/
+        title: docker compose rm
+      - path: /engine/reference/commandline/compose_run/
+        title: docker compose run
+      - path: /engine/reference/commandline/compose_start/
+        title: docker compose start
+      - path: /engine/reference/commandline/compose_stop/
+        title: docker compose stop
+      - path: /engine/reference/commandline/compose_top/
+        title: docker compose top
+      - path: /engine/reference/commandline/compose_unpause/
+        title: docker compose unpause
+      - path: /engine/reference/commandline/compose_up/
+        title: docker compose up
+      - path: /engine/reference/commandline/compose_version/
+        title: docker compose version
+      - path: /engine/reference/commandline/compose_wait/
+        title: docker compose wait
+      - path: /engine/reference/commandline/compose_watch/
+        title: docker compose watch
+  - sectiontitle: docker config
+    section:
+    - path: /engine/reference/commandline/config/
+      title: docker config
+    - path: /engine/reference/commandline/config_create/
+      title: docker config create
+    - path: /engine/reference/commandline/config_inspect/
+      title: docker config inspect
+    - path: /engine/reference/commandline/config_ls/
+      title: docker config ls
+    - path: /engine/reference/commandline/config_rm/
+      title: docker config rm
+  - sectiontitle: docker container
+    section:
+    - path: /engine/reference/commandline/container/
+      title: docker container
+    - path: /engine/reference/commandline/container_attach/
+      title: docker container attach
+    - path: /engine/reference/commandline/container_commit/
+      title: docker container commit
+    - path: /engine/reference/commandline/container_cp/
+      title: docker container cp
+    - path: /engine/reference/commandline/container_create/
+      title: docker container create
+    - path: /engine/reference/commandline/container_diff/
+      title: docker container diff
+    - path: /engine/reference/commandline/container_exec/
+      title: docker container exec
+    - path: /engine/reference/commandline/container_export/
+      title: docker container export
+    - path: /engine/reference/commandline/container_inspect/
+      title: docker container inspect
+    - path: /engine/reference/commandline/container_kill/
+      title: docker container kill
+    - path: /engine/reference/commandline/container_logs/
+      title: docker container logs
+    - path: /engine/reference/commandline/container_ls/
+      title: docker container ls
+    - path: /engine/reference/commandline/container_pause/
+      title: docker container pause
+    - path: /engine/reference/commandline/container_port/
+      title: docker container port
+    - path: /engine/reference/commandline/container_prune/
+      title: docker container prune
+    - path: /engine/reference/commandline/container_rename/
+      title: docker container rename
+    - path: /engine/reference/commandline/container_restart/
+      title: docker container restart
+    - path: /engine/reference/commandline/container_rm/
+      title: docker container rm
+    - path: /engine/reference/commandline/container_run/
+      title: docker container run
+    - path: /engine/reference/commandline/container_start/
+      title: docker container start
+    - path: /engine/reference/commandline/container_stats/
+      title: docker container stats
+    - path: /engine/reference/commandline/container_stop/
+      title: docker container stop
+    - path: /engine/reference/commandline/container_top/
+      title: docker container top
+    - path: /engine/reference/commandline/container_unpause/
+      title: docker container unpause
+    - path: /engine/reference/commandline/container_update/
+      title: docker container update
+    - path: /engine/reference/commandline/container_wait/
+      title: docker container wait
+  - sectiontitle: docker context
+    section:
+      - path: /engine/reference/commandline/context/
+        title: docker context
+      - path: /engine/reference/commandline/context_create/
+        title: docker context create
+      - path: /engine/reference/commandline/context_export/
+        title: docker context export
+      - path: /engine/reference/commandline/context_import/
+        title: docker context import
+      - path: /engine/reference/commandline/context_inspect/
+        title: docker context inspect
+      - path: /engine/reference/commandline/context_ls/
+        title: docker context ls
+      - path: /engine/reference/commandline/context_rm/
+        title: docker context rm
+      - path: /engine/reference/commandline/context_show/
+        title: docker context show
+      - path: /engine/reference/commandline/context_update/
+        title: docker context update
+      - path: /engine/reference/commandline/context_use/
+        title: docker context use
+  - path: /engine/reference/commandline/cp/
+    title: docker cp
+  - path: /engine/reference/commandline/create/
+    title: docker create
+  - path: /engine/reference/commandline/diff/
+    title: docker diff
+  - path: /engine/reference/commandline/events/
+    title: docker events
+  - path: /engine/reference/commandline/exec/
+    title: docker exec
+  - path: /engine/reference/commandline/export/
+    title: docker export
+  - path: /engine/reference/commandline/history/
+    title: docker history
+  - sectiontitle: docker image
+    section:
+    - path: /engine/reference/commandline/image/
+      title: docker image
+    - path: /engine/reference/commandline/image_build/
+      title: docker image build
+    - path: /engine/reference/commandline/image_history/
+      title: docker image history
+    - path: /engine/reference/commandline/image_import/
+      title: docker image import
+    - path: /engine/reference/commandline/image_inspect/
+      title: docker image inspect
+    - path: /engine/reference/commandline/image_load/
+      title: docker image load
+    - path: /engine/reference/commandline/image_ls/
+      title: docker image ls
+    - path: /engine/reference/commandline/image_prune/
+      title: docker image prune
+    - path: /engine/reference/commandline/image_pull/
+      title: docker image pull
+    - path: /engine/reference/commandline/image_push/
+      title: docker image push
+    - path: /engine/reference/commandline/image_rm/
+      title: docker image rm
+    - path: /engine/reference/commandline/image_save/
+      title: docker image save
+    - path: /engine/reference/commandline/image_tag/
+      title: docker image tag
+  - path: /engine/reference/commandline/images/
+    title: docker images
+  - path: /engine/reference/commandline/import/
+    title: docker import
+  - path: /engine/reference/commandline/info/
+    title: docker info
+  - path: /engine/reference/commandline/init/
+    title: docker init (Beta)
+  - path: /engine/reference/commandline/inspect/
+    title: docker inspect
+  - path: /engine/reference/commandline/kill/
+    title: docker kill
+  - path: /engine/reference/commandline/load/
+    title: docker load
+  - path: /engine/reference/commandline/login/
+    title: docker login
+  - path: /engine/reference/commandline/logout/
+    title: docker logout
+  - path: /engine/reference/commandline/logs/
+    title: docker logs
+  - sectiontitle: docker manifest
+    section:
+    - path: /engine/reference/commandline/manifest/
+      title: docker manifest
+    - path: /engine/reference/commandline/manifest_annotate/
+      title: docker manifest annotate
+    - path: /engine/reference/commandline/manifest_create/
+      title: docker manifest create
+    - path: /engine/reference/commandline/manifest_inspect/
+      title: docker manifest inspect
+    - path: /engine/reference/commandline/manifest_push/
+      title: docker manifest push
+    - path: /engine/reference/commandline/manifest_rm/
+      title: docker manifest rm
+  - sectiontitle: docker network
+    section:
+    - path: /engine/reference/commandline/network/
+      title: docker network
+    - path: /engine/reference/commandline/network_connect/
+      title: docker network connect
+    - path: /engine/reference/commandline/network_create/
+      title: docker network create
+    - path: /engine/reference/commandline/network_disconnect/
+      title: docker network disconnect
+    - path: /engine/reference/commandline/network_inspect/
+      title: docker network inspect
+    - path: /engine/reference/commandline/network_ls/
+      title: docker network ls
+    - path: /engine/reference/commandline/network_prune/
+      title: docker network prune
+    - path: /engine/reference/commandline/network_rm/
+      title: docker network rm
+  - sectiontitle: docker node
+    section:
+    - path: /engine/reference/commandline/node/
+      title: docker node
+    - path: /engine/reference/commandline/node_demote/
+      title: docker node demote
+    - path: /engine/reference/commandline/node_inspect/
+      title: docker node inspect
+    - path: /engine/reference/commandline/node_ls/
+      title: docker node ls
+    - path: /engine/reference/commandline/node_promote/
+      title: docker node promote
+    - path: /engine/reference/commandline/node_ps/
+      title: docker node ps
+    - path: /engine/reference/commandline/node_rm/
+      title: docker node rm
+    - path: /engine/reference/commandline/node_update/
+      title: docker node update
+  - path: /engine/reference/commandline/pause/
+    title: docker pause
+  - sectiontitle: docker plugin
+    section:
+    - path: /engine/reference/commandline/plugin/
+      title: docker plugin
+    - path: /engine/reference/commandline/plugin_create/
+      title: docker plugin create
+    - path: /engine/reference/commandline/plugin_disable/
+      title: docker plugin disable
+    - path: /engine/reference/commandline/plugin_enable/
+      title: docker plugin enable
+    - path: /engine/reference/commandline/plugin_inspect/
+      title: docker plugin inspect
+    - path: /engine/reference/commandline/plugin_install/
+      title: docker plugin install
+    - path: /engine/reference/commandline/plugin_ls/
+      title: docker plugin ls
+    - path: /engine/reference/commandline/plugin_rm/
+      title: docker plugin rm
+    - path: /engine/reference/commandline/plugin_set/
+      title: docker plugin set
+    - path: /engine/reference/commandline/plugin_upgrade/
+      title: docker plugin upgrade
+  - path: /engine/reference/commandline/port/
+    title: docker port
+  - path: /engine/reference/commandline/ps/
+    title: docker ps
+  - path: /engine/reference/commandline/pull/
+    title: docker pull
+  - path: /engine/reference/commandline/push/
+    title: docker push
+  - path: /engine/reference/commandline/rename/
+    title: docker rename
+  - path: /engine/reference/commandline/restart/
+    title: docker restart
+  - path: /engine/reference/commandline/rm/
+    title: docker rm
+  - path: /engine/reference/commandline/rmi/
+    title: docker rmi
+  - path: /engine/reference/commandline/run/
+    title: docker run
+  - path: /engine/reference/commandline/save/
+    title: docker save
+  - sectiontitle: docker scout
+    section:
+    - path: /engine/reference/commandline/scout/
+      title: docker scout
+    - path: /engine/reference/commandline/scout_cache/
+      title: docker scout cache
+    - path: /engine/reference/commandline/scout_cache_df/
+      title: docker scout cache df
+    - path: /engine/reference/commandline/scout_cache_prune/
+      title: docker scout cache prune
+    - path: /engine/reference/commandline/scout_compare/
+      title: docker scout compare
+    - path: /engine/reference/commandline/scout_config/
+      title: docker scout config
+    - path: /engine/reference/commandline/scout_cves/
+      title: docker scout cves
+    - path: /engine/reference/commandline/scout_enroll/
+      title: docker scout enroll
+    - path: /engine/reference/commandline/scout_environment/
+      title: docker scout environment
+    - path: /engine/reference/commandline/scout_integration/
+      title: docker scout integration
+    - path: /engine/reference/commandline/scout_integration_configure/
+      title: docker scout integration configure
+    - path: /engine/reference/commandline/scout_integration_delete/
+      title: docker scout integration delete
+    - path: /engine/reference/commandline/scout_integration_list/
+      title: docker scout integration list
+    - path: /engine/reference/commandline/scout_policy/
+      title: docker scout policy
+    - path: /engine/reference/commandline/scout_quickview/
+      title: docker scout quickview
+    - path: /engine/reference/commandline/scout_recommendations/
+      title: docker scout recommendations
+    - path: /engine/reference/commandline/scout_repo/
+      title: docker scout repo
+    - path: /engine/reference/commandline/scout_repo_disable/
+      title: docker scout repo disable
+    - path: /engine/reference/commandline/scout_repo_enable/
+      title: docker scout repo enable
+    - path: /engine/reference/commandline/scout_repo_list/
+      title: docker scout repo list
+    - path: /engine/reference/commandline/scout_sbom/
+      title: docker scout sbom
+    - path: /engine/reference/commandline/scout_stream/
+      title: docker scout stream
+    - path: /engine/reference/commandline/scout_version/
+      title: docker scout version
+    - path: /engine/reference/commandline/scout_watch/
+      title: docker scout watch
+  - path: /engine/reference/commandline/search/
+    title: docker search
+  - sectiontitle: docker secret
+    section:
+    - path: /engine/reference/commandline/secret/
+      title: docker secret
+    - path: /engine/reference/commandline/secret_create/
+      title: docker secret create
+    - path: /engine/reference/commandline/secret_inspect/
+      title: docker secret inspect
+    - path: /engine/reference/commandline/secret_ls/
+      title: docker secret ls
+    - path: /engine/reference/commandline/secret_rm/
+      title: docker secret rm
+  - sectiontitle: docker service
+    section:
+    - path: /engine/reference/commandline/service/
+      title: docker service
+    - path: /engine/reference/commandline/service_create/
+      title: docker service create
+    - path: /engine/reference/commandline/service_inspect/
+      title: docker service inspect
+    - path: /engine/reference/commandline/service_logs/
+      title: docker service logs
+    - path: /engine/reference/commandline/service_ls/
+      title: docker service ls
+    - path: /engine/reference/commandline/service_ps/
+      title: docker service ps
+    - path: /engine/reference/commandline/service_rollback/
+      title: docker service rollback
+    - path: /engine/reference/commandline/service_rm/
+      title: docker service rm
+    - path: /engine/reference/commandline/service_scale/
+      title: docker service scale
+    - path: /engine/reference/commandline/service_update/
+      title: docker service update
+  - sectiontitle: docker stack
+    section:
+    - path: /engine/reference/commandline/stack/
+      title: docker stack
+    - path: /engine/reference/commandline/stack_config/
+      title: docker stack config
+    - path: /engine/reference/commandline/stack_deploy/
+      title: docker stack deploy
+    - path: /engine/reference/commandline/stack_ls/
+      title: docker stack ls
+    - path: /engine/reference/commandline/stack_ps/
+      title: docker stack ps
+    - path: /engine/reference/commandline/stack_rm/
+      title: docker stack rm
+    - path: /engine/reference/commandline/stack_services/
+      title: docker stack services
+  - path: /engine/reference/commandline/start/
+    title: docker start
+  - path: /engine/reference/commandline/stats/
+    title: docker stats
+  - path: /engine/reference/commandline/stop/
+    title: docker stop
+  - sectiontitle: docker swarm
+    section:
+    - path: /engine/reference/commandline/swarm/
+      title: docker swarm
+    - path: /engine/reference/commandline/swarm_ca/
+      title: docker swarm ca
+    - path: /engine/reference/commandline/swarm_init/
+      title: docker swarm init
+    - path: /engine/reference/commandline/swarm_join-token/
+      title: docker swarm join-token
+    - path: /engine/reference/commandline/swarm_join/
+      title: docker swarm join
+    - path: /engine/reference/commandline/swarm_leave/
+      title: docker swarm leave
+    - path: /engine/reference/commandline/swarm_unlock-key/
+      title: docker swarm unlock-key
+    - path: /engine/reference/commandline/swarm_unlock/
+      title: docker swarm unlock
+    - path: /engine/reference/commandline/swarm_update/
+      title: docker swarm update
+  - sectiontitle: docker system
+    section:
+    - path: /engine/reference/commandline/system/
+      title: docker system
+    - path: /engine/reference/commandline/system_df/
+      title: docker system df
+    - path: /engine/reference/commandline/system_events/
+      title: docker system events
+    - path: /engine/reference/commandline/system_info/
+      title: docker system info
+    - path: /engine/reference/commandline/system_prune/
+      title: docker system prune
+  - path: /engine/reference/commandline/tag/
+    title: docker tag
+  - path: /engine/reference/commandline/top/
+    title: docker top
+  - sectiontitle: docker trust
+    section:
+    - path: /engine/reference/commandline/trust/
+      title: docker trust
+    - path: /engine/reference/commandline/trust_inspect/
+      title: docker trust inspect
+    - path: /engine/reference/commandline/trust_key/
+      title: docker trust key
+    - path: /engine/reference/commandline/trust_key_generate/
+      title: docker trust key generate
+    - path: /engine/reference/commandline/trust_key_load/
+      title: docker trust key load
+    - path: /engine/reference/commandline/trust_revoke/
+      title: docker trust revoke
+    - path: /engine/reference/commandline/trust_sign/
+      title: docker trust sign
+    - path: /engine/reference/commandline/trust_signer/
+      title: docker trust signer
+    - path: /engine/reference/commandline/trust_signer_add/
+      title: docker trust signer add
+    - path: /engine/reference/commandline/trust_signer_remove/
+      title: docker trust signer remove
+  - path: /engine/reference/commandline/unpause/
+    title: docker unpause
+  - path: /engine/reference/commandline/update/
+    title: docker update
+  - path: /engine/reference/commandline/version/
+    title: docker version
+  - sectiontitle: docker volume
+    section:
+    - path: /engine/reference/commandline/volume_create/
+      title: docker volume create
+    - path: /engine/reference/commandline/volume_inspect/
+      title: docker volume inspect
+    - path: /engine/reference/commandline/volume_ls/
+      title: docker volume ls
+    - path: /engine/reference/commandline/volume_prune/
+      title: docker volume prune
+    - path: /engine/reference/commandline/volume_rm/
+      title: docker volume rm
+    - path: /engine/reference/commandline/volume_update/
+      title: docker volume update
+  - path: /engine/reference/commandline/wait/
+    title: docker wait
+- title: Dockerfile reference
+  path: /engine/reference/builder/
+- title: Daemon CLI (dockerd)
+  path: /engine/reference/commandline/dockerd/
 - sectiontitle: API reference
   section:
   - sectiontitle: Docker Engine API
@@ -960,8 +953,6 @@ Reference:
         title: ExecResultV0
       - path: /desktop/extensions-sdk/dev/api/reference/interfaces/BackendV0/
         title: BackendV0
-- title: Dockerfile reference
-  path: /engine/reference/builder/
 - sectiontitle: Compose file reference
   section:
     - sectiontitle: Compose Specification
@@ -1526,64 +1517,110 @@ Manuals:
       section:
       - path: /network/links/
         title: (Legacy) Container links
-  - sectiontitle: Working with Docker Engine
+  - sectiontitle: Containers
+    section:
+    - path: /engine/reference/run/
+      title: Docker run reference
+    - path: /config/containers/resource_constraints/
+      title: Configure runtime resource constraints
+    - path: /config/containers/multi-service_container/
+      title: Run multiple processes in a container
+    - path: /config/containers/start-containers-automatically/
+      title: Start containers automatically
+  - sectiontitle: CLI
+    section:
+    - path: /engine/reference/commandline/cli/
+      title: Use the Docker command line
+    - path: /config/filter/
+      title: Filter commands
+    - path: /config/formatting/
+      title: Format command and log output
+  - sectiontitle: Manage resources
+    section:
+    - path: /config/pruning/
+      title: Prune unused objects
+    - path: /config/labels-custom-metadata/
+      title: Labels
+    - path: /engine/context/working-with-contexts/
+      title: Contexts
+  - sectiontitle: Daemon
     section:
     - path: /config/daemon/start/
       title: Start the daemon
-    - path: /config/pruning/
-      title: Prune unused objects
-    - path: /config/formatting/
-      title: Format command and log output
-    - path: /config/filter/
-      title: Filter commands
-    - path: /config/containers/start-containers-automatically/
-      title: Start containers automatically
-    - path: /config/labels-custom-metadata/
-      title: Labels
-    - path: /engine/sbom/
-      title: Docker SBOM (Experimental)
-  - sectiontitle: Logging
+    - path: /config/daemon/
+      title: Configure the daemon
+    - path: /config/daemon/systemd/
+      title: Configure with systemd
+    - path: /config/containers/live-restore/
+      title: Live restore
+    - path: /config/daemon/troubleshoot/
+      title: Troubleshoot
+    - path: /config/daemon/remote-access/
+      title: Remote access
+    - path: /engine/alternative-runtimes/
+      title: Alternative container runtimes
+    - sectiontitle: Engine plugins
+      section:
+      - path: /engine/extend/
+        title: Managed plugin system
+      - path: /engine/extend/plugins_authorization/
+        title: Access authorization plugin
+      - path: /engine/extend/legacy_plugins/
+        title: Extending Docker with plugins
+      - path: /engine/extend/plugins_network/
+        title: Network plugins
+      - path: /engine/extend/plugins_logging/
+        title: Logging plugins
+      - path: /engine/extend/plugins_volume/
+        title: Volume plugins
+      - title: Plugin configuration
+        path: /engine/extend/config/
+      - path: /engine/extend/plugin_api/
+        title: Plugin API
+  - sectiontitle: Logs and metrics
     section:
     - sectiontitle: Container logs
       section:
       - path: /config/containers/logging/
         title: View container logs
-      - sectiontitle: Manage container logs
+      - path: /config/containers/logging/configure/
+        title: Configure logging drivers
+      - path: /config/containers/logging/dual-logging/
+        title: Use a remote logging driver
+      - path: /config/containers/logging/plugins/
+        title: Use a logging driver plugin
+      - path: /config/containers/logging/log_tags/
+        title: Customize log driver output
+      - sectiontitle: Logging drivers
         section:
-        - path: /config/containers/logging/configure/
-          title: Configure logging drivers
-        - path: /config/containers/logging/dual-logging/
-          title: Use a remote logging driver
-        - path: /config/containers/logging/plugins/
-          title: Use a logging driver plugin
-        - path: /config/containers/logging/log_tags/
-          title: Customize log driver output
-        - sectiontitle: Logging drivers
-          section:
-          - path: /config/containers/logging/local/
-            title: Local file logging driver
-          - path: /config/containers/logging/logentries/
-            title: Logentries logging driver
-          - path: /config/containers/logging/json-file/
-            title: JSON File logging driver
-          - path: /config/containers/logging/gelf/
-            title: Graylog Extended Format (GELF) logging driver
-          - path: /config/containers/logging/syslog/
-            title: Syslog logging driver
-          - path: /config/containers/logging/awslogs/
-            title: Amazon CloudWatch logs logging driver
-          - path: /config/containers/logging/etwlogs/
-            title: ETW logging driver
-          - path: /config/containers/logging/fluentd/
-            title: Fluentd logging driver
-          - path: /config/containers/logging/gcplogs/
-            title: Google Cloud logging driver
-          - path: /config/containers/logging/journald/
-            title: Journald logging driver
-          - path: /config/containers/logging/splunk/
-            title: Splunk logging driver
+        - path: /config/containers/logging/local/
+          title: Local file logging driver
+        - path: /config/containers/logging/logentries/
+          title: Logentries logging driver
+        - path: /config/containers/logging/json-file/
+          title: JSON File logging driver
+        - path: /config/containers/logging/gelf/
+          title: Graylog Extended Format (GELF) logging driver
+        - path: /config/containers/logging/syslog/
+          title: Syslog logging driver
+        - path: /config/containers/logging/awslogs/
+          title: Amazon CloudWatch logs logging driver
+        - path: /config/containers/logging/etwlogs/
+          title: ETW logging driver
+        - path: /config/containers/logging/fluentd/
+          title: Fluentd logging driver
+        - path: /config/containers/logging/gcplogs/
+          title: Google Cloud logging driver
+        - path: /config/containers/logging/journald/
+          title: Journald logging driver
+        - path: /config/containers/logging/splunk/
+          title: Splunk logging driver
     - path: /config/daemon/logs/
       title: Daemon logs
+    - path: /config/containers/runmetrics/
+      title: Collect runtime metrics
+    - path: /config/daemon/prometheus/
+      title: Collect metrics with Prometheus
   - sectiontitle: Security
     section:
       - path: /engine/security/
@@ -1678,50 +1715,6 @@ Manuals:
       title: Swarm administration guide
     - path: /engine/swarm/raft/
       title: Raft consensus in Swarm mode
-  - sectiontitle: Advanced concepts
-    section:
-    - sectiontitle: Container runtime
-      section:
-      - path: /engine/alternative-runtimes/
-        title: Alternative container runtimes
-      - path: /config/containers/resource_constraints/
-        title: Configure runtime resource constraints
-      - path: /config/containers/runmetrics/
-        title: Collect runtime metrics
-      - path: /config/containers/multi-service_container/
-        title: Run multiple processes in a container
-      - path: /config/daemon/prometheus/
-        title: Collect metrics with Prometheus
-    - sectiontitle: Daemon configuration
-      section:
-      - path: /config/daemon/
-        title: Configuration overview
-      - path: /config/daemon/systemd/
-        title: Configure with systemd
-      - path: /config/containers/live-restore/
-        title: Live restore
-      - path: /config/daemon/troubleshoot/
-        title: Troubleshoot
-      - path: /config/daemon/remote-access/
-        title: Remote access
-      - path: /engine/context/working-with-contexts/
-        title: Contexts
-    - sectiontitle: Engine plugins
-      section:
-      - path: /engine/extend/
-        title: Managed plugin system
-      - path: /engine/extend/plugins_authorization/
-        title: Access authorization plugin
-      - path: /engine/extend/legacy_plugins/
-        title: Extending Docker with plugins
-      - path: /engine/extend/plugins_network/
-        title: Docker network driver plugins
-      - path: /engine/extend/plugins_volume/
-        title: Volume plugins
-      - title: Plugin configuration
-        path: /engine/extend/config/
-      - path: /engine/extend/plugin_api/
-        title: Plugins
   - path: /engine/deprecated/
     title: Deprecated features
   - sectiontitle: Release notes


### PR DESCRIPTION
### Proposed changes

Quick attempt to improve the navigation structure for engine

- Restructured the manuals section for Docker Engine
- Restructured the CLI reference section
  - Moved a few of the pages that were previously in the reference section to the manuals section

Bonus: remove the SBOM page from the TOC.

### Related issues (optional)

<!--
  Refer to related PRs or issues:

  #1234
  Closes #1234
  Closes docker/cli#1234
-->
