### PR TITLE
engine: fix link to containerd shim api readme

### DIFF
--- a/content/engine/alternative-runtimes.md
+++ b/content/engine/alternative-runtimes.md
@@ -17,7 +17,7 @@ By default, containerd uses runc as its container runtime.
 ## What runtimes can I use?
 
 You can use any runtime that implements the containerd 
-[shim API](https://github.com/containerd/containerd/blob/main/runtime/v2/README.md).
+[shim API](https://github.com/containerd/containerd/blob/main/core/runtime/v2/README.md).
 Such runtimes ship with a containerd shim, and you can use them without any
 additional configuration. See [Use containerd shims](#use-containerd-shims).
 


### PR DESCRIPTION
Signed-off-by: David Karlsson <35727626+dvdksn@users.noreply.github.com>

<!--
  Thank you for contributing to Docker documentation!

  Here are a few things to keep in mind:

  - Links between pages should use a relative path
  - Remember to add an alt text for images

  ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
  ┃     Review our contribution guidelines:       ┃
  ┃                                               ┃
  ┃ https://docs.docker.com/contribute/overview/  ┃
  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
-->

### Proposed changes

The link to the c8d shim API readme was broken because the page had moved

### Related issues (optional)

<!--
  Refer to related PRs or issues:

  #1234
  Closes #1234
  Closes docker/cli#1234
-->
