### PR TITLE
WIP: persistent tab groups

### DIFF
--- a/assets/js/src/alpine.js
+++ b/assets/js/src/alpine.js
@@ -1,9 +1,12 @@
 import Alpine from 'alpinejs'
 import collapse from '@alpinejs/collapse'
+import persist from '@alpinejs/persist'
  
 window.Alpine = Alpine
 
 Alpine.plugin(collapse)
 Alpine.store("showSidebar", false)
+
+Alpine.plugin(persist)
 
 Alpine.start()

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -40,12 +40,11 @@
 <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:400,500&display=fallback" />
 <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Roboto+Mono&display=fallback" />
 {{ partial "utils/css.html" . }}
-{{ $theme := resources.Get "js/theme.js" | js.Build (dict "minify" true) }}
+{{ $theme := resources.Get "js/theme.js" }}
 <script>{{ $theme.Content | safeJS }}</script>
 {{ $js := resources.Match "js/src/**.js"
   | resources.Concat "scripts.js"
   | js.Build (dict
-    "minify" true
     "params" (dict
       "apikey" site.Params.algolia.apikey
       "appid" site.Params.algolia.appid

--- a/layouts/shortcodes/tabs.html
+++ b/layouts/shortcodes/tabs.html
@@ -1,16 +1,23 @@
 {{ with .Inner }}{{/* don't do anything, just call it */}}{{ end }}
-{{ $default := (index (.Scratch.Get "tabs") 0).name }}
+{{ $first := urlize (index (.Scratch.Get "tabs") 0).name }}
 {{ $group := .Get "group" }}
-
+{{ $groupID := fmt.Printf "tabgroup-%s" (urlize $group) }}
+{{ $persist := .Get "persist" }}
 
 <div
-  x-data="{ selected: '{{ $default | urlize }}' }"
   {{ with $group }}
-    @tab-select.window="$event.detail.group === '{{ . }}' ? selected =
-    $event.detail.name : null"
+    {{ if $persist }}
+      x-data="{ selected: $persist('{{$first}}').as('{{$groupID}}') }"
+    {{ else }}
+      x-data="{ selected: '{{$first}}' }"
+    {{ end }}
+    @tab-select.window="$event.detail.group === '{{ . }}'
+      ? selected = $event.detail.name
+      : null"
+  {{ else }}
+    x-data="{ selected: '{{ $first }}' }"
   {{ end }}
-  aria-role="tabpanel"
->
+  aria-role="tabpanel">
   <div aria-role="tablist" class="space-x-2">
     {{ range (.Scratch.Get "tabs") }}
       <button

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "Apache License 2.0",
       "devDependencies": {
         "@alpinejs/collapse": "^3.11.1",
+        "@alpinejs/persist": "^3.13.5",
         "@docsearch/js": "^3.5.2",
         "@material-symbols/svg-400": "^0.14.6",
         "@tailwindcss/nesting": "^0.0.0-insiders.565cd3e",
@@ -216,6 +217,12 @@
       "version": "3.13.5",
       "resolved": "https://registry.npmjs.org/@alpinejs/collapse/-/collapse-3.13.5.tgz",
       "integrity": "sha512-LHtSF/T3Zrhr0WOeVm4ebdXNH6ftqoZMbmkBTU1n/j8r0joV3oLUsPCyn5qOU8+27d2P/N2a057etOm0MH60oQ==",
+      "dev": true
+    },
+    "node_modules/@alpinejs/persist": {
+      "version": "3.13.5",
+      "resolved": "https://registry.npmjs.org/@alpinejs/persist/-/persist-3.13.5.tgz",
+      "integrity": "sha512-nmULi5Kp/v5/h4FtGpqyzzMPlulc2fmQ+Olhk0NwTcBKSCZDg6OtXgS998rnHpcWO0jsjCmvXn/Pul2av7D8lA==",
       "dev": true
     },
     "node_modules/@braintree/sanitize-url": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "homepage": "https://docs.docker.com/",
   "devDependencies": {
     "@alpinejs/collapse": "^3.11.1",
+    "@alpinejs/persist": "^3.13.5",
     "@docsearch/js": "^3.5.2",
     "@material-symbols/svg-400": "^0.14.6",
     "@tailwindcss/nesting": "^0.0.0-insiders.565cd3e",


### PR DESCRIPTION
Signed-off-by: David Karlsson <35727626+dvdksn@users.noreply.github.com>

<!--
  Thank you for contributing to Docker documentation!

  Here are a few things to keep in mind:

  - Links between pages should use a relative path
  - Remember to add an alt text for images

  ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
  ┃     Review our contribution guidelines:       ┃
  ┃                                               ┃
  ┃ https://docs.docker.com/contribute/overview/  ┃
  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
-->

### Proposed changes

Persist tab state for grouped tabs with a new `persist` shortcode param.

```
{{< tabs group=os persist=true >}}
{{< tab name=Linux >}}
{{< /tab >}}
{{< tab name=Windows >}}
{{< /tab >}}
{{< /tabs >}}
```

### Related issues (optional)

<!--
  Refer to related PRs or issues:

  #1234
  Closes #1234
  Closes docker/cli#1234
-->
