### PR TITLE
build: clarify that attestations expose build args

### DIFF
--- a/content/build/attestations/slsa-provenance.md
+++ b/content/build/attestations/slsa-provenance.md
@@ -136,13 +136,18 @@ well as:
 - Source maps describing the relationship between build steps and image layers.
 
 When possible, you should prefer `mode=max` as it contains significantly more
-detailed information for analysis. However, on some builds it may not be
-appropriate, as it includes the values of
-[build arguments](../../engine/reference/commandline/buildx_build.md#build-arg)
-and metadata about secrets and SSH mounts. If you pass sensitive information
-using build arguments, consider refactoring builds to pass secret values using
-[build secrets](../../engine/reference/commandline/buildx_build.md#secret), to
-prevent leaking of sensitive information.
+detailed information for analysis.
+
+> **Warning**
+>
+> Note that `mode=max` exposes the values of
+> [build arguments](../../engine/reference/commandline/buildx_build.md#build-arg).
+>
+> If you're misusing build arguments to pass credentials, authentication
+> tokens, or other secrets, you should refactor your build to pass the secrets using
+> [secret mounts](../../engine/reference/commandline/buildx_build.md#secret) instead.
+> Secret mounts don't leak outside of the build and are never included in provenance attestations.
+{.warning}
 
 ## Inspecting Provenance
 

--- a/content/build/ci/github-actions/attestations.md
+++ b/content/build/ci/github-actions/attestations.md
@@ -25,6 +25,18 @@ attestations to your image, with the following conditions:
   attestations are added to the image. These output formats don't support
   attestations.
 
+> **Warning**
+>
+> If you're using `docker/build-push-action` to build images for code in a
+> public GitHub repository, the provenance attestations attached to your image
+> by default contains the values of build arguments. If you're misusing build
+> arguments to pass secrets to your build, such as user credentials or
+> authentication tokens, those secrets are exposed in the provenance
+> attestation. Refactor your build to pass those secrets using
+> [secret mounts](../../../engine/reference/commandline/buildx_build.md#secret)
+> instead. Also remember to rotate any secrets you may have exposed.
+{ .warning }
+
 ## Max-level provenance
 
 It's recommended that you build your images with max-level provenance


### PR DESCRIPTION
<!--
  Thank you for contributing to Docker documentation!

  Here are a few things to keep in mind:

  - Links between pages should use a relative path
  - Remember to add an alt text for images

  ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
  ┃     Review our contribution guidelines:       ┃
  ┃                                               ┃
  ┃ https://docs.docker.com/contribute/overview/  ┃
  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
-->

### Proposed changes

People need to stop using build arguments for secrets.

Signed-off-by: David Karlsson <35727626+dvdksn@users.noreply.github.com>

### Related issues (optional)

moby/buildkit#4608
