### PR TITLE
build: clarify cache backend protocol compatibility

### DIFF
--- a/content/build/cache/backends/gha.md
+++ b/content/build/cache/backends/gha.md
@@ -13,9 +13,10 @@ aliases:
 { .restricted }
 
 The GitHub Actions cache utilizes the
-[GitHub-provided Action's cache](https://github.com/actions/cache) available
-from within your CI execution environment. This is the recommended cache to use
-inside your GitHub action pipelines, as long as your use case falls within the
+[GitHub-provided Action's cache](https://github.com/actions/cache) or other
+cache services supporting the GitHub Actions cache protocol. This is the
+recommended cache to use inside your GitHub Actions workflows, as long as your
+use case falls within the
 [size and usage limits set by GitHub](https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows#usage-limits-and-eviction-policy).
 
 This cache storage backend is not supported with the default `docker` driver.

--- a/content/build/cache/backends/s3.md
+++ b/content/build/cache/backends/s3.md
@@ -13,8 +13,8 @@ aliases:
 { .restricted }
 
 The `s3` cache storage uploads your resulting build cache to
-[Amazon S3 file storage service](https://aws.amazon.com/s3/),
-into a specified bucket.
+[Amazon S3 file storage service](https://aws.amazon.com/s3/)
+or other S3-compatible services, such as [MinIO](https://min.io/).
 
 This cache storage backend is not supported with the default `docker` driver.
 To use this feature, create a new builder using a different driver. See


### PR DESCRIPTION
### Proposed changes

S3 and GHA cache backends can be used with other services compatible
with the S3/GHA protocols.

### Related issues (optional)

Addresses moby/buildkit#4312
