### PR TITLE
release: Compose v2.26.1

### DIFF
--- a/_vendor/modules.txt
+++ b/_vendor/modules.txt
@@ -2,4 +2,4 @@
 # github.com/moby/buildkit v0.13.0
 # github.com/docker/buildx v0.13.1
 # github.com/docker/cli v26.0.0+incompatible
-# github.com/docker/compose/v2 v2.26.0
+# github.com/docker/compose/v2 v2.26.1

--- a/content/compose/release-notes.md
+++ b/content/compose/release-notes.md
@@ -12,6 +12,19 @@ aliases:
 For more detailed information, see the [release notes in the Compose repo](https://github.com/docker/compose/releases/).
 
 ## 2.26.0
+{{< release-date date="2024-03-29" >}}
+
+### Update
+- Dependencies upgrade: opencontainers/image-spec v1.1.0
+
+### Bug fixes and enhancements
+- Added image pull failure reason in output
+- Fixed crash when running up with `--no-build` and `--watch`
+- Fixed crash when no TTY available and menu enabled
+- Improved legibility of menu actions
+
+
+## 2.26.0
 {{< release-date date="2024-03-22" >}}
 
 ### Update

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ toolchain go1.21.1
 require (
 	github.com/docker/buildx v0.13.1 // indirect
 	github.com/docker/cli v26.0.0+incompatible // indirect
-	github.com/docker/compose/v2 v2.26.0 // indirect
+	github.com/docker/compose/v2 v2.26.1 // indirect
 	github.com/moby/buildkit v0.13.0 // indirect
 	github.com/moby/moby v26.0.0+incompatible // indirect
 )

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -96,7 +96,7 @@ params:
 
   latest_engine_api_version: "1.45"
   docker_ce_version: "26.0.0"
-  compose_version: "v2.26.0"
+  compose_version: "v2.26.1"
   compose_file_v3: "3.8"
   compose_file_v2: "2.4"
   buildkit_version: "0.13.1"


### PR DESCRIPTION
## Description
Add release notes for Compose [v2.26.1](https://github.com/docker/compose/releases/tag/v2.26.1)
<!-- Tell us what you did and why -->

## Reviews
@aevesdocker 