### PR TITLE
scout: "Fixable vulnerabilities only" config option

### DIFF
--- a/content/scout/policy/_index.md
+++ b/content/scout/policy/_index.md
@@ -77,8 +77,8 @@ available. Essentially, this means that there's an easy fix that you can deploy
 for images that fail this policy: upgrade the vulnerable package to a version
 containing a fix for the vulnerability.
 
-This policy only flags critical and high severity vulnerabilities that were
-published more than 30 days ago. The rationale for only flagging
+By default, this policy only flags critical and high severity vulnerabilities
+disclosed more than 30 days ago. The rationale for only flagging
 vulnerabilities of a certain age is that newly discovered vulnerabilities
 shouldn't cause your evaluations to fail until you've had a chance to address
 them.
@@ -86,8 +86,15 @@ them.
 This policy is unfulfilled if an artifact is affected by one or more critical-
 or high-severity vulnerability, where a fix version is available.
 
-You can configure the severity level and age thresholds by creating a custom
-policy. For more information, see [Configure policies](./configure.md).
+You can configure the parameters of this policy by creating a custom version of the policy.
+The following policy parameters are configurable in a custom version:
+
+- Name and description of the policy
+- Severity levels to consider
+- Age threshold (set to `0` to flag all vulnerabilities, regardless of age)
+- Whether or not to only report vulnerabilities with a fix version available
+
+For more information about configuring policies, see [Configure policies](./configure.md).
 
 ### Copyleft licenses
 

--- a/content/scout/release-notes.md
+++ b/content/scout/release-notes.md
@@ -14,7 +14,13 @@ for what's coming next.
 
 ## Q1 2024
 
-New features and enhancements released in the first quarter of of 2024.
+New features and enhancements released in the first quarter of 2024.
+
+### 2024-03-20
+
+The **Fixable critical and high vulnerabilities** policy now supports a
+**Fixable vulnerabilities only** configuration option, which lets you decide
+whether or not to only flag vulnerabilities with an available fix version.
 
 ### 2024-03-14
 


### PR DESCRIPTION
## Description

The "Fixable critical and high vulnerabilities" OOTB policy now supports
a "Fixable vulnerabilities only" configuration option when customizing
the policy.

Signed-off-by: David Karlsson <35727626+dvdksn@users.noreply.github.com>

## Reviews

- [x] Technical review @chrispatrick 
- [x] Editorial review
