### PR TITLE
Update 06_bind_mounts.md with a semantic fix

### DIFF
--- a/content/get-started/06_bind_mounts.md
+++ b/content/get-started/06_bind_mounts.md
@@ -79,7 +79,7 @@ setting, see the topic for [Mac](../desktop/settings/mac.md/#file-sharing),
    {{< /tab >}}
    {{< /tabs >}}
    
-   The `--mount` option tells Docker to create a bind mount, where `src` is the
+   The `--mount type=bind` option tells Docker to create a bind mount, where `src` is the
    current working directory on your host machine (`getting-started-app`), and
    `target` is where that directory should appear inside the container (`/src`).
 


### PR DESCRIPTION
`--mount` takes in a few key-value pairs and its`type=bind` that specifies that the volume is bind mount.

<!--Delete sections as needed -->

## Description

"The `--mount` option tells Docker to create a bind mount, where..." is wrong. 

According to the docs:
`--mount` flag tells docker to create a volume and consists of multiple key-value pairs, separated by commas and each consisting of a `<key>=<value>` tuple, where `type` key's value sets the type of volume to be created: `bind`, `tmpfs`, and `volume`. For bind mounts, it's set to `bind`.

There was an error in the description of the command. I fixed it.

## Related issues or tickets

<!-- Related issues, pull requests, or Jira tickets -->

## Reviews

As I'm typing this, I found even my change to be bit lacking, so IMO, the final text should start as:

"The `--mount` option tells Docker to create a volume, where `type` is the type of volume to be created (here, `bind` for bind mounts), and where `src` is...." 

Please change it to that.

Thank you for your time. 


<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Technical review
- [ ] Editorial review
- [ ] Product review