### PR TITLE
site: add rss template and enable rss output for home

### DIFF
--- a/hugo.yaml
+++ b/hugo.yaml
@@ -66,6 +66,7 @@ outputs:
     - html
     - redirects
     - robots
+    - rss
   term:
     - html
     - json

--- a/layouts/index.rss.xml
+++ b/layouts/index.rss.xml
@@ -1,0 +1,27 @@
+{{- printf "<?xml version=\"1.0\" encoding=\"utf-8\" standalone=\"yes\"?>" | safeHTML }}
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+  <channel>
+    <title>{{ site.Title }}</title>
+    <link>{{ site.BaseURL }}</link>
+    <description>Recent content in {{ site.Title }}</description>
+    <generator>Hugo -- gohugo.io</generator>
+    <language>{{ site.Language.LanguageCode }}</language>
+    <copyright>Copyright © 2013-{{ time.Now.Year}} Docker Inc. All rights reserved.</copyright>
+    <lastBuildDate>{{ hugo.BuildDate | safeHTML }}</lastBuildDate>
+    {{- with .OutputFormats.Get "RSS" }}
+    {{ printf "<atom:link href=%q rel=\"self\" type=%q />" .Permalink .MediaType | safeHTML }}
+    {{- end }}
+    {{- range site.RegularPages }}
+    {{ $authorEmail := .GitInfo.AuthorEmail }}
+    {{ $authorName := .GitInfo.AuthorName }}
+    <item>
+      <title>{{ .Title }}</title>
+      <link>{{ .Permalink }}</link>
+      <pubDate>{{ .Lastmod.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</pubDate>
+      {{- with $authorEmail }}<author>{{ . }}{{ with $authorName }} ({{ . }}){{ end }}</author>{{ end }}
+      <guid>{{ .Permalink }}</guid>
+      <description>{{ .Description | transform.XMLEscape | safeHTML }}</description>
+    </item>
+    {{- end }}
+  </channel>
+</rss>

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -57,3 +57,6 @@
 <script defer src="{{ $js.Permalink }}"></script>
 <link rel="preconnect" href="https://{{ site.Params.algolia.appid }}-dsn.algolia.net" crossorigin />
 {{ partialCached "utils/resources.html" . }}
+{{ with .OutputFormats.Get "rss" -}}
+  {{ printf `<link rel=%q type=%q href=%q title=%q>` .Rel .MediaType.Type .Permalink site.Title | safeHTML }}
+{{ end }}


### PR DESCRIPTION
Signed-off-by: David Karlsson <35727626+dvdksn@users.noreply.github.com>

<!--
  Thank you for contributing to Docker documentation!

  Here are a few things to keep in mind:

  - Links between pages should use a relative path
  - Remember to add an alt text for images

  ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
  ┃     Review our contribution guidelines:       ┃
  ┃                                               ┃
  ┃ https://docs.docker.com/contribute/overview/  ┃
  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
-->

### Proposed changes

Adds an RSS template and enables RSS output for the home page

https://deploy-preview-19303--docsdocker.netlify.app/index.xml

Currently this just lists all RegularPages on the site.
Depending on how (if) anyone would use this feature, we could consider adding a limit to the number of pages that appear in the index (e.g., 100 most recently updated pages). The RSS feed is currently 371KB in size, pretty big but not sure if that's a problem.

**Edit**: doesn't look like site.RegularPages is the correct slice to render, seems to be missing some entries

### Related issues (optional)

<!--
  Refer to related PRs or issues:

  #1234
  Closes #1234
  Closes docker/cli#1234
-->
