### PR TITLE
Add clarification on when to use collaborators

### DIFF
--- a/content/docker-hub/repos/access.md
+++ b/content/docker-hub/repos/access.md
@@ -10,7 +10,9 @@ Within your repository, you can give others access to push and pull to your repo
 ## Collaborators and their role
 
 A collaborator is someone you want to give access to a private repository. Once designated, they can `push` and `pull` to your repositories. They're not
-allowed to perform any administrative tasks such as deleting the repository or changing its status from private to public.
+allowed to perform any administrative tasks such as deleting the repository or changing its status from private to public. 
+
+You can add collaborators to a personal account's repositories. You can add unlimited collaborators to public repositories, and [Docker Pro](../../subscription/details.md#docker-pro) accounts can add up to 1 collaborator on private repositories.
 
 You can choose collaborators and manage their access to a private
 repository from that repository's **Settings** page.

--- a/content/docker-hub/repos/access.md
+++ b/content/docker-hub/repos/access.md
@@ -12,7 +12,7 @@ Within your repository, you can give others access to push and pull to your repo
 A collaborator is someone you want to give access to a private repository. Once designated, they can `push` and `pull` to your repositories. They're not
 allowed to perform any administrative tasks such as deleting the repository or changing its status from private to public. 
 
-You can add collaborators to a personal account's repositories. You can add unlimited collaborators to public repositories, and [Docker Pro](../../subscription/details.md#docker-pro) accounts can add up to 1 collaborator on private repositories.
+Personal account repositories can use collaborators. You can add unlimited collaborators to public repositories, and [Docker Pro](../../subscription/details.md#docker-pro) accounts can add up to 1 collaborator on private repositories. Organization repositories can't use collaborators. Organization owners can control repository access with [member roles](../../security/for-admins/roles-and-permissions.md) and [teams](../../admin/organization/manage-a-team.md).
 
 You can choose collaborators and manage their access to a private
 repository from that repository's **Settings** page.
@@ -20,7 +20,7 @@ repository from that repository's **Settings** page.
 > **Note**
 >
 > A collaborator can't add other collaborators. Only the owner of
-> the repository has administrative access. Also, you can't add collaborators to organization repositories. Organization owners can control repository access with member roles and teams. See [Roles and permissions](../../security/for-admins/roles-and-permissions.md).
+> the repository has administrative access.
 
 You can also assign more granular collaborator rights ("Read", "Write", or
 "Admin") on Docker Hub by using organizations and teams. For more information

--- a/content/docker-hub/repos/access.md
+++ b/content/docker-hub/repos/access.md
@@ -12,7 +12,7 @@ Within your repository, you can give others access to push and pull to your repo
 A collaborator is someone you want to give access to a private repository. Once designated, they can `push` and `pull` to your repositories. They're not
 allowed to perform any administrative tasks such as deleting the repository or changing its status from private to public. 
 
-Personal account repositories can use collaborators. You can add unlimited collaborators to public repositories, and [Docker Pro](../../subscription/details.md#docker-pro) accounts can add up to 1 collaborator on private repositories. Organization repositories can't use collaborators. Organization owners can control repository access with [member roles](../../security/for-admins/roles-and-permissions.md) and [teams](../../admin/organization/manage-a-team.md).
+Only personal account repositories can use collaborators. You can add unlimited collaborators to public repositories, and [Docker Pro](../../subscription/details.md#docker-pro) accounts can add up to 1 collaborator on private repositories. Organization repositories can't use collaborators. Organization owners can control repository access with [member roles](../../security/for-admins/roles-and-permissions.md) and [teams](../../admin/organization/manage-a-team.md).
 
 You can choose collaborators and manage their access to a private
 repository from that repository's **Settings** page.


### PR DESCRIPTION
<!--
  Thank you for contributing to Docker documentation!

  Here are a few things to keep in mind:

  - Links between pages should use a relative path
  - Remember to add an alt text for images

  ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
  ┃     Review our contribution guidelines:       ┃
  ┃                                               ┃
  ┃ https://docs.docker.com/contribute/overview/  ┃
  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
-->

### Proposed changes

<!-- Tell us what you did and why -->

This PR makes clear that collaborators can be added to repos of personal accounts (not orgs).

[Deploy preview](https://deploy-preview-19136--docsdocker.netlify.app/docker-hub/repos/access/)

### Related issues (optional)

<!--
  Refer to related PRs or issues:

  #1234
  Closes #1234
  Closes docker/cli#1234
-->
Closes JIRA https://docker.atlassian.net/browse/ENGDOCS-1946 and #19055 