### PR TITLE
scout: simplify dashboard instructions with direct links

### DIFF
--- a/content/billing/scout-billing.md
+++ b/content/billing/scout-billing.md
@@ -15,16 +15,13 @@ In this section, learn how to buy and manage a Docker Scout Team subscription fo
 
 ## Buy Docker Scout Team
 
-1. Sign in to [Docker Scout](https://scout.docker.com/) with your Docker ID.
-2. Select your personal account or organization namespace from the drop-down in the navigation menu on the left side of the screen.
-3. Select **Settings**.
-4. Select **Billing**.
-5. The default plan is Docker Scout Free. Next to the plan name, select **Change plan**.
-6. Select **Purchase Scout Team**.
-7. Choose annual or monthly billing cycle, then select the number of Scout-enabled repositories you want from the repository quantity drop-down. You can select groups of five.
-8. Select **Continue to payment**.
-9. This redirects you to the payment processing page. Enter your email if this field isn't pre-populated. Then, enter your payment information.
-10. Select **Subscribe**.
+1. Go to [Billing settings](https://scout.docker.com/settings/billing) in the Docker Scout Dashboard.
+2. The default plan is Docker Scout Free. Next to the plan name, select **Change plan**.
+3. Select **Purchase Scout Team**.
+4. Choose annual or monthly billing cycle, then select the number of Scout-enabled repositories you want from the repository quantity drop-down. You can select groups of five.
+5. Select **Continue to payment**.
+6. This redirects you to the payment processing page. Enter your email if this field isn't pre-populated. Then, enter your payment information.
+7. Select **Subscribe**.
 
 Subscribing redirects you back to the billing page in Docker Scout, where you can find your active Docker Scout plan. Once your purchase is complete, you receive a confirmation email and a copy of your invoice.
 
@@ -46,23 +43,17 @@ On a Docker Scout Team plan, you can add or remove the number of repositories as
 
 To add repositories:
 
-1. Sign in to [Docker Scout](https://scout.docker.com/) with your Docker ID.
-2. Select your personal account or organization namespace from the drop-down in the navigation menu on the left side of the screen.
-3. Select **Settings**.
-4. Select **Billing**.
-5. Select **Add repositories**.
-6. Select the number of repositories you want to add, then select **Purchase**.
+1. Go to [Billing settings](https://scout.docker.com/settings/billing) in the Docker Scout Dashboard.
+2. Select **Add repositories**.
+3. Select the number of repositories you want to add, then select **Purchase**.
 
 This purchase charges your default payment method.
 
 To remove repositories:
 
-1. Sign in to [Docker Scout](https://scout.docker.com/) with your Docker ID.
-2. Select your personal account or organization namespace from the drop-down in the navigation menu on the left side of the screen.
-3. Select **Settings**.
-4. Select **Billing**.
-5. Select **Remove repositories**.
-6. Select the number of repositories you want to remove, then select **Remove**.
+1. Go to [Billing settings](https://scout.docker.com/settings/billing) in the Docker Scout Dashboard.
+2. Select **Remove repositories**.
+3. Select the number of repositories you want to remove, then select **Remove**.
 
 The number of repositories updates on your next billing cycle.
 
@@ -81,20 +72,14 @@ You can downgrade from Docker Scout Team or Docker Scout Business to a Docker Sc
 >
 { .tip }
 
-1. Sign in to [Docker Scout](https://scout.docker.com/) with your Docker ID.
-2. Select your personal account or organization namespace from the drop-down in the navigation menu on the left side of the screen.
-3. Select **Settings**.
-4. Select **Billing**.
-5. Find your Docker Scout plan, then select **Change plan**.
-6. On the Docker Scout Free card, select **Downgrade to this plan**, then review the warning message.
-7. To confirm the downgrade, select **Continue to Downgrade**.
+1. Go to [Billing settings](https://scout.docker.com/settings/billing) in the Docker Scout Dashboard.
+2. Find your Docker Scout plan, then select **Change plan**.
+3. On the Docker Scout Free card, select **Downgrade to this plan**, then review the warning message.
+4. To confirm the downgrade, select **Continue to Downgrade**.
 
 ### Cancel your subscription downgrade
 
 You can cancel a subscription downgrade at anytime before the end of the billing cycle. You can find this date in the details for your current plan.
 
-1. Sign in to [Docker Scout](https://scout.docker.com/) with your Docker ID.
-2. Select your personal account or organization namespace from the drop-down in the navigation menu on the left side of the screen.
-3. Select **Settings**.
-4. Select **Billing**.
-5. Select **Cancel the downgrade** in the top-right corner of your billing details page.
+1. Go to [Billing settings](https://scout.docker.com/settings/billing) in the Docker Scout Dashboard.
+2. Select **Cancel the downgrade** in the top-right corner of your billing details page.

--- a/content/scout/image-analysis.md
+++ b/content/scout/image-analysis.md
@@ -46,12 +46,9 @@ See [Container registry integrations](./integrations/_index.md#container-registr
 
 To activate image analysis:
 
-1. Go to the [Docker Scout Dashboard](https://scout.docker.com/)
-2. Sign in with your Docker ID.
-3. Make sure that the correct Docker organization is selected.
-4. Open the settings menu and select **Repository settings**.
-5. Select the repositories that you want to enable.
-6. Select **Enable image analysis**.
+1. Go to [Repository settings](https://scout.docker.com/settings/repos) in the Docker Scout Dashboard.
+2. Select the repositories that you want to enable.
+3. Select **Enable image analysis**.
 
 If your repositories already contain images,
 Docker Scout pulls and analyzes the latest images automatically.
@@ -85,12 +82,9 @@ analysis is activated.
    > The default `docker` driver only supports build attestations if you use the
    > [containerd image store](../desktop/containerd.md).
 
-3. Go to the [Docker Scout Dashboard](https://scout.docker.com/)
-4. Sign in with your Docker ID.
-5. Select the Docker organization that contains the image you just pushed.
-6. Go to the **Images** tab. The image appears in the list shortly after you
-   push it to the registry.
+3. Go to the [Images page](https://scout.docker.com/reports/images) in the Docker Scout Dashboard.
 
+   The image appears in the list shortly after you push it to the registry.
    It may take a few minutes for the analysis results to appear.
 
 ## Analyze images locally

--- a/content/scout/integrations/environment/_index.md
+++ b/content/scout/integrations/environment/_index.md
@@ -90,10 +90,9 @@ $ docker scout compare --to-env production myorg/webapp:latest
 
 To view the images for an environment:
 
-1. Go to the [Docker Scout Dashboard](https://scout.docker.com/).
-2. Select the **Images** tab.
-3. Open the **Environments** drop-down menu.
-4. Select the environment that you want to view.
+1. Go to the [Images page](https://scout.docker.com/) in the Docker Scout Dashboard.
+2. Open the **Environments** drop-down menu.
+3. Select the environment that you want to view.
 
 The list displays all images that have been assigned to the selected
 environment. If you've deployed multiple versions of the same image in an

--- a/content/scout/integrations/environment/sysdig.md
+++ b/content/scout/integrations/environment/sysdig.md
@@ -99,5 +99,5 @@ monitoring](./_index.md).
 > If you created a new environment for this integration, the environment
 > appears in Docker Scout when at least one image has been analyzed.
 
-To integrate more clusters, go to the [Sysdig integrations page](https://scout.docker.com/settings/integrations/sysdig/),
-select **Sysdig** > **Manage** and select the **Add** button.
+To integrate more clusters, go to the [Sysdig integrations page](https://scout.docker.com/settings/integrations/sysdig/)
+and select the **Add** button.

--- a/content/scout/integrations/registry/acr.md
+++ b/content/scout/integrations/registry/acr.md
@@ -68,19 +68,17 @@ the Azure resources.
 
 ## Integrate a registry
 
-1. Go to [Integrations](https://scout.docker.com/settings/integrations/) on the
+1. Go to [ACR integration page](https://scout.docker.com/settings/integrations/azure/) on the
    Docker Scout Dashboard.
-2. Select the **Analyze my images from another registry** filter option.
-3. Find **Azure Container Registry** in the list, and select **Integrate**.
-4. In the **How to integrate** section, enter the **Registry hostname** of the
+2. In the **How to integrate** section, enter the **Registry hostname** of the
    registry you want to integrate.
-5. Select **Next**.
-6. Select **Deploy to Azure** to open the template deployment wizard in Azure.
+3. Select **Next**.
+4. Select **Deploy to Azure** to open the template deployment wizard in Azure.
 
    You may be prompted to sign in to your Azure account if you're not already
    signed in.
 
-7. In the template wizard, configure your deployment:
+5. In the template wizard, configure your deployment:
 
    - **Resource group**: enter the same resource group as you're using for the
      container registry. The Docker Scout resources must be deployed to the
@@ -89,21 +87,21 @@ the Azure resources.
    - **Registry name**: the field is pre-filled with the subdomain of the
      registry hostname.
 
-8. Select **Review + create**, and then **Create** to deploy the template.
+6. Select **Review + create**, and then **Create** to deploy the template.
 
-9. Wait until the deployment is complete.
-10. In the **Deployment details** section click on the newly created resource
+7. Wait until the deployment is complete.
+8. In the **Deployment details** section click on the newly created resource
     of the type **Container registry token**. Generate a new password for this token.
     
     Alternatively, use the search function in Azure to navigate to the
     **Container registry** resource that you're looking to integrate, and
     generate the new password for the created access token.
 
-11. Copy the generated password and head back to the Docker Scout Dashboard to
+9. Copy the generated password and head back to the Docker Scout Dashboard to
     finalize the integration.
 
-12. Paste the generated password into the **Registry token** field.
-13. Select **Enable integration**.
+10. Paste the generated password into the **Registry token** field.
+11. Select **Enable integration**.
 
 After selecting **Enable integration**, Docker Scout performs a connection test
 to verify the integration. If the verification was successful, you're
@@ -111,7 +109,7 @@ redirected to the Azure registry summary page, which shows you all your Azure
 integrations for the current organization.
 
 Next, activate Docker Scout for the repositories that you want to analyze in
-[repository settings](https://scout.docker.com/settings/repos/).
+[Repository settings](https://scout.docker.com/settings/repos/).
 
 After activating repositories, images that you push are analyzed by Docker
 Scout. The analysis results appear in the Docker Scout Dashboard.

--- a/content/scout/integrations/registry/artifactory.md
+++ b/content/scout/integrations/registry/artifactory.md
@@ -179,14 +179,12 @@ line flag.
 
 You can view the image analysis results in the Docker Scout Dashboard.
 
-1. Go to [Docker Scout Dashboard](https://scout.docker.com).
-2. Sign in using your Docker ID.
+1. Go to [Images page](https://scout.docker.com/reports/images/) in the Docker Scout Dashboard.
 
-   Once signed in, you're taken to the **Images** page. This page displays the
-   repositories in your organization connected to Docker Scout.
+   This page displays the Docker Scout-enabled repositories in your organization.
 
-3. Select the image in the list.
-4. Select the tag.
+2. Select the image in the list.
+3. Select the tag.
 
 When you have selected a tag, you're taken to the vulnerability report for that
 tag. Here, you can select if you want to view all vulnerabilities in the image,

--- a/content/scout/integrations/registry/ecr.md
+++ b/content/scout/integrations/registry/ecr.md
@@ -116,7 +116,7 @@ To add additional registries:
    is **Connected**.
 
 Next, activate Docker Scout for the repositories that you want to analyze in
-[repository settings](https://scout.docker.com/settings/repos/).
+[Repository settings](https://scout.docker.com/settings/repos/).
 
 ## Remove integration
 

--- a/content/scout/policy/_index.md
+++ b/content/scout/policy/_index.md
@@ -134,7 +134,7 @@ The list includes the following vulnerabilities:
 - [CVE-2014-0160 (OpenSSL Heartbleed)](https://scout.docker.com/v/CVE-2014-0160)
 - [CVE-2021-44228 (Log4Shell)](https://scout.docker.com/v/CVE-2021-44228)
 - [CVE-2023-38545 (cURL SOCKS5 heap buffer overflow)](https://scout.docker.com/v/CVE-2023-38545)
-- [CVE-2023-44487 (HTTP/2 Rapid Reset)](https://scout.docker.com/v/CVE-2023-44487)
+:cc
 - [CVE-2024-3094 (XZ backdoor)](https://scout.docker.com/v/CVE-2024-3094)
 
 You can configure the CVEs included in this list by creating a custom policy.
@@ -306,13 +306,11 @@ You can also configure the policy to:
 
 This policy isn't enabled by default. To enable the policy:
 
-1. Go to the [Docker Scout Dashboard](https://scout.docker.com/).
-2. Go to the **Policies** section.
-3. Select the **Unapproved base images** policy in the list.
-4. Enter the patterns that you want to allow.
-5. Select whether you want to allow only supported tags or supported distro
-   versions of official images.
-6. Select **Save and enable**.
+1. [Create a new policy](https://scout.docker.com/reports/policies/create?fromDefinition=approved-base-images&fromNamespace=docker) in the Docker Scout Dashboard.
+2. Under **Approved base image sources**, specify the image reference patterns that you want to allow.
+3. Select whether you want to allow only supported tags for official images,
+   and supported Linux distribution versions.
+4. Select **Save and enable**.
 
    The policy is now enabled for your current organization.
 

--- a/content/scout/policy/configure.md
+++ b/content/scout/policy/configure.md
@@ -21,23 +21,20 @@ policy you used as a base for your custom policy.
 
 To configure a policy:
 
-1. Go to the [Docker Scout Dashboard](https://scout.docker.com/).
-2. Go to the **Policies** section.
-3. Select the policy you want to configure.
-4. Select the **View configuration** button to open the policy configuration.
+1. Go to the [Policies page](https://scout.docker.com/reports/policy) in the Docker Scout Dashboard.
+2. Select the policy you want to configure.
+3. Select **View policy details** to open the policy side panel.
 
-   If the button is disabled, the selected policy doesn't have any
+   If this button is grayed out, then the selected policy doesn't have any
    configuration parameters.
 
-5. Select the **Edit policy** button. This prompts you to create a clone of the
-   default policy.
-6. Select **Copy and edit policy** to create a clone of the default policy.
-7. Update the policy parameters.
-8. Save the changes:
+4. In the side panel, select **Copy to customize** to open the policy configuration page.
+5. Update the policy parameters.
+6. Save the changes:
 
    - Select **Save and enable** to commit the changes and enable the policy for
      your current organization.
-   - Select **Save changes** to save the policy configuration without enabling
+   - Select **Save policy** to save the policy configuration without enabling
      it.
 
 ## Disable a policy
@@ -50,7 +47,6 @@ still be available.
 
 To disable a policy:
 
-1. Go to the [Docker Scout Dashboard](https://scout.docker.com/).
-2. Go to the **Policies** section.
-3. Select the policy you want to disable.
-4. Select **Disable policy**.
+1. Go to the [Policies page](https://scout.docker.com/reports/policy) in the Docker Scout Dashboard.
+2. Select the policy you want to disable.
+3. Select the **Disable** button.

--- a/content/scout/policy/remediation.md
+++ b/content/scout/policy/remediation.md
@@ -30,9 +30,8 @@ prerequisites that ensure Docker Scout can successfully evaluate the policy.
 Recommendations appear on the policy details pages of the Docker Scout
 Dashboard. To get to this page:
 
-1. Open the [Docker Scout Dashboard](https://scout.docker.com/)
-2. Go to the **Policies** page.
-3. Select a policy in the list.
+1. Go to the [Policies page](https://scout.docker.com/reports/policy) in the Docker Scout Dashboard.
+2. Select a policy in the list.
 
 The policy details page groups evaluation results into two different tabs
 depending on the policy status:

--- a/content/scout/quickstart.md
+++ b/content/scout/quickstart.md
@@ -220,9 +220,9 @@ results through a different lens: the Docker Scout Dashboard.
 
 1. Open the [Docker Scout Dashboard](https://scout.docker.com/).
 2. Sign in with your Docker account.
-3. Go to the **Images** tab.
+3. Select **Images** in the left-hand navigation.
 
-The images tab lists your Scout-enabled repositories.
+The images page lists your Scout-enabled repositories.
 Select the image in the list to open the **Image details** sidebar.
 The sidebar shows a compliance overview for the last pushed tag of a repository.
 


### PR DESCRIPTION
## Description

Simplify the instructions for how to use the Docker Scout Dashboard, by replacing lengthy descriptions on how to navigate the site, and instead embedding direct links to specific pages in the docs.

## Related issues or tickets

https://docker.atlassian.net/browse/SDC-767
