### PR TITLE
Use consistent array style in Profiles example

### DIFF
--- a/content/compose/profiles.md
+++ b/content/compose/profiles.md
@@ -26,14 +26,12 @@ array of profile names:
 services:
   frontend:
     image: frontend
-    profiles: ["frontend"]
+    profiles: [frontend]
 
   phpmyadmin:
     image: phpmyadmin
-    depends_on:
-      - db
-    profiles:
-      - debug
+    depends_on: [db]
+    profiles: [debug]
 
   backend:
     image: backend


### PR DESCRIPTION
<!--
  Thank you for contributing to Docker documentation!

  Here are a few things to keep in mind:

  - Links between pages should use a relative path
  - Remember to add an alt text for images

  ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
  ┃     Review our contribution guidelines:       ┃
  ┃                                               ┃
  ┃ https://docs.docker.com/contribute/overview/  ┃
  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
-->

### Proposed changes

The config example for Profiles uses a mixture of different array styles. In order to avoid confusion and reduce the vertical size of the example config, this PR amends it to use minimal quoting and inline arrays.

### Related issues (optional)

<!--
  Refer to related PRs or issues:

  #1234
  Closes #1234
  Closes docker/cli#1234
-->
