### PR TITLE
Update fedora.md

### DIFF
--- a/content/engine/install/fedora.md
+++ b/content/engine/install/fedora.md
@@ -81,7 +81,8 @@ your DNF repositories) and set up the repository.
 
 ```console
 $ sudo dnf -y install dnf-plugins-core
-$ sudo dnf config-manager --add-repo {{% param "download-url-base" %}}/docker-ce.repo
+$ sudo dnf config-manager \
+--add-repo=https://download.docker.com/linux/centos/docker-ce.repo
 ```
 
 #### Install Docker Engine


### PR DESCRIPTION
WRONG URL:
sudo dnf config-manager \
    --add-repo \
    https://download.docker.com/linux/fedora/docker-ce.repo
CORRECT URL:
sudo dnf config-manager \
--add-repo=https://download.docker.com/linux/centos/docker-ce.repo


https://stackoverflow.com/questions/70358656/rhel8-fedora-yum-dns-causes-cannot-download-repodata-repomd-xml-for-docker-ce

<!--Delete sections as needed -->

## Description

<!-- Tell us what you did and why -->

## Related issues or tickets

<!-- Related issues, pull requests, or Jira tickets -->

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Technical review
- [ ] Editorial review
- [ ] Product review