### PR TITLE
fix "List all port bidings"

### DIFF
--- a/data/engine-cli/docker_inspect.yaml
+++ b/data/engine-cli/docker_inspect.yaml
@@ -139,7 +139,7 @@ examples: |-
     You can loop over arrays and maps in the results to produce simple text output:
 
     ```console
-    $ docker inspect --format='{{range $p, $conf := .NetworkSettings.Ports}} {{$p}} -> {{(index $conf 0).HostPort}} {{end}}' $INSTANCE_ID
+    $ docker inspect --format='{{range $p, $conf := .NetworkSettings.Ports}} {{$p}} -> {{if $conf}}{{(index $conf 0).HostPort}}{{else}}null{{end}} {{end}}' $INSTANCE_ID
     ```
 
     ### Find a specific port mapping


### PR DESCRIPTION
If a port is exposed in the container but not mapped in the host, `$conf` is null and the previous suggested command fails. Adding a `if` avoids the failure.