### PR TITLE
engine: add additional redirects for deprecated API versions

### DIFF
--- a/content/engine/api/_index.md
+++ b/content/engine/api/_index.md
@@ -159,4 +159,4 @@ You can find archived documentation for deprecated versions of the API in the
 code repository on GitHub:
 
 - [Documentation for API versions 1.23 and before](https://github.com/moby/moby/tree/v24.0.7/docs/api).
-- [Documentation for API versions 1.6 and before](https://github.com/moby/moby/tree/v1.9.1/docs/reference/api).
+- [Documentation for API versions 1.17 and before](https://github.com/moby/moby/tree/v1.9.1/docs/reference/api).

--- a/data/redirects.yml
+++ b/data/redirects.yml
@@ -86,12 +86,24 @@
 "/desktop/mac/apple-silicon/":
   - /go/apple-silicon/
 "/engine/api/#deprecated-api-versions":
-  - /engine/api/v1.23/
-  - /engine/api/v1.22/
-  - /engine/api/v1.21/
-  - /engine/api/v1.20/
-  - /engine/api/v1.19/
   - /engine/api/v1.18/
+  - /engine/api/v1.19/
+  - /engine/api/v1.20/
+  - /engine/api/v1.21/
+  - /engine/api/v1.22/
+  - /engine/api/v1.23/
+  - /engine/reference/api/docker_remote_api_v1.18/
+  - /engine/reference/api/docker_remote_api_v1.19/
+  - /engine/reference/api/docker_remote_api_v1.20/
+  - /engine/reference/api/docker_remote_api_v1.21/
+  - /engine/reference/api/docker_remote_api_v1.22/
+  - /engine/reference/api/docker_remote_api_v1.23/
+  - /reference/api/docker_remote_api_v1.18/
+  - /reference/api/docker_remote_api_v1.19/
+  - /reference/api/docker_remote_api_v1.20/
+  - /reference/api/docker_remote_api_v1.21/
+  - /reference/api/docker_remote_api_v1.22/
+  - /reference/api/docker_remote_api_v1.23/
 
 "/engine/security/#docker-daemon-attack-surface":
   # Details about the "Docker Daemon attack surface". This redirect is currently


### PR DESCRIPTION
- relates to https://github.com/moby/moby/pull/47124

The deprecated API docs in the upstream repository contained redirects for old URLs. As those docs will be removed in upstream, we should inherit the redirects that will be removed.

Also adjusted the API versions that can be found in the v1.9.1 tag in upstream (API v1.17 and before).

<!--
  Thank you for contributing to Docker documentation!

  Here are a few things to keep in mind:

  - Links between pages should use a relative path
  - Remember to add an alt text for images

  ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
  ┃     Review our contribution guidelines:       ┃
  ┃                                               ┃
  ┃ https://docs.docker.com/contribute/overview/  ┃
  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
-->

### Proposed changes

<!-- Tell us what you did and why -->

### Related issues (optional)

<!--
  Refer to related PRs or issues:

  #1234
  Closes #1234
  Closes docker/cli#1234
-->
