### PR TITLE
fix: dockerfile tooltips should match only keywords

### DIFF
--- a/assets/js/src/tooltip.js
+++ b/assets/js/src/tooltip.js
@@ -1,4 +1,25 @@
-const cmds = document.querySelectorAll(".language-dockerfile span.k");
+const keywords = [
+  "ADD",
+  "ARG",
+  "CMD",
+  "COPY",
+  "ENTRYPOINT",
+  "ENV",
+  "EXPOSE",
+  "FROM",
+  "HEALTHCHECK",
+  "LABEL",
+  // "MAINTAINER",
+  "ONBUILD",
+  "RUN",
+  "SHELL",
+  "STOPSIGNAL",
+  "USER",
+  "VOLUME",
+  "WORKDIR",
+]
+const cmds = Array.from(document.querySelectorAll(".language-dockerfile span.k"))
+  .filter((el) => keywords.some(kwd => el.textContent.includes(kwd)));
 
 for (const cmd of cmds) {
   const name = cmd.textContent;


### PR DESCRIPTION

### Proposed changes

Before this change, the Dockerfile tooltip script marked all occurences
of keywords, as defined by the lexer, as Dockerfile instructions in a
`dockerfile` code block. This meant some tokens parsed from heredocs
would be included. The matched keyword token is now compared against a
hard-coded list of actual Dockerfile instructions before they're
annotated.

Before/after

<img width="795" alt="Screenshot 2024-01-12 at 11 59 39" src="https://github.com/docker/docs/assets/35727626/e355d4b3-7a3d-47fb-8e7d-7b247abf38f5">
<img width="805" alt="Screenshot 2024-01-12 at 12 13 14" src="https://github.com/docker/docs/assets/35727626/6e5a1f6b-388c-4689-9b8b-699e3d268b8e">


### Related issues (optional)

Fixes an issue in #19087