### PR TITLE
Simplify removal of conflicting packages

### DIFF
--- a/content/engine/install/ubuntu.md
+++ b/content/engine/install/ubuntu.md
@@ -70,7 +70,7 @@ conflicts with the versions bundled with Docker Engine.
 Run the following command to uninstall all conflicting packages:
 
 ```console
-$ for pkg in docker.io docker-doc docker-compose docker-compose-v2 podman-docker containerd runc; do sudo apt-get remove $pkg; done
+$ sudo apt-get purge docker.io docker-doc docker-compose docker-compose-v2 podman-docker containerd runc
 ```
 
 `apt-get` might report that you have none of these packages installed.


### PR DESCRIPTION
### Proposed changes
A for loop isn't needed because apt-get can handle multiple packages as parameters.
