### PR TITLE
add --rm to docker run line

### DIFF
--- a/content/manuals/engine/install/ubuntu.md
+++ b/content/manuals/engine/install/ubuntu.md
@@ -176,7 +176,7 @@ Docker from the repository.
    `hello-world` image.
 
    ```console
-   $ sudo docker run hello-world
+   $ sudo docker run --rm hello-world
    ```
 
    This command downloads a test image and runs it in a container. When the


### PR DESCRIPTION
<!--
  Thank you for contributing to Docker documentation!

  Here are a few things to keep in mind:

  - Links between pages should use a relative path
  - Remember to add an alt text for images

  ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
  ┃     Review our contribution guidelines:       ┃
  ┃                                               ┃
  ┃ https://docs.docker.com/contribute/overview/  ┃
  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
-->

### Proposed changes

Add `--rm` to the example `docker run hello-world` calls in the docs.

This would avoid leaving a (stopped) container lying around, as can be seen in `docker ps -a`.

I believe that, if you agree, multiple pages would want this change. Let me know and I'll push more commits (and I'm happy to squash afterwards).


### Related issues (optional)

<!--
  Refer to related PRs or issues:

  #1234
  Closes #1234
  Closes docker/cli#1234
-->
