### PR TITLE
Adding missed packages for this installation

### DIFF
--- a/content/engine/install/debian.md
+++ b/content/engine/install/debian.md
@@ -96,7 +96,7 @@ Docker from the repository.
    ```bash
    # Add Docker's official GPG key:
    sudo apt-get update
-   sudo apt-get install ca-certificates curl
+   sudo apt-get install -y apt-transport-https ca-certificates curl gnupg
    sudo install -m 0755 -d /etc/apt/keyrings
    sudo curl -fsSL {{% param "download-url-base" %}}/gpg -o /etc/apt/keyrings/docker.asc
    sudo chmod a+r /etc/apt/keyrings/docker.asc

--- a/content/engine/install/raspberry-pi-os.md
+++ b/content/engine/install/raspberry-pi-os.md
@@ -98,7 +98,7 @@ Docker from the repository.
    ```bash
    # Add Docker's official GPG key:
    sudo apt-get update
-   sudo apt-get install ca-certificates curl
+   sudo apt-get install -y apt-transport-https ca-certificates curl gnupg
    sudo install -m 0755 -d /etc/apt/keyrings
    sudo curl -fsSL {{% param "download-url-base" %}}/gpg -o /etc/apt/keyrings/docker.asc
    sudo chmod a+r /etc/apt/keyrings/docker.asc

--- a/content/engine/install/ubuntu.md
+++ b/content/engine/install/ubuntu.md
@@ -106,7 +106,7 @@ Docker from the repository.
    ```bash
    # Add Docker's official GPG key:
    sudo apt-get update
-   sudo apt-get install ca-certificates curl
+   sudo apt-get install -y apt-transport-https ca-certificates curl gnupg
    sudo install -m 0755 -d /etc/apt/keyrings
    sudo curl -fsSL {{% param "download-url-base" %}}/gpg -o /etc/apt/keyrings/docker.asc
    sudo chmod a+r /etc/apt/keyrings/docker.asc


### PR DESCRIPTION
## Description

- To complete the installation, it needs to install the `gnupg` and `apt-transport-https` packages.
  - The `gnupg` package is used to make the `gpg` command available.
  - The `apt-transport-https` is used to let `apt` command can make the request for mirror sites via the HTTPS protocol.

## Reviews

- [ ] Technical review
- [X] Editorial review
- [ ] Product review