### PR TITLE
Update CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,9 +46,11 @@ Help make reviewing easier by following these guidelines:
 
 ### Local setup
 
-You can use Docker (surprise) to build and serve the files locally. This
-requires Docker Desktop version 4.24 or later, or Docker Engine with Docker
-Compose version 2.22 or later.
+You can use Docker (surprise) to build and serve the files locally. 
+
+> [!IMPORTANT]  
+> This requires Docker Desktop version **4.24** or later, or Docker Engine with Docker
+> Compose version [**2.22**](https://docs.docker.com/compose/file-watch/) or later.
 
 1. Clone the repository:
 


### PR DESCRIPTION
# Highlight docker version dependency

I went to go inspect other changes i have made, and found the local setup docs. I "skipped" past the version requirements.
After googling what `docker compose watch` was, I came back to the docs and found it right there before the first step.

### Proposed changes

This just highlights it so that first time readers will see the version requirement. I think that it can be removed once people have more recent versions of Docker installed.

I used [!IMPORTANT] since users mainly read this on github. https://github.com/orgs/community/discussions/16925.
Happy to explore other ways of demarcating it, and/or rejecting the request if I fall into the `PEBKAC` crew.

Before: https://github.com/docker/docs/blob/48b3eb2672c0d16fd156126570315fa335e0d775/CONTRIBUTING.md#local-setup
![image](https://github.com/docker/docs/assets/6406312/232fcca9-19d4-4091-afef-5daf905e46df)

After: https://github.com/alex-ong/docker-docs/blob/alex-ong-patch-1/CONTRIBUTING.md#local-setup
![image](https://github.com/docker/docs/assets/6406312/9f0b1095-6891-4462-a6ba-e2221771c164)
