### PR TITLE
engine: deprecate API versions < 1.24

### DIFF
--- a/content/engine/api/_index.md
+++ b/content/engine/api/_index.md
@@ -151,14 +151,12 @@ You can specify the API version to use in any of the following ways:
 | 1.13.1         | [1.26](/engine/api/v1.26/) | [changes](/engine/api/version-history/#v126-api-changes) |
 | 1.13           | [1.25](/engine/api/v1.26/) | [changes](/engine/api/version-history/#v125-api-changes) |
 | 1.12           | [1.24](/engine/api/v1.24/) | [changes](/engine/api/version-history/#v124-api-changes) |
-| 1.11           | [1.23](/engine/api/v1.23/) | [changes](/engine/api/version-history/#v123-api-changes) |
-| 1.10           | [1.22](/engine/api/v1.22/) | [changes](/engine/api/version-history/#v122-api-changes) |
-| 1.9            | [1.21](/engine/api/v1.21/) | [changes](/engine/api/version-history/#v121-api-changes) |
-| 1.8            | [1.20](/engine/api/v1.20/) | [changes](/engine/api/version-history/#v120-api-changes) |
-| 1.7            | [1.19](/engine/api/v1.19/) | [changes](/engine/api/version-history/#v119-api-changes) |
-| 1.6            | [1.18](/engine/api/v1.18/) | [changes](/engine/api/version-history/#v118-api-changes) |
 
-### Archived API versions
+### Deprecated API versions
 
-You can find archived documentation for older versions of the API
-in the [Docker code repository on GitHub](https://github.com/moby/moby/tree/v1.9.1/docs/reference/api)
+API versions before v1.24 are [deprecated](/engine/deprecated/#deprecate-legacy-api-versions).
+You can find archived documentation for deprecated versions of the API in the
+code repository on GitHub:
+
+- [Documentation for API versions 1.23 and before](https://github.com/moby/moby/tree/v24.0.7/docs/api).
+- [Documentation for API versions 1.6 and before](https://github.com/moby/moby/tree/v1.9.1/docs/reference/api).

--- a/data/redirects.yml
+++ b/data/redirects.yml
@@ -85,6 +85,14 @@
   - /go/access-tokens/
 "/desktop/mac/apple-silicon/":
   - /go/apple-silicon/
+"/engine/api/#deprecated-api-versions":
+  - /engine/api/v1.23/
+  - /engine/api/v1.22/
+  - /engine/api/v1.21/
+  - /engine/api/v1.20/
+  - /engine/api/v1.19/
+  - /engine/api/v1.18/
+
 "/engine/security/#docker-daemon-attack-surface":
   # Details about the "Docker Daemon attack surface". This redirect is currently
   # used in warnings printed by the Docker Engine, and in the installation script

--- a/data/toc.yaml
+++ b/data/toc.yaml
@@ -897,18 +897,6 @@ Reference:
         title: v1.25 reference
       - path: /engine/api/v1.24/
         title: v1.24 reference
-      - path: /engine/api/v1.23/
-        title: v1.23 reference
-      - path: /engine/api/v1.22/
-        title: v1.22 reference
-      - path: /engine/api/v1.21/
-        title: v1.21 reference
-      - path: /engine/api/v1.20/
-        title: v1.20 reference
-      - path: /engine/api/v1.19/
-        title: v1.19 reference
-      - path: /engine/api/v1.18/
-        title: v1.18 reference
   - sectiontitle: Docker Hub API
     section:
       - title: Docker Hub API


### PR DESCRIPTION
Docker Engine v25.0 deprecates old API versions, and disables them by default.

<!--
  Thank you for contributing to Docker documentation!

  Here are a few things to keep in mind:

  - Links between pages should use a relative path
  - Remember to add an alt text for images

  ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
  ┃     Review our contribution guidelines:       ┃
  ┃                                               ┃
  ┃ https://docs.docker.com/contribute/overview/  ┃
  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
-->

### Proposed changes

<!-- Tell us what you did and why -->

### Related issues (optional)

<!--
  Refer to related PRs or issues:

  #1234
  Closes #1234
  Closes docker/cli#1234
-->
