### PR TITLE
build: git remote authentication secrets

### DIFF
--- a/hugo_stats.json
+++ b/hugo_stats.json
@@ -400,6 +400,7 @@
       "xl:grid-cols-1",
       "xl:grid-cols-2",
       "xl:grid-cols-3",
+      "youtube-video",
       "z-10",
       "z-20",
       "z-30"


### PR DESCRIPTION
`GIT_AUTH_TOKEN` and `GIT_AUTH_HEADER` pre-defined secrets for authenticating to a remote Git server with BuildKit

https://deploy-preview-19739--docsdocker.netlify.app/build/building/secrets/#git-authentication-for-remote-contexts

