### PR TITLE
ci: bump actions/download-artifact to 4

### DIFF
--- a/.github/workflows/validate-upstream.yml
+++ b/.github/workflows/validate-upstream.yml
@@ -31,7 +31,7 @@ jobs:
           repository: docker/docs
       -
         name: Download data files
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         if: ${{ inputs.data-files-id != '' && inputs.data-files-folder != '' }}
         with:
           name: ${{ inputs.data-files-id }}


### PR DESCRIPTION
### Proposed changes

Bump `actions/download-artifact` to 4

### Related issues (optional)

* related to https://github.com/docker/buildx/pull/2210#issuecomment-1911663381
* closes #18933
<!--
  Refer to related PRs or issues:

  #1234
  Closes #1234
  Closes docker/cli#1234
-->
