### PR TITLE
redirect: fix typo in alias for old container_run

### DIFF
--- a/content/reference/cli/docker/container/run.md
+++ b/content/reference/cli/docker/container/run.md
@@ -4,7 +4,7 @@ datafile: docker_container_run
 linkTitle: docker run
 title: docker container run
 aliases:
-- /engine/reference/commandline/container_rm/
+- /engine/reference/commandline/container_run/
 - /engine/reference/commandline/run/
 - /reference/cli/docker/run/
 layout: cli


### PR DESCRIPTION
Closes #19465