### PR TITLE
FIX: Update 05_persisting_data.md (error in the cmd for running a container and mounting a volume in Git Bash)

### DIFF
--- a/content/get-started/05_persisting_data.md
+++ b/content/get-started/05_persisting_data.md
@@ -111,7 +111,7 @@ You can create the volume and start the container using the CLI or Docker Deskto
    > If you're using Git Bash, you must use different syntax for this command.
    >
    > ```console
-   > $ docker run -dp 127.0.0.1:3000:3000 --mount type=volume,src=todo-db, target=//etc/todos getting-started
+   > $ docker run -dp 127.0.0.1:3000:3000 --mount type=volume,src=todo-db,target=//etc/todos getting-started
    > ```
    >
    > For more details about Git Bash's syntax differences, see


### PR DESCRIPTION


## Description
An extra space space after:
`--mount type=volume,src=todo-db,`

gives the following error:

invalid argument "type=volume,src=todo-db" for "--mount" flag: target is required See 'docker run --help'.
![image](https://github.com/docker/docs/assets/86506425/6e8ba8a4-77d9-44f4-a7b4-56f3386c8c7d)

---

## Reviews

After removing the extra space, it works as expected:

![image](https://github.com/docker/docs/assets/86506425/7d800910-d5d7-429f-98b8-0a3b97be6d5e)

