### PR TITLE
Describe a '--internal' network

### DIFF
--- a/data/engine-cli/docker_network_create.yaml
+++ b/data/engine-cli/docker_network_create.yaml
@@ -313,7 +313,8 @@ examples: |-
     | `com.docker.network.container_iface_prefix`      | -           | Set a custom prefix for container interfaces          |
 
     The following arguments can be passed to `docker network create` for any
-    network driver, again with their approximate equivalents to `docker daemon`.
+    network driver, again with their approximate equivalents to Docker daemon
+    flags used for the docker0 bridge:
 
     | Argument     | Equivalent     | Description                                |
     |--------------|----------------|--------------------------------------------|

--- a/data/engine-cli/docker_network_create.yaml
+++ b/data/engine-cli/docker_network_create.yaml
@@ -335,6 +335,13 @@ examples: |-
 
     ### Network internal mode (--internal) {#internal}
 
+    Containers on an internal network may communicate between each other, but are
+    precluded from communicating with any networks the host has access to (LAN or
+    WAN) as no default route is configured, and firewall rules are set up to drop
+    all outgoing traffic. Communication with the gateway IP address (and thus
+    appropriately configured host services) is possible, and the host may
+    communicate with any container IP directly.
+
     By default, when you connect a container to an `overlay` network, Docker also
     connects a bridge network to it to provide external connectivity. If you want
     to create an externally isolated `overlay` network, you can specify the


### PR DESCRIPTION
## Description

Add a description of a `--internal` network (written by @neersighted) to the CLI docs - as they currently only mention overlay networks.

(Also, while I was there, update the description for the table listing 'network create' options, to make it consistent with the table listing 'bridge' options.)

## Reviews

<!-- Notes for reviewers here -->

We should probably add similar words to [compose docs](https://docs.docker.com/compose/compose-file/06-networks/#internal).

<!-- List applicable reviews (optionally @tag reviewers) -->

@neersighted 
@dvdksn 

- [ ] Technical review
- [ ] Editorial review
- [ ] Product review