### PR TITLE
network: multiple nets with --network

### DIFF
--- a/content/network/_index.md
+++ b/content/network/_index.md
@@ -139,8 +139,9 @@ A container receives an IP address out of the IP subnet of the network.
 The Docker daemon performs dynamic subnetting and IP address allocation for containers.
 Each network also has a default subnet mask and gateway.
 
-When a container starts, it can only attach to a single network, using the `--network` flag.
-You can connect a running container to additional networks using the `docker network connect` command.
+You can connect a running container to multiple networks,
+either by passing the `--network` flag multiple times when creating the container,
+or using the `docker network connect` command for already running containers.
 In both cases, you can use the `--ip` or `--ip6` flags to specify the container's IP address on that particular network.
 
 In the same way, a container's hostname defaults to be the container's ID in Docker.


### PR DESCRIPTION

Signed-off-by: David Karlsson <35727626+dvdksn@users.noreply.github.com>

<!--Delete sections as needed -->

## Description

Corrects a false statement that you can't connect to multiple networks
with the `--network` flag.

## Related issues or tickets

Closes #19533
