### PR TITLE
fix: add a note about experimental windows support

### DIFF
--- a/content/build/buildkit/_index.md
+++ b/content/build/buildkit/_index.md
@@ -107,7 +107,7 @@ daemon.
 
 > **Warning**
 >
-> BuildKit only supports building Linux containers. Now there is experimental
-> Windows support that is tracked in
+> BuildKit only fully supports building Linux containers. Experimental Windows
+> container support is tracked in
 > [`moby/buildkit#616`](https://github.com/moby/buildkit/issues/616)
 { .warning }

--- a/content/build/buildkit/_index.md
+++ b/content/build/buildkit/_index.md
@@ -107,7 +107,7 @@ daemon.
 
 > **Warning**
 >
-> BuildKit only supports building Linux containers. Windows support is tracked
-> in
+> BuildKit only supports building Linux containers. Now there is experimental
+> Windows support that is tracked in
 > [`moby/buildkit#616`](https://github.com/moby/buildkit/issues/616)
 { .warning }


### PR DESCRIPTION
## Description

We are now releasing buildkitd.exe for Window as an experimental release. This commit updates the docs to reflect that new development.

## Reviews

- [ ] Editorial review
