### PR TITLE
deps: bump and pin actions/labeler@v5

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -16,6 +16,4 @@ jobs:
     steps:
       -
         name: Run
-        uses: actions/labeler@v4
-        with:
-          dot: true
+        uses: actions/labeler@8558fd74291d67161a8a78ce36a881fa63b766a9 # v5.0.0


### PR DESCRIPTION
- Upgrades node16 to node20
- Uses dot: true by default

https://github.com/actions/labeler/releases/tag/v5.0.0
