### PR TITLE
ci: UPSTREAM_COMMIT was never declared as a variable in bake

### DIFF
--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -155,7 +155,7 @@ variable "UPSTREAM_MODULE_NAME" {
 variable "UPSTREAM_REPO" {
   default = null
 }
-variable "UPSTREAM_MODULE_NAME" {
+variable "UPSTREAM_COMMIT" {
   default = null
 }
 


### PR DESCRIPTION
Signed-off-by: David Karlsson <35727626+dvdksn@users.noreply.github.com>

<!--Delete sections as needed -->

## Description

The `validate-upstream` workflow uses `UPSTREAM_COMMIT` to define which
Git commit to use for a temporary vendor of upstream doc files.

https://github.com/docker/docs/blob/main/Dockerfile#L64-L65

But due to a typo in the Bake file, `UPSTREAM_MODULE_NAME` is defined as a variable twice,
and `UPSTREAM_COM is never defined as a variable:

https://github.com/docker/docs/blob/main/docker-bake.hcl#L152-L160

I don't know how `validate-upstream` has successfully ran before.
We don't set the commit version as a build-arg, we use `ENV`.
I thought that meant we need to declare a `null` variable in the bake file.
Maybe it works anyway. But this is "more correct" anyway.

