### PR TITLE
typo: `detects` in configs docs

### DIFF
--- a/content/compose/compose-file/08-configs.md
+++ b/content/compose/compose-file/08-configs.md
@@ -78,4 +78,4 @@ configs:
     name: "${HTTP_CONFIG_KEY}"
 ```
 
-If `external` is set to `true`, all other attributes apart from `name` are irrelevant. If Compose detecs any other attribute, it rejects the Compose file as invalid.
+If `external` is set to `true`, all other attributes apart from `name` are irrelevant. If Compose detects any other attribute, it rejects the Compose file as invalid.


### PR DESCRIPTION
<!--Delete sections as needed -->

## Description

<!-- Tell us what you did and why -->
Fix typo I noticed while reading - `s/detecs/detects`

## Related issues or tickets

<!-- Related issues, pull requests, or Jira tickets -->
None

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Technical review
- [ ] Editorial review
- [ ] Product review