### PR TITLE
hack: center the cookie consent closing button

### DIFF
--- a/assets/css/hack.css
+++ b/assets/css/hack.css
@@ -1,0 +1,4 @@
+/* center the closing button for the cookie consent modal */
+.ot-floating-button__close {
+  @apply flex justify-center items-center;
+}

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -4,6 +4,7 @@
 @import "/assets/css/global";
 @import "/assets/css/typography";
 @import "/assets/css/search";
+@import "/assets/css/hack";
 
 @import "tailwindcss/components";
 @import "/assets/css/code";


### PR DESCRIPTION
### Proposed changes

Center the closing button for cookie consent.

<img width="78" alt="image" src="https://github.com/docker/docs/assets/35727626/7be9887d-c133-401b-9b92-9c86c0047dc7">

### Related issues (optional)

<!--
  Refer to related PRs or issues:

  #1234
  Closes #1234
  Closes docker/cli#1234
-->
