### PR TITLE
debug: add `go` redirect for docker debug

### DIFF
--- a/data/redirects.yml
+++ b/data/redirects.yml
@@ -689,3 +689,6 @@
   - /engine/reference/builder/
 "/get-started/04_sharing_app":
   - /go/get-started-sharing/
+
+"/reference/cli/docker/debug/":
+  - /go/debug-cli/


### PR DESCRIPTION
Signed-off-by: David Karlsson <35727626+dvdksn@users.noreply.github.com>

## Description

Adds a `go` redirect for docker debug cli reference
