### PR TITLE
cli: add debug callout in exec

### DIFF
--- a/content/engine/reference/commandline/container_exec.md
+++ b/content/engine/reference/commandline/container_exec.md
@@ -9,6 +9,16 @@ aliases:
 layout: cli
 ---
 
+> **Introducing Docker Debug**
+>
+> To easily get a debug shell into any container, use `docker debug`. Docker
+> Debug is a replacement for debugging with` docker exec`. With it, you can get
+> a shell into any container or image, even slim ones, without modifications.
+> Plus, you can bring along your favorite debugging tools in its customizable
+> toolbox.
+>
+> Explore [Docker Debug](./debug.md) now.
+
 <!--
 This page is automatically generated from Docker's source code. If you want to
 suggest a change to the text that appears here, open a ticket or pull request

--- a/content/engine/reference/commandline/container_exec.md
+++ b/content/engine/reference/commandline/container_exec.md
@@ -12,7 +12,7 @@ layout: cli
 > **Introducing Docker Debug**
 >
 > To easily get a debug shell into any container, use `docker debug`. Docker
-> Debug is a replacement for debugging with` docker exec`. With it, you can get
+> Debug is a replacement for debugging with `docker exec`. With it, you can get
 > a shell into any container or image, even slim ones, without modifications.
 > Plus, you can bring along your favorite debugging tools in its customizable
 > toolbox.


### PR DESCRIPTION
Added callout to `docker exec` CLI reference page to introduce Docker Debug.

Preview: https://deploy-preview-19423--docsdocker.netlify.app/engine/reference/commandline/container_exec/

ENGDOCS-1991