### PR TITLE
fix horizontal overflow

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -13,7 +13,7 @@
       {{ block "left" . }}
       {{ end }}
     </div>
-    <div class="p-6 pt-0">
+    <div class="p-6 pt-0 md:w-screen overflow-clip">
       {{ block "main" . }}
       {{ end }}
     </div>

--- a/layouts/partials/breadcrumbs.html
+++ b/layouts/partials/breadcrumbs.html
@@ -2,17 +2,17 @@
 {{ $ctx := . }}
 
 
-<nav id="breadcrumbs" class="py-4 gap-4 flex items-center overflow-hidden text-gray-light dark:text-gray-dark">
+<nav id="breadcrumbs" class="py-4 gap-4 flex items-center text-gray-light dark:text-gray-dark max-w-full min-w-0">
   {{ with ($scratch.GetSortedMapValues "sections") }}
     {{ range $i, $e := . }}
       {{- if $i -}}
         <span>/</span>
       {{- end -}}
-      <a href="{{ $e.path }}" class="flex items-center gap-2 link whitespace-nowrap">{{ markdownify $e.title }}</a>
+      <a href="{{ $e.path }}" class="link whitespace-nowrap overflow-hidden overflow-ellipsis">{{ markdownify $e.title }}</a>
     {{- end -}}
   {{- end -}}
   {{- with $scratch.Get "lastsection" -}}
   <span>/</span>
-  <span class="flex items-center gap-2">{{ markdownify .title }}</span>
+  <span class="shrink-0">{{ markdownify .title }}</span>
   {{- end -}}
 </nav>


### PR DESCRIPTION
- css: prevent horizontal overflow on md/sm/xs screens
- css: improve rendering of breadcrumbs on small screens

before
<img width="599" alt="image" src="https://github.com/docker/docs/assets/35727626/64ff420d-fa68-4452-b33a-b9b996854450">


after
<img width="603" alt="image" src="https://github.com/docker/docs/assets/35727626/5294aaec-6f27-44ab-a95a-9dc0912d0739">
