### PR TITLE
redirects: catch old dockerfile reference location

### DIFF
--- a/data/redirects.yml
+++ b/data/redirects.yml
@@ -691,6 +691,7 @@
 "/reference/dockerfile":
   - /go/dockerfile-reference/
   - /engine/reference/builder/
+  - /reference/builder/
 "/get-started/04_sharing_app":
   - /go/get-started-sharing/
 


### PR DESCRIPTION
Closes #19744 (and whatever other links there are to this url out in the wild)
