### PR TITLE
moby 25.0.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -53,9 +53,9 @@ ARG MODULE
 RUN <<"EOT"
 set -ex
 if [ -n "$MODULE" ]; then
-    go mod edit -dropreplace ${MODULE/@*/}
     hugo mod get ${MODULE}
-    go mod edit -replace ${MODULE/@*/}=${MODULE};
+    RESOLVED=$(cat go.mod | grep -m 1 "${MODULE/@*/}" | awk '{print $1 "@" $2}')
+    go mod edit -replace "${MODULE/@*/}=${RESOLVED}";
 else \
     echo "no module set"; \
 fi

--- a/_vendor/github.com/docker/compose/v2/docs/reference/compose_create.md
+++ b/_vendor/github.com/docker/compose/v2/docs/reference/compose_create.md
@@ -13,6 +13,7 @@ Creates containers for a service
 | `--no-build`       |               |          | Don't build an image, even if it's policy                                                     |
 | `--no-recreate`    |               |          | If containers already exist, don't recreate them. Incompatible with --force-recreate.         |
 | `--pull`           | `string`      | `policy` | Pull image before running ("always"\|"missing"\|"never"\|"build")                             |
+| `--quiet-pull`     |               |          | Pull without printing progress information                                                    |
 | `--remove-orphans` |               |          | Remove containers for services not defined in the Compose file                                |
 | `--scale`          | `stringArray` |          | Scale SERVICE to NUM instances. Overrides the `scale` setting in the Compose file if present. |
 

--- a/_vendor/github.com/docker/compose/v2/docs/reference/compose_up.md
+++ b/_vendor/github.com/docker/compose/v2/docs/reference/compose_up.md
@@ -32,6 +32,7 @@ Create and start containers
 | `--timestamps`               |               |          | Show timestamps                                                                                         |
 | `--wait`                     |               |          | Wait for services to be running\|healthy. Implies detached mode.                                        |
 | `--wait-timeout`             | `int`         | `0`      | Maximum duration to wait for the project to be running\|healthy                                         |
+| `-w`, `--watch`              |               |          | Watch source code and rebuild/refresh containers when files are updated.                                |
 
 
 <!---MARKER_GEN_END-->

--- a/_vendor/github.com/docker/compose/v2/docs/reference/docker_compose_create.yaml
+++ b/_vendor/github.com/docker/compose/v2/docs/reference/docker_compose_create.yaml
@@ -57,6 +57,16 @@ options:
       experimentalcli: false
       kubernetes: false
       swarm: false
+    - option: quiet-pull
+      value_type: bool
+      default_value: "false"
+      description: Pull without printing progress information
+      deprecated: false
+      hidden: false
+      experimental: false
+      experimentalcli: false
+      kubernetes: false
+      swarm: false
     - option: remove-orphans
       value_type: bool
       default_value: "false"

--- a/_vendor/github.com/docker/compose/v2/docs/reference/docker_compose_up.yaml
+++ b/_vendor/github.com/docker/compose/v2/docs/reference/docker_compose_up.yaml
@@ -274,6 +274,18 @@ options:
       experimentalcli: false
       kubernetes: false
       swarm: false
+    - option: watch
+      shorthand: w
+      value_type: bool
+      default_value: "false"
+      description: |
+        Watch source code and rebuild/refresh containers when files are updated.
+      deprecated: false
+      hidden: false
+      experimental: false
+      experimentalcli: false
+      kubernetes: false
+      swarm: false
 inherited_options:
     - option: dry-run
       value_type: bool

--- a/_vendor/github.com/moby/moby/docs/api/v1.44.yaml
+++ b/_vendor/github.com/moby/moby/docs/api/v1.44.yaml
@@ -1743,8 +1743,12 @@ definitions:
         description: |
           Date and time at which the image was created, formatted in
           [RFC 3339](https://www.ietf.org/rfc/rfc3339.txt) format with nano-seconds.
+
+          This information is only available if present in the image,
+          and omitted otherwise.
         type: "string"
-        x-nullable: false
+        format: "dateTime"
+        x-nullable: true
         example: "2022-02-04T21:20:12.497794809Z"
       Container:
         description: |

--- a/_vendor/github.com/moby/moby/docs/api/version-history.md
+++ b/_vendor/github.com/moby/moby/docs/api/version-history.md
@@ -79,6 +79,8 @@ keywords: "API, Docker, rcli, REST, documentation"
   `SecondaryIPv6Addresses` available in `NetworkSettings` when calling `GET /containers/{id}/json` are
   deprecated and will be removed in a future release. You should instead look for the default network in
   `NetworkSettings.Networks`.
+* `GET /images/{id}/json` omits the `Created` field (previously it was `0001-01-01T00:00:00Z`)
+  if the `Created` field is missing from the image config.
 
 ## v1.43 API changes
 

--- a/_vendor/modules.txt
+++ b/_vendor/modules.txt
@@ -1,4 +1,4 @@
-# github.com/moby/moby v25.0.3-0.20240203133757-341a7978a541+incompatible
+# github.com/moby/moby v25.0.4+incompatible
 # github.com/moby/buildkit v0.13.0
 # github.com/docker/buildx v0.12.0-rc2.0.20231219140829-617f538cb315
 # github.com/docker/scout-cli v1.4.1

--- a/_vendor/modules.txt
+++ b/_vendor/modules.txt
@@ -1,6 +1,6 @@
 # github.com/moby/moby v25.0.4+incompatible
-# github.com/moby/buildkit v0.13.0
-# github.com/docker/buildx v0.12.0-rc2.0.20231219140829-617f538cb315
+# github.com/moby/buildkit v0.0.0-00010101000000-000000000000
+# github.com/docker/buildx v0.0.0-00010101000000-000000000000
 # github.com/docker/scout-cli v1.4.1
 # github.com/docker/cli v26.0.0-rc1+incompatible
-# github.com/docker/compose/v2 v2.24.7
+# github.com/docker/compose/v2 v2.0.0-00010101000000-000000000000

--- a/_vendor/modules.txt
+++ b/_vendor/modules.txt
@@ -1,6 +1,6 @@
 # github.com/moby/moby v25.0.3-0.20240203133757-341a7978a541+incompatible
-# github.com/moby/buildkit v0.13.0-rc3.0.20240307092343-22d4212fed7e
-# github.com/docker/buildx v0.0.0-00010101000000-000000000000
+# github.com/moby/buildkit v0.13.0
+# github.com/docker/buildx v0.12.0-rc2.0.20231219140829-617f538cb315
 # github.com/docker/scout-cli v1.4.1
 # github.com/docker/cli v26.0.0-rc1+incompatible
-# github.com/docker/compose/v2 v2.0.0-00010101000000-000000000000
+# github.com/docker/compose/v2 v2.24.7

--- a/content/engine/api/v1.45.md
+++ b/content/engine/api/v1.45.md
@@ -1,0 +1,3 @@
+---
+layout: engine-api
+---

--- a/content/engine/release-notes/25.0.md
+++ b/content/engine/release-notes/25.0.md
@@ -19,6 +19,36 @@ For more information about:
 - Deprecated and removed features, see [Deprecated Engine Features](../deprecated.md).
 - Changes to the Engine API, see [Engine API version history](../api/version-history.md).
 
+## 25.0.4
+
+{{< release-date date="2024-03-07" >}}
+
+For a full list of pull requests and changes in this release, refer to the relevant GitHub milestones:
+
+- [docker/cli, 25.0.4 milestone](https://github.com/docker/cli/issues?q=is%3Aclosed+milestone%3A25.0.4)
+- [moby/moby, 25.0.4 milestone](https://github.com/moby/moby/issues?q=is%3Aclosed+milestone%3A25.0.4)
+
+### Bug fixes and enhancements
+
+- Restore DNS names for containers in the default "nat" network on Windows. [moby/moby#47490](https://github.com/moby/moby/pull/47490)
+- Fix `docker start` failing when used with `--checkpoint` [moby/moby#47466](https://github.com/moby/moby/pull/47466)
+- Don't enforce new validation rules for existing swarm networks [moby/moby#47482](https://github.com/moby/moby/pull/47482)
+- Restore IP connectivity between the host and containers on an internal bridge network. [moby/moby#47481](https://github.com/moby/moby/pull/47481)
+- Fix a regression introduced in v25.0 that prevented the classic builder from adding tar archive with `xattrs` created on a non-Linux OS [moby/moby#47483](https://github.com/moby/moby/pull/47483)
+- containerd image store: Fix image pull not emitting `Pulling fs layer status` [moby/moby#47484](https://github.com/moby/moby/pull/47484)
+- API: To preserve backwards compatibility, make read-only mounts non-recursive by default when using older clients (API versions < v1.44). [moby/moby#47393](https://github.com/moby/moby/pull/47393)
+- API: `GET /images/{id}/json` omits the `Created` field (previously it was `0001-01-01T00:00:00Z`) if the `Created` field was missing from the image config. [moby/moby#47451](https://github.com/moby/moby/pull/47451)
+- API: Populate a missing `Created` field in `GET /images/{id}/json` with `0001-01-01T00:00:00Z` for API versions <= 1.43. [moby/moby#47387](https://github.com/moby/moby/pull/47387)
+- API: Fix a regression that caused API socket connection failures to report an API version negotiation failure instead. [moby/moby#47470](https://github.com/moby/moby/pull/47470)
+- API: Preserve supplied endpoint configuration in a container-create API request, when a container-wide MAC address is specified, but `NetworkMode` name or id is not the same as the name or id used in `NetworkSettings.Networks`. [moby/moby#47510](https://github.com/moby/moby/pull/47510)
+
+### Packaging updates
+
+- Upgrade Go runtime to 1.21.8. [moby/moby#47503](https://github.com/moby/moby/pull/47503)
+- Upgrade RootlessKit to v2.0.2. [moby/moby#47508](https://github.com/moby/moby/pull/47508)
+- Upgrade Compose to v2.24.7. [docker/docker-ce-packaging#998](https://github.com/moby/moby/pull/998)
+- Upgrade Buildx to v0.13.0. [docker/docker-ce-packaging#997](https://github.com/moby/moby/pull/997)
+
 ## 25.0.3
 
 {{< release-date date="2024-02-06" >}}
@@ -27,7 +57,6 @@ For a full list of pull requests and changes in this release, refer to the relev
 
 - [docker/cli, 25.0.3 milestone](https://github.com/docker/cli/issues?q=is%3Aclosed+milestone%3A25.0.3)
 - [moby/moby, 25.0.3 milestone](https://github.com/moby/moby/issues?q=is%3Aclosed+milestone%3A25.0.3)
-
 
 ### Bug fixes and enhancements
 

--- a/data/toc.yaml
+++ b/data/toc.yaml
@@ -830,6 +830,10 @@ Reference:
       section:
       - path: /engine/api/version-history/
         title: Version history overview
+      - path: /engine/api/v1.44/
+        title: v1.44 reference
+      - path: /engine/api/v1.43/
+        title: v1.43 reference
       - path: /engine/api/v1.42/
         title: v1.42 reference
       - path: /engine/api/v1.41/

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/docker/compose/v2 v2.24.7 // indirect
 	github.com/docker/scout-cli v1.4.1 // indirect
 	github.com/moby/buildkit v0.13.0 // indirect
-	github.com/moby/moby v25.0.3-0.20240203133757-341a7978a541+incompatible // indirect
+	github.com/moby/moby v25.0.4+incompatible // indirect
 )
 
 replace (
@@ -19,5 +19,5 @@ replace (
 	github.com/docker/compose/v2 => github.com/docker/compose/v2 v2.24.7
 	github.com/docker/scout-cli => github.com/docker/scout-cli v1.4.1
 	github.com/moby/buildkit => github.com/moby/buildkit v0.13.0-rc3.0.20240307092343-22d4212fed7e
-	github.com/moby/moby => github.com/moby/moby v25.0.3-0.20240203133757-341a7978a541+incompatible
+	github.com/moby/moby => github.com/moby/moby v25.0.4+incompatible
 )

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ toolchain go1.21.1
 require (
 	github.com/docker/buildx v0.12.0-rc2.0.20231219140829-617f538cb315 // indirect
 	github.com/docker/cli v26.0.0-rc1+incompatible // indirect
-	github.com/docker/compose/v2 v2.0.0-00010101000000-000000000000 // indirect
+	github.com/docker/compose/v2 v2.24.7 // indirect
 	github.com/docker/scout-cli v1.4.1 // indirect
 	github.com/moby/buildkit v0.13.0 // indirect
 	github.com/moby/moby v25.0.3-0.20240203133757-341a7978a541+incompatible // indirect
@@ -16,9 +16,8 @@ require (
 replace (
 	github.com/docker/buildx => github.com/docker/buildx v0.13.1-0.20240307093612-37b7ad1465d2
 	github.com/docker/cli => github.com/docker/cli v25.0.4-0.20240221083216-f67e569a8fb9+incompatible
-	github.com/docker/compose/v2 => github.com/docker/compose/v2 v2.24.6
+	github.com/docker/compose/v2 => github.com/docker/compose/v2 v2.24.7
 	github.com/docker/scout-cli => github.com/docker/scout-cli v1.4.1
 	github.com/moby/buildkit => github.com/moby/buildkit v0.13.0-rc3.0.20240307092343-22d4212fed7e
 	github.com/moby/moby => github.com/moby/moby v25.0.3-0.20240203133757-341a7978a541+incompatible
 )
-

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ toolchain go1.21.1
 require (
 	github.com/docker/buildx v0.12.0-rc2.0.20231219140829-617f538cb315 // indirect
 	github.com/docker/cli v26.0.0-rc1+incompatible // indirect
-	github.com/docker/compose/v2 v2.24.7 // indirect
+	github.com/docker/compose/v2 v2.0.0-00010101000000-000000000000 // indirect
 	github.com/docker/scout-cli v1.4.1 // indirect
 	github.com/moby/buildkit v0.13.0 // indirect
 	github.com/moby/moby v25.0.4+incompatible // indirect
@@ -15,7 +15,7 @@ require (
 
 replace (
 	github.com/docker/buildx => github.com/docker/buildx v0.13.1-0.20240307093612-37b7ad1465d2
-	github.com/docker/cli => github.com/docker/cli v25.0.4-0.20240221083216-f67e569a8fb9+incompatible
+	github.com/docker/cli => github.com/docker/cli v25.0.4+incompatible
 	github.com/docker/compose/v2 => github.com/docker/compose/v2 v2.24.7
 	github.com/docker/scout-cli => github.com/docker/scout-cli v1.4.1
 	github.com/moby/buildkit => github.com/moby/buildkit v0.13.0-rc3.0.20240307092343-22d4212fed7e

--- a/go.sum
+++ b/go.sum
@@ -112,6 +112,8 @@ github.com/docker/compose/v2 v2.24.5 h1:7K173fhy+ghA88C8ib5YNa+kAZCx0CBeGW7lHcdo
 github.com/docker/compose/v2 v2.24.5/go.mod h1:gg+RsqCXYD/TOIJgya4N9mtj/UmFJGEls7y3h/kadVE=
 github.com/docker/compose/v2 v2.24.6 h1:V5fOXgga0hYy4wHsygCquO6/k++8q3WuckU7Qo1cnXk=
 github.com/docker/compose/v2 v2.24.6/go.mod h1:ugV3/2KoKEeM98ZYF9vsYwnSExC4xLGxblAqXB6HUXQ=
+github.com/docker/compose/v2 v2.24.7 h1:1WSo4CVf18tnGJMC6V78jYsAxSDD61ry6L3JwVT+8EI=
+github.com/docker/compose/v2 v2.24.7/go.mod h1:7U3QbXdRJfBylTgkdlrjOg8hWLZqM09mof9DVZ5Fh4E=
 github.com/docker/distribution v2.8.2+incompatible h1:T3de5rq0dB1j30rp0sA2rER+m322EBzniBPB6ZIzuh8=
 github.com/docker/distribution v2.8.2+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
 github.com/docker/distribution v2.8.3+incompatible h1:AtKxIZ36LoNK51+Z6RpzLpddBirtxJnzDrHLEKxTAYk=

--- a/go.sum
+++ b/go.sum
@@ -221,6 +221,8 @@ github.com/moby/moby v25.0.0+incompatible h1:KIFudkwXNK+kBrnCxWZNwhEf/jJzdjQAP7E
 github.com/moby/moby v25.0.0+incompatible/go.mod h1:fDXVQ6+S340veQPv35CzDahGBmHsiclFwfEygB/TWMc=
 github.com/moby/moby v25.0.3-0.20240203133757-341a7978a541+incompatible h1:0Vgi62q5Zo4E0wl1ZBj8bRq9rZeOGK+xwz1SBr3Naz8=
 github.com/moby/moby v25.0.3-0.20240203133757-341a7978a541+incompatible/go.mod h1:fDXVQ6+S340veQPv35CzDahGBmHsiclFwfEygB/TWMc=
+github.com/moby/moby v25.0.4+incompatible h1:vea1J80wDM5x5geaZSaywFkfFxLABJIQ3mmR4ewZGbU=
+github.com/moby/moby v25.0.4+incompatible/go.mod h1:fDXVQ6+S340veQPv35CzDahGBmHsiclFwfEygB/TWMc=
 github.com/moby/sys/symlink v0.1.0/go.mod h1:GGDODQmbFOjFsXvfLVn3+ZRxkch54RkSiGqsZeMYowQ=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/morikuni/aec v1.0.0/go.mod h1:BbKIizmSmc5MMPqRYbxO4ZU0S0+P200+tUnFx7PXmsc=

--- a/go.sum
+++ b/go.sum
@@ -88,6 +88,8 @@ github.com/docker/cli v25.0.1+incompatible h1:mFpqnrS6Hsm3v1k7Wa/BO23oz0k121MTbT
 github.com/docker/cli v25.0.1+incompatible/go.mod h1:JLrzqnKDaYBop7H2jaqPtU4hHvMKP+vjCwu2uszcLI8=
 github.com/docker/cli v25.0.4-0.20240221083216-f67e569a8fb9+incompatible h1:crlBDc5Kfph4aUtWf9Rz+BtcNdB17bE3NLU+3+WuAaw=
 github.com/docker/cli v25.0.4-0.20240221083216-f67e569a8fb9+incompatible/go.mod h1:JLrzqnKDaYBop7H2jaqPtU4hHvMKP+vjCwu2uszcLI8=
+github.com/docker/cli v25.0.4+incompatible h1:DatRkJ+nrFoYL2HZUzjM5Z5sAmcA5XGp+AW0oEw2+cA=
+github.com/docker/cli v25.0.4+incompatible/go.mod h1:JLrzqnKDaYBop7H2jaqPtU4hHvMKP+vjCwu2uszcLI8=
 github.com/docker/compose-cli v1.0.35 h1:uZyEHLalfqBS2PiTpA1LAULyJmuQ+YtZg7nG4Xl3/Cc=
 github.com/docker/compose-cli v1.0.35/go.mod h1:mSXI4hFLpRU3EtI8NTo32bNwI0UXSr8jnq+/rYjGAUU=
 github.com/docker/compose/v2 v2.22.0 h1:3rRz4L7tPU75wRsV8JZh2/aTgerQvPa1cpzZN+tHqUY=

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -91,8 +91,8 @@ params:
   repo: https://github.com/docker/docs
   docs_url: https://docs.docker.com
 
-  latest_engine_api_version: "1.44"
-  docker_ce_version: "25.0.0"
+  latest_engine_api_version: "1.45"
+  docker_ce_version: "25.0.4"
   compose_version: "v2.24.6"
   compose_file_v3: "3.8"
   compose_file_v2: "2.4"

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -93,7 +93,7 @@ params:
 
   latest_engine_api_version: "1.45"
   docker_ce_version: "25.0.4"
-  compose_version: "v2.24.6"
+  compose_version: "v2.24.7"
   compose_file_v3: "3.8"
   compose_file_v2: "2.4"
   buildkit_version: "0.12.3"


### PR DESCRIPTION
## Description

Update docker engine and related components to v25.0.4.
Add release notes.

- **build: pin resolved module version in replace directive**
- **vendor: github.com/docker/compose/v2 v2.24.7**
- **vendor: github.com/moby/moby v25.0.4**
- **vendor: github.com/docker/cli v25.0.4**
- **engine: update api version**
- **engine: 25.0.4 release notes**
- **config: update compose to v2.24.7**
