### PR TITLE
storage: ephemeral anonymous volumes

### DIFF
--- a/content/storage/_index.md
+++ b/content/storage/_index.md
@@ -73,11 +73,13 @@ running container is using a volume, the volume is still available to Docker
 and isn't removed automatically. You can remove unused volumes using `docker
 volume prune`.
 
-When you mount a volume, it may be named or anonymous. Anonymous
-volumes aren't given an explicit name when they're first mounted into a
-container, so Docker gives them a random name that's guaranteed to be unique
-within a given Docker host. Besides the name, named and anonymous volumes
-behave in the same ways.
+When you mount a volume, it may be named or anonymous. Anonymous volumes are
+given a random name that's guaranteed to be unique within a given Docker host.
+Just like named volumes, anonymous volumes persist even if you remove the
+container that uses them, except if you use the `--rm` flag when creating the
+container. Docker automatically removes anonymous volume mounts for containers
+created with the `--rm` flag. See [Remove anonymous
+volumes](volumes.md#remove-anonymous-volumes).
 
 Volumes also support the use of volume drivers, which allow you to store
 your data on remote hosts or cloud providers, among other possibilities.

--- a/content/storage/_index.md
+++ b/content/storage/_index.md
@@ -50,69 +50,74 @@ mounts is to think about where the data lives on the Docker host.
 - `tmpfs` mounts are stored in the host system's memory only, and are never
   written to the host system's filesystem.
 
-### More details about mount types
-
-- [Volumes](volumes.md): Created and managed by Docker. You can create a
-  volume explicitly using the `docker volume create` command, or Docker can
-  create a volume during container or service creation.
-
-  When you create a volume, it is stored within a directory on the Docker
-  host. When you mount the volume into a container, this directory is what is
-  mounted into the container. This is similar to the way that bind mounts work,
-  except that volumes are managed by Docker and are isolated from the core
-  functionality of the host machine.
-
-  A given volume can be mounted into multiple containers simultaneously. When no
-  running container is using a volume, the volume is still available to Docker
-  and is not removed automatically. You can remove unused volumes using `docker
-  volume prune`.
-
-  When you mount a volume, it may be named or anonymous. Anonymous
-  volumes are not given an explicit name when they are first mounted into a
-  container, so Docker gives them a random name that is guaranteed to be unique
-  within a given Docker host. Besides the name, named and anonymous volumes
-  behave in the same ways.
-
-  Volumes also support the use of volume drivers, which allow you to store
-  your data on remote hosts or cloud providers, among other possibilities.
-
-- [Bind mounts](bind-mounts.md): Available since the early days of Docker.
-  Bind mounts have limited functionality compared to volumes. When you use a
-  bind mount, a file or directory on the host machine is mounted into a
-  container. The file or directory is referenced by its full path on the host
-  machine. The file or directory doesn't need to exist on the Docker host
-  already. It is created on demand if it does not yet exist. Bind mounts are
-  very performant, but they rely on the host machine's filesystem having a
-  specific directory structure available. If you are developing new Docker
-  applications, consider using named volumes instead. You can't use
-  Docker CLI commands to directly manage bind mounts.
-
-  > **Important**
-  >
-  > Bind mounts allow access to sensitive files.
-  >
-  > One side effect of using bind mounts, for better or for worse,
-  > is that you can change the host filesystem via processes running in a
-  > container, including creating, modifying, or deleting important system
-  > files or directories. This is a powerful ability which can have security
-  > implications, including impacting non-Docker processes on the host system.
-  { .important }
-
-- **[tmpfs mounts](tmpfs.md)**: A `tmpfs` mount is not persisted on disk, either
-  on the Docker host or within a container. It can be used by a container during
-  the lifetime of the container, to store non-persistent state or sensitive
-  information. For instance, internally, swarm services use `tmpfs` mounts to
-  mount [secrets](../engine/swarm/secrets.md) into a service's containers.
-
-- **[named pipes](https://docs.microsoft.com/en-us/windows/desktop/ipc/named-pipes)**: An `npipe`
-  mount can be used for communication between the Docker host and a container. Common use case is
-  to run a third-party tool inside of a container and connect to the Docker Engine API using a named pipe.
-
 Bind mounts and volumes can both be mounted into containers using the `-v` or
 `--volume` flag, but the syntax for each is slightly different. For `tmpfs`
 mounts, you can use the `--tmpfs` flag. We recommend using the `--mount` flag
 for both containers and services, for bind mounts, volumes, or `tmpfs` mounts,
 as the syntax is more clear.
+
+### Volumes
+
+Volumes are created and managed by Docker. You can create a volume explicitly
+using the `docker volume create` command, or Docker can create a volume during
+container or service creation.
+
+When you create a volume, it's stored within a directory on the Docker
+host. When you mount the volume into a container, this directory is what's
+mounted into the container. This is similar to the way that bind mounts work,
+except that volumes are managed by Docker and are isolated from the core
+functionality of the host machine.
+
+A given volume can be mounted into multiple containers simultaneously. When no
+running container is using a volume, the volume is still available to Docker
+and isn't removed automatically. You can remove unused volumes using `docker
+volume prune`.
+
+When you mount a volume, it may be named or anonymous. Anonymous
+volumes aren't given an explicit name when they're first mounted into a
+container, so Docker gives them a random name that's guaranteed to be unique
+within a given Docker host. Besides the name, named and anonymous volumes
+behave in the same ways.
+
+Volumes also support the use of volume drivers, which allow you to store
+your data on remote hosts or cloud providers, among other possibilities.
+
+### Bind mounts
+
+Bind mounts have limited functionality compared to volumes. When you use a bind
+mount, a file or directory on the host machine is mounted into a container. The
+file or directory is referenced by its full path on the host machine. The file
+or directory doesn't need to exist on the Docker host already. It is created on
+demand if it doesn't yet exist. Bind mounts are fast, but they rely on the host
+machine's filesystem having a specific directory structure available. If you
+are developing new Docker applications, consider using named volumes instead.
+You can't use Docker CLI commands to directly manage bind mounts.
+
+> **Important**
+>
+> Bind mounts allow write access to files on the host by default.
+>
+> One side effect of using bind mounts is that you can change the host
+> filesystem via processes running in a container, including creating,
+> modifying, or deleting important system files or directories. This is a
+> powerful ability which can have security implications, including impacting
+> non-Docker processes on the host system.
+{ .important }
+
+### tmpfs
+
+A `tmpfs` mount isn't persisted on disk, either on the Docker host or within a
+container. It can be used by a container during the lifetime of the container,
+to store non-persistent state or sensitive information. For instance,
+internally, Swarm services use `tmpfs` mounts to mount
+[secrets](../engine/swarm/secrets.md) into a service's containers.
+
+### Named pipes
+
+[Named pipes](https://docs.microsoft.com/en-us/windows/desktop/ipc/named-pipes)
+can be used for communication between the Docker host and a container. Common
+use case is to run a third-party tool inside of a container and connect to the
+Docker Engine API using a named pipe.
 
 ## Good use cases for volumes
 


### PR DESCRIPTION
### Proposed changes

- improve formatting for the mount types overview
- clarify that anonymous volume mounts created for a container with the `--rm`
  flag are automatically removed when the container is removed. 052f261c6aa47addf30c9767c6c5c184c56daacf

### Related issues (optional)

Closes #18317
