### PR TITLE
add docker debug cli reference

### DIFF
--- a/content/engine/reference/commandline/debug.md
+++ b/content/engine/reference/commandline/debug.md
@@ -5,13 +5,6 @@ title: docker debug
 layout: cli
 ---
 
-<!--
-This page is automatically generated from Docker's source code. If you want to
-suggest a change to the text that appears here, open a ticket or pull request
-in the source repository on GitHub:
-
-https://github.com/docker/docker-init
--->
 > **Beta**
 >
-> The Docker Debug plugin is currently in [Beta](../../../release-lifecycle.md#beta). Docker recommends that you do not use this in production environments.
+> Docker Debug is currently in [Beta](../../../release-lifecycle.md#beta). Docker recommends that you do not use this in production environments.

--- a/content/engine/reference/commandline/debug.md
+++ b/content/engine/reference/commandline/debug.md
@@ -1,0 +1,17 @@
+---
+datafolder: debug-cli
+datafile: docker_debug
+title: docker debug
+layout: cli
+---
+
+<!--
+This page is automatically generated from Docker's source code. If you want to
+suggest a change to the text that appears here, open a ticket or pull request
+in the source repository on GitHub:
+
+https://github.com/docker/docker-init
+-->
+> **Beta**
+>
+> The Docker Debug plugin is currently in [Beta](../../../release-lifecycle.md#beta). Docker recommends that you do not use this in production environments.

--- a/data/debug-cli/docker_debug.yaml
+++ b/data/debug-cli/docker_debug.yaml
@@ -145,7 +145,7 @@ examples: |-
   The `--host` flag may be used with all other examples, including getting a
   shell into an image.
   
-  Example 4: Get a shell into a running container that has no shell
+  ### Example 4: Get a shell into a running container that has no shell
   
   ```console
   $ docker run --detach --rm --volume=/var/run/docker.sock:/var/run/docker.sock -p 8080:8080 --name my-container amir20/dozzle

--- a/data/debug-cli/docker_debug.yaml
+++ b/data/debug-cli/docker_debug.yaml
@@ -1,0 +1,162 @@
+command: docker debug
+short: Get a shell into any container or image.
+long: |-
+  Get an enhanced shell with additional tools into any container or image.  
+  
+  The shell contains the following builtin commands:
+  - `install [tool1] [tool2]`: Add Nix packages from: https://search.nixos.org/packages.
+  - `uninstall [tool1] [tool2]`: Uninstall NixOS package(s).
+  - `entrypoint`: Print/lint/run the entrypoint.
+  - `builtins`: Show builtin commands.
+
+  For images and stopped containers, all changes are discarded when leaving the
+  shell. At no point, do changes affect the actual image or container. When
+  accessing running or paused containers, all filesystem changes are directly
+  visible to the container. The `/nix` directory is never visible to the actual
+  image or container.
+usage: debug [OPTIONS] {CONTAINER|IMAGE}
+pname: docker
+plink: docker.yaml
+options:
+    - option: shell
+      value_type: shell
+      default_value: "auto"
+      description: "Select a shell. Supported: `bash`, `fish`, `zsh`, `auto`."
+      deprecated: false
+      hidden: false
+      experimental: false
+      experimentalcli: false
+      kubernetes: false
+      swarm: false
+    - option: command
+      shorthand: c
+      value_type: string
+      default_value: false
+      description: Evaluate the specified commands instead, passing additional positional arguments through $argv.
+      deprecated: false
+      hidden: false
+      experimental: false
+      experimentalcli: false
+      kubernetes: false
+      swarm: false
+    - option: host
+      value_type: string
+      default_value: false
+      description: "Daemon docker socket to connect to. E.g.: `ssh://root@example.org`, `unix:///some/path/docker.sock`"
+      deprecated: false
+      hidden: false
+      experimental: false
+      experimentalcli: false
+      kubernetes: false
+      swarm: false
+    - option: version
+      value_type: bool
+      default_value: "false"
+      description: Display version of the docker-debug plugin
+      deprecated: false
+      hidden: false
+      experimental: false
+      experimentalcli: false
+      kubernetes: false
+      swarm: false
+deprecated: false
+experimental: false
+experimentalcli: false
+kubernetes: false
+swarm: false
+examples: |-
+  ### Example 1: Get a shell into any image
+  This example pulls an nginx image and gets a shell into it without ever running a container.
+  
+  ```console
+  $ docker pull nginx
+  $ docker debug nginx
+  
+  Builtin commands:
+  - install [tool1] [tool2] ...    Add Nix packages from: https://search.nixos.org/packages
+  - uninstall [tool1] [tool2] ...  Uninstall NixOS package(s).
+  - entrypoint                     Print/lint/run the entrypoint.
+  - builtins                       Show builtin commands.
+  
+  Checks:
+  ✓ distro:            Debian GNU/Linux 12 (bookworm)
+  ✓ entrypoint linter: no errors (run 'entrypoint' for details)
+
+  Note: This is a sandbox shell. All changes will not affect the actual image.
+                                                                                                                     Version: 0.0.18 (BETA)
+  root@a8758716bb6a / [nginx:latest]
+  docker >
+  ```
+  
+  The console now has a shell in the read-only filesystem of the nginx image.
+  You can now run `entrypoint` to inspect the entrypoint or run `builtins` to
+  see all builtin commands.
+  
+  ### Example 2: Dumping a file from an image to stdout by using the -c mode
+  
+  Use the `-c` (`--command`) flag to directly evaluate a command instead of
+  running the shell in interactive mode.
+  
+  The following example dumps the default `index.html` file of nginx to stdout.
+
+  ```console
+  $ docker pull nginx
+  $ docker debug nginx -c "cat /usr/share/nginx/html/index.html"
+  <!DOCTYPE html>
+  <html>
+  <head>
+  <title>Welcome to nginx!</title>
+  <style>
+  html { color-scheme: light dark; }
+  body { width: 35em; margin: 0 auto;
+  font-family: Tahoma, Verdana, Arial, sans-serif; }
+  </style>
+  </head>
+  <body>
+  <h1>Welcome to nginx!</h1>
+  <p>If you see this page, the nginx web server is successfully installed and
+  working. Further configuration is required.</p>
+  
+  <p>For online documentation and support please refer to
+  <a href="http://nginx.org/">nginx.org</a>.<br/>
+  Commercial support is available at
+  <a href="http://nginx.com/">nginx.com</a>.</p>
+  
+  <p><em>Thank you for using nginx.</em></p>
+  </body>
+  </html>
+  ```
+  
+  ### Example 3: Get a shell into a stopped container via SSH
+  
+  Use the `--host` flag to connect to a different Docker Engine other than the
+  default.
+  
+  The following example connects to a remote Docker instance via SSH.
+  
+  ```console
+  $ docker debug --host ssh://root@example.org my-container
+  ```
+  
+  The `--host` flag may be used with all other examples, including getting a
+  shell into an image.
+  
+  Example 4: Get a shell into a running container that has no shell
+  
+  ```console
+  $ docker run --detach --rm --volume=/var/run/docker.sock:/var/run/docker.sock -p 8080:8080 --name my-container amir20/dozzle
+  $ docker debug my-container
+  ```
+  
+  Once the shell is attached to the container, you can add further tools with
+  the built-in `install` command. For example, run `install nmap`. Adding
+  further tools to your debugging shell does not modify the target container. 
+  
+  The built-in `forward` command lets you use remote tools. The following example starts a web file browser.
+  
+  ```console
+  $ forward --port 9000:9012 -- webfsd -F -p 9012
+  ```
+  
+  You can access the file browser on your host's browser at
+  http://localhost:9000.

--- a/data/debug-cli/docker_debug.yaml
+++ b/data/debug-cli/docker_debug.yaml
@@ -1,7 +1,12 @@
 command: docker debug
 short: Get a shell into any container or image.
 long: |-
-  Get an enhanced shell with additional tools into any container or image.  
+  > **Note**
+  >
+  > Docker Debug requires a [Pro, Team, or Business subcription](/subscription/details/).
+  > You must [sign in](/desktop/get-started/) to use this command.
+
+  Get an enhanced shell with additional tools into any container or image.
   
   The shell contains the following builtin commands:
   - `install [tool1] [tool2]`: Add Nix packages from: https://search.nixos.org/packages.
@@ -14,6 +19,7 @@ long: |-
   accessing running or paused containers, all filesystem changes are directly
   visible to the container. The `/nix` directory is never visible to the actual
   image or container.
+  
 usage: debug [OPTIONS] {CONTAINER|IMAGE}
 pname: docker
 plink: docker.yaml

--- a/data/debug-cli/docker_debug.yaml
+++ b/data/debug-cli/docker_debug.yaml
@@ -7,13 +7,19 @@ long: |-
   > You must [sign in](/desktop/get-started/) to use this command.
 
   Get an enhanced shell with additional tools into any container or image.
-  
+
   The shell contains the following builtin commands:
   - `install [tool1] [tool2]`: Add Nix packages from: https://search.nixos.org/packages.
-  - `uninstall [tool1] [tool2]`: Uninstall NixOS package(s).
-  - `entrypoint`: Print/lint/run the entrypoint.
+  - `uninstall [tool1] [tool2]`: Uninstall Nix packages.
+  - `entrypoint`: Print, lint, or run the entrypoint.
   - `builtins`: Show builtin commands.
-
+  
+  The shell already has many popular tools installed, for example `vim`, `nano`,
+  and `htop`. Use the builtin `install` and `uninstall` commands to manage the
+  tools. Any tool installed in the shell is available to all future debug
+  sessions. The tools are not installed in the actual image or container that
+  you are debugging.
+  
   For images and stopped containers, all changes are discarded when leaving the
   shell. At no point, do changes affect the actual image or container. When
   accessing running or paused containers, all filesystem changes are directly
@@ -38,7 +44,7 @@ options:
       shorthand: c
       value_type: string
       default_value: false
-      description: Evaluate the specified commands instead, passing additional positional arguments through $argv.
+      description: Evaluate the specified commands instead of starting an interactive session.
       deprecated: false
       hidden: false
       experimental: false
@@ -55,34 +61,29 @@ options:
       experimentalcli: false
       kubernetes: false
       swarm: false
-    - option: version
-      value_type: bool
-      default_value: "false"
-      description: Display version of the docker-debug plugin
-      deprecated: false
-      hidden: false
-      experimental: false
-      experimentalcli: false
-      kubernetes: false
-      swarm: false
 deprecated: false
 experimental: false
 experimentalcli: false
 kubernetes: false
 swarm: false
 examples: |-
-  ### Example 1: Get a shell into any image
-  This example pulls an nginx image and gets a shell into it without ever running a container.
+  ### Examples using the options
+  #### Example of using --shell
+
+  The following example shows how to use the `--shell` option to select a shell.
+  The example gets a shell into the `nginx` image using the `fish` shell and
+  runs `echo $SHELL` to verify that the shell is `fish`. It then runs `exit` to
+  exit the interactive session.
   
   ```console
-  $ docker debug nginx
-  
+  $ docker debug --shell fish nginx
+
   Builtin commands:
   - install [tool1] [tool2] ...    Add Nix packages from: https://search.nixos.org/packages
   - uninstall [tool1] [tool2] ...  Uninstall NixOS package(s).
   - entrypoint                     Print/lint/run the entrypoint.
   - builtins                       Show builtin commands.
-  
+
   Checks:
   ✓ distro:            Debian GNU/Linux 12 (bookworm)
   ✓ entrypoint linter: no errors (run 'entrypoint' for details)
@@ -90,22 +91,34 @@ examples: |-
   Note: This is a sandbox shell. All changes will not affect the actual image.
                                                                                                                      Version: 0.0.18 (BETA)
   root@a8758716bb6a / [nginx:latest]
-  docker >
+  
+  docker > echo $SHELL
+  fish
+
+  docker > exit
   ```
   
-  The console now has a shell in the read-only filesystem of the nginx image.
-  You can now run `entrypoint` to inspect the entrypoint or run `builtins` to
-  see all builtin commands.
+  If `--shell` isn't specified, the default `auto` is used. You can also get a
+  shell into an image that doesn't include a shell. The following example shows
+  how to get a shell into the `hello-world` image and then run `cat /etc/shells`
+  to verify that there isn't a shell available in the image.
   
-  ### Example 2: Dumping a file from an image to stdout by using the -c mode
-  
-  Use the `-c` (`--command`) flag to directly evaluate a command instead of
-  running the shell in interactive mode.
-  
-  The following example dumps the default `index.html` file of nginx to stdout.
-
   ```console
-  $ docker debug nginx -c "cat /usr/share/nginx/html/index.html"
+  $ docker debug hello-world
+  ...
+  docker > cat /etc/shells
+  cat: /etc/shells: No such file or directory
+  ```
+
+  #### Example of using --command
+  
+  The following example shows how to use the `--command` option to evaluate a
+  command instead of starting an interactive session. The example runs the `cat`
+  command in the nginx image without starting an interactive session.
+  
+  ```console
+  $ docker debug --command "cat /usr/share/nginx/html/index.html" nginx
+
   <!DOCTYPE html>
   <html>
   <head>
@@ -131,36 +144,231 @@ examples: |-
   </html>
   ```
   
-  ### Example 3: Get a shell into a stopped container via SSH
+  #### Example of using --host
   
-  Use the `--host` flag to connect to a different Docker Engine other than the
-  default.
-  
-  The following example connects to a remote Docker instance via SSH.
+  The following examples shows how to use the `--host` option. The first example uses SSH to connect to a remote Docker instance at `example.org` as the `root` user, and get a shell into the `my-container` container.
   
   ```console
   $ docker debug --host ssh://root@example.org my-container
   ```
   
-  The `--host` flag may be used with all other examples, including getting a
-  shell into an image.
-  
-  ### Example 4: Get a shell into a running container that has no shell
+  The following example connects to a different local Docker Engine, and gets a
+  shell into the `my-container` container.
   
   ```console
-  $ docker run --detach --rm --volume=/var/run/docker.sock:/var/run/docker.sock -p 8080:8080 --name my-container amir20/dozzle
+  $ docker debug --host=unix:///some/path/docker.sock my-container
+  ```
+
+  ### Examples of using the builtin commands
+  #### Example of using the install and uninstall commands
+  
+  The following example shows how to use the `install` command to add Nix packages. The example installs Nmap and then runs `nmap --version` to show that it's installed. It then runs a container and tries to run `nmap` to verify that the tool isn't installed in the actual image.
+  
+  ```console
+  $ docker debug nginx
+  ...
+  docker > install nmap
+  Tip: You can install any package available at: https://search.nixos.org/packages.
+  installing 'nmap-7.93'
+  these 2 paths will be fetched (5.58 MiB download, 26.27 MiB unpacked):
+  /nix/store/brqjf4i23fagizaq2gn4d6z0f406d0kg-lua-5.3.6
+  /nix/store/xqd17rhgmn6pg85a3g18yqxpcya6d06r-nmap-7.93
+  copying path '/nix/store/brqjf4i23fagizaq2gn4d6z0f406d0kg-lua-5.3.6' from 'https://cache.nixos.org'...
+  copying path '/nix/store/xqd17rhgmn6pg85a3g18yqxpcya6d06r-nmap-7.93' from 'https://cache.nixos.org'...
+  building '/nix/store/k8xw5wwarh8dc1dvh5zx8rlwamxfsk3d-user-environment.drv'...
+  
+  docker > nmap --version
+  Nmap version 7.93 ( https://nmap.org )
+  Platform: x86_64-unknown-linux-gnu
+  Compiled with: liblua-5.3.6 openssl-3.0.11 libssh2-1.11.0 nmap-libz-1.2.12 libpcre-8.45 libpcap-1.10.4 nmap-libdnet-1.12 ipv6
+  Compiled without:
+  Available nsock engines: epoll poll select
+  
+  docker > exit
+
+  $ docker run --rm nginx nmap --version
+  /docker-entrypoint.sh: 47: exec: nmap: not found
+  ```
+  
+  Nmap is now installed only in the debug shell. The changes aren't applied to
+  the actual image or container. Nmap will be available in all future debug
+  sessions.
+  
+  The following example shows that Nmap is now available in a future debug
+  session when debugging a different image. In the previous example, Nmap was
+  installed during the interactive session for the `nginx` image. In this
+  example, Nmap is ran without installing it during an interactive sesion for
+  the `hello-world` image.
+  
+  ```console
+  $ docker debug hello-world
+  ...
+  docker > nmap --version
+  
+  Nmap version 7.93 ( https://nmap.org )
+  Platform: x86_64-unknown-linux-gnu
+  Compiled with: liblua-5.3.6 openssl-3.0.11 libssh2-1.11.0 nmap-libz-1.2.12 libpcre-8.45 libpcap-1.10.4 nmap-libdnet-1.12 ipv6
+  Compiled without:
+  Available nsock engines: epoll poll select
+  
+  docker > exit
+  ```
+  
+  Use `uninstall` to remove tools. Uninstalled tools are no longer available in future debug sessions. The following example shows how to uninstall Nmap and then run `nmap --version` to verify that it's no longer installed.
+  
+  ```console
+  $ docker debug ubuntu
+  ...
+  docker > uninstall nmap
+  uninstalling 'nmap-7.93'
+  building '/nix/store/f7awdcrllpdc9ss4vnx945hxm062n4lk-user-environment.drv'...
+  
+  docker > nmap --version
+  bash: nmap: command not found
+  ```
+  
+  #### Example of using the entrypoint command
+
+  The following examples show how to use the `entrypoint` command to print, lint, or run the entrypoint.
+  
+  The following example runs `entrypoint` without any options.
+  ```console
+  $ docker debug nginx
+  ...
+  docker > entrypoint
+  Understand how ENTRYPOINT/CMD work and if they are set correctly.
+  From CMD in Dockerfile:
+   ['nginx', '-g', 'daemon off;']
+  
+  From ENTRYPOINT in Dockerfile:
+   ['/docker-entrypoint.sh']
+  
+  By default, any container from this image will be started with following   command:
+  
+  /docker-entrypoint.sh nginx -g daemon off;
+  
+  path: /docker-entrypoint.sh
+  args: nginx -g daemon off;
+  cwd:
+  PATH: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+  
+  Lint results:
+   PASS: '/docker-entrypoint.sh' found
+   PASS: no mixing of shell and exec form
+   PASS: no double use of shell form
+  
+  Docs:
+  - https://docs.docker.com/engine/reference/builder/#cmd
+  - https://docs.docker.com/engine/reference/builder/#entrypoint
+  - https://docs.docker.com/engine/reference/builder/#understand-how-cmd-and-entrypoint-interact
+  ```
+  
+  The following example runs `entrypoint --lint` to lint the entrypoint. Linting
+  checks for common issues with the entrypoint, such as mixing shell and exec
+  form, using the entrypoint shell form more than once, and missing the
+  entrypoint. For more information, see [Shell and exec form](/engine/reference/builder/#shell-and-exec-form).
+  
+  ```console
+  $ docker debug nginx
+  ...
+  docker > entrypoint --lint
+  Lint results:
+  PASS: '/docker-entrypoint.sh' found
+  PASS: no mixing of shell and exec form
+  PASS: no double use of shell form
+  ```
+  
+  The following example runs `entrypoint --run` to run the entrypoint.
+  
+  ```console
+  $ docker debug nginx
+  ...
+  docker > entrypoint --run
+  /docker-entrypoint.sh: /docker-entrypoint.d/ is not empty, will attempt to perform configuration
+  /docker-entrypoint.sh: Looking for shell scripts in /docker-entrypoint.d/
+  /docker-entrypoint.sh: Launching /docker-entrypoint.d/10-listen-on-ipv6-by-default.sh
+  10-listen-on-ipv6-by-default.sh: info: Getting the checksum of /etc/nginx/conf.d/default.conf
+  10-listen-on-ipv6-by-default.sh: info: Enabled listen on IPv6 in /etc/nginx/conf.d/default.conf
+  /docker-entrypoint.sh: Sourcing /docker-entrypoint.d/15-local-resolvers.envsh
+  /docker-entrypoint.sh: Launching /docker-entrypoint.d/20-envsubst-on-templates.sh
+  /docker-entrypoint.sh: Launching /docker-entrypoint.d/30-tune-worker-processes.sh
+  /docker-entrypoint.sh: Configuration complete; ready for start up
+  2024/01/19 17:34:39 [notice] 50#50: using the "epoll" event method
+  2024/01/19 17:34:39 [notice] 50#50: nginx/1.25.3
+  2024/01/19 17:34:39 [notice] 50#50: built by gcc 12.2.0 (Debian 12.2.0-14)
+  2024/01/19 17:34:39 [notice] 50#50: OS: Linux 5.15.133.1-microsoft-standard-WSL2
+  2024/01/19 17:34:39 [notice] 50#50: getrlimit(RLIMIT_NOFILE): 1048576:1048576
+  2024/01/19 17:34:39 [notice] 50#50: start worker processes
+  2024/01/19 17:34:39 [notice] 50#50: start worker process 77
+  ...
+  ```
+  
+  Press `Ctrl`+`C` to exit running the entrypoint.
+  
+  The following example run `entrypoint --print` to print the entrypoint.
+  
+  ```console
+  $ docker debug nginx
+  ...
+  docker > entrypoint --print
+  /bin/bash
+  ```
+  
+  ### Other examples
+  
+  #### Example of modifying the filesystem of a running container
+  
+  When accessing running or paused containers, all filesystem changes are
+  directly visible to the container. The `/nix` directory is never visible to
+  the actual image or container.
+
+  The following example:
+  1. Creates and runs a container.
+  2. Opens a shell into the container using `docker debug`.
+  3. Creates a file in the debug shell.
+  4. Lists the file using `docker exec` to verify that the file is visible outside of the debug shell.
+  
+  ```console
+  $ docker run -d --name my-container nginx
+  d3d6074d0ea901c96cac8e49e6dad21359616bef3dc0623b3c2dfa536c31dfdb
+  
   $ docker debug my-container
+  ...
+  docker > touch myfile
+  
+  docker > exit
+  
+  $ docker exec my-container ls | grep myfile
+  myfile
   ```
+  #### Example of modifying the filesystem of a stopped container
   
-  Once the shell is attached to the container, you can add further tools with
-  the built-in `install` command. For example, run `install nmap`. Adding
-  further tools to your debugging shell does not modify the target container. 
+  For images and stopped containers, all changes are discarded when leaving the
+  shell.
   
-  The built-in `forward` command lets you use remote tools. The following example starts a web file browser.
+  The following example:
+  1. Creates and runs a container.
+  2. Stops the container.
+  3. Opens a shell into the stopped container using `docker debug`.
+  4. Creates a file in the debug shell
+  5. Restarts the container.
+  6. Lists the file using `docker exec` to verify that the file isn't visible outside of the debug shell.
   
   ```console
-  docker > forward --port 9000:9012 -- webfsd -F -p 9012
-  ```
+  $ docker run -d --name my-container nginx
+  d3d6074d0ea901c96cac8e49e6dad21359616bef3dc0623b3c2dfa536c31dfdb
   
-  You can access the file browser on your host's browser at
-  http://localhost:9000.
+  $ docker stop my-container
+  my-container
+  
+  $ docker debug my-container
+  ...
+  docker > touch my-other-file
+  
+  docker > exit
+  
+  $ docker start my-container
+  
+  $ docker exec my-container ls | grep my-other-file
+  -
+  ```

--- a/data/debug-cli/docker_debug.yaml
+++ b/data/debug-cli/docker_debug.yaml
@@ -75,7 +75,6 @@ examples: |-
   This example pulls an nginx image and gets a shell into it without ever running a container.
   
   ```console
-  $ docker pull nginx
   $ docker debug nginx
   
   Builtin commands:
@@ -106,7 +105,6 @@ examples: |-
   The following example dumps the default `index.html` file of nginx to stdout.
 
   ```console
-  $ docker pull nginx
   $ docker debug nginx -c "cat /usr/share/nginx/html/index.html"
   <!DOCTYPE html>
   <html>
@@ -161,7 +159,7 @@ examples: |-
   The built-in `forward` command lets you use remote tools. The following example starts a web file browser.
   
   ```console
-  $ forward --port 9000:9012 -- webfsd -F -p 9012
+  docker > forward --port 9000:9012 -- webfsd -F -p 9012
   ```
   
   You can access the file browser on your host's browser at

--- a/data/toc.yaml
+++ b/data/toc.yaml
@@ -491,6 +491,8 @@ Reference:
         title: docker context update
       - path: /engine/reference/commandline/context_use/
         title: docker context use
+  - path: /engine/reference/commandline/debug/
+    title: docker debug (Beta)
   - path: /engine/reference/commandline/exec/
     title: docker exec
   - sectiontitle: docker image


### PR DESCRIPTION
### Proposed changes

Add CLI reference docs for Docker Debug.
https://deploy-preview-19135--docsdocker.netlify.app/engine/reference/commandline/debug/

### Related issues (optional)

DACC-26
