### PR TITLE
scout: create dedicated installation page

### DIFF
--- a/content/scout/image-analysis.md
+++ b/content/scout/image-analysis.md
@@ -122,30 +122,6 @@ By default, the results are printed to standard output.
 You can also export results to a file in a structured format,
 such as Static Analysis Results Interchange Format (SARIF).
 
-#### Install
-
-The Docker Scout CLI plugin comes pre-installed with Docker Desktop.
-You can also install it as a standalone binary.
-
-To install the latest version of the plugin manually, run the following commands:
-
-```console
-$ curl -fsSL https://raw.githubusercontent.com/docker/scout-cli/main/install.sh -o install-scout.sh
-$ sh install-scout.sh
-```
-
-> **Note**
->
-> Always examine scripts downloaded from the internet before running them
-> locally. Before installing, make yourself familiar with potential risks and
-> limitations of the convenience script.
-
-If you want to install the plugin manually, you can find full instructions in
-the [plugin's repository](https://github.com/docker/scout-cli).
-
-The plugin is also available as [a container image](https://hub.docker.com/r/docker/scout-cli)
-and as [a GitHub action](https://github.com/docker/scout-action).
-
 #### Quickview
 
 The `docker scout quickview` command provides an overview of the

--- a/content/scout/install.md
+++ b/content/scout/install.md
@@ -1,0 +1,30 @@
+---
+title: Install Docker Scout
+description: Installation instructions for the Docker Scout CLI plugin
+keywords: scout, cli, install, download
+---
+
+The Docker Scout CLI plugin comes pre-installed with Docker Desktop.
+
+If you run Docker Engine without Docker Desktop,
+Docker Scout doesn't come pre-installed,
+but you can install it as a standalone binary.
+
+To install the latest version of the plugin, run the following commands:
+
+```console
+$ curl -fsSL https://raw.githubusercontent.com/docker/scout-cli/main/install.sh -o install-scout.sh
+$ sh install-scout.sh
+```
+
+> **Note**
+>
+> Always examine scripts downloaded from the internet before running them
+> locally. Before installing, make yourself familiar with potential risks and
+> limitations of the convenience script.
+
+If you want to install the plugin manually, you can find full instructions
+and links to download in the [scout-cli repository](https://github.com/docker/scout-cli).
+
+The Docker Scout CLI plugin is also available as [a container image](https://hub.docker.com/r/docker/scout-cli)
+and as [a GitHub action](https://github.com/docker/scout-action).

--- a/data/toc.yaml
+++ b/data/toc.yaml
@@ -1321,6 +1321,8 @@ Manuals:
       title: Overview
     - path: /scout/quickstart/
       title: Quickstart
+    - path: /scout/install/
+      title: Install
     - sectiontitle: Explore Docker Scout
       section:
       - path: /scout/dashboard/


### PR DESCRIPTION
Signed-off-by: David Karlsson <35727626+dvdksn@users.noreply.github.com>

<!--Delete sections as needed -->

## Description

CLI installation was buried under image analysis.
Moving it to the top level in a dedicated page.

