### PR TITLE
update docker init reference

### DIFF
--- a/data/init-cli/docker_init.yaml
+++ b/data/init-cli/docker_init.yaml
@@ -10,7 +10,11 @@ long: |-
     * compose.yaml
     * README.Docker.md
     
-    If any of the files already exist, a prompt appears and provides a warning as well as giving you the option to overwrite all the files.
+    If any of the files already exist, a prompt appears and provides a warning
+    as well as giving you the option to overwrite all the files. If
+    `docker-compose.yaml` already exists instead of `compose.yaml`, `docker
+    init` can overwrite it, using `docker-compose.yaml`as the name for the
+    Compose file.
     
     > **Warning**
     >

--- a/data/init-cli/docker_init.yaml
+++ b/data/init-cli/docker_init.yaml
@@ -13,7 +13,7 @@ long: |-
     If any of the files already exist, a prompt appears and provides a warning
     as well as giving you the option to overwrite all the files. If
     `docker-compose.yaml` already exists instead of `compose.yaml`, `docker
-    init` can overwrite it, using `docker-compose.yaml`as the name for the
+    init` can overwrite it, using `docker-compose.yaml` as the name for the
     Compose file.
     
     > **Warning**


### PR DESCRIPTION
`docker init` will overwrite and use `docker-compose.yaml` as the Compose file name if it already exists. It will prompt the user, but the behavior can be confusing as the examples all use `compose.yaml`.


ENGDOCS-1998
Ran into the issue in #19390