### PR TITLE
reference: add CLI cheat sheet

### DIFF
--- a/assets/css/print.css
+++ b/assets/css/print.css
@@ -1,0 +1,13 @@
+@layer base {
+  @page {
+    /* Page margins for print */
+    margin: 2cm;
+  }
+
+  @media print {
+    /* Colorize the h1. Why? Why not. */
+    h1 {
+      color: theme("colors.blue.light.500") !important;
+    }
+  }
+}

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -4,6 +4,7 @@
 @import "/assets/css/global";
 @import "/assets/css/typography";
 @import "/assets/css/search";
+@import "/assets/css/print";
 
 @import "tailwindcss/components";
 @import "/assets/css/code";

--- a/content/cheat-sheets/cli.md
+++ b/content/cheat-sheets/cli.md
@@ -1,0 +1,89 @@
+---
+title: Docker CLI cheat sheet
+description: A cheat sheet for the most common Docker CLI commands
+keywords: docker, cli, cheat sheet, cheatsheet, commands
+skip_read_time: true
+general:
+  - Start the docker daemon: "dockerd"
+  - Get help with Docker: "docker [COMMAND] help"
+  - Display system-wide information: "docker info"
+  - Display Docker version: "docker version"
+images:
+  - Build an Image from a Dockerfile: "docker build -t <image_name>"
+  - Build an Image from a Dockerfile without the cache: "docker build -t <image_name> . –no-cache"
+  - List local images: "docker images"
+  - Delete an Image: "docker rmi <image_name>"
+  - Remove all unused images: "docker image prune"
+containers:
+  - Create and run a container from an image, with a custom name: "docker run --name <container_name> <image_name>"
+  - Run a container with and publish a container’s port(s) to the host: "docker run -p <host_port>:<container_port> <image_name>"
+  - Run a container in the background: "docker run -d <image_name>"
+  - Start an existing container: "docker start <container_name>"
+  - Stop an existing container: "docker stop <container_name>"
+  - Remove a stopped container: "docker rm <container_name>"
+  - Open a shell inside a running container: "docker exec -it <container_name> sh"
+  - Fetch and follow the logs of a container: "docker logs -f <container_name>"
+  - Inspect a running container: "docker inspect <container_name>"
+  - List currently running containers: "docker ps"
+  - List all docker containers (running and stopped): "docker ps --all"
+  - View resource usage stats: "docker container stats"
+hub:
+  - Login into Docker: "docker login -u <username>"
+  - Publish an image to Docker Hub: "docker push <username>/<image_name>"
+  - Search Hub for an image: "docker search <image_name>"
+  - Pull an image from a Docker Hub: "docker pull <image_name>"
+---
+
+Docker provides the ability to package and run an application in a loosely
+isolated environment called a container. The isolation and security allows you
+to run many containers simultaneously on a given host. Containers are
+lightweight and contain everything needed to run the application, so you do not
+need to rely on what is currently installed on the host. You can easily share
+containers while you work, and be sure that everyone you share with gets the
+same container that works in the same way.
+
+<a href="javascript:print();">Print this page</a>
+
+## General commands
+
+{{< cheats.inline "general" >}}
+
+{{ $list := index .Page.Params (.Get 0) }}
+{{ range $index, $item := $list }}
+{{ range $k, $v := $item }}
+
+<div class="p-2 border-b bg-gray-light-100 border-b-divider-light dark:bg-gray-dark-200 dark:border-b-divider-dark">
+<span class="text-base text-gray-light dark:text-gray-dark">{{ $k }}</span>
+<br>
+<span class="font-mono">{{ transform.HTMLEscape $v }}</span>
+</div>
+
+{{ end }}
+{{ end }}
+{{< /cheats.inline >}}
+
+## Images
+
+Docker images are a lightweight, standalone, executable package
+of software that includes everything needed to run an application:
+code, runtime, system tools, system libraries and settings.
+
+{{< cheats.inline "images" />}}
+
+## Containers
+
+A container is a runtime instance of a docker image. A container
+will always run the same, regardless of the infrastructure.
+Containers isolate software from its environment and ensure
+that it works uniformly despite differences for instance between
+development and staging.
+
+{{< cheats.inline "containers" />}}
+
+## Docker Hub
+
+Docker Hub is a service provided by Docker for finding and sharing
+container images with your team. Learn more and find images
+at <https://hub.docker.com/>.
+
+{{< cheats.inline "hub" />}}

--- a/content/cheat-sheets/cli.md
+++ b/content/cheat-sheets/cli.md
@@ -42,7 +42,7 @@ need to rely on what is currently installed on the host. You can easily share
 containers while you work, and be sure that everyone you share with gets the
 same container that works in the same way.
 
-<a href="javascript:print();">Print this page</a>
+<a class="print:hidden" href="javascript:print();">Print this page</a>
 
 ## General commands
 

--- a/data/toc.yaml
+++ b/data/toc.yaml
@@ -1005,6 +1005,8 @@ Reference:
           title: Version 2
 - path: /glossary/
   title: Glossary
+- path: /cheat-sheets/cli/
+  title: CLI cheat sheet
 
 
 

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -8,9 +8,9 @@
 <body
   class="bg-background-light dark:bg-background-dark text-base divide-y divide-divider-light dark:divide-divider-dark flex flex-col h-max dark:text-white">
   {{ partial "header.html" . }}
-  <main class="min-h-screen flex items-stretch">
+  <main class="flex items-stretch">
     <div id="sidebar"
-      class="z-10 flex flex-col items-end sticky top-16 h-[calc(100vh-theme(space.16))] overflow-y-scroll flex-shrink-0 flex-grow md:fixed md:w-screen md:hidden bg-background-light dark:bg-gray-dark-100">
+      class="print:hidden z-10 flex flex-col items-end sticky top-16 h-[calc(100vh-theme(space.16))] overflow-y-scroll flex-shrink-0 flex-grow md:fixed md:w-screen md:hidden bg-background-light dark:bg-gray-dark-100">
       {{ block "left" . }}
       {{ end }}
     </div>
@@ -18,12 +18,12 @@
       {{ block "main" . }}
       {{ end }}
     </div>
-    <div class="sticky w-[300px] top-16 p-5 h-[calc(100vh-theme(space.16))] flex-grow overflow-y-auto lg:hidden">
+    <div class="print:hidden sticky w-[300px] top-16 p-5 h-[calc(100vh-theme(space.16))] flex-grow overflow-y-auto lg:hidden">
       {{ block "right" . }}
       {{ end }}
     </div>
   </main>
-  <footer>
+  <footer class="print:hidden">
     {{ partialCached "footer.html" . }}
   </footer>
 </body>

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -1,4 +1,4 @@
-<header class="sticky top-0 z-20 h-16 px-4 text-white bg-gradient-to-r from-accent-light to-blue-light-500 dark:from-accent-dark dark:to-blue-dark-100">
+<header class="print:hidden sticky top-0 z-20 h-16 px-4 text-white bg-gradient-to-r from-accent-light to-blue-light-500 dark:from-accent-dark dark:to-blue-dark-100">
   <div class="mx-auto flex h-full max-w-[1440px] items-center justify-between">
     <div class="flex h-full items-center gap-8 md:gap-2">
       <button x-data tabindex="4" @click="() => {

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,7 +1,9 @@
+const plugin = require('tailwindcss/plugin')
+
 /** @type {import('tailwindcss').Config} */
 module.exports = {
   content: ["./hugo_stats.json","./layouts/**/*.{html,js}", "./content/**/*.md", "assets/js/**/*.js"],
-  darkMode: "class",
+  darkMode: null,
   theme: {
     extend: {
       typography: (theme) => ({
@@ -256,5 +258,11 @@ module.exports = {
       icons: ["Material Symbols Rounded"],
     },
   },
-  plugins: [require("@tailwindcss/typography")],
+  plugins: [
+    // disable dark mode for @media print
+    plugin(function({ addVariant }) {
+      addVariant('dark', '@media not print { .dark & }')
+    }),
+    require("@tailwindcss/typography")
+  ],
 };

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -64,6 +64,8 @@ module.exports = {
       md: { max: "1024px" },
       lg: { max: "1280px" },
       xl: { max: "1440px" },
+      print: { raw: 'print' },
+      screen: { raw: 'screen' },
     },
 
     colors: {


### PR DESCRIPTION
Signed-off-by: David Karlsson <35727626+dvdksn@users.noreply.github.com>

<!--
  Thank you for contributing to Docker documentation!

  Here are a few things to keep in mind:

  - Links between pages should use a relative path
  - Remember to add an alt text for images

  ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
  ┃     Review our contribution guidelines:       ┃
  ┃                                               ┃
  ┃ https://docs.docker.com/contribute/overview/  ┃
  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
-->

### Proposed changes

Adds the CLI cheat sheet to the documentation

https://deploy-preview-19061--docsdocker.netlify.app/cheat-sheets/cli/

Also adds some rudimentary styles to make pages appear a little nicer in print (in case folks do want to print the cheat sheet to PDF)

I did experiment with using pandoc for generating the PDF at build-time. But that pipeline gets kind of involved quickly, and it's difficult to get a cheat sheet to look good in HTML and PDF simultanously using two different build tools, so went with the CSS-based approach instead.

### Related issues (optional)

<!--
  Refer to related PRs or issues:

  #1234
  Closes #1234
  Closes docker/cli#1234
-->
