### PR TITLE
ci: remove negative glob patterns for labeler

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -24,15 +24,12 @@ area/desktop:
   - changed-files:
       - any-glob-to-any-file:
           - content/desktop/**
-          - "!content/desktop/extensions/**"
-          - "!content/desktop/extensions-sdk/**"
 
 area/engine:
   - changed-files:
       - any-glob-to-any-file:
           - content/engine/**
           - content/config/**
-          - "!content/engine/reference/commandline/*"
 
 area/install:
   - changed-files:


### PR DESCRIPTION
the negated globs caused all PRs to get the labels for engine and desktop

follow-up to #19704

