### PR TITLE
cli reference template improvements

### DIFF
--- a/layouts/_default/cli.html
+++ b/layouts/_default/cli.html
@@ -94,65 +94,68 @@
       {{ . | $.RenderString (dict "display" "block") }}
     {{ end }}
     {{ with $data.options }}
-      {{ $heading := dict "level" 2 "text" "Options" }}
-      {{ partial "heading.html" $heading }}
-      {{ $.Scratch.Add "headings" $heading }}
-      <table>
-        <thead>
-          <tr>
-            <th>Option</th>
-            <th>Default</th>
-            <th>Description</th>
-          </tr>
-        </thead>
-        <tbody>
-          {{ range where . "hidden" false }}
+      {{ $opts := where . "hidden" false }}
+      {{ with $opts }}
+        {{ $heading := dict "level" 2 "text" "Options" }}
+        {{ partial "heading.html" $heading }}
+        {{ $.Scratch.Add "headings" $heading }}
+        <table>
+          <thead>
             <tr>
-              {{ $short := .shorthand }}
-              {{ $long := .option }}
-              <td>
-                {{ with .details_url }}
-                <a class="link" href="{{ . }}">
-                  <code>{{ with $short }}-{{ . }}, {{end}}--{{ $long }}</code>
-                </a>
-                {{ else }}
-                <code>{{ with $short }}-{{ . }}, {{end}}--{{ $long }}</code>
-                {{ end }}
-              </td>
-              {{ $skipDefault := `[],map[],false,0,0s,default,'',""` }}
-              <td>
-                {{ with .default_value }}
-                  {{ cond (in $skipDefault .) "" (printf "<code>%s</code>" . | safeHTML) }}
-                {{ end }}
-              </td>
-              <td>
-                {{ with .min_api_version }}
-                  {{ partial "components/badge.html" (dict "color" "blue" "content" (printf "API %s+" .)) }}
-                {{ end }}
-                {{ with .deprecated }}
-                  {{ partial "components/badge.html" (dict "color" "red" "content" "Deprecated") }}
-                {{ end }}
-                {{ with .experimental }}
-                  {{ partial "components/badge.html" (dict "color" "amber" "content" "experimental (daemon)") }}
-                {{ end }}
-                {{ with .experimentalcli }}
-                  {{ partial "components/badge.html" (dict "color" "amber" "content" "experimental (CLI)") }}
-                {{ end }}
-                {{ with .kubernetes }}
-                  {{ partial "components/badge.html" (dict "color" "blue" "content" "Kubernetes") }}
-                {{ end }}
-                {{ with .swarm }}
-                  {{ partial "components/badge.html" (dict "color" "blue" "content" "Swarm") }}
-                {{ end }}
-                {{ if .description }}
-                  {{/* replace newlines in long desc with break tags */}}
-                  {{ markdownify (strings.Replace .description "\n" "<br>") }}
-                {{ end }}
-              </td>
+              <th>Option</th>
+              <th>Default</th>
+              <th>Description</th>
             </tr>
-          {{ end }}
-        </tbody>
-      </table>
+          </thead>
+          <tbody>
+            {{ range . }}
+              <tr>
+                {{ $short := .shorthand }}
+                {{ $long := .option }}
+                <td>
+                  {{ with .details_url }}
+                  <a class="link" href="{{ . }}">
+                    <code>{{ with $short }}-{{ . }}, {{end}}--{{ $long }}</code>
+                  </a>
+                  {{ else }}
+                  <code>{{ with $short }}-{{ . }}, {{end}}--{{ $long }}</code>
+                  {{ end }}
+                </td>
+                {{ $skipDefault := `[],map[],false,0,0s,default,'',""` }}
+                <td>
+                  {{ with .default_value }}
+                    {{ cond (in $skipDefault .) "" (printf "<code>%s</code>" . | safeHTML) }}
+                  {{ end }}
+                </td>
+                <td>
+                  {{ with .min_api_version }}
+                    {{ partial "components/badge.html" (dict "color" "blue" "content" (printf "API %s+" .)) }}
+                  {{ end }}
+                  {{ with .deprecated }}
+                    {{ partial "components/badge.html" (dict "color" "red" "content" "Deprecated") }}
+                  {{ end }}
+                  {{ with .experimental }}
+                    {{ partial "components/badge.html" (dict "color" "amber" "content" "experimental (daemon)") }}
+                  {{ end }}
+                  {{ with .experimentalcli }}
+                    {{ partial "components/badge.html" (dict "color" "amber" "content" "experimental (CLI)") }}
+                  {{ end }}
+                  {{ with .kubernetes }}
+                    {{ partial "components/badge.html" (dict "color" "blue" "content" "Kubernetes") }}
+                  {{ end }}
+                  {{ with .swarm }}
+                    {{ partial "components/badge.html" (dict "color" "blue" "content" "Swarm") }}
+                  {{ end }}
+                  {{ if .description }}
+                    {{/* replace newlines in long desc with break tags */}}
+                    {{ markdownify (strings.Replace .description "\n" "<br>") }}
+                  {{ end }}
+                </td>
+              </tr>
+            {{ end }}
+          </tbody>
+        </table>
+      {{ end }}
     {{ end }}
     {{ with $data.examples }}
       {{ $heading := dict "level" 2 "text" "Examples" }}

--- a/layouts/_default/cli.html
+++ b/layouts/_default/cli.html
@@ -169,6 +169,28 @@
       {{ end }}
       {{ $.RenderString (dict "display" "block") . }}
     {{ end }}
+    {{ if eq .Kind "section" }}
+      {{ $heading := dict "level" 2 "text" "Subcommands" }}
+      {{ partial "heading.html" $heading }}
+      {{ $.Scratch.Add "headings" $heading }}
+      <table>
+        <thead>
+          <tr>
+            <th class="text-left">Command</th>
+            <th class="text-left">Description</th>
+          </tr>
+        </thead>
+        <tbody>
+          {{ range .Pages }}
+            <tr>
+              <td class="text-left"><a class="link" href="{{ .Permalink }}"><code>{{ .Title }}</code></a></th>
+              {{ $data := index (index site.Data .Params.datafolder) .Params.datafile }}
+              <td class="text-left">{{ $data.short }}</th>
+            </tr>
+          {{ end }}
+        </tbody>
+      </table>
+    {{ end }}
   </article>
 {{ end }}
 


### PR DESCRIPTION
<!--Delete sections as needed -->

## Description

- Don't render options table if a command only contains hidden options

  Previously, the table header was rendered but the tbody would be empty.
  This change makes the entire table rendering conditional depending on the existence of non-hidden options.

  Example (before): 
  
  <img width="839" alt="image" src="https://github.com/docker/docs/assets/35727626/62888918-52ba-43a2-9067-e2ed0dc5a890">
  
  Example after: https://deploy-preview-19539--docsdocker.netlify.app/reference/cli/docker/scout/


- Render links to subcommands

  Intermediate commands don't have any action but they have subcommands with actions.
  This change renders links to all the subcommands automatically.

  Example: 
  
  <img width="824" alt="image" src="https://github.com/docker/docs/assets/35727626/f83248fe-b7cb-4a3b-996b-4764e0411f78">


