### PR TITLE
fix: missing redirect for /registry/configuration

### DIFF
--- a/content/registry.md
+++ b/content/registry.md
@@ -4,6 +4,7 @@ description: The Docker Hub registry implementation
 keywords: registry, distribution, docker hub, spec, schema, api, manifest, auth
 aliases:
   - /registry/compatibility/
+  - /registry/configuration/
   - /registry/deploying/
   - /registry/deprecated/
   - /registry/garbage-collection/


### PR DESCRIPTION
Signed-off-by: David Karlsson <35727626+dvdksn@users.noreply.github.com>

<!--
  Thank you for contributing to Docker documentation!

  Here are a few things to keep in mind:

  - Links between pages should use a relative path
  - Remember to add an alt text for images

  ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
  ┃     Review our contribution guidelines:       ┃
  ┃                                               ┃
  ┃ https://docs.docker.com/contribute/overview/  ┃
  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
-->

### Proposed changes

<!-- Tell us what you did and why -->

### Related issues (optional)

Closes #19194