### PR TITLE
engine: 25.0.3 release notes

### DIFF
--- a/content/engine/release-notes/25.0.md
+++ b/content/engine/release-notes/25.0.md
@@ -19,6 +19,43 @@ For more information about:
 - Deprecated and removed features, see [Deprecated Engine Features](../deprecated.md).
 - Changes to the Engine API, see [Engine API version history](../api/version-history.md).
 
+## 25.0.3
+
+{{< release-date date="2024-02-06" >}}
+
+For a full list of pull requests and changes in this release, refer to the relevant GitHub milestones:
+
+- [docker/cli, 25.0.3 milestone](https://github.com/docker/cli/issues?q=is%3Aclosed+milestone%3A25.0.3)
+- [moby/moby, 25.0.3 milestone](https://github.com/moby/moby/issues?q=is%3Aclosed+milestone%3A25.0.3)
+
+
+### Bug fixes and enhancements
+
+- containerd image store: Fix a bug where `docker image history` would fail if a manifest wasn't found in the content store. [moby/moby#47348](https://github.com/moby/moby/pull/47348)
+- Ensure that a generated MAC address is not restored when a container is restarted, but a configured MAC address is preserved. [moby/moby#47304](https://github.com/moby/moby/pull/47304)
+
+  > **Note**
+  >
+  > - Containers created with Docker Engine version 25.0.0 may have duplicate MAC addresses.
+  >   They must be re-created.
+  > - Containers with user-defined MAC addresses created with Docker Engine versions 25.0.0 or 25.0.1
+  >   receive new MAC addresses when started using Docker Engine version 25.0.2.
+  >   They must also be re-created.
+
+- Fix `docker save <image>@<digest>` producing an OCI archive with index without manifests. [moby/moby#47294](https://github.com/moby/moby/pull/47294)
+- Fix a bug preventing bridge networks from being created with an MTU higher than 1500 on RHEL and CentOS 7. [moby/moby#47308](https://github.com/moby/moby/issues/47308), [moby/moby#47311](https://github.com/moby/moby/pull/47311)
+- Fix a bug where containers are unable to communicate over an `internal` network. [moby/moby#47303](https://github.com/moby/moby/pull/47303)
+- Fix a bug where the value of the `ipv6` daemon option was ignored. [moby/moby#47310](https://github.com/moby/moby/pull/47310)
+- Fix a bug where trying to install a pulling using a digest revision would cause a panic. [moby/moby#47323](https://github.com/moby/moby/pull/47323)
+- Fix a potential race condition in the managed containerd supervisor. [moby/moby#47313](https://github.com/moby/moby/pull/47313)
+- Fix an issue with the `journald` log driver preventing container logs from being followed correctly with systemd version 255. [moby/moby47243](https://github.com/moby/moby/pull/47243)
+- seccomp: Update the builtin seccomp profile to include syscalls added in kernel v5.17 - v6.7 to align the profile with the profile used by containerd. [moby/moby#47341](https://github.com/moby/moby/pull/47341)
+- Windows: Fix cache not being used when building images based on Windows versions older than the host's version. [moby/moby#47307](https://github.com/moby/moby/pull/47307), [moby/moby#47337](https://github.com/moby/moby/pull/47337)
+
+### Packaging updates
+
+- Removed support for Ubuntu Lunar (23.04). [docker/ce-packaging#986](https://github.com/docker/docker-ce-packaging/pull/986)
+
 ## 25.0.2
 
 {{< release-date date="2024-01-31" >}}


### PR DESCRIPTION
### Proposed changes

Adds release notes for Docker Engine v25.0.3
https://github.com/moby/moby/releases/tag/v25.0.3

Preview link: https://deploy-preview-19327--docsdocker.netlify.app/engine/release-notes/25.0/#2503

### Related issues (optional)

<!--
  Refer to related PRs or issues:

  #1234
  Closes #1234
  Closes docker/cli#1234
-->
