### PR TITLE
Update volumes.md

### DIFF
--- a/content/storage/volumes.md
+++ b/content/storage/volumes.md
@@ -466,8 +466,7 @@ Each volume driver may have zero or more configurable options.
 ```console
 $ docker run -d \
   --name sshfs-container \
-  --volume-driver vieux/sshfs \
-  --mount src=sshvolume,target=/app,volume-opt=sshcmd=test@node2:/home/test,volume-opt=password=testpassword \
+  --mount type=volume,volume-driver=vieux/sshfs,src=sshvolume,target=/app,volume-opt=sshcmd=test@node2:/home/test,volume-opt=password=testpassword \
   nginx:latest
 ```
 


### PR DESCRIPTION
[CORRECTION] --volume-driver flag is ignored when using --mount. Updated instruction code to fix for users following documentation.

## Description

I updated the instructions to use the proper syntax when starting a container that creates a volume with a specific volume-driver.

## Related issues or tickets

Didn't see any

## Reviews

- [ ] Technical review
- [ ] Editorial review
- [ ] Product review