### PR TITLE
cli: hoist content in CLI stubs to top

### DIFF
--- a/layouts/_default/cli.html
+++ b/layouts/_default/cli.html
@@ -25,6 +25,7 @@
     <h1 class="scroll-mt-36">{{ .Title }}</h1>
     {{ end }}
     {{ $data.short | .RenderString (dict "display" "block") }}
+    {{ .Content }}
     {{ if $data.deprecated }}
       <blockquote class="warning">
         <p><strong>This command is deprecated</strong></p>
@@ -161,7 +162,6 @@
       {{ end }}
       {{ $.RenderString (dict "display" "block") . }}
     {{ end }}
-    {{ .Content }}
   </article>
 {{ end }}
 


### PR DESCRIPTION
Signed-off-by: David Karlsson <35727626+dvdksn@users.noreply.github.com>

## Description

Moves the content of CLI stub files to the top of the page (from the bottom)

Before:

<img width="891" alt="image" src="https://github.com/docker/docs/assets/35727626/34d73124-27f1-4e77-8d7a-00caea220329">
...
<img width="927" alt="image" src="https://github.com/docker/docs/assets/35727626/fe0d884e-0879-41c0-931d-322ba2e9bf41">


After:

<img width="878" alt="image" src="https://github.com/docker/docs/assets/35727626/bbbc4170-16b5-4431-a2b8-c1f96b3db77c">



## Related issues

<!-- Related issues and pull requests -->
