### PR TITLE
debug: rephrase "replacement" to "alternative" for debug vs exec

### DIFF
--- a/data/debug-cli/docker_debug.yaml
+++ b/data/debug-cli/docker_debug.yaml
@@ -1,5 +1,5 @@
 command: docker debug
-short: Get a shell into any container or image. Replacement for `docker exec`.
+short: Get a shell into any container or image. An alternative to debugging with `docker exec`.
 long: |-
   > **Note**
   >


### PR DESCRIPTION
Signed-off-by: David Karlsson <35727626+dvdksn@users.noreply.github.com>

<!--Delete sections as needed -->

## Description

Rephrased "replacement" to "debugging alternative" to avoid any confusions w.r.t. capabilities of Docker Debug.

