### PR TITLE
Fine-tune GitHub's language detection for the repo

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,5 @@
 # Auto-detect text files, ensure they use LF.
 * text=auto eol=lf
+
+# Fine-tune GitHub's language detection
+content/**/*.md linguist-detectable


### PR DESCRIPTION
## Description

Since the whole repo is dedicated to documentation, documentation is the "source code" of this repo. In order to capture this in language stats (and potentially attract more contributors) count [Markdown files in content/ folder](https://github.com/docker/docs/blob/b808684e041751f1196f788a94e752fb1bb2445b/CONTRIBUTING.md#editing-content) as "source".

As a result of this change the main language of the repo is expected to change from HTML to Markdown.

|Before|After|
|---|---|
|![image](https://github.com/docker/docs/assets/25753618/89e2e1ca-c11e-4372-b7da-5a5926adf765)|![image](https://github.com/docker/docs/assets/25753618/0bb377aa-1f42-4411-a2ea-1c506a00e2f5)|
|![image](https://github.com/docker/docs/assets/25753618/c2e73d0d-7182-492b-bb77-0aff9431f6d4)|![image](https://github.com/docker/docs/assets/25753618/fdb8c763-80e6-4401-b784-ce7027bdb138)|

## Reviews

- [ ] Technical review
- [x] Editorial review
- [ ] Product review