### PR TITLE
Clarify enforce sign-in steps

### DIFF
--- a/content/security/for-admins/configure-sign-in.md
+++ b/content/security/for-admins/configure-sign-in.md
@@ -68,12 +68,12 @@ details, see [Manage members](/admin/organization/members/).
 
 4. Verify that sign-in is enforced.
 
-    Start Docker Desktop on the user’s machine and verify that the **Sign in
-    required!** prompt appears.
+    Restart Docker Desktop on the user’s machine and verify that the **Sign in
+    required!** prompt appears. In some cases, a system reboot may be necessary for the enforcement to take effect.
 
     > **Tip**
     >
-    > If your users have issues starting Docker Desktop after you enforce sign-in, they may need to update to the latest version.
+    > If your users have issues starting Docker Desktop after you enforce sign-in, they may need to update to the latest version. 
     { .tip }
 
 ## Alternative methods to create a registry.json file

--- a/content/security/for-admins/configure-sign-in.md
+++ b/content/security/for-admins/configure-sign-in.md
@@ -68,12 +68,14 @@ details, see [Manage members](/admin/organization/members/).
 
 4. Verify that sign-in is enforced.
 
-    Restart Docker Desktop on the user’s machine and verify that the **Sign in
-    required!** prompt appears. In some cases, a system reboot may be necessary for the enforcement to take effect.
+    To activate the `registry.json` file, restart Docker Desktop on the user’s machine. When Docker Desktop starts, verify that the **Sign in
+    required!** prompt appears. 
+    
+    In some cases, a system reboot may be necessary for the enforcement to take effect.
 
     > **Tip**
     >
-    > If your users have issues starting Docker Desktop after you enforce sign-in, they may need to update to the latest version. 
+    > If your users have issues starting Docker Desktop after you enforce sign-in, they may need to update to the latest version.
     { .tip }
 
 ## Alternative methods to create a registry.json file


### PR DESCRIPTION
This PR adds the following to the Enforce sign-in docs:
- Clarifies that you need to restart vs start Docker Desktop
- Adds a tip that a system reboot may be necessary based on feedback from customers

Closes JIRA https://docker.atlassian.net/browse/ENGDOCS-2006