### PR TITLE
Explain explicit property in default non-root user policy

### DIFF
--- a/content/scout/policy/_index.md
+++ b/content/scout/policy/_index.md
@@ -229,7 +229,10 @@ default `root` user. To comply with this policy, images must specify a non-root
 user in the image configuration. Images violate this policy if they don't
 specify a non-root default user for the runtime stage.
 
-In instances where an image does not adhere to this policy, the evaluation result will communicate through the `Explicit` property whether the Dockerfile explicitly specifies the use of the `USER root` instruction. This information serves to enhance developers' comprehension regarding the deliberate or inadvertent setting of the `root` user, aiding in the identification of intentional configurations.
+For non-compliant images, evaluation results show whether or not the `root`
+user was set explicitly for the image. This helps you distinguish between
+policy violations caused by images where the `root` user is implicit, and
+images where `root` is set on purpose.
 
 The following Dockerfile runs as `root` by default despite not being explicitly set:
 ```Dockerfile
@@ -237,7 +240,7 @@ FROM alpine
 RUN echo "Hi"
 ```
 
-Whereas in the case below the `root` user is explictly set:
+Whereas in the following case, the `root` user is explicitly set:
 
 ```Dockerfile
 FROM alpine

--- a/content/scout/policy/_index.md
+++ b/content/scout/policy/_index.md
@@ -229,6 +229,22 @@ default `root` user. To comply with this policy, images must specify a non-root
 user in the image configuration. Images violate this policy if they don't
 specify a non-root default user for the runtime stage.
 
+In instances where an image does not adhere to this policy, the evaluation result will communicate through the `Explicit` property whether the Dockerfile explicitly specifies the use of the `USER root` instruction. This information serves to enhance developers' comprehension regarding the deliberate or inadvertent setting of the `root` user, aiding in the identification of intentional configurations.
+
+The following Dockerfile runs as `root` by default despite not being explicitly set:
+```Dockerfile
+FROM alpine
+RUN echo "Hi"
+```
+
+Whereas in the case below the `root` user is explictly set:
+
+```Dockerfile
+FROM alpine
+USER root
+RUN echo "Hi"
+```
+
 > **Note**
 >
 > This policy only checks for the default user of the image, as set in the


### PR DESCRIPTION
<!--
  Thank you for contributing to Docker documentation!

  Here are a few things to keep in mind:

  - Links between pages should use a relative path
  - Remember to add an alt text for images

  ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
  ┃     Review our contribution guidelines:       ┃
  ┃                                               ┃
  ┃ https://docs.docker.com/contribute/overview/  ┃
  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
-->

### Proposed changes

This PR explains the `Explicit` property in the evaluation result of the Default non-root user policy.

### Related issues (optional)

<!--
  Refer to related PRs or issues:

  #1234
  Closes #1234
  Closes docker/cli#1234
-->
