### PR TITLE
Update kubectl get nodes output example

### DIFF
--- a/content/desktop/kubernetes.md
+++ b/content/desktop/kubernetes.md
@@ -68,7 +68,7 @@ You can test the command by listing the available nodes:
 $ kubectl get nodes
 
 NAME                 STATUS    ROLES     AGE       VERSION
-docker-desktop       Ready     master    3h        v1.19.7
+docker-desktop       Ready     control-plane    3h        v1.29.1
 ```
 
 For more information about `kubectl`, see the


### PR DESCRIPTION
## Description

I just updated the output of the kubectl get nodes command, as master has been deprecated in favor of control-plane some time ago.

## Related issues or tickets

none

## Reviews

Anyone can look at this.