### PR TITLE
Add Build Cloud links to billing and subscription pages

### DIFF
--- a/content/billing/_index.md
+++ b/content/billing/_index.md
@@ -19,6 +19,10 @@ grid:
   description: Explore how to buy and manage a Docker Scout subscription.
   link: /billing/scout-billing/
   icon: query_stats
+- title: Docker Build Cloud billing
+  description: Learn how to buy and manage a Docker Build Cloud subscription.
+  link: /billing/build-billing/
+  icon: build
 - title: Billing FAQs
   description: Find the answers you need and explore common questions.
   link: /billing/faqs/

--- a/content/subscription/_index.md
+++ b/content/subscription/_index.md
@@ -11,6 +11,10 @@ grid:
   description: Discover how a Docker Scout subscription can help you create a more secure supply chain.
   link: /subscription/scout-details/
   icon: query_stats
+- title: Docker Build Cloud subscriptions and features
+  description: Learn how a Docker Build Cloud subscription can accelerate your builds.
+  link: /subscription/build-details/
+  icon: build
 - title: Upgrade your subscription
   description: Learn how to upgrade your plan to the next level.
   link: /subscription/upgrade/

--- a/content/subscription/build-details.md
+++ b/content/subscription/build-details.md
@@ -4,7 +4,7 @@ description: Learn about the Docker Build Cloud subscriptions plans and features
 keywords: subscription, pro, team, business, features, build, cloud, Build Cloud, remote builder
 ---
 
-You can enhance your teams' builds with a Build Cloud subscription. This page describes the features available for the different subscription tiers.
+You can enhance your teams' builds with a Build Cloud subscription. This page describes the features available for the different subscription tiers. To compare features available for each tier, see [Docker Build Cloud pricing](https://www.docker.com/products/build-cloud/#pricing).
 
 ## Docker Build Cloud Starter
 


### PR DESCRIPTION
<!--
  Thank you for contributing to Docker documentation!

  Here are a few things to keep in mind:

  - Links between pages should use a relative path
  - Remember to add an alt text for images

  ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
  ┃     Review our contribution guidelines:       ┃
  ┃                                               ┃
  ┃ https://docs.docker.com/contribute/overview/  ┃
  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
-->

### Proposed changes

<!-- Tell us what you did and why -->

This PR adds Build Cloud tiles to the billing and overview pages, and links to the pricing marketing page for tier breakdowns.

### Related issues (optional)

<!--
  Refer to related PRs or issues:

  #1234
  Closes #1234
  Closes docker/cli#1234
-->
Closes JIRA https://docker.atlassian.net/browse/ENGDOCS-1964