### PR TITLE
buildx: kubernetes: add ephemeral-storage options to kuberentes-driver

### DIFF
--- a/content/build/drivers/kubernetes.md
+++ b/content/build/drivers/kubernetes.md
@@ -29,25 +29,27 @@ $ docker buildx create \
 The following table describes the available driver-specific options that you
 can pass to `--driver-opt`:
 
-| Parameter         | Type              | Default                                 | Description                                                                                                                          |
-| ----------------- | ----------------- | --------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
-| `image`           | String            |                                         | Sets the image to use for running BuildKit.                                                                                          |
-| `namespace`       | String            | Namespace in current Kubernetes context | Sets the Kubernetes namespace.                                                                                                       |
-| `replicas`        | Integer           | 1                                       | Sets the number of Pod replicas to create. See [scaling BuildKit][1]                                                                 |
-| `requests.cpu`    | CPU units         |                                         | Sets the request CPU value specified in units of Kubernetes CPU. For example `requests.cpu=100m` or `requests.cpu=2`                 |
-| `requests.memory` | Memory size       |                                         | Sets the request memory value specified in bytes or with a valid suffix. For example `requests.memory=500Mi` or `requests.memory=4G` |
-| `limits.cpu`      | CPU units         |                                         | Sets the limit CPU value specified in units of Kubernetes CPU. For example `requests.cpu=100m` or `requests.cpu=2`                   |
-| `limits.memory`   | Memory size       |                                         | Sets the limit memory value specified in bytes or with a valid suffix. For example `requests.memory=500Mi` or `requests.memory=4G`   |
-| `default-load`    | Boolean           | `false`                                 | Automatically load images to the Docker Engine image store.                                                                          |
-| `nodeselector`    | CSV string        |                                         | Sets the pod's `nodeSelector` label(s). See [node assignment][2].                                                                    |
-| `annotation`      | CSV string        |                                         | Sets additional annotations on the deployments and pods.                                                                             |
-| `labels`          | CSV string        |                                         | Sets additional labels on the deployments and pods.                                                                                  |
-| `tolerations`     | CSV string        |                                         | Configures the pod's taint toleration. See [node assignment][2].                                                                     |
-| `serviceaccount`  | String            |                                         | Sets the pod's `serviceAccountName`.                                                                                                 |
-| `rootless`        | `true`,`false`    | `false`                                 | Run the container as a non-root user. See [rootless mode][3].                                                                        |
-| `loadbalance`     | `sticky`,`random` | `sticky`                                | Load-balancing strategy. If set to `sticky`, the pod is chosen using the hash of the context path.                                   |
-| `qemu.install`    | `true`,`false`    |                                         | Install QEMU emulation for multi platforms support. See [QEMU][4].                                                                   |
-| `qemu.image`      | String            | `tonistiigi/binfmt:latest`              | Sets the QEMU emulation image. See [QEMU][4].                                                                                        |
+| Parameter                    | Type              | Default                                 | Description                                                                                                                          |
+| ---------------------------- | ----------------- | --------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
+| `image`                      | String            |                                         | Sets the image to use for running BuildKit.                                                                                          |
+| `namespace`                  | String            | Namespace in current Kubernetes context | Sets the Kubernetes namespace.                                                                                                       |
+| `default-load`               | Boolean           | `false`                                 | Automatically load images to the Docker Engine image store.                                                                          |
+| `replicas`                   | Integer           | 1                                       | Sets the number of Pod replicas to create. See [scaling BuildKit][1]                                                                 |
+| `requests.cpu`               | CPU units         |                                         | Sets the request CPU value specified in units of Kubernetes CPU. For example `requests.cpu=100m` or `requests.cpu=2`                 |
+| `requests.memory`            | Memory size       |                                         | Sets the request memory value specified in bytes or with a valid suffix. For example `requests.memory=500Mi` or `requests.memory=4G` |
+| `requests.ephemeral-storage` | Storage size      |                                         | Sets the request ephemeral-storage value specified in bytes or with a valid suffix. For example `requests.ephemeral-storage=2Gi`     |
+| `limits.cpu`                 | CPU units         |                                         | Sets the limit CPU value specified in units of Kubernetes CPU. For example `requests.cpu=100m` or `requests.cpu=2`                   |
+| `limits.memory`              | Memory size       |                                         | Sets the limit memory value specified in bytes or with a valid suffix. For example `requests.memory=500Mi` or `requests.memory=4G`   |
+| `limits.ephemeral-storage`   | Storage size      |                                         | Sets the limit ephemeral-storage value specified in bytes or with a valid suffix. For example `requests.ephemeral-storage=100M`      |
+| `nodeselector`               | CSV string        |                                         | Sets the pod's `nodeSelector` label(s). See [node assignment][2].                                                                    |
+| `annotation`                 | CSV string        |                                         | Sets additional annotations on the deployments and pods.                                                                             |
+| `labels`                     | CSV string        |                                         | Sets additional labels on the deployments and pods.                                                                                  |
+| `tolerations`                | CSV string        |                                         | Configures the pod's taint toleration. See [node assignment][2].                                                                     |
+| `serviceaccount`             | String            |                                         | Sets the pod's `serviceAccountName`.                                                                                                 |
+| `rootless`                   | `true`,`false`    | `false`                                 | Run the container as a non-root user. See [rootless mode][3].                                                                        |
+| `loadbalance`                | `sticky`,`random` | `sticky`                                | Load-balancing strategy. If set to `sticky`, the pod is chosen using the hash of the context path.                                   |
+| `qemu.install`               | `true`,`false`    |                                         | Install QEMU emulation for multi platforms support. See [QEMU][4].                                                                   |
+| `qemu.image`                 | String            | `tonistiigi/binfmt:latest`              | Sets the QEMU emulation image. See [QEMU][4].                                                                                        |
 
 [1]: #scaling-buildkit
 [2]: #node-assignment
@@ -66,7 +68,7 @@ is configurable using the following driver options:
   only creates a single pod. Increasing the number of replicas lets you take
   advantage of multiple nodes in your cluster.
 
-- `requests.cpu`, `requests.memory`, `limits.cpu`, `limits.memory`
+- `requests.cpu`, `requests.memory`, `requests.ephemeral-storage`, `limits.cpu`, `limits.memory`, `limits.ephemeral-storage`
 
   These options allow requesting and limiting the resources available to each
   BuildKit pod according to the official Kubernetes documentation


### PR DESCRIPTION
## Description

Enhances the documentation by incorporating two newly added parameters, `requests.ephemeral-storage` and `limits.ephemeral-storage`.

## Related issues or tickets

issue: https://github.com/docker/buildx/issues/2369
PR to docker/buildx: https://github.com/docker/buildx/pull/2370

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Technical review
- [ ] Editorial review
- [ ] Product review