### PR TITLE
compose: add volume subpath to spec

### DIFF
--- a/content/compose/compose-file/05-services.md
+++ b/content/compose/compose-file/05-services.md
@@ -1728,6 +1728,7 @@ services:
         target: /data
         volume:
           nocopy: true
+          subpath: sub
       - type: bind
         source: /var/run/postgres/postgres.sock
         target: /var/run/postgres/postgres.sock
@@ -1779,6 +1780,7 @@ expressed in the short form.
   - `selinux`: The SELinux re-labeling option `z` (shared) or `Z` (private)
 - `volume`: Configures additional volume options:
   - `nocopy`: Flag to disable copying of data from a container when a volume is created.
+  - `subpath`: Path inside a volume to mount instead of the volume root.
 - `tmpfs`: Configures additional tmpfs options:
   - `size`: The size for the tmpfs mount in bytes (either numeric or as bytes unit).
   - `mode`: The file mode for the tmpfs mount as Unix permission bits as an octal number.


### PR DESCRIPTION
## Description
Add volume `subpath` to Compose spec for a service.

Imported from compose-spec.

⚠️ This requires Moby v26 (v4.29+)

## Related issues or tickets
* https://github.com/compose-spec/compose-spec/pull/471

## Reviews
@aevesdocker 