### PR TITLE
scout: add cli/gha release notes to docs site

### DIFF
--- a/content/release-notes.md
+++ b/content/release-notes.md
@@ -18,9 +18,12 @@ grid:
 - title: Docker Hub
   icon: widgets
   link: /docker-hub/release-notes/
-- title: Docker Scout
+- title: Docker Scout (platform)
   icon: query_stats
-  link: /scout/release-notes/
+  link: /scout/release-notes/platform/
+- title: Docker Scout (CLI)
+  icon: query_stats
+  link: /scout/release-notes/cli/
 ---
 
 Find out what's new in Docker. Release notes contain information about new

--- a/content/scout/release-notes/cli.md
+++ b/content/scout/release-notes/cli.md
@@ -1,0 +1,117 @@
+---
+title: Docker Scout CLI release notes
+description: Learn about the latest features of the Docker Scout CLI plugin
+keywords: docker scout, release notes, changelog, cli, features, changes, delta, new, releases, github actions
+---
+
+This page contains information about the new features, improvements, known
+issues, and bug fixes in the Docker Scout [CLI plugin](https://github.com/docker/scout-cli/)
+and the `docker/scout-action` [GitHub Action](https://github.com/docker/scout-action).
+
+## 1.6.4
+
+{{< release-date date="2024-03-26" >}}
+
+### Bug fix
+
+- Fix epoch handling for rpm-based images.
+
+## 1.6.3
+
+{{< release-date date="2024-03-22" >}}
+
+### Bug fixes and enhancements
+
+- Improve package detection to ignore referenced but not installed packages.
+
+## 1.6.2
+
+{{< release-date date="2024-03-22" >}}
+
+### Bug fixes and enhancements
+
+- EPSS data is now fetched via the backend, as opposed to via the CLI client.
+- Fix an issue when rendering markdown output using the `sbom://` prefix.
+
+### Removed
+
+- The `docker scout cves --epss-date` and `docker scout cache prune --epss` flags have been removed.
+
+## 1.6.1
+
+{{< release-date date="2024-03-20" >}}
+
+> **Note**
+>
+> This release only affects the `docker/scout-action` GitHub Action.
+
+### New
+
+- Add support for passing in SBOM files in SDPX or in-toto SDPX format
+
+  ```yaml
+  uses: docker/scout-action@v1
+  with:
+      command: cves
+      image: sbom://alpine.spdx.json
+  ```
+
+- Add support for SBOM files in `syft-json` format
+
+  ```yaml
+  uses: docker/scout-action@v1
+  with:
+      command: cves
+      image: sbom://alpine.syft.json
+  ```
+
+## 1.6.0
+
+{{< release-date date="2024-03-19" >}}
+
+> **Note**
+>
+> This release only affects the CLI plugin, not the GitHub Action
+
+### New
+
+- Add support for passing in SBOM files in SDPX or in-toto SDPX format
+
+  ```console
+  $ docker scout cves sbom://path/to/sbom.spdx.json
+  ```
+
+- Add support for SBOM files in `syft-json` format
+
+  ```console
+  $ docker scout cves sbom://path/to/sbom.syft.json
+  ```
+
+- Reads SBOM files from standard input
+
+  ```console
+  $ syft -o json alpine | docker scout cves sbom://
+  ```
+
+- Prioritize CVEs by EPSS score
+
+  - `--epss` to display and prioritise the CVEs
+  - `--epss-score` and `--epss-percentile` to filter by score and percentile
+  - Prune cached EPSS files with `docker scout cache prune --epss`
+
+### Bug fixes and enhancements
+
+- Use Windows cache from WSL2
+  
+  When inside WSL2 with Docker Desktop running, the Docker Scout CLI plugin now
+  uses the cache from Windows. That way, if an image has been indexed for
+  instance by Docker Desktop there's no need anymore to re-index it on WSL2
+  side.
+
+- Fix a panic that would occur when analyzing a single-image `oci-dir` input
+- Improve local attestation support with the containerd image store
+
+## Earlier versions
+
+Release notes for earlier versions of the Docker Scout CLI plugin are available
+on [GitHub](https://github.com/docker/scout-cli/releases).

--- a/content/scout/release-notes/platform.md
+++ b/content/scout/release-notes/platform.md
@@ -2,12 +2,14 @@
 title: Docker Scout release notes
 description: Learn about the latest features of Docker Scout
 keywords: docker scout, release notes, changelog, features, changes, delta, new, releases
+aliases:
+- /scout/release-notes/
 ---
 
 This page contains information about the new features, improvements, known
 issues, and bug fixes in Docker Scout releases. These release notes cover the
 Docker Scout platform, including the Dashboard. For CLI release notes, refer to
-the `docker/scout-cli` [GitHub repository](https://github.com/docker/scout-cli/releases).
+[Docker Scout CLI release notes](./cli.md).
 
 Take a look at the [Docker Public Roadmap](https://github.com/docker/roadmap/projects/1)
 for what's coming next.
@@ -32,11 +34,11 @@ making the now-removed **All critical vulnerabilities** policy redundant.
 ### 2024-01-26
 
 **Azure Container Registry** integration graduated from
-[Early Access](../release-lifecycle.md#early-access-ea) to
-[General Availability](../release-lifecycle.md#genera-availability-ga).
+[Early Access](../../release-lifecycle.md#early-access-ea) to
+[General Availability](../../release-lifecycle.md#genera-availability-ga).
 
 For more information and setup instructions, see
-[Integrate Azure Container Registry](./integrations/registry/acr.md).
+[Integrate Azure Container Registry](../integrations/registry/acr.md).
 
 ### 2024-01-23
 
@@ -46,7 +48,7 @@ pattern. Base images whose image reference don't match the specified patterns
 cause the policy to fail.
 
 For more information, see
-[Unapproved base images](./policy/_index.md#unapproved-base-images).
+[Unapproved base images](../policy/_index.md#unapproved-base-images).
 
 ### 2024-01-12
 
@@ -55,11 +57,11 @@ New **Default non-root user** policy, which flags images that would run as the
 Specifying a non-root default user for your images can help strengthen your
 runtime security.
 
-For more information, see [Default non-root user](./policy/_index.md#default-non-root-user).
+For more information, see [Default non-root user](../policy/_index.md#default-non-root-user).
 
 ### 2024-01-11
 
-[Beta](../release-lifecycle.md#beta) launch of a new GitHub app for integrating
+[Beta](../../release-lifecycle.md#beta) launch of a new GitHub app for integrating
 Docker Scout with your source code management, and a remediation feature for
 helping you improve policy compliance.
 
@@ -74,11 +76,11 @@ more precise recommendations.
 
 For more information about the types of recommendations that Docker Scout can
 provide to help you improve policy compliance, see
-[Remediation](./policy/remediation.md).
+[Remediation](../policy/remediation.md).
 
 For more information about how to authorize the Docker Scout GitHub app on your
 source repositories, see
-[Integrate Docker Scout with GitHub](./integrations/source-code-management/github.md).
+[Integrate Docker Scout with GitHub](../integrations/source-code-management/github.md).
 
 ## Q4 2023
 
@@ -87,11 +89,11 @@ New features and enhancements released in the fourth quarter of 2023.
 ### 2023-12-20
 
 **Azure Container Registry** integration graduated from
-[Beta](../release-lifecycle.md#beta) to
-[Early Access](../release-lifecycle.md#early-access-ea).
+[Beta](../../release-lifecycle.md#beta) to
+[Early Access](../../release-lifecycle.md#early-access-ea).
 
 For more information and setup instructions, see
-[Integrate Azure Container Registry](./integrations/registry/acr.md).
+[Integrate Azure Container Registry](../integrations/registry/acr.md).
 
 ### 2023-12-06
 
@@ -104,17 +106,17 @@ images, and see the SonarQube quality gate conditions surfaced in the new
 
 For more information, see:
 
-- [Integration and setup instructions](./integrations/code-quality/sonarqube.md)
-- [Quality gates passed policy](./policy/_index.md#quality-gates-passed)
+- [Integration and setup instructions](../integrations/code-quality/sonarqube.md)
+- [Quality gates passed policy](../policy/_index.md#quality-gates-passed)
 
 ### 2023-12-01
 
-[Beta](../release-lifecycle.md#beta) release of a new **Azure Container
+[Beta](../../release-lifecycle.md#beta) release of a new **Azure Container
 Registry** (ACR) integration, which lets Docker Scout pull and analyze images
 in ACR repositories automatically.
 
 To learn more about the integration and how to get started, see
-[Integrate Azure Container Registry](./integrations/registry/acr.md).
+[Integrate Azure Container Registry](../integrations/registry/acr.md).
 
 ### 2023-11-21
 
@@ -127,7 +129,7 @@ policies for your organization include:
 - Customize the list of "high-profile vulnerabilities"
 - Add or remove software licenses to flag as "copyleft"
 
-For more information, see [Configurable policies](./policy/configure.md).
+For more information, see [Configurable policies](../policy/configure.md).
 
 ### 2023-11-10
 
@@ -136,7 +138,7 @@ images are built with SBOM and provenance attestations. Adding attestations to
 images is a good first step in improving your supply chain conduct, and is
 often a prerequisite for doing more.
 
-See [Supply chain attestations policy](./policy/_index.md#supply-chain-attestations)
+See [Supply chain attestations policy](../policy/_index.md#supply-chain-attestations)
 for details.
 
 ### 2023-11-01
@@ -145,7 +147,7 @@ New **High-profile vulnerabilities** policy, which ensures your artifacts are
 free from a curated list of vulnerabilities widely recognized to be risky.
 
 For more information, see
-[High-profile vulnerabilities policy](./policy/_index.md#high-profile-vulnerabilities).
+[High-profile vulnerabilities policy](../policy/_index.md#high-profile-vulnerabilities).
 
 ### 2023-10-04
 
@@ -164,7 +166,7 @@ Policy Evaluation is an early access feature that helps you ensure software
 integrity and track how your artifacts are doing over time. This release ships
 with four out-of-the-box policies, enabled by default for all organizations.
 
-![Policy overview in Dashboard](./images/release-notes/policy-ea.webp)
+![Policy overview in Dashboard](../images/release-notes/policy-ea.webp)
 
 - **Base images not up-to-date** evaluates whether the base images are out of
   date, and require updating. Up-to-date base images help you ensure that your
@@ -179,7 +181,7 @@ with four out-of-the-box policies, enabled by default for all organizations.
 
 You can view and evaluate policy status for images using the Docker Scout
 Dashboard and the `docker scout policy` CLI command. For more information,
-refer to the [Policy Evaluation documentation](./policy/_index.md).
+refer to the [Policy Evaluation documentation](../policy/_index.md).
 
 #### Amazon ECR integration
 
@@ -194,7 +196,7 @@ metadata about the image contents, and not the container images themselves.
 The integration offers a straightforward process for adding additional
 repositories, activating Docker Scout for specific repositories, and removing
 the integration if needed. To learn more, refer to the [Amazon ECR integration
-documentation](./integrations/registry/ecr.md).
+documentation](../integrations/registry/ecr.md).
 
 #### Sysdig integration
 
@@ -207,19 +209,19 @@ by automatically excluding vulnerabilities in programs that are never loaded
 into memory, using VEX documents.
 
 For more information and getting started, see [Sysdig integration
-documentation](./integrations/environment/sysdig.md).
+documentation](../integrations/environment/sysdig.md).
 
 #### JFrog Artifactory integration
 
 The new JFrog Artifactory integration enables automatic image analysis on
 Artifactory registries.
 
-![Animation of how to integrate Artifactory](./images/release-notes/artifactory-agent.gif)
+![Animation of how to integrate Artifactory](../images/release-notes/artifactory-agent.gif)
 
 The integration involves deploying a Docker Scout Artifactory agent that polls
 for new images, performs analysis, and uploads results to Docker Scout, all
 while preserving the integrity of image data. Learn more in the [Artifactory
-integration documentation](./integrations/registry/artifactory.md)
+integration documentation](../integrations/registry/artifactory.md)
 
 #### Known limitations
 

--- a/data/toc.yaml
+++ b/data/toc.yaml
@@ -1405,8 +1405,12 @@ Manuals:
         section:
         - title: GitHub
           path: /scout/integrations/source-code-management/github/
-    - path: /scout/release-notes/
-      title: Release notes
+    - sectiontitle: Release notes
+      section:
+      - path: /scout/release-notes/cli/
+        title: CLI and GitHub Action
+      - path: /scout/release-notes/platform/
+        title: Platform
 
 - sectiontitle: Docker Engine
   section:


### PR DESCRIPTION
Add CLI/GHA release notes for scout to docs website

Porting only the latest minor + patch releases,
older release notes available on gh

Signed-off-by: David Karlsson <35727626+dvdksn@users.noreply.github.com>
