### PR TITLE
ci: fix validate upstream workflow

### DIFF
--- a/.github/workflows/validate-upstream.yml
+++ b/.github/workflows/validate-upstream.yml
@@ -19,9 +19,9 @@ on:
       data-files-folder:
         required: false
         type: string
-      data-files-placeholder-folder:
+      create-placeholder-stubs:
+        type: boolean
         required: false
-        type: string
 
 jobs:
   run:
@@ -41,10 +41,9 @@ jobs:
           path: /tmp/data/${{ inputs.data-files-folder }}
       -
         # Copy data files from /tmp/data/${{ inputs.data-files-folder }} to
-        # data/${{ inputs.data-files-folder }}. If data-files-placeholder-folder
-        # is set, then check if a placeholder file exists for each data file in
-        # that folder. If not, then creates a placeholder file with the same
-        # name as the data file, but with a .md extension.
+        # data/${{ inputs.data-files-folder }}. If create-placeholder-stubs
+        # is set to true, then check if a placeholder file exists for each data file in
+        # that folder. If not, create a placeholder stub file for the data file.
         name: Copy data files
         if: ${{ inputs.data-files-id != '' && inputs.data-files-folder != '' }}
         uses: actions/github-script@v7
@@ -52,13 +51,18 @@ jobs:
           script: |
             const fs = require('fs');
             const path = require('path');
-            const dataFilesPlaceholderFolder = `content/${{ inputs.data-files-placeholder-folder }}`;
             const globber = await glob.create(`/tmp/data/${{ inputs.data-files-folder }}/*.yaml`);
             for await (const yamlSrcPath of globber.globGenerator()) {
               const yamlSrcFilename = path.basename(yamlSrcPath);
+              const yamlSrcNoExt = yamlSrcPath.replace(".yaml", "");
+              const hasSubCommands = (await (await glob.create(yamlSrcNoExt)).glob()).length > 1;
               const yamlDestPath = path.join('data', `${{ inputs.data-files-folder }}`, yamlSrcFilename);
-              const placeholderPath = path.join(dataFilesPlaceholderFolder, yamlSrcFilename.replace(/^docker_/, '').replace(/\.yaml$/, '.md'));
-              if (dataFilesPlaceholderFolder !== '' && !fs.existsSync(placeholderPath)) {
+              let placeholderPath = path.join("content/reference/cli", yamlSrcFilename.replace('_', '/').replace(/\.yaml$/, '.md'));
+              if (hasSubCommands) {
+                placeholderPath = placeholderPath.replace('.md', '/_index.md');
+              };
+              if (`${{ inputs.create-placeholder-stubs }}` && !fs.existsSync(placeholderPath)) {
+                fs.mkdirSync(path.dirname(placeholderPath), { recursive: true });
                 const placeholderContent = `---
             datafolder: ${{ inputs.data-files-folder }}
             datafile: ${yamlSrcFilename.replace(/\.[^/.]+$/, '')}


### PR DESCRIPTION
Signed-off-by: David Karlsson <35727626+dvdksn@users.noreply.github.com>

## Description

Moving the CLI reference files caused the upstream validation workflow
to break.

This changes the logic in how placeholder files are created in the
validation workflow, to match the new filesystem structure for markdown
stubs.

## Related issues

docker/buildx#2269

Verified with https://github.com/docker/buildx/pull/2273
