### PR TITLE
fix: incorrect syntax for ENTRYPOINT

### DIFF
--- a/_vendor/github.com/moby/buildkit/frontend/dockerfile/docs/reference.md
+++ b/_vendor/github.com/moby/buildkit/frontend/dockerfile/docs/reference.md
@@ -453,7 +453,7 @@ The exec form is parsed as a JSON array, which means that
 you must use double-quotes (") around words, not single-quotes (').
 
 ```dockerfile
-ENTRYPOINT ["/bin/bash", "-c", "echo", "hello"]
+ENTRYPOINT ["/bin/bash", "-c", "echo hello"]
 ```
 
 The exec form is best used to specify an `ENTRYPOINT` instruction, combined


### PR DESCRIPTION

## Description
 too many quotes in ENTRYPOINT
<!-- Tell us what you did and why -->

`ENTRYPOINT ["/bin/bash", "-c", "echo" "hello"]`
should read
`ENTRYPOINT ["/bin/bash", "-c", "echo hello"]`
## Related issues or tickets
[ incorrect syntax for Dockerfile ENTRYPOINT #19670 ](https://github.com/docker/docs/issues/19670)


## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Technical review
- [ ] Editorial review
- [ ] Product review