### PR TITLE
update buildkit vendor

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -56,8 +56,8 @@ if [ -n "$MODULE" ]; then
     hugo mod get ${MODULE}
     RESOLVED=$(cat go.mod | grep -m 1 "${MODULE/@*/}" | awk '{print $1 "@" $2}')
     go mod edit -replace "${MODULE/@*/}=${RESOLVED}";
-else \
-    echo "no module set"; \
+else
+    echo "no module set";
 fi
 EOT
 RUN hugo mod vendor

--- a/_vendor/github.com/moby/buildkit/frontend/dockerfile/docs/reference.md
+++ b/_vendor/github.com/moby/buildkit/frontend/dockerfile/docs/reference.md
@@ -669,6 +669,7 @@ The supported mount types are:
 | ---------------------------------------- | --------------------------------------------------------------------------------------------------------- |
 | [`bind`](#run---mounttypebind) (default) | Bind-mount context directories (read-only).                                                               |
 | [`cache`](#run---mounttypecache)         | Mount a temporary directory to cache directories for compilers and package managers.                      |
+| [`tmpfs`](#run---mounttypetmpfs)         | Mount a `tmpfs` in the build container.                                                                   |
 | [`secret`](#run---mounttypesecret)       | Allow the build container to access secure files such as private keys without baking them into the image. |
 | [`ssh`](#run---mounttypessh)             | Allow the build container to access SSH keys via SSH agents, with support for passphrases.                |
 

--- a/_vendor/modules.txt
+++ b/_vendor/modules.txt
@@ -1,5 +1,5 @@
 # github.com/moby/moby v25.0.4+incompatible
-# github.com/moby/buildkit v0.0.0-00010101000000-000000000000
+# github.com/moby/buildkit v0.13.0-rc3.0.20240308080452-a38011b9f57d
 # github.com/docker/buildx v0.0.0-00010101000000-000000000000
 # github.com/docker/scout-cli v1.4.1
 # github.com/docker/cli v26.0.0-rc1+incompatible

--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,6 @@ replace (
 	github.com/docker/cli => github.com/docker/cli v25.0.4+incompatible
 	github.com/docker/compose/v2 => github.com/docker/compose/v2 v2.24.7
 	github.com/docker/scout-cli => github.com/docker/scout-cli v1.4.1
-	github.com/moby/buildkit => github.com/moby/buildkit v0.13.0-rc3.0.20240307092343-22d4212fed7e
+	github.com/moby/buildkit => github.com/moby/buildkit v0.13.0-rc3.0.20240308080452-a38011b9f57d
 	github.com/moby/moby => github.com/moby/moby v25.0.4+incompatible
 )

--- a/go.sum
+++ b/go.sum
@@ -208,6 +208,8 @@ github.com/moby/buildkit v0.13.0-rc3.0.20240307012628-5a4c2975457b h1:lMLGJ3ErbA
 github.com/moby/buildkit v0.13.0-rc3.0.20240307012628-5a4c2975457b/go.mod h1:P5zIr3pyh1VQoK751o5JFtogepVcLi9+77PTfmvJwls=
 github.com/moby/buildkit v0.13.0-rc3.0.20240307092343-22d4212fed7e h1:lEQehVlOgEMJ6bZvx3TWFjFE9Cic4fWJplNNQtYUX/A=
 github.com/moby/buildkit v0.13.0-rc3.0.20240307092343-22d4212fed7e/go.mod h1:P5zIr3pyh1VQoK751o5JFtogepVcLi9+77PTfmvJwls=
+github.com/moby/buildkit v0.13.0-rc3.0.20240308080452-a38011b9f57d h1:q8sI5enL3NBniNUIeVyrbUj6WCSc0gg+tAQgX1m6oTM=
+github.com/moby/buildkit v0.13.0-rc3.0.20240308080452-a38011b9f57d/go.mod h1:P5zIr3pyh1VQoK751o5JFtogepVcLi9+77PTfmvJwls=
 github.com/moby/buildkit v0.13.0 h1:reVR1Y+rbNIUQ9jf0Q1YZVH5a/nhOixZsl+HJ9qQEGI=
 github.com/moby/buildkit v0.13.0/go.mod h1:aNmNQKLBFYAOFuzQjR3VA27/FijlvtBD1pjNwTSN37k=
 github.com/moby/locker v1.0.1/go.mod h1:S7SDdo5zpBK84bzzVlKr2V0hz+7x9hWbYC/kq7oQppc=


### PR DESCRIPTION
- **dockerfile: cleanup trailing backslashes in heredoc**
- **vendor: github.com/moby/buildkit a38011b9f57d**
