### PR TITLE
Update SSC attestations policy description

### DIFF
--- a/content/scout/policy/_index.md
+++ b/content/scout/policy/_index.md
@@ -165,24 +165,16 @@ The **Supply chain attestations** policy requires that your artifacts have
 [provenance](../../build/attestations/slsa-provenance.md) attestations.
 
 This policy is unfulfilled if an artifact lacks either an SBOM attestation or a
-provenance attestation, or if the provenance attestation lacks information
-about the Git repository and base images being used. To ensure compliance,
+provenance attestation with max mode. To ensure compliance,
 update your build command to attach these attestations at build-time:
 
 ```console
 $ docker buildx build --provenance=true --sbom=true -t <IMAGE> --push .
 ```
 
-BuildKit automatically detects the Git repository and base images when this
-information is available in the build context. For more information about
+For more information about
 building with attestations, see
 [Attestations](../../build/attestations/_index.md).
-
-> **Note**
->
-> Docker Scout is currently unable to discern the difference between using
-> `scratch` as a base image and having no base image provenance. As a result,
-> images based on `scratch` always fail the Supply chain attestations policy.
 
 ### Quality gates passed
 


### PR DESCRIPTION
<!--
  Thank you for contributing to Docker documentation!

  Here are a few things to keep in mind:

  - Links between pages should use a relative path
  - Remember to add an alt text for images

  ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
  ┃     Review our contribution guidelines:       ┃
  ┃                                               ┃
  ┃ https://docs.docker.com/contribute/overview/  ┃
  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
-->

### Proposed changes

This PR updates the SSC attestations policy description to check only for the presence of SBOM attestation and **max mode** provenance attestation.

### Related issues (optional)

<!--
  Refer to related PRs or issues:

  #1234
  Closes #1234
  Closes docker/cli#1234
-->
