### PR TITLE
scout: add release note about CVE-2024-3094

### DIFF
--- a/content/scout/policy/_index.md
+++ b/content/scout/policy/_index.md
@@ -135,6 +135,7 @@ The list includes the following vulnerabilities:
 - [CVE-2021-44228 (Log4Shell)](https://scout.docker.com/v/CVE-2021-44228)
 - [CVE-2023-38545 (cURL SOCKS5 heap buffer overflow)](https://scout.docker.com/v/CVE-2023-38545)
 - [CVE-2023-44487 (HTTP/2 Rapid Reset)](https://scout.docker.com/v/CVE-2023-44487)
+- [CVE-2024-3094 (XZ backdoor)](https://scout.docker.com/v/CVE-2024-3094)
 
 You can configure the CVEs included in this list by creating a custom policy.
 For more information, see [Configure policies](./configure.md).

--- a/content/scout/release-notes/platform.md
+++ b/content/scout/release-notes/platform.md
@@ -18,6 +18,14 @@ for what's coming next.
 
 New features and enhancements released in the first quarter of 2024.
 
+### 2024-03-29
+
+The **High-profile vulnerabilities** policy now reports the `xz` backdoor
+vulnerability [CVE-2024-3094](https://scout.docker.com/v/CVE-2024-3094). Any
+images in your Docker organization containing the version of `xz/liblzma` with
+the backdoor will be non-compliant with the **High-profile vulnerabilities**
+policy.
+
 ### 2024-03-20
 
 The **Fixable critical and high vulnerabilities** policy now supports a


### PR DESCRIPTION
## Description

Adds the `xz/liblzma` backdoor vulnerability (CVE-2024-3094) to the **High-profile vulnerabilities** policy.

