### PR TITLE
build: fix stage name references

### DIFF
--- a/content/build/guide/build-args.md
+++ b/content/build/guide/build-args.md
@@ -40,11 +40,11 @@ has to be. Build arguments make life easier:
       go build -o /bin/server ./cmd/server
 
   FROM scratch AS client
-  COPY --from=build /bin/client /bin/
+  COPY --from=build-client /bin/client /bin/
   ENTRYPOINT [ "/bin/client" ]
 
   FROM scratch AS server
-  COPY --from=build /bin/server /bin/
+  COPY --from=build-server /bin/server /bin/
   ENTRYPOINT [ "/bin/server" ]
 ```
 


### PR DESCRIPTION
<!--
  Thank you for contributing to Docker documentation!

  Here are a few things to keep in mind:

  - Links between pages should use a relative path
  - Remember to add an alt text for images

  ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
  ┃     Review our contribution guidelines:       ┃
  ┃                                               ┃
  ┃ https://docs.docker.com/contribute/overview/  ┃
  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
-->

### Proposed changes

<!-- Tell us what you did and why -->

Today I read this web page
https://docs.docker.com/build/guide/build-args/
and noticed that a Dockerfile contained
```
--from=build 
```
but the Dockerfile had no  stage with that name.
I assume this is a documentation typo.

### Related issues (optional)

<!--
  Refer to related PRs or issues:

  #1234
  Closes #1234
  Closes docker/cli#1234
-->
