### PR TITLE
engine: add chmod a+r for gpg key

### DIFF
--- a/content/engine/install/debian.md
+++ b/content/engine/install/debian.md
@@ -96,7 +96,7 @@ Docker from the repository.
    ```bash
    # Add Docker's official GPG key:
    sudo apt-get update
-   sudo apt-get install ca-certificates curl gnupg
+   sudo apt-get install ca-certificates curl
    sudo install -m 0755 -d /etc/apt/keyrings
    sudo curl -fsSL {{% param "download-url-base" %}}/gpg -o /etc/apt/keyrings/docker.asc
    sudo chmod a+r /etc/apt/keyrings/docker.asc

--- a/content/engine/install/debian.md
+++ b/content/engine/install/debian.md
@@ -99,6 +99,7 @@ Docker from the repository.
    sudo apt-get install ca-certificates curl gnupg
    sudo install -m 0755 -d /etc/apt/keyrings
    sudo curl -fsSL {{% param "download-url-base" %}}/gpg -o /etc/apt/keyrings/docker.asc
+   sudo chmod a+r /etc/apt/keyrings/docker.asc
 
    # Add the repository to Apt sources:
    echo \

--- a/content/engine/install/raspberry-pi-os.md
+++ b/content/engine/install/raspberry-pi-os.md
@@ -98,7 +98,7 @@ Docker from the repository.
    ```bash
    # Add Docker's official GPG key:
    sudo apt-get update
-   sudo apt-get install ca-certificates curl gnupg
+   sudo apt-get install ca-certificates curl
    sudo install -m 0755 -d /etc/apt/keyrings
    sudo curl -fsSL {{% param "download-url-base" %}}/gpg -o /etc/apt/keyrings/docker.asc
    sudo chmod a+r /etc/apt/keyrings/docker.asc

--- a/content/engine/install/raspberry-pi-os.md
+++ b/content/engine/install/raspberry-pi-os.md
@@ -101,6 +101,7 @@ Docker from the repository.
    sudo apt-get install ca-certificates curl gnupg
    sudo install -m 0755 -d /etc/apt/keyrings
    sudo curl -fsSL {{% param "download-url-base" %}}/gpg -o /etc/apt/keyrings/docker.asc
+   sudo chmod a+r /etc/apt/keyrings/docker.asc
 
    # Set up Docker's APT repository:
    echo \

--- a/content/engine/install/ubuntu.md
+++ b/content/engine/install/ubuntu.md
@@ -110,6 +110,7 @@ Docker from the repository.
    sudo apt-get install ca-certificates curl gnupg
    sudo install -m 0755 -d /etc/apt/keyrings
    sudo curl -fsSL {{% param "download-url-base" %}}/gpg -o /etc/apt/keyrings/docker.asc
+   sudo chmod a+r /etc/apt/keyrings/docker.asc
    
    # Add the repository to Apt sources:
    echo \

--- a/content/engine/install/ubuntu.md
+++ b/content/engine/install/ubuntu.md
@@ -107,7 +107,7 @@ Docker from the repository.
    ```bash
    # Add Docker's official GPG key:
    sudo apt-get update
-   sudo apt-get install ca-certificates curl gnupg
+   sudo apt-get install ca-certificates curl
    sudo install -m 0755 -d /etc/apt/keyrings
    sudo curl -fsSL {{% param "download-url-base" %}}/gpg -o /etc/apt/keyrings/docker.asc
    sudo chmod a+r /etc/apt/keyrings/docker.asc


### PR DESCRIPTION
### Proposed changes

- Add a step to change permission mode for the downloaded gpg key

### Related issues (optional)

- https://github.com/docker/docker-install/pull/391
- https://github.com/docker/docs/pull/19138#discussion_r1467060214
- https://github.com/docker/docs/pull/17070#discussion_r1161130453