### PR TITLE
redirects: add build-ga redirect

### DIFF
--- a/data/redirects.yml
+++ b/data/redirects.yml
@@ -619,6 +619,8 @@
   - /go/builders/selected/
 "https://www.docker.com/build-early-access-program/?utm_campaign=onboard-30-customer-zero&utm_medium=in-product-ad&utm_source=desktop_v4":
   - /go/build-eap/
+"https://build.docker.com/":
+  - /go/build-ga/
 "/build/building/multi-platform/":
   - /go/build-multi-platform/
 "/build/cache/backends/":


### PR DESCRIPTION
### Proposed changes

redirects: add build-ga redirect (counterpart to build-eap)

used in old versions of desktop

### Related issues (optional)

n/a