### PR TITLE
Update Docker Engine API docs to use "go install" for installing the Go SDK

### DIFF
--- a/content/engine/api/sdk/_index.md
+++ b/content/engine/api/sdk/_index.md
@@ -23,7 +23,7 @@ installed and coexist together.
 ### Go SDK
 
 ```console
-$ go get github.com/docker/docker/client
+$ go install github.com/docker/docker/client@latest
 ```
 
 The client requires a recent version of Go. Run `go version` and ensure that you're running a currently supported version of Go.


### PR DESCRIPTION
## Description

When installing the Docker Go SDK using the instruction at the page [Develop with Docker Engine SDKs -> Go SDK](https://docs.docker.com/engine/api/sdk/#install-the-sdks) I received the following error:
```
go get github.com/docker/docker/client
go: go.mod file not found in current directory or any parent directory.
        'go get' is no longer supported outside a module.
        To build and install a command, use 'go install' with a version,
        like 'go install example.com/cmd@latest'
        For more information, see https://golang.org/doc/go-get-install-deprecation
        or run 'go help get' or 'go help install'.
```

I was able to install using the updated command in the proposed change.