### PR TITLE
Add length restrictions to token_label in API spec

### DIFF
--- a/content/docker-hub/api/latest.yaml
+++ b/content/docker-hub/api/latest.yaml
@@ -1689,6 +1689,8 @@ components:
           type: string
           description: Friendly name for you to identify the token.
           example: My read only token
+          minLength: 1
+          maxLength: 100
         scopes:
           type: array
           description: |
@@ -1730,6 +1732,8 @@ components:
         token_label:
           type: string
           example: My read only token
+          minLength: 1
+          maxLength: 100
         is_active:
           type: boolean
           example: false


### PR DESCRIPTION
There are maximums enforced here that we document in the API spec. Hoping that this gets rendered in html here: https://docs.docker.com/docker-hub/api/latest/#tag/access-tokens