### PR TITLE
Fix importing GPG key approach for Debian-based

### DIFF
--- a/content/engine/install/debian.md
+++ b/content/engine/install/debian.md
@@ -96,14 +96,12 @@ Docker from the repository.
    ```bash
    # Add Docker's official GPG key:
    sudo apt-get update
-   sudo apt-get install ca-certificates curl
-   sudo install -m 0755 -d /etc/apt/keyrings
-   sudo curl -fsSL {{% param "download-url-base" %}}/gpg -o /etc/apt/keyrings/docker.asc
-   sudo chmod a+r /etc/apt/keyrings/docker.asc
+   sudo apt-get install -y apt-transport-https ca-certificates curl gnupg
+   sudo curl -fsSL {{% param "download-url-base" %}}/gpg | sudo gpg --dearmor -o /usr/share/keyrings/docker.gpg
 
    # Add the repository to Apt sources:
    echo \
-     "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] {{% param "download-url-base" %}} \
+     "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/docker.gpg] {{% param "download-url-base" %}} \
      $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | \
      sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
    sudo apt-get update

--- a/content/engine/install/raspberry-pi-os.md
+++ b/content/engine/install/raspberry-pi-os.md
@@ -98,14 +98,12 @@ Docker from the repository.
    ```bash
    # Add Docker's official GPG key:
    sudo apt-get update
-   sudo apt-get install ca-certificates curl
-   sudo install -m 0755 -d /etc/apt/keyrings
-   sudo curl -fsSL {{% param "download-url-base" %}}/gpg -o /etc/apt/keyrings/docker.asc
-   sudo chmod a+r /etc/apt/keyrings/docker.asc
+   sudo apt-get install -y apt-transport-https ca-certificates curl gnupg
+   sudo curl -fsSL {{% param "download-url-base" %}}/gpg | sudo gpg --dearmor -o /usr/share/keyrings/docker.gpg
 
    # Set up Docker's APT repository:
    echo \
-     "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] {{% param "download-url-base" %}} \
+     "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/docker.gpg] {{% param "download-url-base" %}} \
      $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | \
      sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
    sudo apt-get update

--- a/content/engine/install/ubuntu.md
+++ b/content/engine/install/ubuntu.md
@@ -106,14 +106,12 @@ Docker from the repository.
    ```bash
    # Add Docker's official GPG key:
    sudo apt-get update
-   sudo apt-get install ca-certificates curl
-   sudo install -m 0755 -d /etc/apt/keyrings
-   sudo curl -fsSL {{% param "download-url-base" %}}/gpg -o /etc/apt/keyrings/docker.asc
-   sudo chmod a+r /etc/apt/keyrings/docker.asc
-   
+   sudo apt-get install -y apt-transport-https ca-certificates curl gnupg
+   sudo curl -fsSL {{% param "download-url-base" %}}/gpg | sudo gpg --dearmor -o /usr/share/keyrings/docker.gpg
+
    # Add the repository to Apt sources:
    echo \
-     "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] {{% param "download-url-base" %}} \
+     "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/docker.gpg] {{% param "download-url-base" %}} \
      $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | \
      sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
    sudo apt-get update


### PR DESCRIPTION
## Description

- According to the original importing GPG key approach, it will be failed in older Debian-based versions.
  And it should be backward compatibility for all versions.
- It seems that Debian-based and Raspberry Pi OS versions will be successful with original approach and this approach.
  To be consistency, it should use the same approach for all Debian-based versions.
- By default, these `apt-transport-https` and `gnupg` are not installed and it should be installed to complete the Docker package installations.

Here are scripts to test the original approach in fresh Ubuntu containers:

```sh
#!/bin/bash

for ver in 16 18 20 22;
do
    echo "Ubuntu $ver";
    docker run -it --network=host --rm ubuntu:$ver.04 bash -c 'apt update &>/dev/null && apt-get install -y apt-transport-https ca-certificates gnupg curl &>/dev/null && install -m 0755 -d /etc/apt/keyrings && curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc && chmod a+r /etc/apt/keyrings/docker.asc && echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | tee \
    /etc/apt/sources.list.d/docker.list &>/dev/null && apt-get update'
    break
done;
```

And running outputs are as follows:

```sh
Ubuntu 16
Unable to find image 'ubuntu:16.04' locally
16.04: Pulling from library/ubuntu
58690f9b18fc: Pull complete
b51569e7c507: Pull complete
da8ef40b9eca: Pull complete
fb15d46c38dc: Pull complete
Digest: sha256:1f1a2d56de1d604801a9671f301190704c25d604a416f59e03c04f5c6ffee0d6
Status: Downloaded newer image for ubuntu:16.04
Get:1 https://download.docker.com/linux/ubuntu xenial InRelease [66.2 kB]
Ign:1 https://download.docker.com/linux/ubuntu xenial InRelease
Get:2 https://download.docker.com/linux/ubuntu xenial/stable amd64 Packages [23.9 kB]
Hit:3 http://archive.ubuntu.com/ubuntu xenial InRelease
Hit:4 http://security.ubuntu.com/ubuntu xenial-security InRelease
Hit:5 http://archive.ubuntu.com/ubuntu xenial-updates InRelease
Hit:6 http://archive.ubuntu.com/ubuntu xenial-backports InRelease
Fetched 90.1 kB in 1s (82.3 kB/s)
Reading package lists... Done
W: GPG error: https://download.docker.com/linux/ubuntu xenial InRelease: The following signatures couldn't be verified because the public key is not available: NO_PUBKEY 7EA0A9C3F273FCD8
W: The repository 'https://download.docker.com/linux/ubuntu xenial InRelease' is not signed.
N: Data from such a repository can't be authenticated and is therefore potentially dangerous to use.
N: See apt-secure(8) manpage for repository creation and user configuration details.
Ubuntu 18
Unable to find image 'ubuntu:18.04' locally
18.04: Pulling from library/ubuntu
7c457f213c76: Pull complete
Digest: sha256:152dc042452c496007f07ca9127571cb9c29697f42acbfad72324b2bb2e43c98
Status: Downloaded newer image for ubuntu:18.04
Get:1 https://download.docker.com/linux/ubuntu bionic InRelease [64.4 kB]
Get:2 https://download.docker.com/linux/ubuntu bionic/stable amd64 Packages [46.4 kB]
Hit:3 http://security.ubuntu.com/ubuntu bionic-security InRelease
Hit:4 http://archive.ubuntu.com/ubuntu bionic InRelease
Hit:5 http://archive.ubuntu.com/ubuntu bionic-updates InRelease
Hit:6 http://archive.ubuntu.com/ubuntu bionic-backports InRelease
Fetched 111 kB in 1s (82.3 kB/s)
Reading package lists... Done
Ubuntu 20
Unable to find image 'ubuntu:20.04' locally
20.04: Pulling from library/ubuntu
17d0386c2fff: Pull complete
Digest: sha256:80ef4a44043dec4490506e6cc4289eeda2d106a70148b74b5ae91ee670e9c35d
Status: Downloaded newer image for ubuntu:20.04
Get:1 https://download.docker.com/linux/ubuntu focal InRelease [57.7 kB]
Get:2 https://download.docker.com/linux/ubuntu focal/stable amd64 Packages [46.1 kB]
Hit:3 http://security.ubuntu.com/ubuntu focal-security InRelease
Hit:4 http://archive.ubuntu.com/ubuntu focal InRelease
Hit:5 http://archive.ubuntu.com/ubuntu focal-updates InRelease
Hit:6 http://archive.ubuntu.com/ubuntu focal-backports InRelease
Fetched 104 kB in 1s (94.3 kB/s)
Reading package lists... Done
Ubuntu 22
Unable to find image 'ubuntu:22.04' locally
22.04: Pulling from library/ubuntu
bccd10f490ab: Pull complete
Digest: sha256:77906da86b60585ce12215807090eb327e7386c8fafb5402369e421f44eff17e
Status: Downloaded newer image for ubuntu:22.04
Get:1 https://download.docker.com/linux/ubuntu jammy InRelease [48.8 kB]
Get:2 https://download.docker.com/linux/ubuntu jammy/stable amd64 Packages [32.6 kB]
Hit:3 http://security.ubuntu.com/ubuntu jammy-security InRelease
Hit:4 http://archive.ubuntu.com/ubuntu jammy InRelease
Hit:5 http://archive.ubuntu.com/ubuntu jammy-updates InRelease
Hit:6 http://archive.ubuntu.com/ubuntu jammy-backports InRelease
Fetched 81.4 kB in 1s (63.6 kB/s)
Reading package lists... Done
```

Here is the test script to use this approach:

```sh
#!/bin/bash

for ver in 16 18 20 22;
do
    echo "Ubuntu $ver";
    docker run -it --network=host --rm ubuntu:$ver.04 bash -c 'apt update &>/dev/null && apt-get install -y apt-transport-https ca-certificates gnupg curl &>/dev/null && curl -fsSL https://download.docker.com/linux/ubuntu/gpg | gpg --dearmor -o /usr/share/keyrings/docker.gpg && echo "deb [arch=amd64 signed-by=/usr/share/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | tee \
    /etc/apt/sources.list.d/docker.list &>/dev/null && apt-get update'
done;
```

And running outputs are as follows:

```sh
Ubuntu 16
Get:1 https://download.docker.com/linux/ubuntu xenial InRelease [66.2 kB]
Get:2 https://download.docker.com/linux/ubuntu xenial/stable amd64 Packages [23.9 kB]
Hit:3 http://archive.ubuntu.com/ubuntu xenial InRelease
Hit:4 http://security.ubuntu.com/ubuntu xenial-security InRelease
Hit:5 http://archive.ubuntu.com/ubuntu xenial-updates InRelease
Hit:6 http://archive.ubuntu.com/ubuntu xenial-backports InRelease
Fetched 90.1 kB in 1s (54.8 kB/s)
Reading package lists... Done
Ubuntu 18
Get:1 https://download.docker.com/linux/ubuntu bionic InRelease [64.4 kB]
Get:2 https://download.docker.com/linux/ubuntu bionic/stable amd64 Packages [46.4 kB]
Hit:3 http://archive.ubuntu.com/ubuntu bionic InRelease
Hit:4 http://security.ubuntu.com/ubuntu bionic-security InRelease
Hit:5 http://archive.ubuntu.com/ubuntu bionic-updates InRelease
Hit:6 http://archive.ubuntu.com/ubuntu bionic-backports InRelease
Fetched 111 kB in 2s (57.1 kB/s)
Reading package lists... Done
Ubuntu 20
Get:1 https://download.docker.com/linux/ubuntu focal InRelease [57.7 kB]
Get:2 https://download.docker.com/linux/ubuntu focal/stable amd64 Packages [46.1 kB]
Hit:3 http://archive.ubuntu.com/ubuntu focal InRelease
Hit:4 http://security.ubuntu.com/ubuntu focal-security InRelease
Hit:5 http://archive.ubuntu.com/ubuntu focal-updates InRelease
Hit:6 http://archive.ubuntu.com/ubuntu focal-backports InRelease
Fetched 104 kB in 2s (48.6 kB/s)
Reading package lists... Done
Ubuntu 22
Get:1 https://download.docker.com/linux/ubuntu jammy InRelease [48.8 kB]
Get:2 https://download.docker.com/linux/ubuntu jammy/stable amd64 Packages [32.6 kB]
Hit:3 http://security.ubuntu.com/ubuntu jammy-security InRelease
Hit:4 http://archive.ubuntu.com/ubuntu jammy InRelease
Hit:5 http://archive.ubuntu.com/ubuntu jammy-updates InRelease
Hit:6 http://archive.ubuntu.com/ubuntu jammy-backports InRelease
Fetched 81.4 kB in 1s (63.6 kB/s)
Reading package lists... Done
```

## Related issues or tickets

- N/A

## Reviews

- [ ] Technical review
- [X] Editorial review
- [ ] Product review