### PR TITLE
storage: clarify that anonymous volumes arent reused

### DIFF
--- a/content/storage/_index.md
+++ b/content/storage/_index.md
@@ -77,9 +77,13 @@ When you mount a volume, it may be named or anonymous. Anonymous volumes are
 given a random name that's guaranteed to be unique within a given Docker host.
 Just like named volumes, anonymous volumes persist even if you remove the
 container that uses them, except if you use the `--rm` flag when creating the
-container. Docker automatically removes anonymous volume mounts for containers
-created with the `--rm` flag. See [Remove anonymous
-volumes](volumes.md#remove-anonymous-volumes).
+container, in which case the anonymous volume is destroyed.
+See [Remove anonymous volumes](volumes.md#remove-anonymous-volumes).
+If you create multiple containers after each other that use anonymous volumes,
+each container creates its own volume.
+Anonymous volumes aren't reused or shared between containers automatically.
+To share an anonymous volume between two or more containers,
+you must mount the anonymous volume using the random volume ID.
 
 Volumes also support the use of volume drivers, which allow you to store
 your data on remote hosts or cloud providers, among other possibilities.


### PR DESCRIPTION
Signed-off-by: David Karlsson <35727626+dvdksn@users.noreply.github.com>

<!--
  Thank you for contributing to Docker documentation!

  Here are a few things to keep in mind:

  - Links between pages should use a relative path
  - Remember to add an alt text for images

  ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
  ┃     Review our contribution guidelines:       ┃
  ┃                                               ┃
  ┃ https://docs.docker.com/contribute/overview/  ┃
  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
-->

### Proposed changes

Clarify that anonymous volumes aren't reused by consecutively created containers

### Related issues (optional)

https://github.com/docker/docs/pull/18996#issuecomment-1874279896