### PR TITLE
Revert "ci: add vale style check"

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,14 +35,6 @@ jobs:
             *.cache-from=type=gha,scope=build
             *.cache-to=type=gha,scope=build,mode=max
 
-  vale:
-    runs-on: ubuntu-22.04
-    steps:
-      - uses: actions/checkout@v4
-      - uses: errata-ai/vale-action@38bf078c328061f59879b347ca344a718a736018 # v2.1.0
-        with:
-          files: content
-
   validate:
     runs-on: ubuntu-22.04
     strategy:


### PR DESCRIPTION
This reverts commit e053b75ad78043918241089f4700202024325654.

## Description

Removing vale check again since it seems like the CI check is throwing errors,
despite its docs saying it shouldn't fail on error by default.

## Related issues

<!-- Related issues and pull requests -->
