### PR TITLE
buildx: default-load driver opt

### DIFF
--- a/content/build/drivers/docker-container.md
+++ b/content/build/drivers/docker-container.md
@@ -33,20 +33,21 @@ container
 The following table describes the available driver-specific options that you can
 pass to `--driver-opt`:
 
-| Parameter        | Type   | Default          | Description                                                                                                            |
-| ---------------- | ------ | ---------------- | ---------------------------------------------------------------------------------------------------------------------- |
-| `image`          | String |                  | Sets the BuildKit image to use for the container.                                                                      |
-| `memory`         | String |                  | Sets the amount of memory the container can use.                                                                       |
-| `memory-swap`    | String |                  | Sets the memory swap limit for the container.                                                                          |
-| `cpu-quota`      | String |                  | Imposes a CPU CFS quota on the container.                                                                              |
-| `cpu-period`     | String |                  | Sets the CPU CFS scheduler period for the container.                                                                   |
-| `cpu-shares`     | String |                  | Configures CPU shares (relative weight) of the container.                                                              |
-| `cpuset-cpus`    | String |                  | Limits the set of CPU cores the container can use.                                                                     |
-| `cpuset-mems`    | String |                  | Limits the set of CPU memory nodes the container can use.                                                              |
-| `network`        | String |                  | Sets the network mode for the container.                                                                               |
-| `cgroup-parent`  | String | `/docker/buildx` | Sets the cgroup parent of the container if Docker is using the "cgroupfs" driver.                                      |
-| `restart-policy` | String | `unless-stopped` | Sets the container's [restart policy](../../config/containers/start-containers-automatically.md#use-a-restart-policy). |
-| `env.<key>`      | String |                  | Sets the environment variable `key` to the specified `value` in the container.                                         |
+| Parameter        | Type    | Default          | Description                                                                                                            |
+| ---------------- | ------- | ---------------- | ---------------------------------------------------------------------------------------------------------------------- |
+| `image`          | String  |                  | Sets the BuildKit image to use for the container.                                                                      |
+| `memory`         | String  |                  | Sets the amount of memory the container can use.                                                                       |
+| `memory-swap`    | String  |                  | Sets the memory swap limit for the container.                                                                          |
+| `cpu-quota`      | String  |                  | Imposes a CPU CFS quota on the container.                                                                              |
+| `cpu-period`     | String  |                  | Sets the CPU CFS scheduler period for the container.                                                                   |
+| `cpu-shares`     | String  |                  | Configures CPU shares (relative weight) of the container.                                                              |
+| `cpuset-cpus`    | String  |                  | Limits the set of CPU cores the container can use.                                                                     |
+| `cpuset-mems`    | String  |                  | Limits the set of CPU memory nodes the container can use.                                                              |
+| `default-load`   | Boolean | `false`          | Automatically load images to the Docker Engine image store.                                                            |
+| `network`        | String  |                  | Sets the network mode for the container.                                                                               |
+| `cgroup-parent`  | String  | `/docker/buildx` | Sets the cgroup parent of the container if Docker is using the "cgroupfs" driver.                                      |
+| `restart-policy` | String  | `unless-stopped` | Sets the container's [restart policy](../../config/containers/start-containers-automatically.md#use-a-restart-policy). |
+| `env.<key>`      | String  |                  | Sets the environment variable `key` to the specified `value` in the container.                                         |
 
 Before you configure the resource limits for the container,
 read about [configuring runtime resource constraints for containers](../../config/containers/resource_constraints/).

--- a/content/build/drivers/kubernetes.md
+++ b/content/build/drivers/kubernetes.md
@@ -38,6 +38,7 @@ can pass to `--driver-opt`:
 | `requests.memory` | Memory size       |                                         | Sets the request memory value specified in bytes or with a valid suffix. For example `requests.memory=500Mi` or `requests.memory=4G` |
 | `limits.cpu`      | CPU units         |                                         | Sets the limit CPU value specified in units of Kubernetes CPU. For example `requests.cpu=100m` or `requests.cpu=2`                   |
 | `limits.memory`   | Memory size       |                                         | Sets the limit memory value specified in bytes or with a valid suffix. For example `requests.memory=500Mi` or `requests.memory=4G`   |
+| `default-load`    | Boolean           | `false`                                 | Automatically load images to the Docker Engine image store.                                                                          |
 | `nodeselector`    | CSV string        |                                         | Sets the pod's `nodeSelector` label(s). See [node assignment][2].                                                                    |
 | `annotation`      | CSV string        |                                         | Sets additional annotations on the deployments and pods.                                                                             |
 | `labels`          | CSV string        |                                         | Sets additional labels on the deployments and pods.                                                                                  |

--- a/content/build/drivers/remote.md
+++ b/content/build/drivers/remote.md
@@ -26,12 +26,13 @@ $ docker buildx create \
 The following table describes the available driver-specific options that you can
 pass to `--driver-opt`:
 
-| Parameter    | Type   | Default            | Description                                                            |
-| ------------ | ------ | ------------------ | ---------------------------------------------------------------------- |
-| `key`        | String |                    | Sets the TLS client key.                                               |
-| `cert`       | String |                    | Absolute path to the TLS client certificate to present to `buildkitd`. |
-| `cacert`     | String |                    | Absolute path to the TLS certificate authority used for validation.    |
-| `servername` | String | Endpoint hostname. | TLS server name used in requests.                                      |
+| Parameter      | Type    | Default            | Description                                                            |
+| -------------- | ------- | ------------------ | ---------------------------------------------------------------------- |
+| `key`          | String  |                    | Sets the TLS client key.                                               |
+| `cert`         | String  |                    | Absolute path to the TLS client certificate to present to `buildkitd`. |
+| `cacert`       | String  |                    | Absolute path to the TLS certificate authority used for validation.    |
+| `servername`   | String  | Endpoint hostname. | TLS server name used in requests.                                      |
+| `default-load` | Boolean | `false`            | Automatically load images to the Docker Engine image store.            |
 
 ## Example: Remote BuildKit over Unix sockets
 


### PR DESCRIPTION
Add buildx driver opt to enable loading images to the local image store for non-docker drivers

relates to https://github.com/docker/buildx/pull/2259
