### PR TITLE
Add callout to enforce sign-in page

### DIFF
--- a/content/security/for-admins/configure-sign-in.md
+++ b/content/security/for-admins/configure-sign-in.md
@@ -73,7 +73,7 @@ details, see [Manage members](/admin/organization/members/).
 
     > **Tip**
     >
-    > If your users have issues starting Docker Desktop after you enforce sign-in, they may need to update to the latest version. This feature is available with [Docker Desktop 4.4.2 and later](../../desktop/release-notes.md).
+    > If your users have issues starting Docker Desktop after you enforce sign-in, they may need to update to the latest version.
     { .tip }
 
 ## Alternative methods to create a registry.json file

--- a/content/security/for-admins/configure-sign-in.md
+++ b/content/security/for-admins/configure-sign-in.md
@@ -71,6 +71,11 @@ details, see [Manage members](/admin/organization/members/).
     Start Docker Desktop on the user’s machine and verify that the **Sign in
     required!** prompt appears.
 
+    > **Tip**
+    >
+    > If your users have issues starting Docker Desktop after you enforce sign-in, they may need to update to the latest version. This feature is available with [Docker Desktop 4.4.2 and later](../../desktop/release-notes.md).
+    { .tip }
+
 ## Alternative methods to create a registry.json file
 
 You can also use the following alternative methods to create a `registry.json` file.


### PR DESCRIPTION
<!--
  Thank you for contributing to Docker documentation!

  Here are a few things to keep in mind:

  - Links between pages should use a relative path
  - Remember to add an alt text for images

  ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
  ┃     Review our contribution guidelines:       ┃
  ┃                                               ┃
  ┃ https://docs.docker.com/contribute/overview/  ┃
  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
-->

### Proposed changes

<!-- Tell us what you did and why -->
This PR adds a callout tip to update DD if there are issues after enforcing sign-in.

### Related issues (optional)

<!--
  Refer to related PRs or issues:

  #1234
  Closes #1234
  Closes docker/cli#1234
-->
Closes JIRA https://docker.atlassian.net/browse/ENGDOCS-1916