### PR TITLE
docs: use buildkit-cache-dance v3.1.0 for cache mounts example

### DIFF
--- a/content/build/ci/github-actions/cache.md
+++ b/content/build/ci/github-actions/cache.md
@@ -137,71 +137,62 @@ jobs:
 
 BuildKit doesn't preserve cache mounts in the GitHub Actions cache by default.
 If you wish to put your cache mounts into GitHub Actions cache and reuse it
-between builds, you can use a workaround provided by
+between builds, you can use this action provided by
 [`reproducible-containers/buildkit-cache-dance`](https://github.com/reproducible-containers/buildkit-cache-dance).
 
 This GitHub Action creates temporary containers to extract and inject the
 cache mount data with your Docker build steps.
 
-The following example shows how to use this workaround with a Go project.
+The following example shows how to cache the apt packages.
 
-Example Dockerfile in `build/package/Dockerfile`
+Example `Dockerfile`:
 ```Dockerfile
-FROM golang:1.21.1-alpine as base-build
-
-WORKDIR /build
-RUN go env -w GOMODCACHE=/root/.cache/go-build
-
-COPY go.mod go.sum ./
-RUN --mount=type=cache,target=/root/.cache/go-build go mod download
-
-COPY ./src ./
-RUN --mount=type=cache,target=/root/.cache/go-build go build -o /bin/app /build/src
-...
+FROM ubuntu:22.04
+ENV DEBIAN_FRONTEND=noninteractive
+RUN \
+  --mount=type=cache,target=/var/cache/apt,sharing=locked \
+  --mount=type=cache,target=/var/lib/apt,sharing=locked \
+  rm -f /etc/apt/apt.conf.d/docker-clean && \
+  echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' >/etc/apt/apt.conf.d/keep-cache && \
+  apt-get update && \
+  apt-get install -y gcc
 ```
 
 Example CI action
 ```yaml
-name: ci
-on: push
+name: CI
+on:
+  push:
 
 jobs:
-  build:
-    name: Build
-    runs-on: ubuntu-latest
+  Build:
+    runs-on: ubuntu-22.04
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Docker meta
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/metadata-action@v5
         id: meta
-        uses: docker/metadata-action@v5
         with:
-          images: YOUR_IMAGE
-          tags: |
-            type=ref,event=branch
-            type=ref,event=pr
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
+          images: Build
 
-      - name: Go Build Cache for Docker
+      - name: Cache
         uses: actions/cache@v3
+        id: cache
         with:
-          path: go-build-cache
-          key: ${{ runner.os }}-go-build-cache-${{ hashFiles('**/go.sum') }}
+          path: |
+            var-cache-apt
+            var-lib-apt
+          key: cache-${{ hashFiles('.github/workflows/test/Dockerfile') }}
 
-      - name: inject go-build-cache into docker
-        # v1 was composed of two actions: "inject" and "extract".
-        # v2 is unified to a single action.
-        uses: reproducible-containers/buildkit-cache-dance@v2.1.2
+      - name: Inject cache into docker
+        uses: reproducible-containers/buildkit-cache-dance@v3.1.0
         with:
-          cache-source: go-build-cache
+          cache-map: |
+            {
+              "var-cache-apt": "/var/cache/apt",
+              "var-lib-apt": "/var/lib/apt"
+            }
+          skip-extraction: ${{ steps.cache.outputs.cache-hit }}
 
       - name: Build and push
         uses: docker/build-push-action@v5
@@ -209,11 +200,11 @@ jobs:
           context: .
           cache-from: type=gha
           cache-to: type=gha,mode=max
-          file: build/package/Dockerfile
+          file: Dockerfile
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          platforms: linux/amd64,linux/arm64
+
 ```
 
 For more information about this workaround, refer to the


### PR DESCRIPTION


<!--Delete sections as needed -->

## Description

This updates the example for caching mounts in GitHub Actions based on `v3.1.0`:

https://github.com/reproducible-containers/buildkit-cache-dance

## Related issues or tickets

<!-- Related issues, pull requests, or Jira tickets -->

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Technical review
- [ ] Editorial review
- [ ] Product review