### PR TITLE
engine: add note about nftables incompatibility to install docs

### DIFF
--- a/content/engine/install/debian.md
+++ b/content/engine/install/debian.md
@@ -18,12 +18,23 @@ To get started with Docker Engine on Debian, make sure you
 
 ## Prerequisites
 
-> **Note**
+### Firewall limitations
+
+> **Warning**
 >
-> If you use ufw or firewalld to manage firewall settings, be aware that
-> when you expose container ports using Docker, these ports bypass your
-> firewall rules. For more information, refer to
-> [Docker and ufw](../../network/packet-filtering-firewalls.md#docker-and-ufw).
+> Before you install Docker, make sure you consider the following
+> security implications and firewall incompatibilities.
+{ .warning }
+
+- If you use ufw or firewalld to manage firewall settings, be aware that
+  when you expose container ports using Docker, these ports bypass your
+  firewall rules. For more information, refer to
+  [Docker and ufw](../../network/packet-filtering-firewalls.md#docker-and-ufw).
+- Docker is only compatible with `iptables-nft` and `iptables-legacy`.
+  Firewall rules created with `nft` are not supported on a system with Docker installed.
+  Make sure that any firewall rulesets you use are created with `iptables` or `iptables6`,
+  and that you add them to the `DOCKER-USER` chain,
+  see [Packet filtering and firewalls](../../network/packet-filtering-firewalls.md).
 
 ### OS requirements
 

--- a/content/engine/install/raspberry-pi-os.md
+++ b/content/engine/install/raspberry-pi-os.md
@@ -24,12 +24,23 @@ To get started with Docker Engine on Raspberry Pi OS, make sure you
 
 ## Prerequisites
 
-> **Note**
+### Firewall limitations
+
+> **Warning**
 >
-> If you use ufw or firewalld to manage firewall settings, be aware that
-> when you expose container ports using Docker, these ports bypass your
-> firewall rules. For more information, refer to
-> [Docker and ufw](../../network/packet-filtering-firewalls.md#docker-and-ufw).
+> Before you install Docker, make sure you consider the following
+> security implications and firewall incompatibilities.
+{ .warning }
+
+- If you use ufw or firewalld to manage firewall settings, be aware that
+  when you expose container ports using Docker, these ports bypass your
+  firewall rules. For more information, refer to
+  [Docker and ufw](../../network/packet-filtering-firewalls.md#docker-and-ufw).
+- Docker is only compatible with `iptables-nft` and `iptables-legacy`.
+  Firewall rules created with `nft` are not supported on a system with Docker installed.
+  Make sure that any firewall rulesets you use are created with `iptables` or `iptables6`,
+  and that you add them to the `DOCKER-USER` chain,
+  see [Packet filtering and firewalls](../../network/packet-filtering-firewalls.md).
 
 ### OS requirements
 

--- a/content/engine/install/ubuntu.md
+++ b/content/engine/install/ubuntu.md
@@ -26,12 +26,23 @@ To get started with Docker Engine on Ubuntu, make sure you
 
 ## Prerequisites
 
-> **Note**
+### Firewall limitations
+
+> **Warning**
 >
-> If you use ufw or firewalld to manage firewall settings, be aware that
-> when you expose container ports using Docker, these ports bypass your
-> firewall rules. For more information, refer to
-> [Docker and ufw](../../network/packet-filtering-firewalls.md#docker-and-ufw).
+> Before you install Docker, make sure you consider the following
+> security implications and firewall incompatibilities.
+{ .warning }
+
+- If you use ufw or firewalld to manage firewall settings, be aware that
+  when you expose container ports using Docker, these ports bypass your
+  firewall rules. For more information, refer to
+  [Docker and ufw](../../network/packet-filtering-firewalls.md#docker-and-ufw).
+- Docker is only compatible with `iptables-nft` and `iptables-legacy`.
+  Firewall rules created with `nft` are not supported on a system with Docker installed.
+  Make sure that any firewall rulesets you use are created with `iptables` or `iptables6`,
+  and that you add them to the `DOCKER-USER` chain,
+  see [Packet filtering and firewalls](../../network/packet-filtering-firewalls.md).
 
 ### OS requirements
 


### PR DESCRIPTION
Adds a warning about nftables (`nft`) incompatibility for Docker to the installation documentation for Debian, Raspbian, and Ubuntu
