### PR TITLE
Update docs for host networking

### DIFF
--- a/content/desktop/networking.md
+++ b/content/desktop/networking.md
@@ -185,5 +185,8 @@ container to random ports on the host.
 $ docker run -d -P --name webserver nginx
 ```
 
+Alternatively, you can also use [host networking](../network/drivers/host.md)
+to give the container direct access to the network stack of the host.
+
 See the [run command](../reference/cli/docker/container/run.md) for more details on
 publish options used with `docker run`.

--- a/content/network/network-tutorial-host.md
+++ b/content/network/network-tutorial-host.md
@@ -23,8 +23,10 @@ host.
   Nginx listen on a different port, see the
   [documentation for the `nginx` image](https://hub.docker.com/_/nginx/)
 
-- The `host` networking driver only works on Linux hosts, and is not supported
-  on Docker Desktop for Mac, Docker Desktop for Windows, or Docker EE for Windows Server.
+- The `host` networking driver only works on Linux hosts, but is availabe as a
+  [beta feature](../../release-lifecycle.md#beta) on Docker Desktop version 4.29
+  and later for Mac, Windows, and Linux. To enable this feature, navigate to the
+  **Features in development** tab in **Settings**, and then select **Enable host networking**.
 
 ## Procedure
 


### PR DESCRIPTION
## Description

Update docs for host networking

The page https://docs.docker.com/desktop/faqs/general/#how-do-i-connect-from-a-container-to-a-service-on-the-host
doesn't need to be updated IMHO because it already refers to https://docs.docker.com/desktop/networking/#i-want-to-connect-from-a-container-to-a-service-on-the-host for details anyway.

## Related issues or tickets

https://docker.atlassian.net/browse/POS-891

## Reviews

- [ ] Technical review
- [ ] Editorial review
- [ ] Product review