### PR TITLE
Update include.md

### DIFF
--- a/content/compose/multiple-compose-files/include.md
+++ b/content/compose/multiple-compose-files/include.md
@@ -6,7 +6,7 @@ title: Include
 
 > **Note**
 >
-> `include` is available in Docker Compose version 2.20 and later, and Docker Desktop version 4.22 and later. 
+> `include` is available in Docker Compose version 2.20.3 and later, and Docker Desktop version 4.22 and later. 
 
 With the [`include` top-level element](../compose-file/14-include.md), you can include a separate Compose file directly in your local Compose file. This solves the relative path problem that [`extends`](extends.md) and [merge](merge.md) present. 
 


### PR DESCRIPTION
https://github.com/docker/compose/issues/10932#issuecomment-1696396507

### Proposed changes

Docker Compose `v2.20.3` is required to have proper `include` feature support.

I had a co-worker using `v2.20.2` which was shipped on Linux `apt` repository, and couldn't understand why it was not working, as the documentation didn't mention the patch version that included a fix regarding `include` feature.

### Related issues
https://github.com/docker/compose/issues/10932#issuecomment-1696396507
