### PR TITLE
docs freshness: get-started

### DIFF
--- a/content/get-started/05_persisting_data.md
+++ b/content/get-started/05_persisting_data.md
@@ -19,10 +19,6 @@ changes won't be seen in another container, even if they're using the same image
 To see this in action, you're going to start two containers and create a file in each.
 What you'll see is that the files created in one container aren't available in another.
 
-> **Note**
->
-> If you use Windows and want to use Git Bash to run Docker commands, see [Working with Git Bash](../desktop/troubleshoot/topics.md#working-with-git-bash) for syntax differences.
-
 1. Start an `ubuntu` container that will create a file named `/data.txt` with a random number
    between 1 and 10000.
 
@@ -34,10 +30,10 @@ What you'll see is that the files created in one container aren't available in a
     commands (why you have the `&&`). The first portion picks a single random number and writes
     it to `/data.txt`. The second command is simply watching a file to keep the container running.
 
-2. Validate that you can see the output by accessing the terminal in the container. To do so, you can use the CLI or Docker Desktop's graphical interface.
+2. Validate that you can see the output by accessing the terminal in the container. To do so, you can use the CLI or Docker Desktop's graphical interface. For the CLI, you can use one of the built-in interfaces, including the terminal on Mac or Linux, or PowerShell or Command Prompt on Windows. Additionally on Windows, you can use Git Bash.
 
    {{< tabs group="ui" >}}
-   {{< tab name="CLI" >}}
+   {{< tab name="Built-in CLI" >}}
 
    On the command line, use the `docker exec` command to access the container. You need to get the
    container's ID (use `docker ps` to get it). In your Mac or Linux terminal, or in Windows Command Prompt or PowerShell, get the content with the following command.
@@ -45,13 +41,32 @@ What you'll see is that the files created in one container aren't available in a
    ```console
    $ docker exec <container-id> cat /data.txt
    ```
-   
+
+   {{< /tab >}}
+   {{< tab name="Git Bash CLI" >}}
+
+   > **Note**
+   >
+   > If you use Windows and want to use Git Bash to run Docker commands, see [Working with Git Bash](../desktop/troubleshoot/topics.md#working-with-git-bash) for syntax differences.
+
+   On the command line, use the `docker exec` command to access the container.
+   You need to get the container's ID (use `docker ps` to get it). Get the
+   content with the following command.
+
+   ```console
+   $ docker exec <container-id> cat //data.txt
+   ```
+
    {{< /tab >}}
    {{< tab name="Docker Desktop" >}}
    
-   In Docker Desktop, go to **Containers**, hover over the container running the **ubuntu** image, and select the **Show container actions** menu. From the drop-down menu, select **Open in terminal**.
+   In Docker Desktop, go to **Containers**, hover over the container running the
+   **ubuntu** image, and select the **Show container actions** menu. From the
+   drop-down menu, select **Open in terminal**.
 
-   You will see a terminal that is running a shell in the Ubuntu container. Run the following command to see the content of the `/data.txt` file. Close this terminal afterwards again.
+   You will see a terminal that is running a shell in the Ubuntu container. Run
+   the following command to see the content of the `/data.txt` file. Close this
+   terminal afterwards again.
 
    ```console
    $ cat /data.txt
@@ -62,15 +77,29 @@ What you'll see is that the files created in one container aren't available in a
 
    You should see a random number.
 
-3. Now, start another `ubuntu` container (the same image) and you'll see you don't have the same file. In your Mac or Linux terminal, or in Windows Command Prompt or PowerShell, get the content with the following command.
+3. Now, start another `ubuntu` container (the same image) and you'll see you
+   don't have the same file.
 
-    ```console
-    $ docker run -it ubuntu ls /
-    ```
+   {{< tabs >}}
+   {{< tab name="Built-in CLI" >}}
 
-    In this case the command lists the files in the root directory of the container.
-    Look, there's no `data.txt` file there! That's because it was written to the scratch space for
-    only the first container.
+   ```console
+   $ docker run -it ubuntu ls /
+   ```
+
+   {{< /tab >}}
+   {{< tab name="Git Bash CLI" >}}
+
+   ```console
+   $ docker run -it ubuntu ls //
+   ```
+
+   {{< /tab >}}
+   {{< /tabs >}}
+
+   In this case the command lists the files in the root directory of the
+   container. Look, there's no `data.txt` file there! That's because it was
+   written to the scratch space for only the first container.
 
 4. Go ahead and remove the first container using the `docker rm -f <container-id>` command.
 
@@ -107,7 +136,7 @@ name of the volume.
 You can create the volume and start the container using the CLI or Docker Desktop's graphical interface.
 
 {{< tabs group="ui" >}}
-{{< tab name="CLI" >}}
+{{< tab name="Built-in CLI" >}}
 
 1. Create a volume by using the `docker volume create` command.
 
@@ -122,6 +151,24 @@ You can create the volume and start the container using the CLI or Docker Deskto
 
    ```console
    $ docker run -dp 127.0.0.1:3000:3000 --mount type=volume,src=todo-db,target=/etc/todos getting-started
+   ```
+
+{{< /tab >}}
+{{< tab name="Git Bash CLI" >}}
+
+1. Create a volume by using the `docker volume create` command.
+
+   ```console
+   $ docker volume create todo-db
+   ```
+
+2. Stop and remove the todo app container once again with `docker rm -f <id>`, as it is still running without using the persistent volume.
+
+3. Start the todo app container, but add the `--mount` option to specify a volume mount. Give the volume a name, and mount
+   it to `/etc/todos` in the container, which captures all files created at the path. In your Mac or Linux terminal, or in Windows Command Prompt or PowerShell, run the following command:
+
+   ```console
+   $ docker run -dp 127.0.0.1:3000:3000 --mount type=volume,src=todo-db,target=//etc/todos getting-started
    ```
 
 {{< /tab >}}

--- a/content/get-started/05_persisting_data.md
+++ b/content/get-started/05_persisting_data.md
@@ -16,92 +16,43 @@ changes won't be seen in another container, even if they're using the same image
 
 ### See this in practice
 
-To see this in action, you're going to start two containers and create a file in each.
-What you'll see is that the files created in one container aren't available in another.
+To see this in action, you're going to start two containers. In one container, you'll create a file. In the other container, you'll verify the file exists.
+What you'll see is that the file created in one container isn't available in another.
 
-1. Start an `ubuntu` container that will create a file named `/data.txt` with a random number
-   between 1 and 10000.
+1. Start an Alpine container and access its shell.
 
     ```console
-    $ docker run -d ubuntu bash -c "shuf -i 1-10000 -n 1 -o /data.txt && tail -f /dev/null"
+    $ docker run -ti --name=mytest alpine
     ```
 
-    In case you're curious about the command, you're starting a bash shell and invoking two
-    commands (why you have the `&&`). The first portion picks a single random number and writes
-    it to `/data.txt`. The second command is simply watching a file to keep the container running.
+2. In the container, create a `greeting.txt` file with `hello` inside.
 
-2. Validate that you can see the output by accessing the terminal in the container. To do so, you can use the CLI or Docker Desktop's graphical interface. For the CLI, you can use one of the built-in interfaces, including the terminal on Mac or Linux, or PowerShell or Command Prompt on Windows. Additionally on Windows, you can use Git Bash.
+    ```console
+    / # echo "hello" > greeting.txt
+    ```
 
-   {{< tabs group="ui" >}}
-   {{< tab name="Built-in CLI" >}}
-
-   On the command line, use the `docker exec` command to access the container. You need to get the
-   container's ID (use `docker ps` to get it). In your Mac or Linux terminal, or in Windows Command Prompt or PowerShell, get the content with the following command.
+3. Exit the container.
 
    ```console
-   $ docker exec <container-id> cat /data.txt
+   / # exit
    ```
 
-   {{< /tab >}}
-   {{< tab name="Git Bash CLI" >}}
-
-   > **Note**
-   >
-   > If you use Windows and want to use Git Bash to run Docker commands, see [Working with Git Bash](../desktop/troubleshoot/topics.md#working-with-git-bash) for syntax differences.
-
-   On the command line, use the `docker exec` command to access the container.
-   You need to get the container's ID (use `docker ps` to get it). Get the
-   content with the following command.
-
-   ```console
-   $ docker exec <container-id> cat //data.txt
-   ```
-
-   {{< /tab >}}
-   {{< tab name="Docker Desktop" >}}
+4. Run a new Alpine container and use the `cat` command to verify that the
+   file does not exist.
    
-   In Docker Desktop, go to **Containers**, hover over the container running the
-   **ubuntu** image, and select the **Show container actions** menu. From the
-   drop-down menu, select **Open in terminal**.
-
-   You will see a terminal that is running a shell in the Ubuntu container. Run
-   the following command to see the content of the `/data.txt` file. Close this
-   terminal afterwards again.
-
    ```console
-   $ cat /data.txt
+   $ docker run alpine cat greetings.txt
    ```
 
-   {{< /tab >}}
-   {{< /tabs >}}
-
-   You should see a random number.
-
-3. Now, start another `ubuntu` container (the same image) and you'll see you
-   don't have the same file.
-
-   {{< tabs >}}
-   {{< tab name="Built-in CLI" >}}
+   You should see output similiar to the following that indicates the file does not exist in the new container.
 
    ```console
-   $ docker run -it ubuntu ls /
+   cat: can't open 'greetings.txt': No such file or directory
    ```
 
-   {{< /tab >}}
-   {{< tab name="Git Bash CLI" >}}
+5. Go ahead and remove the containers using `docker ps --all` to get the IDs,
+   and then `docker rm -f <container-id>` to remove the containers.
 
-   ```console
-   $ docker run -it ubuntu ls //
-   ```
-
-   {{< /tab >}}
-   {{< /tabs >}}
-
-   In this case the command lists the files in the root directory of the
-   container. Look, there's no `data.txt` file there! That's because it was
-   written to the scratch space for only the first container.
-
-4. Go ahead and remove the first container using the `docker rm -f <container-id>` command.
 
 ## Container volumes
 
@@ -135,8 +86,8 @@ name of the volume.
 
 You can create the volume and start the container using the CLI or Docker Desktop's graphical interface.
 
-{{< tabs group="ui" >}}
-{{< tab name="Built-in CLI" >}}
+{{< tabs >}}
+{{< tab name="CLI" >}}
 
 1. Create a volume by using the `docker volume create` command.
 
@@ -144,32 +95,28 @@ You can create the volume and start the container using the CLI or Docker Deskto
    $ docker volume create todo-db
    ```
 
-2. Stop and remove the todo app container once again with `docker rm -f <id>`, as it is still running without using the persistent volume.
+2. Stop and remove the todo app container once again with `docker rm -f <id>`,
+   as it is still running without using the persistent volume.
 
-3. Start the todo app container, but add the `--mount` option to specify a volume mount. Give the volume a name, and mount
-   it to `/etc/todos` in the container, which captures all files created at the path. In your Mac or Linux terminal, or in Windows Command Prompt or PowerShell, run the following command:
+3. Start the todo app container, but add the `--mount` option to specify a
+   volume mount. Give the volume a name, and mount it to `/etc/todos` in the
+   container, which captures all files created at the path.
 
    ```console
    $ docker run -dp 127.0.0.1:3000:3000 --mount type=volume,src=todo-db,target=/etc/todos getting-started
    ```
 
-{{< /tab >}}
-{{< tab name="Git Bash CLI" >}}
+   > **Note**
+   >
+   > If you're using Git Bash, you must use different syntax for this command.
+   >
+   > ```console
+   > $ docker run -dp 127.0.0.1:3000:3000 --mount type=volume,src=todo-db, target=//etc/todos getting-started
+   > ```
+   >
+   > For more details about Git Bash's syntax differences, see
+   > [Working with Git Bash](../desktop/troubleshoot/topics/#working-with-git-bash).
 
-1. Create a volume by using the `docker volume create` command.
-
-   ```console
-   $ docker volume create todo-db
-   ```
-
-2. Stop and remove the todo app container once again with `docker rm -f <id>`, as it is still running without using the persistent volume.
-
-3. Start the todo app container, but add the `--mount` option to specify a volume mount. Give the volume a name, and mount
-   it to `/etc/todos` in the container, which captures all files created at the path. In your Mac or Linux terminal, or in Windows Command Prompt or PowerShell, run the following command:
-
-   ```console
-   $ docker run -dp 127.0.0.1:3000:3000 --mount type=volume,src=todo-db,target=//etc/todos getting-started
-   ```
 
 {{< /tab >}}
 {{< tab name="Docker Desktop" >}}

--- a/content/get-started/06_bind_mounts.md
+++ b/content/get-started/06_bind_mounts.md
@@ -1,9 +1,6 @@
 ---
 title: Use bind mounts
-keywords: 'get started, setup, orientation, quickstart, intro, concepts, containers,
-  docker desktop
-
-  '
+keywords: 'get started, setup, orientation, quickstart, intro, concepts, containers, docker desktop'
 description: Using bind mounts in our application
 ---
 
@@ -25,13 +22,17 @@ frameworks.
 
 ## Quick volume type comparisons
 
+The following are examples of a named volume and a bind mount using `--mount`:
+
+- Named volume: `type=volume,src=my-volume,target=/usr/local/data`
+- Bind mount: `type=bind,src=/path/to/data,target=/usr/local/data`
+
 The following table outlines the main differences between volume mounts and bind
 mounts.
 
 |                                              | Named volumes                                      | Bind mounts                                          |
 | -------------------------------------------- | -------------------------------------------------- | ---------------------------------------------------- |
 | Host location                                | Docker chooses                                     | You decide                                           |
-| Mount example (using `--mount`)              | `type=volume,src=my-volume,target=/usr/local/data` | `type=bind,src=/path/to/data,target=/usr/local/data` |
 | Populates new volume with container contents | Yes                                                | No                                                   |
 | Supports Volume Drivers                      | Yes                                                | No                                                   |
 
@@ -40,10 +41,6 @@ mounts.
 Before looking at how you can use bind mounts for developing your application,
 you can run a quick experiment to get a practical understanding of how bind mounts
 work.
-
-> **Note**
->
-> If you use Windows and want to use Git Bash to run Docker commands, see [Working with Git Bash](../desktop/troubleshoot/topics.md#working-with-git-bash) for syntax differences.
 
 1. Verify that your `getting-started-app` directory is in a directory defined in
 Docker Desktop's file sharing setting. This setting defines which parts of your
@@ -59,26 +56,24 @@ setting, see the topic for [Mac](../desktop/settings/mac.md/#file-sharing),
    bind mount.
 
    {{< tabs >}}
-   {{< tab name="Mac / Linux" >}}
+   {{< tab name="Mac / Linux / PowerShell" >}}
 
    ```console
    $ docker run -it --mount type=bind,src="$(pwd)",target=/src ubuntu bash
    ```
    
    {{< /tab >}}
-   {{< tab name="Windows (PowerShell)" >}}
-
-
-   ```powershell
-   $ docker run -it --mount "type=bind,src=$pwd,target=/src" ubuntu bash
-   ```
-   
-   {{< /tab >}}
-   {{< tab name="Windows (Command Prompt)" >}}
-
+   {{< tab name="Command Prompt" >}}
 
    ```console
    $ docker run -it --mount "type=bind,src=%cd%,target=/src" ubuntu bash
+   ```
+   
+   {{< /tab >}}
+   {{< tab name="Git Bash" >}}
+
+   ```console
+   $ docker run -it --mount type=bind,src="/$(pwd)",target=/src ubuntu bash
    ```
    
    {{< /tab >}}
@@ -164,7 +159,7 @@ mount that does the following:
 You can use the CLI or Docker Desktop to run your container with a bind mount.
 
 {{< tabs >}}
-{{< tab name="CLI (Mac / Linux)" >}}
+{{< tab name="Mac / Linux CLI" >}}
 
 1. Make sure you don't have any `getting-started` containers currently running.
 
@@ -210,14 +205,11 @@ You can use the CLI or Docker Desktop to run your container with a bind mount.
    When you're done watching the logs, exit out by hitting `Ctrl`+`C`.
 
 {{< /tab >}}
-{{< tab name="CLI (Windows)" >}}
+{{< tab name="PowerShell CLI" >}}
 
 1. Make sure you don't have any `getting-started` containers currently running.
 
 2. Run the following command from the `getting-started-app` directory.
-
-   Run this command in PowerShell.
-
 
    ```powershell
    $ docker run -dp 127.0.0.1:3000:3000 `
@@ -232,6 +224,98 @@ You can use the CLI or Docker Desktop to run your container with a bind mount.
    - `-w /app` - sets the "working directory" or the current directory that the
      command will run from
    - `--mount "type=bind,src=$pwd,target=/app"` - bind mount the current
+     directory from the host into the `/app` directory in the container
+   - `node:18-alpine` - the image to use. Note that this is the base image for
+     your app from the Dockerfile
+   - `sh -c "yarn install && yarn run dev"` - the command. You're starting a
+     shell using `sh` (alpine doesn't have `bash`) and running `yarn install` to
+     install packages and then running `yarn run dev` to start the development
+     server. If you look in the `package.json`, you'll see that the `dev` script
+     starts `nodemon`.
+
+3. You can watch the logs using `docker logs <container-id>`. You'll know you're
+   ready to go when you see this:
+
+   ```console
+   $ docker logs -f <container-id>
+   nodemon -L src/index.js
+   [nodemon] 2.0.20
+   [nodemon] to restart at any time, enter `rs`
+   [nodemon] watching path(s): *.*
+   [nodemon] watching extensions: js,mjs,json
+   [nodemon] starting `node src/index.js`
+   Using sqlite database at /etc/todos/todo.db
+   Listening on port 3000
+   ```
+
+   When you're done watching the logs, exit out by hitting `Ctrl`+`C`.
+
+{{< /tab >}}
+{{< tab name="Command Prompt CLI" >}}
+
+1. Make sure you don't have any `getting-started` containers currently running.
+
+2. Run the following command from the `getting-started-app` directory.
+
+   ```console
+   $ docker run -dp 127.0.0.1:3000:3000 ^
+       -w /app --mount "type=bind,src=%cd%,target=/app" ^
+       node:18-alpine ^
+       sh -c "yarn install && yarn run dev"
+   ```
+
+   The following is a breakdown of the command:
+   - `-dp 127.0.0.1:3000:3000` - same as before. Run in detached (background) mode and
+     create a port mapping
+   - `-w /app` - sets the "working directory" or the current directory that the
+     command will run from
+   - `--mount "type=bind,src=%cd%,target=/app"` - bind mount the current
+     directory from the host into the `/app` directory in the container
+   - `node:18-alpine` - the image to use. Note that this is the base image for
+     your app from the Dockerfile
+   - `sh -c "yarn install && yarn run dev"` - the command. You're starting a
+     shell using `sh` (alpine doesn't have `bash`) and running `yarn install` to
+     install packages and then running `yarn run dev` to start the development
+     server. If you look in the `package.json`, you'll see that the `dev` script
+     starts `nodemon`.
+
+3. You can watch the logs using `docker logs <container-id>`. You'll know you're
+   ready to go when you see this:
+
+   ```console
+   $ docker logs -f <container-id>
+   nodemon -L src/index.js
+   [nodemon] 2.0.20
+   [nodemon] to restart at any time, enter `rs`
+   [nodemon] watching path(s): *.*
+   [nodemon] watching extensions: js,mjs,json
+   [nodemon] starting `node src/index.js`
+   Using sqlite database at /etc/todos/todo.db
+   Listening on port 3000
+   ```
+
+   When you're done watching the logs, exit out by hitting `Ctrl`+`C`.
+
+{{< /tab >}}
+{{< tab name="Git Bash CLI" >}}
+
+1. Make sure you don't have any `getting-started` containers currently running.
+
+2. Run the following command from the `getting-started-app` directory.
+
+   ```console
+   $ docker run -dp 127.0.0.1:3000:3000 \
+       -w //app --mount type=bind,src="/$(pwd)",target=/app \
+       node:18-alpine \
+       sh -c "yarn install && yarn run dev"
+   ```
+
+   The following is a breakdown of the command:
+   - `-dp 127.0.0.1:3000:3000` - same as before. Run in detached (background) mode and
+     create a port mapping
+   - `-w //app` - sets the "working directory" or the current directory that the
+     command will run from
+   - `--mount type=bind,src="/$(pwd)",target=/app` - bind mount the current
      directory from the host into the `/app` directory in the container
    - `node:18-alpine` - the image to use. Note that this is the base image for
      your app from the Dockerfile

--- a/content/get-started/07_multi_container.md
+++ b/content/get-started/07_multi_container.md
@@ -44,7 +44,7 @@ In the following steps, you'll create the network first and then attach the MySQ
    database will use to initialize the database. To learn more about the MySQL environment variables, see the "Environment Variables" section in the [MySQL Docker Hub listing](https://hub.docker.com/_/mysql/).
 
    {{< tabs >}}
-   {{< tab name="Mac / Linux" >}}
+   {{< tab name="Mac / Linux / Git Bash" >}}
    
    ```console
    $ docker run -d \
@@ -56,7 +56,7 @@ In the following steps, you'll create the network first and then attach the MySQ
    ```
 
    {{< /tab >}}
-   {{< tab name="Windows (PowerShell)" >}}
+   {{< tab name="PowerShell" >}}
 
    ```powershell
    $ docker run -d `
@@ -68,7 +68,7 @@ In the following steps, you'll create the network first and then attach the MySQ
    ```
    
    {{< /tab >}}
-   {{< tab name="Windows (Command Prompt)" >}}
+   {{< tab name="Command Prompt" >}}
 
    ```console
    $ docker run -d ^
@@ -219,7 +219,7 @@ You can now start your dev-ready container.
    ```
    
    {{< /tab >}}
-   {{< tab name="Windows (PowerShell)" >}}
+   {{< tab name="PowerShell" >}}
    In Windows, run this command in PowerShell.
 
    ```powershell
@@ -235,7 +235,7 @@ You can now start your dev-ready container.
    ```
 
    {{< /tab >}}
-   {{< tab name="Windows (Command Prompt)" >}}
+   {{< tab name="Command Prompt" >}}
    In Windows, run this command in Command Prompt.
 
    ```console
@@ -250,6 +250,21 @@ You can now start your dev-ready container.
      sh -c "yarn install && yarn run dev"
    ```
 
+   {{< /tab >}}
+   {{< tab name="Git Bash" >}}
+
+   ```console
+   $ docker run -dp 127.0.0.1:3000:3000 \
+     -w //app -v "/$(pwd):/app" \
+     --network todo-app \
+     -e MYSQL_HOST=mysql \
+     -e MYSQL_USER=root \
+     -e MYSQL_PASSWORD=secret \
+     -e MYSQL_DB=todos \
+     node:18-alpine \
+     sh -c "yarn install && yarn run dev"
+   ```
+   
    {{< /tab >}}
    {{< /tabs >}}
 


### PR DESCRIPTION
<!--Delete sections as needed -->

## Description

Docs freshness for get-started.
When applicable, listed the different syntax for all 4 CLIs: Mac/Linux, PowerShell, CMD, and Git Bash.

In "Use bind mounts", pulled the examples out of the "Quick volume type comparisons" table because the formatting for the generated content was clipped and smushed.
 

## Related issues or tickets

ENGDOCS-2014

## Reviews

- [ ] Editorial review

## Updated pages

- https://deploy-preview-19574--docsdocker.netlify.app/get-started/05_persisting_data/
- https://deploy-preview-19574--docsdocker.netlify.app/get-started/06_bind_mounts/
- https://deploy-preview-19574--docsdocker.netlify.app/get-started/07_multi_container/