### PR TITLE
fix override file name in the merge.md

### DIFF
--- a/content/compose/compose-file/13-merge.md
+++ b/content/compose/compose-file/13-merge.md
@@ -157,7 +157,7 @@ services:
       FOO: BAR           
 ```
 
-And an `override.compose.yaml` file:
+And an `compose.override.yaml` file:
 
 ```yaml
 services:


### PR DESCRIPTION
<!--Delete sections as needed -->

## Description
Fix the name of the override file defined in the `13-merge.md` file

## Related issues or tickets
fixes https://github.com/compose-spec/compose-spec/issues/476

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Technical review
- [ ] Editorial review
- [ ] Product review