### PR TITLE
hugo: Correct API version

### DIFF
--- a/hugo.yaml
+++ b/hugo.yaml
@@ -94,7 +94,7 @@ params:
   repo: https://github.com/docker/docs
   docs_url: https://docs.docker.com
 
-  latest_engine_api_version: "1.45"
+  latest_engine_api_version: "1.44"
   docker_ce_version: "25.0.4"
   compose_version: "v2.24.7"
   compose_file_v3: "3.8"


### PR DESCRIPTION
Moby v25 is on API 1.44

<!--Delete sections as needed -->

## Description

<!-- Tell us what you did and why -->

## Related issues or tickets

<!-- Related issues, pull requests, or Jira tickets -->

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Technical review
- [ ] Editorial review
- [ ] Product review