### PR TITLE
font: use font-display:fallback

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -37,8 +37,8 @@
   </script>
 {{ end }}
 <link rel="preconnect" href="https://fonts.googleapis.com" />
-<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:400,500&display=optional" />
-<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Roboto+Mono&display=optional" />
+<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:400,500&display=fallback" />
+<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Roboto+Mono&display=fallback" />
 {{ partial "utils/css.html" . }}
 {{ $theme := resources.Get "js/theme.js" | js.Build (dict "minify" true) }}
 <script>{{ $theme.Content | safeJS }}</script>


### PR DESCRIPTION
Provides a more stable experience than `optional`, as it doesn't let the
browser decide whether or not to apply the font.

https://css-tricks.com/almanac/properties/f/font-display/#aa-values
https://developer.chrome.com/blog/font-display#fallback