### PR TITLE
scout: add note about cache permissions

### DIFF
--- a/content/scout/integrations/ci/jenkins.md
+++ b/content/scout/integrations/ci/jenkins.md
@@ -40,3 +40,10 @@ pipeline {
 This installs Docker Scout, logs into Docker Hub, and then runs Docker Scout to
 generate a CVE report for an image and tag. It only shows critical or
 high-severity vulnerabilities.
+
+> **Note**
+>
+> If you're seeing a `permission denied` error related to the image cache, try
+> setting the [`DOCKER_SCOUT_CACHE_DIR`](../../env-vars.md) environment
+> variable to a writable directory. Or alternatively, disable local caching
+> entirely with `DOCKER_SCOUT_NO_CACHE=true`.


### PR DESCRIPTION
### Proposed changes

Added a note to the Jenkins CI example for Docker Scout about fixing a possible permissions error with the local cache.

https://deploy-preview-19079--docsdocker.netlify.app/scout/integrations/ci/jenkins/

### Related issues (optional)

Related to docker/scout-cli#80
