### PR TITLE
redirect: add go link for VEX guide

### DIFF
--- a/data/redirects.yml
+++ b/data/redirects.yml
@@ -635,6 +635,8 @@
   - "/go/scout-sq/"
 "/scout/integrations/source-code-management/github/":
   - "/go/scout-github/"
+"/scout/guides/vex/":
+  - "/go/vex-guide/"
 
 # Build links (internal)
 "/build/bake/reference/":


### PR DESCRIPTION
Signed-off-by: David Karlsson <35727626+dvdksn@users.noreply.github.com>

## Description

Add `/go/` redirect to the VEX use case guide for use in the UI

## Related issues

<!-- Related issues and pull requests -->
