### PR TITLE
Update configure-ci-cd.md to include 'linux/arm64' to run on Apple Silicon

### DIFF
--- a/content/language/python/configure-ci-cd.md
+++ b/content/language/python/configure-ci-cd.md
@@ -92,6 +92,7 @@ to Docker Hub.
            uses: docker/build-push-action@v5
            with:
              context: .
+             platforms: linux/amd64,linux/arm64
              push: true
              tags: ${{ secrets.DOCKER_USERNAME }}/${{ github.event.repository.name }}:latest
    ```


### PR DESCRIPTION
Update configure-ci-cd.md to include 'linux/arm64' so people could run the demo on Apple Silicon

Currently, as no platform is defined, it builds for platform 'linux/amd64' which will not work for people trying to run the Kubernetes example https://docs.docker.com/language/python/deploy/ on Apple Silicon as no container is build with platform 'linux/arm64'.

## Description
Currently, as no platform is defined, it builds for platform 'linux/amd64' which will not work for people trying to run the Kubernetes example https://docs.docker.com/language/python/deploy/ on Apple Silicon as no container is build with platform 'linux/arm64'.

Added a new line under 'name: Build and push':
`platforms: linux/amd64,linux/arm64`


## Related issues or tickets
Did not find any open issues or tickers

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Technical review
- [ ] Editorial review
- [ ] Product review