### PR TITLE
fix: remove underscore in buildx debug build title

### DIFF
--- a/content/reference/cli/docker/buildx/debug/build.md
+++ b/content/reference/cli/docker/buildx/debug/build.md
@@ -1,7 +1,7 @@
 ---
 datafolder: buildx
 datafile: docker_buildx_debug_build
-title: docker buildx debug_build
+title: docker buildx debug build
 layout: cli
 aliases:
 - /engine/reference/commandline/buildx_debug_build/


### PR DESCRIPTION
## Description

Removes an underscore in a title

## Related issues or tickets

Closes #19723
