### PR TITLE
Update networking.md to use unambiguous term "service name" (#19041)

### DIFF
--- a/content/compose/networking.md
+++ b/content/compose/networking.md
@@ -40,7 +40,7 @@ When you run `docker compose up`, the following happens:
 3.  A container is created using `db`'s configuration. It joins the network
     `myapp_default` under the name `db`.
 
-Each container can now look up the hostname `web` or `db` and
+Each container can now look up the service name `web` or `db` and
 get back the appropriate container's IP address. For example, `web`'s
 application code could connect to the URL `postgres://db:5432` and start
 using the Postgres database.


### PR DESCRIPTION
<!--
  Thank you for contributing to Docker documentation!

  Here are a few things to keep in mind:

  - Links between pages should use a relative path
  - Remember to add an alt text for images

  ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
  ┃     Review our contribution guidelines:       ┃
  ┃                                               ┃
  ┃ https://docs.docker.com/contribute/overview/  ┃
  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
-->

### Proposed changes

Service name is unambiguous and hence is the best choice.
Hostname is ambiguous here. The article uses the term hostname as meaning "the unique name of the computer" is "db" and web". However, this can be confused with the docker term "hostname".

### Related issues (optional)

<!--
  Refer to related PRs or issues:

#19041 
-->
