### PR TITLE
dockerd config location

### DIFF
--- a/content/config/daemon/_index.md
+++ b/content/config/daemon/_index.md
@@ -48,17 +48,31 @@ You can use both of these options together as long as you don't specify the same
 option both as a flag and in the JSON file. If that happens, the Docker daemon
 won't start and prints an error message.
 
-To configure the Docker daemon using a JSON file, create a file at
-`/etc/docker/daemon.json` on Linux systems, or
-`C:\ProgramData\docker\config\daemon.json` on Windows.
+### Configuration file
 
-Using this configuration file, run the Docker daemon in debug mode, using TLS, and
-listen for traffic routed to `192.168.59.3` on port `2376`. You can learn what
-configuration options are available in the
+The following table shows the location where the Docker daemon expects to find
+the configuration file by default, depending on your system and how you're
+running the daemon.
+
+| OS and configuration | File location                              |
+| -------------------- | ------------------------------------------ |
+| Linux, regular setup | `/etc/docker/daemon.json`                  |
+| Linux, rootless mode | `~/.config/docker/daemon.json`             |
+| Windows              | `C:\ProgramData\docker\config\daemon.json` |
+
+For rootless mode, the daemon respects the `XDG_CONFIG_HOME` variable. If set,
+the expected file location is `$XDG_CONFIG_HOME/docker/daemon.json`.
+
+You can also explicitly specify the location of the configuration file on
+startup, using the `dockerd --config-file` flag.
+
+You can learn what configuration options are available in the
 [dockerd reference docs](../../engine/reference/commandline/dockerd.md#daemon-configuration-file)
 
-You can also start the Docker daemon manually and configure it using flags. This
-can be useful for troubleshooting problems.
+### Configuration using flags
+
+You can also start the Docker daemon manually and configure it using flags.
+This can be useful for troubleshooting problems.
 
 Here's an example of how to manually start the Docker daemon, using the same
 configurations as shown in the previous JSON configuration:

--- a/content/config/daemon/_index.md
+++ b/content/config/daemon/_index.md
@@ -126,5 +126,5 @@ documentation. Some places to go next include:
 - [Automatically start containers](../containers/start-containers-automatically.md)
 - [Limit a container's resources](../containers/resource_constraints.md)
 - [Configure storage drivers](../../storage/storagedriver/select-storage-driver.md)
-- [Container security](../../engine/security/index.md)
+- [Container security](../../engine/security/_index.md)
 - [Configure the Docker daemon to use a proxy](./systemd.md#httphttps-proxy)

--- a/content/config/daemon/_index.md
+++ b/content/config/daemon/_index.md
@@ -66,7 +66,7 @@ the expected file location is `$XDG_CONFIG_HOME/docker/daemon.json`.
 You can also explicitly specify the location of the configuration file on
 startup, using the `dockerd --config-file` flag.
 
-You can learn what configuration options are available in the
+Learn about the available configuration options in the
 [dockerd reference docs](../../engine/reference/commandline/dockerd.md#daemon-configuration-file)
 
 ### Configuration using flags
@@ -85,7 +85,7 @@ $ dockerd --debug \
   --host tcp://192.168.59.3:2376
 ```
 
-You can learn what configuration options are available in the
+Learn about the available configuration options in the
 [dockerd reference docs](../../engine/reference/commandline/dockerd.md), or by
 running:
 

--- a/content/config/daemon/_index.md
+++ b/content/config/daemon/_index.md
@@ -127,3 +127,4 @@ documentation. Some places to go next include:
 - [Limit a container's resources](../containers/resource_constraints.md)
 - [Configure storage drivers](../../storage/storagedriver/select-storage-driver.md)
 - [Container security](../../engine/security/index.md)
+- [Configure the Docker daemon to use a proxy](./systemd.md#httphttps-proxy)

--- a/content/config/daemon/_index.md
+++ b/content/config/daemon/_index.md
@@ -93,11 +93,6 @@ running:
 $ dockerd --help
 ```
 
-You can configure most daemon options using the `daemon.json` file. One thing
-you can't configure using daemon.json mechanism is an HTTP proxy. For
-instructions on using a proxy, see
-[Configure Docker to use a proxy server](../../network/proxy.md).
-
 ## Daemon data directory
 
 The Docker daemon persists all data in a single directory. This tracks

--- a/content/config/daemon/_index.md
+++ b/content/config/daemon/_index.md
@@ -93,14 +93,6 @@ running:
 $ dockerd --help
 ```
 
-Many specific configuration options are discussed throughout the Docker
-documentation. Some places to go next include:
-
-- [Automatically start containers](../containers/start-containers-automatically.md)
-- [Limit a container's resources](../containers/resource_constraints.md)
-- [Configure storage drivers](../../storage/storagedriver/select-storage-driver.md)
-- [Container security](../../engine/security/index.md)
-
 You can configure most daemon options using the `daemon.json` file. One thing
 you can't configure using daemon.json mechanism is an HTTP proxy. For
 instructions on using a proxy, see
@@ -130,3 +122,13 @@ Since the state of a Docker daemon is kept on this directory, make sure you use
 a dedicated directory for each daemon. If two daemons share the same directory,
 for example, an NFS share, you are going to experience errors that are difficult
 to troubleshoot.
+
+## Next steps
+
+Many specific configuration options are discussed throughout the Docker
+documentation. Some places to go next include:
+
+- [Automatically start containers](../containers/start-containers-automatically.md)
+- [Limit a container's resources](../containers/resource_constraints.md)
+- [Configure storage drivers](../../storage/storagedriver/select-storage-driver.md)
+- [Container security](../../engine/security/index.md)


### PR DESCRIPTION
### Proposed changes

- engine: clarify daemon.json config file location
- engine: move "next steps" to separate section
- engine: remove incorrect statement about proxy config with daemon.json

### Related issues (optional)

Relates to moby/moby#47058