### PR TITLE
Fix JSON syntax error in Daemon configuration file

### DIFF
--- a/_vendor/github.com/docker/cli/docs/reference/commandline/dockerd.md
+++ b/_vendor/github.com/docker/cli/docs/reference/commandline/dockerd.md
@@ -1079,7 +1079,7 @@ The following is a full example of the allowed configuration options on Linux:
   "proxies": {
     "http-proxy": "http://proxy.example.com:80",
     "https-proxy": "https://proxy.example.com:443",
-    "no-proxy": "*.test.example.com,.example.org",
+    "no-proxy": "*.test.example.com,.example.org"
   },
   "icc": false,
   "init": false,


### PR DESCRIPTION
I checked the issue and ensured the comma was causing the JSON config to be invalid. I removed the extraneous comma and now the JSON is valid.
Fixes #19397 