### PR TITLE
update use-case guides toc

### DIFF
--- a/data/toc.yaml
+++ b/data/toc.yaml
@@ -149,7 +149,7 @@ Guides:
     - title: "Test your deployment"
       path: /language/php/deploy/
 
-- sectiontitle: Use-case guides
+- sectiontitle: Use-case guides {{< badge color=violet text=New >}}
   section:
     - sectiontitle: Generative AI
       section:
@@ -177,10 +177,10 @@ Guides:
         title: Text classification
       - path: /guides/use-case/nlp/text-summarization/
         title: Text summarization
-    - path: /scout/guides/vex/
-      title: Suppress CVEs with VEX
     - path: /guides/use-case/jupyter/
       title: Data science with JupyterLab
+    - path: /scout/guides/vex/
+      title: Suppress CVEs with VEX
 
 
 - sectiontitle: Develop with Docker


### PR DESCRIPTION
- Reordered the Jupyter use-case guide in the navigation to be closer to the other AI/ML guides.
- Added the "new" label to the use-case guides to try to drum up more awareness. 
  
![image](https://github.com/docker/docs/assets/103533812/af2ce31a-a1ad-4413-a8e2-4050b887a645)


ENGDOCS-2005