### PR TITLE
fix: remove heading IDs for h1 elements

### DIFF
--- a/layouts/_default/cli.html
+++ b/layouts/_default/cli.html
@@ -14,7 +14,7 @@
   {{ partial "breadcrumbs.html" . }}
   <article class="DocSearch-content prose max-w-none dark:prose-invert">
     {{ with .Title }}
-    <h1 id="{{ anchorize . }}" class="scroll-mt-36">{{ . }}</h1>
+    <h1 class="scroll-mt-36">{{ . }}</h1>
     {{ end }}
     {{ $data.short | .RenderString (dict "display" "block") }}
     {{ if $data.deprecated }}

--- a/layouts/_default/glossary.html
+++ b/layouts/_default/glossary.html
@@ -6,7 +6,7 @@
   {{ partial "breadcrumbs.html" . }}
   <article class="DocSearch-content prose max-w-none dark:prose-invert">
     {{ with .Title }}
-    <h1 id="{{ anchorize . }}" class="scroll-mt-36">{{ . }}</h1>
+    <h1 class="scroll-mt-36">{{ . }}</h1>
     {{ end }}
     <table>
       <thead>

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -6,7 +6,7 @@
   {{ partial "breadcrumbs.html" . }}
   <article class="DocSearch-content prose max-w-none dark:prose-invert">
     {{ with .Title }}
-    <h1 id="{{ anchorize . }}" class="scroll-mt-36">{{ . }}</h1>
+    <h1 class="scroll-mt-36">{{ . }}</h1>
     {{ end }}
     {{ .Content }}
   </article>

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -6,7 +6,7 @@
   {{ partial "breadcrumbs.html" . }}
   <article class="DocSearch-content prose max-w-none dark:prose-invert">
     {{ with .Title }}
-    <h1 id="{{ anchorize . }}" class="scroll-mt-36">{{ . }}</h1>
+    <h1 class="scroll-mt-36">{{ . }}</h1>
     {{ end }}
     {{ .Content }}
   </article>

--- a/layouts/samples/single.html
+++ b/layouts/samples/single.html
@@ -6,7 +6,7 @@
   {{ partial "breadcrumbs.html" . }}
   <article class="DocSearch-content prose max-w-none dark:prose-invert">
     {{ with .Title }}
-    <h1 id="{{ anchorize . }}" class="scroll-mt-36">{{ . }}</h1>
+    <h1 class="scroll-mt-36">{{ . }}</h1>
     {{ end }}
     <blockquote>
       <p><strong>Note</strong></p>


### PR DESCRIPTION
### Proposed changes

Removes `id` from `<h1>` elements.

### Related issues (optional)

Closes #18983