### PR TITLE
scout: add containerd image store prereq to vex guide

### DIFF
--- a/content/scout/guides/vex.md
+++ b/content/scout/guides/vex.md
@@ -24,6 +24,7 @@ In this guide, you will learn about:
 If you want to follow along the steps of this guide, you'll need the following:
 
 - The latest version of Docker Desktop
+- The [containerd image store](../../desktop/containerd.md) must be enabled
 - Git
 - A [Docker account](../../docker-id/_index.md)
 - A GitHub account


### PR DESCRIPTION
Signed-off-by: David Karlsson <35727626+dvdksn@users.noreply.github.com>

## Description

The containerd image store must be enabled to build and push images with
attestations without creating a new buildx builder.
