### PR TITLE
fix: sidebar background in light mode

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -9,7 +9,7 @@
   {{ partial "header.html" . }}
   <main class="grid grid-cols-main md:flex xl:grid-cols-main-xl">
     <div id="sidebar"
-      class="sticky top-16 h-[calc(100lvh-theme(space.16))] overflow-y-scroll flex flex-row-reverse dark:bg-gray-dark-100 md:fixed md:z-10 md:hidden md:h-screen md:w-screen">
+      class="sticky top-16 h-[calc(100lvh-theme(space.16))] overflow-y-scroll flex flex-row-reverse bg-background-light dark:bg-gray-dark-100 md:fixed md:z-10 md:hidden md:h-screen md:w-screen">
       {{ block "left" . }}
       {{ end }}
     </div>


### PR DESCRIPTION
The background for the sidebar on small screens was transparent. Added a background color.

Before:


https://github.com/docker/docs/assets/35727626/8dff36f7-a73e-491b-8cd2-0f8a09fed670

Related issue:  https://docker.enterprise.slack.com/archives/C04BMTUC41E/p1706187621148629

