### PR TITLE
docker init: add java, remove beta

### DIFF
--- a/content/engine/reference/commandline/init.md
+++ b/content/engine/reference/commandline/init.md
@@ -12,6 +12,3 @@ in the source repository on GitHub:
 
 https://github.com/docker/docker-init
 -->
-> **Beta**
->
-> The Docker Init plugin is currently in [Beta](../../../release-lifecycle.md#beta). Docker recommends that you do not use this in production environments.

--- a/data/init-cli/docker_init.yaml
+++ b/data/init-cli/docker_init.yaml
@@ -3,7 +3,7 @@ short: Creates Docker-related starter files for your project
 long: |-
   Initialize a project with the files necessary to run the project in a container.
 
-  Docker Desktop 4.18 and later provides the Docker Init plugin with the `docker init` CLI command. Run `docker init` in your project directory to be walked through the creation of the following files with sensible defaults for your project:
+  Docker Desktop provides the `docker init` CLI command. Run `docker init` in your project directory to be walked through the creation of the following files with sensible defaults for your project:
     
     * .dockerignore
     * Dockerfile
@@ -22,6 +22,7 @@ long: |-
     
     * ASP.NET Core: Suitable for an ASP.NET Core application.
     * Go: Suitable for a Go server application.
+    * Java: suitable for a Java application that uses Maven and packages as an uber jar.
     * Node: Suitable for a Node server application.
     * PHP with Apache: Suitable for a PHP web application.
     * Python: Suitable for a Python server application.
@@ -73,7 +74,8 @@ examples: |-
   
   ? What application platform does your project use?  [Use arrows to move, type to filter]
   > PHP with Apache - (detected) suitable for a PHP web application
-    Go - (detected) suitable for a Go server application
+    Go - suitable for a Go server application
+    Java - suitable for a Java application that uses Maven and packages as an uber jar
     Python - suitable for a Python server application
     Node - suitable for a Node server application
     Rust - suitable for a Rust server application
@@ -235,6 +237,32 @@ examples: |-
   Take a moment to review them and tailor them to your application.
 
   If your application requires specific PHP extensions, you can follow the instructions in the Dockerfile to add them.
+  
+  When you're ready, start your application by running: docker compose up --build
+  
+  Your application will be available at http://localhost:9000
+
+  Consult README.Docker.md for more information about using the generated files.
+  ```
+
+  ### Example of selecting Java
+  
+  The following example shows the prompts that appear after selecting `Java` and example input.
+  
+  ```console
+  ? What application platform does your project use? Java
+  ? What version of Java do you want to use? 17
+  ? What's the relative directory (with a leading .) for your app? ./src
+  ? What port does your server listen on? 9000
+  
+  CREATED: .dockerignore
+  CREATED: Dockerfile
+  CREATED: compose.yaml
+  CREATED: README.Docker.md
+  
+  ✔ Your Docker files are ready!
+  
+  Take a moment to review them and tailor them to your application.
   
   When you're ready, start your application by running: docker compose up --build
   

--- a/data/toc.yaml
+++ b/data/toc.yaml
@@ -532,7 +532,7 @@ Reference:
   - path: /engine/reference/commandline/info/
     title: docker info
   - path: /engine/reference/commandline/init/
-    title: docker init (Beta)
+    title: docker init
   - path: /engine/reference/commandline/inspect/
     title: docker inspect
   - path: /engine/reference/commandline/kill/


### PR DESCRIPTION
### Proposed changes

Add Java template to docker init.
Remove Beta label from docker init.
Remove the version (4.18) info. I don't think we list the version on any other command, and versions older than 4.18 are no longer officially supported. 

### Related issues (optional)

DCKR-68
