### PR TITLE
vendor: buildx and buildkit

### DIFF
--- a/_vendor/github.com/docker/buildx/docs/bake-reference.md
+++ b/_vendor/github.com/docker/buildx/docs/bake-reference.md
@@ -1069,13 +1069,13 @@ target "webapp-dev" {
 
 [attestations]: https://docs.docker.com/build/attestations/
 [bake_stdlib]: https://github.com/docker/buildx/blob/master/bake/hclparser/stdlib.go
-[build-arg]: https://docs.docker.com/engine/reference/commandline/build/#build-arg
+[build-arg]: https://docs.docker.com/engine/reference/commandline/image_build/#build-arg
 [build-context]: https://docs.docker.com/engine/reference/commandline/buildx_build/#build-context
 [cache-backends]: https://docs.docker.com/build/cache/backends/
 [cache-from]: https://docs.docker.com/engine/reference/commandline/buildx_build/#cache-from
 [cache-to]: https://docs.docker.com/engine/reference/commandline/buildx_build/#cache-to
 [context]: https://docs.docker.com/engine/reference/commandline/buildx_build/#build-context
-[file]: https://docs.docker.com/engine/reference/commandline/build/#file
+[file]: https://docs.docker.com/engine/reference/commandline/image_build/#file
 [go-cty]: https://github.com/zclconf/go-cty/tree/main/cty/function/stdlib
 [hcl-funcs]: https://docs.docker.com/build/bake/hcl-funcs/
 [output]: https://docs.docker.com/engine/reference/commandline/buildx_build/#output
@@ -1083,6 +1083,6 @@ target "webapp-dev" {
 [run_mount_secret]: https://docs.docker.com/engine/reference/builder/#run---mounttypesecret
 [secret]: https://docs.docker.com/engine/reference/commandline/buildx_build/#secret
 [ssh]: https://docs.docker.com/engine/reference/commandline/buildx_build/#ssh
-[tag]: https://docs.docker.com/engine/reference/commandline/build/#tag
-[target]: https://docs.docker.com/engine/reference/commandline/build/#target
+[tag]: https://docs.docker.com/engine/reference/commandline/image_build/#tag
+[target]: https://docs.docker.com/engine/reference/commandline/image_build/#target
 [userfunc]: https://github.com/hashicorp/hcl/tree/main/ext/userfunc

--- a/_vendor/github.com/docker/cli/docs/reference/commandline/dockerd.md
+++ b/_vendor/github.com/docker/cli/docs/reference/commandline/dockerd.md
@@ -849,7 +849,9 @@ flag for the dockerd command line interface, or the `host-gateway-ip` key in
 the daemon configuration file.
 
 ```console
-$ dockerd --host-gateway-ip 192.0.2.0
+$ cat > /etc/docker/daemon.json
+{ "host-gateway-ip": "192.0.2.0" }
+$ sudo systemctl restart docker
 $ docker run -it --add-host host.docker.internal:host-gateway \
   busybox ping host.docker.internal 
 PING host.docker.internal (192.0.2.0): 56 data bytes
@@ -1072,6 +1074,7 @@ The following is a full example of the allowed configuration options on Linux:
   "fixed-cidr": "",
   "fixed-cidr-v6": "",
   "group": "",
+  "host-gateway-ip": "",
   "hosts": [],
   "proxies": {
     "http-proxy": "http://proxy.example.com:80",
@@ -1181,6 +1184,7 @@ The following is a full example of the allowed configuration options on Windows:
   "features": {},
   "fixed-cidr": "",
   "group": "",
+  "host-gateway-ip": "",
   "hosts": [],
   "insecure-registries": [],
   "labels": [],

--- a/_vendor/github.com/moby/buildkit/docs/buildkitd.toml.md
+++ b/_vendor/github.com/moby/buildkit/docs/buildkitd.toml.md
@@ -7,9 +7,8 @@ of daemon configuration.
 The file path is `/etc/buildkit/buildkitd.toml` for rootful mode,
 `~/.config/buildkit/buildkitd.toml` for rootless mode.
 
-The following is a complete `buildkitd.toml` configuration example, please
-note some configuration is only good for edge cases, please take care of it
-carefully.
+The following is a complete `buildkitd.toml` configuration example.
+Note that some configuration options are only useful in edge cases.
 
 ```toml
 # debug enables additional debug logging

--- a/_vendor/github.com/moby/buildkit/frontend/dockerfile/docs/reference.md
+++ b/_vendor/github.com/moby/buildkit/frontend/dockerfile/docs/reference.md
@@ -1260,12 +1260,9 @@ doesn't support authentication.
 `ADD` obeys the following rules:
 
 - The `<src>` path must be inside the build context;
-  you can't use `COPY ../something /something`, because the builder can only
+  you can't use `ADD ../something /something`, because the builder can only
   access files from the context, and `../something` specifies a parent file or
   directory of the build context root.
-
-- If `<src>` is a directory, the entire contents of the directory are copied,
-  including filesystem metadata.
 
 - If `<src>` is a URL and `<dest>` does end with a trailing slash, then the
   filename is inferred from the URL and the file is downloaded to
@@ -1308,8 +1305,8 @@ doesn't support authentication.
   use of a wildcard, then `<dest>` must be a directory, and it must end with
   a slash `/`.
 
-- If `<dest>` doesn't end with a trailing slash, it will be considered a
-  regular file and the contents of `<src>` will be written at `<dest>`.
+- If `<src>` is a file, and `<dest>` doesn't end with a trailing slash,
+  the contents of `<src>` will be written as filename `<dest>`.
 
 - If `<dest>` doesn't exist, it's created, along with all missing directories
   in its path.
@@ -1487,8 +1484,8 @@ attempted to be used instead.
   use of a wildcard, then `<dest>` must be a directory, and it must end with
   a slash `/`.
 
-- If `<dest>` doesn't end with a trailing slash, it will be considered a
-  regular file and the contents of `<src>` will be written at `<dest>`.
+- If `<src>` is a file, and `<dest>` doesn't end with a trailing slash,
+  the contents of `<src>` will be written as filename `<dest>`.
 
 - If `<dest>` doesn't exist, it's created, along with all missing directories
   in its path.

--- a/_vendor/modules.txt
+++ b/_vendor/modules.txt
@@ -1,6 +1,6 @@
 # github.com/moby/moby v25.0.0+incompatible
-# github.com/moby/buildkit v0.13.0-beta1.0.20240116143623-28ce478b1fde
+# github.com/moby/buildkit v0.13.0-beta1.0.20240126101002-6bd81372ad6f
 # github.com/docker/buildx v0.12.2-0.20240126114058-d43cf8c2c6b4
 # github.com/docker/scout-cli v1.3.0
-# github.com/docker/cli v25.0.1-0.20240119143135-01f933261885+incompatible
+# github.com/docker/cli v25.0.1+incompatible
 # github.com/docker/compose/v2 v2.24.2

--- a/_vendor/modules.txt
+++ b/_vendor/modules.txt
@@ -1,6 +1,6 @@
 # github.com/moby/moby v25.0.0+incompatible
 # github.com/moby/buildkit v0.13.0-beta1.0.20240116143623-28ce478b1fde
-# github.com/docker/buildx v0.12.1
+# github.com/docker/buildx v0.12.2-0.20240126114058-d43cf8c2c6b4
 # github.com/docker/scout-cli v1.3.0
 # github.com/docker/cli v25.0.1-0.20240119143135-01f933261885+incompatible
 # github.com/docker/compose/v2 v2.24.2

--- a/go.mod
+++ b/go.mod
@@ -6,9 +6,9 @@ toolchain go1.21.1
 
 require (
 	github.com/docker/buildx v0.12.2-0.20240126114058-d43cf8c2c6b4 // indirect
-	github.com/docker/cli v25.0.1-0.20240119143135-01f933261885+incompatible // indirect
+	github.com/docker/cli v25.0.1+incompatible // indirect
 	github.com/docker/compose/v2 v2.24.2 // indirect
 	github.com/docker/scout-cli v1.3.0 // indirect
-	github.com/moby/buildkit v0.13.0-beta1.0.20240116143623-28ce478b1fde // indirect
+	github.com/moby/buildkit v0.13.0-beta1.0.20240126101002-6bd81372ad6f // indirect
 	github.com/moby/moby v25.0.0+incompatible // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.21
 toolchain go1.21.1
 
 require (
-	github.com/docker/buildx v0.12.1 // indirect
+	github.com/docker/buildx v0.12.2-0.20240126114058-d43cf8c2c6b4 // indirect
 	github.com/docker/cli v25.0.1-0.20240119143135-01f933261885+incompatible // indirect
 	github.com/docker/compose/v2 v2.24.2 // indirect
 	github.com/docker/scout-cli v1.3.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -56,6 +56,8 @@ github.com/docker/buildx v0.12.1-0.20231214091505-b68ee824c673 h1:mZ2+TyEERNA4GY
 github.com/docker/buildx v0.12.1-0.20231214091505-b68ee824c673/go.mod h1:SBLnQH9q+77aVvpvS5LLIly9+nHVlwscl5GEegGMD5g=
 github.com/docker/buildx v0.12.1 h1:oahmdKmkGaa8NnaWKvtDZe2vpSYsKZ+WsHOMLQTDCk8=
 github.com/docker/buildx v0.12.1/go.mod h1:SBLnQH9q+77aVvpvS5LLIly9+nHVlwscl5GEegGMD5g=
+github.com/docker/buildx v0.12.2-0.20240126114058-d43cf8c2c6b4 h1:aEFpoxTw5LIRjN0jFdHsOa1POpELzgwJ0SnhykCa8dg=
+github.com/docker/buildx v0.12.2-0.20240126114058-d43cf8c2c6b4/go.mod h1:SBLnQH9q+77aVvpvS5LLIly9+nHVlwscl5GEegGMD5g=
 github.com/docker/cli v24.0.2+incompatible h1:QdqR7znue1mtkXIJ+ruQMGQhpw2JzMJLRXp6zpzF6tM=
 github.com/docker/cli v24.0.2+incompatible/go.mod h1:JLrzqnKDaYBop7H2jaqPtU4hHvMKP+vjCwu2uszcLI8=
 github.com/docker/cli v24.0.4+incompatible h1:Y3bYF9ekNTm2VFz5U/0BlMdJy73D+Y1iAAZ8l63Ydzw=

--- a/go.sum
+++ b/go.sum
@@ -78,6 +78,8 @@ github.com/docker/cli v25.0.0-beta.1+incompatible h1:bJzIgR4mKNpceAwwi19SqZK0Abz
 github.com/docker/cli v25.0.0-beta.1+incompatible/go.mod h1:JLrzqnKDaYBop7H2jaqPtU4hHvMKP+vjCwu2uszcLI8=
 github.com/docker/cli v25.0.1-0.20240119143135-01f933261885+incompatible h1:UkZcGfKrx1PUDTT/TEzeYpyeRvNVbNqsj01yasxHuvA=
 github.com/docker/cli v25.0.1-0.20240119143135-01f933261885+incompatible/go.mod h1:JLrzqnKDaYBop7H2jaqPtU4hHvMKP+vjCwu2uszcLI8=
+github.com/docker/cli v25.0.1+incompatible h1:mFpqnrS6Hsm3v1k7Wa/BO23oz0k121MTbTO1lpcGSkU=
+github.com/docker/cli v25.0.1+incompatible/go.mod h1:JLrzqnKDaYBop7H2jaqPtU4hHvMKP+vjCwu2uszcLI8=
 github.com/docker/compose-cli v1.0.35 h1:uZyEHLalfqBS2PiTpA1LAULyJmuQ+YtZg7nG4Xl3/Cc=
 github.com/docker/compose-cli v1.0.35/go.mod h1:mSXI4hFLpRU3EtI8NTo32bNwI0UXSr8jnq+/rYjGAUU=
 github.com/docker/compose/v2 v2.22.0 h1:3rRz4L7tPU75wRsV8JZh2/aTgerQvPa1cpzZN+tHqUY=
@@ -177,6 +179,8 @@ github.com/moby/buildkit v0.13.0-beta1.0.20231219135447-957cb50df991 h1:r80LLQ91
 github.com/moby/buildkit v0.13.0-beta1.0.20231219135447-957cb50df991/go.mod h1:6MddWPSL5jxy+W8eMMHWDOfZzzRRKWXPZqajw72YHBc=
 github.com/moby/buildkit v0.13.0-beta1.0.20240116143623-28ce478b1fde h1:t6dpbzyD4GYAX3zlm0s0+uH8xxx2UqF9uW9zuFIr+vg=
 github.com/moby/buildkit v0.13.0-beta1.0.20240116143623-28ce478b1fde/go.mod h1:NK6kY+05bXjxhEmtGEMAwvSJ19gagBukPz6N4FFzlNs=
+github.com/moby/buildkit v0.13.0-beta1.0.20240126101002-6bd81372ad6f h1:weCt2sfZGVAeThzpVyv4ibC0oFfvSxtbiTE7W77wXpc=
+github.com/moby/buildkit v0.13.0-beta1.0.20240126101002-6bd81372ad6f/go.mod h1:vEcIVw63dZyhTgbcyQWXlZrtrKnvFoSI8LhfV+Vj0Jg=
 github.com/moby/locker v1.0.1/go.mod h1:S7SDdo5zpBK84bzzVlKr2V0hz+7x9hWbYC/kq7oQppc=
 github.com/moby/moby v24.0.2+incompatible h1:yH+5dRHH1x3XRKzl1THA2aGTy6CHYnkt5N924ADMax8=
 github.com/moby/moby v24.0.2+incompatible/go.mod h1:fDXVQ6+S340veQPv35CzDahGBmHsiclFwfEygB/TWMc=


### PR DESCRIPTION
Pull the latest buildx and buildkit:

- buildx v0.12 with updated bake file links
- buildkit with misc minor fixes

Related issues:

- Closes #19152
- Closes #19151
- Closes #19165