### PR TITLE
cli: use redirects for noncanonical commands

### DIFF
--- a/content/reference/cli/docker/container/exec.md
+++ b/content/reference/cli/docker/container/exec.md
@@ -7,6 +7,7 @@ aliases:
 - /edge/engine/reference/commandline/container_exec/
 - /engine/reference/commandline/container_exec/
 - /engine/reference/commandline/exec/
+- /reference/cli/docker/exec/
 layout: cli
 ---
 

--- a/content/reference/cli/docker/container/ls.md
+++ b/content/reference/cli/docker/container/ls.md
@@ -7,6 +7,7 @@ aliases:
 - /edge/engine/reference/commandline/container_ls/
 - /engine/reference/commandline/container_ls/
 - /engine/reference/commandline/ps/
+- /reference/cli/docker/ps/
 layout: cli
 ---
 

--- a/content/reference/cli/docker/container/run.md
+++ b/content/reference/cli/docker/container/run.md
@@ -6,6 +6,7 @@ title: docker container run
 aliases:
 - /engine/reference/commandline/container_rm/
 - /engine/reference/commandline/run/
+- /reference/cli/docker/run/
 layout: cli
 ---
 

--- a/content/reference/cli/docker/image/build.md
+++ b/content/reference/cli/docker/image/build.md
@@ -8,6 +8,8 @@ aliases:
 - /engine/reference/commandline/image_build/
 - /engine/reference/commandline/build/
 - /engine/reference/commandline/builder_build/
+- /reference/cli/docker/build/
+- /reference/cli/docker/builder/build/
 layout: cli
 ---
 

--- a/content/reference/cli/docker/image/ls.md
+++ b/content/reference/cli/docker/image/ls.md
@@ -7,6 +7,7 @@ aliases:
 - /edge/engine/reference/commandline/image_ls/
 - /engine/reference/commandline/image_ls/
 - /engine/reference/commandline/images/
+- /reference/cli/docker/images/
 layout: cli
 ---
 

--- a/content/reference/cli/docker/image/pull.md
+++ b/content/reference/cli/docker/image/pull.md
@@ -7,6 +7,7 @@ aliases:
 - /edge/engine/reference/commandline/image_pull/
 - /engine/reference/commandline/image_pull/
 - /engine/reference/commandline/pull/
+- /reference/cli/docker/pull/
 layout: cli
 ---
 

--- a/content/reference/cli/docker/image/push.md
+++ b/content/reference/cli/docker/image/push.md
@@ -7,6 +7,7 @@ aliases:
 - /edge/engine/reference/commandline/image_push/
 - /engine/reference/commandline/image_push/
 - /engine/reference/commandline/push/
+- /reference/cli/docker/push/
 layout: cli
 ---
 

--- a/content/reference/cli/docker/image/rm.md
+++ b/content/reference/cli/docker/image/rm.md
@@ -6,6 +6,7 @@ aliases:
 - /edge/engine/reference/commandline/image_rm/
 - /engine/reference/commandline/image_rm/
 - /engine/reference/commandline/rmi/
+- /reference/cli/docker/rmi/
 layout: cli
 ---
 

--- a/content/reference/cli/docker/image/save.md
+++ b/content/reference/cli/docker/image/save.md
@@ -6,6 +6,7 @@ aliases:
 - /edge/engine/reference/commandline/image_save/
 - /engine/reference/commandline/image_save/
 - /engine/reference/commandline/save/
+- /reference/cli/docker/save/
 layout: cli
 ---
 

--- a/content/reference/cli/docker/system/info.md
+++ b/content/reference/cli/docker/system/info.md
@@ -7,6 +7,7 @@ aliases:
 - /edge/engine/reference/commandline/system_info/
 - /engine/reference/commandline/system_info/
 - /engine/reference/commandline/info/
+- /reference/cli/docker/info/
 layout: cli
 ---
 

--- a/data/toc.yaml
+++ b/data/toc.yaml
@@ -293,13 +293,13 @@ Reference:
   section:
   - path: /reference/cli/docker/
     title: docker (base command)
-  - path: /reference/cli/docker/image/build/
+  - path: /reference/cli/docker/build/
     title: docker build
   - sectiontitle: docker builder
     section:
       - path: /reference/cli/docker/builder/
         title: docker builder
-      - path: /reference/cli/docker/image/build/
+      - path: /reference/cli/docker/builder/build/
         title: docker builder build
       - path: /reference/cli/docker/builder/prune/
         title: docker builder prune
@@ -509,7 +509,7 @@ Reference:
         title: docker context use
   - path: /reference/cli/docker/debug/
     title: docker debug (Beta)
-  - path: /reference/cli/docker/container/exec/
+  - path: /reference/cli/docker/exec/
     title: docker exec
   - sectiontitle: docker image
     section:
@@ -539,9 +539,9 @@ Reference:
       title: docker image save
     - path: /reference/cli/docker/image/tag/
       title: docker image tag
-  - path: /reference/cli/docker/image/ls/
+  - path: /reference/cli/docker/images/
     title: docker images
-  - path: /reference/cli/docker/system/info/
+  - path: /reference/cli/docker/info/
     title: docker info
   - path: /reference/cli/docker/init/
     title: docker init
@@ -623,13 +623,13 @@ Reference:
       title: docker plugin set
     - path: /reference/cli/docker/plugin/upgrade/
       title: docker plugin upgrade
-  - path: /reference/cli/docker/container/ls/
+  - path: /reference/cli/docker/ps/
     title: docker ps
-  - path: /reference/cli/docker/image/pull/
+  - path: /reference/cli/docker/pull/
     title: docker pull
-  - path: /reference/cli/docker/image/push/
+  - path: /reference/cli/docker/push/
     title: docker push
-  - path: /reference/cli/docker/container/run/
+  - path: /reference/cli/docker/run/
     title: docker run
   - sectiontitle: docker scout
     section:


### PR DESCRIPTION


Signed-off-by: David Karlsson <35727626+dvdksn@users.noreply.github.com>

## Description

The pages for commands with aliases, e.g. `docker build`, where linked
twice in `toc.yaml` which resulted in strange highlighting for the
current page in the sidebar. Updated the link targets for non-canonical
commands in the `toc.yaml` to point to the (redirected) shorthand paths
instead.

Behavior before this change:

https://github.com/docker/docs/assets/35727626/3ab040a0-749a-4de1-b26e-2297220b78d5


## Related issues

<!-- Related issues and pull requests -->
