### PR TITLE
section Install using the `apt` repository - missing docker start

### DIFF
--- a/content/engine/install/ubuntu.md
+++ b/content/engine/install/ubuntu.md
@@ -165,6 +165,7 @@ Docker from the repository.
    `hello-world` image.
 
    ```console
+   $ sudo service docker start
    $ sudo docker run hello-world
    ```
 


### PR DESCRIPTION
In the section 'Verify that the Docker Engine installation is successful by running the hello-world image.'   
There is no indication that you need to start the docker daemon, then the test fails

### Proposed changes
I've just added this line:  

**sudo service docker start**

