### PR TITLE
docs: update wrong numeral adjectives in multi-platform.md

### DIFF
--- a/content/build/guide/multi-platform.md
+++ b/content/build/guide/multi-platform.md
@@ -76,7 +76,7 @@ $ docker build \
     --platform=linux/amd64,linux/arm64,linux/arm/v7 .
 ```
 
-This command uses emulation to run the same build four times, once for each
+This command uses emulation to run the same build three times, once for each
 platform. The build results are exported to a `bin` directory.
 
 ```text
@@ -94,7 +94,7 @@ bin
 
 When you build for multiple platforms concurrently,
 BuildKit runs all of the build steps under emulation for each platform that you specify.
-Effectively forking the build into two concurrent processes.
+Effectively forking the build into multiple concurrent processes.
 
 ![Build pipelines using emulation](./images/emulation.png)
 


### PR DESCRIPTION
An example build command used three platforms, then quantified the number of concurrent processes as four.

The image just after the command that created those three builds shows a diagram with two builds. Instead of using another different quantifier for the same thought that should exist in the reader's mind, I changed the sentence after to just say "multiple".