### PR TITLE
Fix : Overflowing Text in build/cache

### DIFF
--- a/content/build/cache/_index.md
+++ b/content/build/cache/_index.md
@@ -50,13 +50,13 @@ anything differently, they still need to re-run.
 
 > **Note**
 >
-> Suppose you have a
-> ```text
+> Suppose you have a step in your Dockerfile
+> to upgrade all the software packages in your
+> Debian-based image to the latest version:
+>
+> ```dockerfile
 > RUN apt-get update && apt-get upgrade -y
-> ``` 
-> step in your
-> Dockerfile to upgrade all the software packages in your Debian-based image to
-> the latest version.
+> ```
 >
 > This doesn't mean that the images you build are always up to date. Rebuilding
 > the image on the same host one week later will still get you the same packages

--- a/content/build/cache/_index.md
+++ b/content/build/cache/_index.md
@@ -50,7 +50,11 @@ anything differently, they still need to re-run.
 
 > **Note**
 >
-> Suppose you have a `RUN apt-get update && apt-get upgrade -y` step in your
+> Suppose you have a
+> ```text
+> RUN apt-get update && apt-get upgrade -y
+> ``` 
+> step in your
 > Dockerfile to upgrade all the software packages in your Debian-based image to
 > the latest version.
 >


### PR DESCRIPTION
## Description

Text is Overflowing at https://docs.docker.com/build/cache in Mobile View

<img src="https://github.com/docker/docs/assets/126388189/cb6ff9f2-68b1-42a0-b221-dfbb132085ed" width="350px">


## Current Result :

<img src="https://github.com/docker/docs/assets/126388189/4b9147e1-4c16-4b42-abba-d99ea25ee05c" width="350px">


## Related issues or tickets

Same issue as #19507