### PR TITLE
use Go toolchain for managing hugo modules

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,11 +50,15 @@ RUN htmltest
 
 FROM build-base as update-modules
 ARG MODULE
-RUN if [ -n "$MODULE" ]; then \
-        hugo mod get ${MODULE}; \
-    else \
-        echo "no module set"; \
-    fi
+RUN <<"EOT"
+if [ -n "$MODULE" ]; then
+    go mod edit -dropdreplace ${MODULE/@*/}
+    hugo mod get ${MODULE}
+    go mod edit -replace ${MODULE/@*/}=${MODULE};
+else \
+    echo "no module set"; \
+fi
+EOT
 RUN hugo mod vendor
 
 FROM scratch as vendor

--- a/go.mod
+++ b/go.mod
@@ -12,3 +12,12 @@ require (
 	github.com/moby/buildkit v0.13.0-beta3.0.20240201135300-d906167d0b34 // indirect
 	github.com/moby/moby v25.0.3-0.20240203133757-341a7978a541+incompatible // indirect
 )
+
+replace (
+	github.com/docker/buildx => github.com/docker/buildx v0.12.2-0.20240220084849-89154c7d3303
+	github.com/docker/cli => github.com/docker/cli v25.0.4-0.20240221083216-f67e569a8fb9+incompatible
+	github.com/docker/compose/v2 => github.com/docker/compose/v2 v2.24.6
+	github.com/docker/scout-cli => github.com/docker/scout-cli v1.4.1
+	github.com/moby/buildkit => github.com/moby/buildkit v0.13.0-beta3.0.20240201135300-d906167d0b34
+	github.com/moby/moby => github.com/moby/moby v25.0.3-0.20240203133757-341a7978a541+incompatible
+)


### PR DESCRIPTION
<!--Delete sections as needed -->

## Description

Add replace directives for all modules and use the Go toolchain (`go mod edit`) to manage Hugo modules instead of Hugo's built-in `hugo mod get`, since Hugo's modules causes transitive dependencies to be updated as well

<!-- Tell us what you did and why -->

## Related issues or tickets

#19570
