### PR TITLE
Remove callout from create orgs page

### DIFF
--- a/content/admin/organization/orgs.md
+++ b/content/admin/organization/orgs.md
@@ -53,12 +53,6 @@ to your organization's **Settings** page.
 8. (Optional) Select annual or monthly billing cycle.
 9. Follow the on-screen instructions to pay for your subscription.
 
-   > **Note**
-   >
-   > If you've already paid for a subscription for the new organization through
-   > a Docker sales representative, then don't enter payment information.
-   > Instead, select **Back** to return to Docker Hub from the billing portal, then select **Organizations** to verify that the organization has been created.
-
 You've now created an organization.
 
 ## View an organization


### PR DESCRIPTION
<!--Delete sections as needed -->

## Description

<!-- Tell us what you did and why -->

This PR removes a callout from the create orgs page around sales-assisted org creation. Pricing is working on a better way to communicate this edge case.

## Related issues or tickets

Closes JIRA https://docker.atlassian.net/browse/ENGDOCS-2050

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Editorial review