### PR TITLE
Fix missing quote on expose example

### DIFF
--- a/content/compose/compose-file/05-services.md
+++ b/content/compose/compose-file/05-services.md
@@ -638,7 +638,7 @@ When not explicitly set, `tcp` protocol is used.
 expose:
   - "3000"
   - "8000"
-  - "8080-8085/tcp
+  - "8080-8085/tcp"
 ```
 
 > **Note**


### PR DESCRIPTION
Found while looking for expose udp example.