### PR TITLE
Complete docs for "restart: on-failure" in "Compose file reference / Services top-level element"

### DIFF
--- a/content/compose/compose-file/05-services.md
+++ b/content/compose/compose-file/05-services.md
@@ -1483,7 +1483,9 @@ If `pull_policy` and `build` are both present, Compose builds the image by defau
 
 - `no`: The default restart policy. It does not restart the container under any circumstances.
 - `always`: The policy always restarts the container until its removal.
-- `on-failure`: The policy restarts the container if the exit code indicates an error.
+- `on-failure[:max-retries]`: The policy restarts the container if the exit code indicates an error.
+Optionally, limit the number of restart retries the Docker daemon attempts.
+The default number of restart retries is 1.
 - `unless-stopped`: The policy restarts the container irrespective of the exit code but stops
   restarting when the service is stopped or removed.
 
@@ -1491,8 +1493,13 @@ If `pull_policy` and `build` are both present, Compose builds the image by defau
     restart: "no"
     restart: always
     restart: on-failure
+    restart: on-failure:3
     restart: unless-stopped
 ```
+
+You can find more detailed information on restart policies in the
+[Restart Policies (--restart)](../../../_vendor/github.com/docker/cli/docs/reference/run.md#restart-policies---restart)
+section of the Docker run reference page.
 
 ## runtime
 


### PR DESCRIPTION
### Complete docs for "restart: on-failure" in "Compose file reference / Services top-level element"

This PR makes the complete documentation for the `on-failure` option of the `restart` element in `Compose file reference / Services top-level element` page.

Option `on-failure` allows specifying the optional maximum attempts.

The PR aims to resolve the issue #19115