### PR TITLE
Add post-install script location hint to install/ubuntu.md

### DIFF
--- a/content/desktop/install/ubuntu.md
+++ b/content/desktop/install/ubuntu.md
@@ -53,7 +53,7 @@ Recommended approach to install Docker Desktop on Ubuntu:
    > N: Download is performed unsandboxed as root, as file '/home/user/Downloads/docker-desktop.deb' couldn't be accessed by user '_apt'. - pkgAcquire::Run (13: Permission denied)
    > ```
 
-There are a few post-install configuration steps done through the post-install script contained in the deb package.
+There are a few post-install configuration steps done through the post-install script contained in the deb package, search for `ls -l /var/lib/dpkg/info/docker*`.
 
 The post-install script:
 


### PR DESCRIPTION
<!--
  Thank you for contributing to Docker documentation!

  Here are a few things to keep in mind:

  - Links between pages should use a relative path
  - Remember to add an alt text for images

  ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
  ┃     Review our contribution guidelines:       ┃
  ┃                                               ┃
  ┃ https://docs.docker.com/contribute/overview/  ┃
  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
-->

### Proposed changes

A post-install script is mentioned after the installation instructions, but the location of the script is nowhere mentioned.


