### PR TITLE
buildx: Kubernetes: fix an incorrect explanation about QEMU

### DIFF
--- a/content/build/drivers/kubernetes.md
+++ b/content/build/drivers/kubernetes.md
@@ -158,7 +158,7 @@ $ docker buildx build \
 
 > **Warning**
 >
-> QEMU performs full-system emulation of non-native platforms, which is much
+> QEMU performs full-CPU emulation of non-native platforms, which is much
 > slower than native builds. Compute-heavy tasks like compilation and
 > compression/decompression will likely take a large performance hit.
 { .warning }


### PR DESCRIPTION

<!--
  Thank you for contributing to Docker documentation!

  Here are a few things to keep in mind:

  - Links between pages should use a relative path
  - Remember to add an alt text for images

  ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
  ┃     Review our contribution guidelines:       ┃
  ┃                                               ┃
  ┃ https://docs.docker.com/contribute/overview/  ┃
  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
-->

### Proposed changes

<!-- Tell us what you did and why -->
Fixed an incorrect explanation about QEMU.
QEMU (user mode) performs full CPU emulation, not full system emulation


### Related issues (optional)

<!--
  Refer to related PRs or issues:

  #1234
  Closes #1234
  Closes docker/cli#1234
-->
