### PR TITLE
installation-docs: systemctl start/enable

### DIFF
--- a/content/engine/install/ubuntu.md
+++ b/content/engine/install/ubuntu.md
@@ -160,7 +160,16 @@ Docker from the repository.
    {{< /tab >}}
    {{< /tabs >}}
 
-3. Verify that the Docker Engine installation is successful by running the
+3. Start and enable Docker in `systemctl`
+   
+   ```console
+   $ systemctl start docker
+   $ systemctl enable docker
+   ```
+   
+    You can check the status by running `systemctl status docker`.
+
+4. Verify that the Docker Engine installation is successful by running the
    `hello-world` image.
 
    ```console


### PR DESCRIPTION
<!--Delete sections as needed -->

## Description
I added a step in the installation guide with the commands to start and enable docker in `systemctl`.

<!-- Tell us what you did and why -->

In the installation guide between points 2 and 3 there was a step missing. The start and enabling of docker in `systemctl`. This is an important step because without running this commands you will encounter the error `docker: Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?.`. The error exists in stack over flow and the accepted answer is related to `systemctl`.

## Related issues or tickets

[StackOverFlow Error](https://stackoverflow.com/questions/71815092/docker-cannot-connect-to-the-docker-daemon-at-unix-var-run-docker-sock-is-th)

<!-- Related issues, pull requests, or Jira tickets -->

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Technical review
- [ x] Editorial review
- [ ] Product review