### PR TITLE
fix(desktop): correct link for bind mount options

### DIFF
--- a/content/desktop/synchronized-file-sharing.md
+++ b/content/desktop/synchronized-file-sharing.md
@@ -45,7 +45,7 @@ When the status indicator displays **Watching for filesystem changes**, your fil
 
 >**Note**
 >
-> When you create a new service, setting the [bind mount option consistency](../engine/reference/commandline/secret_create.md#options-for-bind-mounts) to `:consistent` bypasses Synchronized file shares. 
+> When you create a new service, setting the [bind mount option consistency](../engine/reference/commandline/service_create.md#options-for-bind-mounts) to `:consistent` bypasses Synchronized file shares.
 
 ## Explore your file share instance
 


### PR DESCRIPTION
### Proposed changes
Fix a link for bind mount options.

This was linking to `secret create`, which is wrong. It's on the `service create` docs (which is almost as random).

### Related issues (optional)
n/a