### PR TITLE
engine: install: remove Ubuntu Lunar 23.04, as it's EOL

### DIFF
--- a/content/engine/install/ubuntu.md
+++ b/content/engine/install/ubuntu.md
@@ -39,7 +39,6 @@ To install Docker Engine, you need the 64-bit version of one of these Ubuntu
 versions:
 
 - Ubuntu Mantic 23.10
-- Ubuntu Lunar 23.04
 - Ubuntu Jammy 22.04 (LTS)
 - Ubuntu Focal 20.04 (LTS)
 


### PR DESCRIPTION
Ubuntu 23.04 reached EOL on January 25, 2024, so should no longer be used. https://wiki.ubuntu.com/Releases#End_of_Life

<!--
  Thank you for contributing to Docker documentation!

  Here are a few things to keep in mind:

  - Links between pages should use a relative path
  - Remember to add an alt text for images

  ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
  ┃     Review our contribution guidelines:       ┃
  ┃                                               ┃
  ┃ https://docs.docker.com/contribute/overview/  ┃
  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
-->

### Proposed changes

<!-- Tell us what you did and why -->

### Related issues (optional)

<!--
  Refer to related PRs or issues:

  #1234
  Closes #1234
  Closes docker/cli#1234
-->
