### PR TITLE
Clarify how JIT works with SAML attributes and impacts SCIM

### DIFF
--- a/content/security/for-admins/scim.md
+++ b/content/security/for-admins/scim.md
@@ -36,7 +36,7 @@ For additional details about supported attributes and SCIM, see [Docker Hub API 
 
 > **Important**
 >
->SSO uses Just-in-Time (JIT) provisioning by default. If you [enable SCIM](scim.md#set-up-scim), JIT values still overwrite the attribute values set by SCIM provisioning whenever users log in. To avoid conflicts, make sure your JIT values match your SCIM values. For example, to make sure that the full name of a user displays in your organization, you would create a `name` attribute in your IdP and ensure the value includes their first name and last name. The exact syntax for these values (for example, `user.firstName + " " + user.lastName`) varies depending on your IdP.
+>SSO uses Just-in-Time (JIT) provisioning by default. If you [enable SCIM](scim.md#set-up-scim), JIT values still overwrite the attribute values set by SCIM provisioning whenever users log in. To avoid conflicts, make sure your JIT values match your SCIM values. For more information, see [SSO attributes](../for-admins/single-sign-on/_index.md#sso-attributes).
 {.important}
 
 ## Set up SCIM

--- a/content/security/for-admins/scim.md
+++ b/content/security/for-admins/scim.md
@@ -34,6 +34,11 @@ The following table lists the supported attributes. Note that your attribute map
 
 For additional details about supported attributes and SCIM, see [Docker Hub API SCIM reference](/docker-hub/api/latest/#tag/scim).
 
+> **Important**
+>
+>SSO uses Just-in-Time (JIT) provisioning by default. If you [enable SCIM](scim.md#set-up-scim), JIT values still overwrite the attribute values set by SCIM provisioning whenever users log in. To avoid conflicts, make sure your JIT values match your SCIM values. For example, to make sure that the full name of a user displays in your organization, you would create a `name` attribute in your IdP and ensure the value includes their first name and last name. The exact syntax for these values (for example, `user.firstName + " " + user.lastName`) varies depending on your IdP.
+{.important}
+
 ## Set up SCIM
 
 You must make sure you have [configured SSO](single-sign-on/configure/_index.md) before you enable SCIM. Enforcing SSO isn't required.

--- a/content/security/for-admins/single-sign-on/_index.md
+++ b/content/security/for-admins/single-sign-on/_index.md
@@ -36,7 +36,12 @@ When a user signs in using SSO, Docker obtains the following attributes from the
 - **Full name** - name of the user
 - **Groups (optional)** - list of groups to which the user belongs
 
-If you use SAML for your SSO connection, Docker obtains these attributes from the SAML assertion message. Your IdP may use different naming for SAML attributes than those in the previous list. The following table lists the possible SAML attributes that can be present in order for your SSO connection to work. 
+If you use SAML for your SSO connection, Docker obtains these attributes from the SAML assertion message. Your IdP may use different naming for SAML attributes than those in the previous list. The following table lists the possible SAML attributes that can be present in order for your SSO connection to work.
+
+> **Important**
+>
+>SSO uses Just-in-Time (JIT) provisioning by default. If you [enable SCIM](../scim.md#set-up-scim), JIT values still overwrite the attribute values set by SCIM provisioning whenever users log in. To avoid conflicts, make sure your JIT values match your SCIM values. For example, to make sure that the full name of a user displays in your organization, you would create a `name` attribute in your IdP and ensure the value includes their first name and last name. The exact syntax for these values (for example, `user.firstName + " " + user.lastName`) varies depending on your IdP.
+{.important}
 
 You can also configure attributes to override default values, such as default team or organization. See [role mapping](../scim.md#set-up-role-mapping).
 
@@ -51,7 +56,7 @@ You can also configure attributes to override default values, such as default te
 
 > **Important**
 >
-> If none of the email address attributes listed in the previous table are found, SSO returns an error.
+> If none of the email address attributes listed in the previous table are found, SSO returns an error. Also, if the `Full name` attribute isn't set, then the name will be displayed as the value of the `Email address`.
 { .important}
 
 ## Prerequisites

--- a/content/security/for-admins/single-sign-on/_index.md
+++ b/content/security/for-admins/single-sign-on/_index.md
@@ -40,7 +40,7 @@ If you use SAML for your SSO connection, Docker obtains these attributes from th
 
 > **Important**
 >
->SSO uses Just-in-Time (JIT) provisioning by default. If you [enable SCIM](../scim.md#set-up-scim), JIT values still overwrite the attribute values set by SCIM provisioning whenever users log in. To avoid conflicts, make sure your JIT values match your SCIM values. For example, to make sure that the full name of a user displays in your organization, you would create a `name` attribute in your IdP and ensure the value includes their first name and last name. The exact syntax for these values (for example, `user.firstName + " " + user.lastName`) varies depending on your IdP.
+>SSO uses Just-in-Time (JIT) provisioning by default. If you [enable SCIM](../scim.md#set-up-scim), JIT values still overwrite the attribute values set by SCIM provisioning whenever users log in. To avoid conflicts, make sure your JIT values match your SCIM values. For example, to make sure that the full name of a user displays in your organization, you would set a `name` attribute in your SAML attributes and ensure the value includes their first name and last name. The exact method for setting these values (for example, constructing it with `user.firstName + " " + user.lastName`) varies depending on your IdP.
 {.important}
 
 You can also configure attributes to override default values, such as default team or organization. See [role mapping](../scim.md#set-up-role-mapping).


### PR DESCRIPTION
<!--
  Thank you for contributing to Docker documentation!

  Here are a few things to keep in mind:

  - Links between pages should use a relative path
  - Remember to add an alt text for images

  ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
  ┃     Review our contribution guidelines:       ┃
  ┃                                               ┃
  ┃ https://docs.docker.com/contribute/overview/  ┃
  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
-->

### Proposed changes

<!-- Tell us what you did and why -->

This PR adds callouts warning that JIT values overwrite SCIM values on user log in, and a workaround to prevent a discrepency is to make sure these values match. Also adds to the callout to emphasize which attributes are required.

### Related issues (optional)

<!--
  Refer to related PRs or issues:

  #1234
  Closes #1234
  Closes docker/cli#1234
-->
Closes JIRA https://docker.atlassian.net/browse/ENGDOCS-1978