### PR TITLE
minor UI fix for Docker Desktop release notes

### DIFF
--- a/layouts/shortcodes/desktop-install.html
+++ b/layouts/shortcodes/desktop-install.html
@@ -17,11 +17,11 @@
     <a target="_blank" rel="noopener" href="https://desktop.docker.com/mac/main/arm64{{ $build_path }}Docker.dmg">Mac
       with Apple chip</a>
     (<a target="_blank" rel="noopener"
-      href="https://desktop.docker.com/mac/main/arm64{{ $build_path }}checksums.txt">checksum</a>)
+      href="https://desktop.docker.com/mac/main/arm64{{ $build_path }}checksums.txt">checksum</a>) |
     <a target="_blank" rel="noopener" href="https://desktop.docker.com/mac/main/amd64{{ $build_path }}Docker.dmg">Mac
       with Intel chip</a>
     (<a target="_blank" rel="noopener"
-      href="https://desktop.docker.com/mac/main/amd64{{ $build_path }}checksums.txt">checksum</a>) |
+      href="https://desktop.docker.com/mac/main/amd64{{ $build_path }}checksums.txt">checksum</a>)
     {{ end -}}
     {{- if or $all $linux }}
     |


### PR DESCRIPTION
<!--
  Thank you for contributing to Docker documentation!

  Here are a few things to keep in mind:

  - Links between pages should use a relative path
  - Remember to add an alt text for images

  ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
  ┃     Review our contribution guidelines:       ┃
  ┃                                               ┃
  ┃ https://docs.docker.com/contribute/overview/  ┃
  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
-->

### Proposed changes

<!-- Tell us what you did and why -->
Noticed this in the Docker Desktop [release notes](https://docs.docker.com/desktop/release-notes/#:~:text=2024%2D02%2D08-,Download%20Docker,-Desktop) : 
<img width="807" alt="image" src="https://github.com/docker/docs/assets/42580324/593c3ad8-d425-4fe7-9884-1ddfb99cce8b">
so this PR : 
- removes the extra pipe before Linux installers
- adds the missing pipe before Mac with intel chip installer



### Related issues (optional)

<!--
  Refer to related PRs or issues:

  #1234
  Closes #1234
  Closes docker/cli#1234
-->
