### PR TITLE
cli: move config etc to base command

### DIFF
--- a/content/compose/environment-variables/envvars.md
+++ b/content/compose/environment-variables/envvars.md
@@ -6,7 +6,7 @@ aliases:
 - /compose/reference/envvars/
 ---
 
-Compose already comes with pre-defined environment variables. It also inherits common Docker CLI environment variables, such as `DOCKER_HOST` and `DOCKER_CONTEXT`. See [Docker CLI environment variable reference](/engine/reference/commandline/cli/#environment-variables) for details.
+Compose already comes with pre-defined environment variables. It also inherits common Docker CLI environment variables, such as `DOCKER_HOST` and `DOCKER_CONTEXT`. See [Docker CLI environment variable reference](/reference/cli/docker/#environment-variables) for details.
 
 This page contains information on how you can set or change the following pre-defined environment variables if you need to:
 
@@ -187,7 +187,7 @@ For more information, see [Migrate to Compose V2](../migrate.md).
 
 - `COMPOSE_API_VERSION`
     By default the API version is negotiated with the server. Use `DOCKER_API_VERSION`.  
-    See the [Docker CLI environment variable reference](../../../engine/reference/commandline/cli/#environment-variables) page.
+    See the [Docker CLI environment variable reference](../../../reference/cli/docker/#environment-variables) page.
 - `COMPOSE_HTTP_TIMEOUT`
 - `COMPOSE_TLS_VERSION`
 - `COMPOSE_FORCE_WINDOWS_HOST`

--- a/content/docker-hub/api/latest.yaml
+++ b/content/docker-hub/api/latest.yaml
@@ -64,7 +64,7 @@ tags:
       The Personal Access Token endpoints lets you manage personal access tokens. For more 
       information, see [Access Tokens](https://docs.docker.com/security/for-developers/access-tokens/).
 
-      You can use a personal access token instead of a password in the [Docker CLI](https://docs.docker.com/engine/reference/commandline/cli/) 
+      You can use a personal access token instead of a password in the [Docker CLI](https://docs.docker.com/reference/cli/docker/) 
       or in the [Create an authentication token](#operation/PostUsersLogin) route to obtain a bearer 
       token.
 

--- a/content/engine/security/trust/deploying_notary.md
+++ b/content/engine/security/trust/deploying_notary.md
@@ -22,7 +22,7 @@ The easiest way to deploy Notary Server is by using Docker Compose. To follow th
 
 3. Make sure that your Docker or Notary client trusts Notary Server's certificate before you try to interact with the Notary server.
 
-See the instructions for [Docker](../../../engine/reference/commandline/cli.md#notary) or
+See the instructions for [Docker](/reference/cli/docker/#notary) or
 for [Notary](https://github.com/docker/notary#using-notary) depending on which one you are using.
 
 ## If you want to use Notary in production

--- a/content/network/proxy.md
+++ b/content/network/proxy.md
@@ -78,7 +78,7 @@ The following table describes the available configuration parameters.
 These settings are used to configure proxy environment variables for containers
 only, and not used as proxy settings for the Docker CLI or the Docker Engine
 itself.
-Refer to the [environment variables](/engine/reference/commandline/cli/#environment-variables)
+Refer to the [environment variables](/reference/cli/docker/#environment-variables)
 and [configure the Docker daemon to use a proxy server](../config/daemon/proxy.md#httphttps-proxy)
 sections for configuring proxy settings for the CLI and daemon.
 

--- a/content/reference/_index.md
+++ b/content/reference/_index.md
@@ -15,7 +15,7 @@ grid_clis:
 - title: Docker CLI
   description: The main Docker CLI, includes all `docker` commands.
   icon: terminal
-  link: /engine/reference/commandline/cli/
+  link: /reference/cli/docker/
 - title: Compose CLI
   description: The CLI for Docker Compose, for building and running multi-container
     applications.

--- a/content/reference/cli/docker/_index.md
+++ b/content/reference/cli/docker/_index.md
@@ -14,6 +14,11 @@ aliases:
 - /engine/reference/commandline/registry_ls/
 - /engine/reference/commandline/registry_rmi/
 - /engine/reference/commandline/docker/
+- /reference/commandline/cli/
+- /engine/reference/commandline/engine/
+- /engine/reference/commandline/engine_activate/
+- /engine/reference/commandline/engine_check/
+- /engine/reference/commandline/engine_update/
 layout: cli
 ---
 

--- a/data/engine-cli/docker.yaml
+++ b/data/engine-cli/docker.yaml
@@ -1,6 +1,340 @@
 command: docker
 short: The base command for the Docker CLI.
-long: The base command for the Docker CLI.
+long: |-
+    Depending on your Docker system configuration, you may be required to preface
+    each `docker` command with `sudo`. To avoid having to use `sudo` with the
+    `docker` command, your system administrator can create a Unix group called
+    `docker` and add users to it.
+
+    For more information about installing Docker or `sudo` configuration, refer to
+    the [installation](/install/) instructions for your operating system.
+
+    ### Display help text
+
+    To list the help on any command just execute the command, followed by the
+    `--help` option.
+
+    ```console
+    $ docker run --help
+
+    Usage: docker run [OPTIONS] IMAGE [COMMAND] [ARG...]
+
+    Create and run a new container from an image
+
+    Options:
+          --add-host value             Add a custom host-to-IP mapping (host:ip) (default [])
+      -a, --attach value               Attach to STDIN, STDOUT or STDERR (default [])
+    <...>
+    ```
+
+    ### Environment variables
+
+    The following list of environment variables are supported by the `docker` command
+    line:
+
+    | Variable                      | Description                                                                                                                                                                                                                                                       |
+    | :---------------------------- | :---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+    | `DOCKER_API_VERSION`          | Override the negotiated API version to use for debugging (e.g. `1.19`)                                                                                                                                                                                            |
+    | `DOCKER_CERT_PATH`            | Location of your authentication keys. This variable is used both by the `docker` CLI and the [`dockerd` daemon](/reference/cli/dockerd/)                                                                                                   |
+    | `DOCKER_CONFIG`               | The location of your client configuration files.                                                                                                                                                                                                                  |
+    | `DOCKER_CONTENT_TRUST_SERVER` | The URL of the Notary server to use. Defaults to the same URL as the registry.                                                                                                                                                                                    |
+    | `DOCKER_CONTENT_TRUST`        | When set Docker uses notary to sign and verify images. Equates to `--disable-content-trust=false` for build, create, pull, push, run.                                                                                                                             |
+    | `DOCKER_CONTEXT`              | Name of the `docker context` to use (overrides `DOCKER_HOST` env var and default context set with `docker context use`)                                                                                                                                           |
+    | `DOCKER_DEFAULT_PLATFORM`     | Default platform for commands that take the `--platform` flag.                                                                                                                                                                                                    |
+    | `DOCKER_HIDE_LEGACY_COMMANDS` | When set, Docker hides "legacy" top-level commands (such as `docker rm`, and `docker pull`) in `docker help` output, and only `Management commands` per object-type (e.g., `docker container`) are printed. This may become the default in a future release.      |
+    | `DOCKER_HOST`                 | Daemon socket to connect to.                                                                                                                                                                                                                                      |
+    | `DOCKER_TLS`                  | Enable TLS for connections made by the `docker` CLI (equivalent of the `--tls` command-line option). Set to a non-empty value to enable TLS. Note that TLS is enabled automatically if any of the other TLS options are set.                                      |
+    | `DOCKER_TLS_VERIFY`           | When set Docker uses TLS and verifies the remote. This variable is used both by the `docker` CLI and the [`dockerd` daemon](/reference/cli/dockerd/)                                                                                       |
+    | `BUILDKIT_PROGRESS`           | Set type of progress output (`auto`, `plain`, `tty`, `rawjson`) when [building](/reference/cli/docker/image/build/) with [BuildKit backend](/build/buildkit/). Use plain to show container output (default `auto`). |
+
+    Because Docker is developed using Go, you can also use any environment
+    variables used by the Go runtime. In particular, you may find these useful:
+
+    | Variable      | Description                                                                    |
+    |:--------------|:-------------------------------------------------------------------------------|
+    | `HTTP_PROXY`  | Proxy URL for HTTP requests unless overridden by NoProxy.                      |
+    | `HTTPS_PROXY` | Proxy URL for HTTPS requests unless overridden by NoProxy.                     |
+    | `NO_PROXY`    | Comma-separated values specifying hosts that should be excluded from proxying. |
+
+    See the [Go specification](https://pkg.go.dev/golang.org/x/net/http/httpproxy#Config)
+    for details on these variables.
+
+    ### Option types
+
+    Single character command line options can be combined, so rather than
+    typing `docker run -i -t --name test busybox sh`,
+    you can write `docker run -it --name test busybox sh`.
+
+    #### Boolean
+
+    Boolean options take the form `-d=false`. The value you see in the help text is
+    the default value which is set if you do **not** specify that flag. If you
+    specify a Boolean flag without a value, this will set the flag to `true`,
+    irrespective of the default value.
+
+    For example, running `docker run -d` will set the value to `true`, so your
+    container **will** run in "detached" mode, in the background.
+
+    Options which default to `true` (e.g., `docker build --rm=true`) can only be
+    set to the non-default value by explicitly setting them to `false`:
+
+    ```console
+    $ docker build --rm=false .
+    ```
+
+    #### Multi
+
+    You can specify options like `-a=[]` multiple times in a single command line,
+    for example in these commands:
+
+    ```console
+    $ docker run -a stdin -a stdout -i -t ubuntu /bin/bash
+
+    $ docker run -a stdin -a stdout -a stderr ubuntu /bin/ls
+    ```
+
+    Sometimes, multiple options can call for a more complex value string as for
+    `-v`:
+
+    ```console
+    $ docker run -v /host:/container example/mysql
+    ```
+
+    > **Note**
+    >
+    > Do not use the `-t` and `-a stderr` options together due to
+    > limitations in the `pty` implementation. All `stderr` in `pty` mode
+    > simply goes to `stdout`.
+
+    #### Strings and Integers
+
+    Options like `--name=""` expect a string, and they
+    can only be specified once. Options like `-c=0`
+    expect an integer, and they can only be specified once.
+
+    ### Configuration files
+
+    By default, the Docker command line stores its configuration files in a
+    directory called `.docker` within your `$HOME` directory.
+
+    Docker manages most of the files in the configuration directory
+    and you shouldn't modify them. However, you can modify the
+    `config.json` file to control certain aspects of how the `docker`
+    command behaves.
+
+    You can modify the `docker` command behavior using environment
+    variables or command-line options. You can also use options within
+    `config.json` to modify some of the same behavior. If an environment variable
+    and the `--config` flag are set, the flag takes precedent over the environment
+    variable. Command line options override environment variables and environment
+    variables override properties you specify in a `config.json` file.
+
+    #### Change the `.docker` directory
+
+    To specify a different directory, use the `DOCKER_CONFIG`
+    environment variable or the `--config` command line option. If both are
+    specified, then the `--config` option overrides the `DOCKER_CONFIG` environment
+    variable. The example below overrides the `docker ps` command using a
+    `config.json` file located in the `~/testconfigs/` directory.
+
+    ```console
+    $ docker --config ~/testconfigs/ ps
+    ```
+
+    This flag only applies to whatever command is being ran. For persistent
+    configuration, you can set the `DOCKER_CONFIG` environment variable in your
+    shell (e.g. `~/.profile` or `~/.bashrc`). The example below sets the new
+    directory to be `HOME/newdir/.docker`.
+
+    ```console
+    $ echo export DOCKER_CONFIG=$HOME/newdir/.docker > ~/.profile
+    ```
+
+    ### Docker CLI configuration file (`config.json`) properties
+
+    <a name="configjson-properties"><!-- included for deep-links to old section --></a>
+
+    Use the Docker CLI configuration to customize settings for the `docker` CLI. The
+    configuration file uses JSON formatting, and properties:
+
+    By default, configuration file is stored in `~/.docker/config.json`. Refer to the
+    [change the `.docker` directory](#change-the-docker-directory) section to use a
+    different location.
+
+    > **Warning**
+    >
+    > The configuration file and other files inside the `~/.docker` configuration
+    > directory may contain sensitive information, such as authentication information
+    > for proxies or, depending on your credential store, credentials for your image
+    > registries. Review your configuration file's content before sharing with others,
+    > and prevent committing the file to version control.
+
+    #### Customize the default output format for commands
+
+    These fields lets you customize the default output format for some commands
+    if no `--format` flag is provided.
+
+    | Property               | Description                                                                                                                                                                                                    |
+    | :--------------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+    | `configFormat`         | Custom default format for `docker config ls` output. See [`docker config ls`](/reference/cli/docker/config/ls/#format) for a list of supported formatting directives.                   |
+    | `imagesFormat`         | Custom default format for `docker images` / `docker image ls` output. See [`docker images`](/reference/cli/docker/image/ls/#format) for a list of supported formatting directives.      |
+    | `networksFormat`       | Custom default format for `docker network ls` output. See [`docker network ls`](/reference/cli/docker/network/ls/#format) for a list of supported formatting directives.                |
+    | `nodesFormat`          | Custom default format for `docker node ls` output. See [`docker node ls`](/reference/cli/docker/node/ls/#format) for a list of supported formatting directives.                         |
+    | `pluginsFormat`        | Custom default format for `docker plugin ls` output. See [`docker plugin ls`](/reference/cli/docker/plugin/ls/#format) for a list of supported formatting directives.                   |
+    | `psFormat`             | Custom default format for `docker ps` / `docker container ps` output. See [`docker ps`](/reference/cli/docker/container/ls/#format) for a list of supported formatting directives.      |
+    | `secretFormat`         | Custom default format for `docker secret ls` output. See [`docker secret ls`](/reference/cli/docker/secret/ls/#format) for a list of supported formatting directives.                   |
+    | `serviceInspectFormat` | Custom default format for `docker service inspect` output. See [`docker service inspect`](/reference/cli/docker/service/inspect/#format) for a list of supported formatting directives. |
+    | `servicesFormat`       | Custom default format for `docker service ls` output. See [`docker service ls`](/reference/cli/docker/service/ls/#format) for a list of supported formatting directives.                |
+    | `statsFormat`          | Custom default format for `docker stats` output. See [`docker stats`](/reference/cli/docker/container/stats/#format) for a list of supported formatting directives.                     |
+    | `tasksFormat`          | Custom default format for `docker stack ps` output. See [`docker stack ps`](/reference/cli/docker/stack/ps/#format) for a list of supported formatting directives.                      |
+    | `volumesFormat`        | Custom default format for `docker volume ls` output. See [`docker volume ls`](/reference/cli/docker/volume/ls/#format) for a list of supported formatting directives.                   |
+
+    #### Custom HTTP headers
+
+    The property `HttpHeaders` specifies a set of headers to include in all messages
+    sent from the Docker client to the daemon. Docker doesn't try to interpret or
+    understand these headers; it simply puts them into the messages. Docker does
+    not allow these headers to change any headers it sets for itself.
+
+    #### Credential store options
+
+    The property `credsStore` specifies an external binary to serve as the default
+    credential store. When this property is set, `docker login` will attempt to
+    store credentials in the binary specified by `docker-credential-<value>` which
+    is visible on `$PATH`. If this property isn't set, credentials are stored
+    in the `auths` property of the CLI configuration file. For more information,
+    see the [**Credential stores** section in the `docker login` documentation](/reference/cli/docker/login/#credential-stores)
+
+    The property `credHelpers` specifies a set of credential helpers to use
+    preferentially over `credsStore` or `auths` when storing and retrieving
+    credentials for specific registries. If this property is set, the binary
+    `docker-credential-<value>` will be used when storing or retrieving credentials
+    for a specific registry. For more information, see the
+    [**Credential helpers** section in the `docker login` documentation](/reference/cli/docker/login/#credential-helpers)
+
+    #### Automatic proxy configuration for containers
+
+    The property `proxies` specifies proxy environment variables to be automatically
+    set on containers, and set as `--build-arg` on containers used during `docker build`.
+    A `"default"` set of proxies can be configured, and will be used for any Docker
+    daemon that the client connects to, or a configuration per host (Docker daemon),
+    for example, `https://docker-daemon1.example.com`. The following properties can
+    be set for each environment:
+
+    | Property       | Description                                                                                             |
+    |:---------------|:--------------------------------------------------------------------------------------------------------|
+    | `httpProxy`    | Default value of `HTTP_PROXY` and `http_proxy` for containers, and as `--build-arg` on `docker build`   |
+    | `httpsProxy`   | Default value of `HTTPS_PROXY` and `https_proxy` for containers, and as `--build-arg` on `docker build` |
+    | `ftpProxy`     | Default value of `FTP_PROXY` and `ftp_proxy` for containers, and as `--build-arg` on `docker build`     |
+    | `noProxy`      | Default value of `NO_PROXY` and `no_proxy` for containers, and as `--build-arg` on `docker build`       |
+    | `allProxy`     | Default value of `ALL_PROXY` and `all_proxy` for containers, and as `--build-arg` on `docker build`     |
+
+    These settings are used to configure proxy settings for containers only, and not
+    used as proxy settings for the `docker` CLI or the `dockerd` daemon. Refer to the
+    [environment variables](#environment-variables) and [HTTP/HTTPS proxy](/config/daemon/systemd/#httphttps-proxy)
+    sections for configuring proxy settings for the cli and daemon.
+
+    > **Warning**
+    >
+    > Proxy settings may contain sensitive information (for example, if the proxy
+    > requires authentication). Environment variables are stored as plain text in
+    > the container's configuration, and as such can be inspected through the remote
+    > API or committed to an image when using `docker commit`.
+    { .warning }
+
+    #### Default key-sequence to detach from containers
+
+    Once attached to a container, users detach from it and leave it running using
+    the using `CTRL-p CTRL-q` key sequence. This detach key sequence is customizable
+    using the `detachKeys` property. Specify a `<sequence>` value for the
+    property. The format of the `<sequence>` is a comma-separated list of either
+    a letter [a-Z], or the `ctrl-` combined with any of the following:
+
+    * `a-z` (a single lowercase alpha character )
+    * `@` (at sign)
+    * `[` (left bracket)
+    * `\\` (two backward slashes)
+    * `_` (underscore)
+    * `^` (caret)
+
+    Your customization applies to all containers started in with your Docker client.
+    Users can override your custom or the default key sequence on a per-container
+    basis. To do this, the user specifies the `--detach-keys` flag with the `docker
+    attach`, `docker exec`, `docker run` or `docker start` command.
+
+    #### CLI plugin options
+
+    The property `plugins` contains settings specific to CLI plugins. The
+    key is the plugin name, while the value is a further map of options,
+    which are specific to that plugin.
+
+    #### Sample configuration file
+
+    Following is a sample `config.json` file to illustrate the format used for
+    various fields:
+
+    ```json
+    {
+      "HttpHeaders": {
+        "MyHeader": "MyValue"
+      },
+      "psFormat": "table {{.ID}}\\t{{.Image}}\\t{{.Command}}\\t{{.Labels}}",
+      "imagesFormat": "table {{.ID}}\\t{{.Repository}}\\t{{.Tag}}\\t{{.CreatedAt}}",
+      "pluginsFormat": "table {{.ID}}\t{{.Name}}\t{{.Enabled}}",
+      "statsFormat": "table {{.Container}}\t{{.CPUPerc}}\t{{.MemUsage}}",
+      "servicesFormat": "table {{.ID}}\t{{.Name}}\t{{.Mode}}",
+      "secretFormat": "table {{.ID}}\t{{.Name}}\t{{.CreatedAt}}\t{{.UpdatedAt}}",
+      "configFormat": "table {{.ID}}\t{{.Name}}\t{{.CreatedAt}}\t{{.UpdatedAt}}",
+      "serviceInspectFormat": "pretty",
+      "nodesFormat": "table {{.ID}}\t{{.Hostname}}\t{{.Availability}}",
+      "detachKeys": "ctrl-e,e",
+      "credsStore": "secretservice",
+      "credHelpers": {
+        "awesomereg.example.org": "hip-star",
+        "unicorn.example.com": "vcbait"
+      },
+      "plugins": {
+        "plugin1": {
+          "option": "value"
+        },
+        "plugin2": {
+          "anotheroption": "anothervalue",
+          "athirdoption": "athirdvalue"
+        }
+      },
+      "proxies": {
+        "default": {
+          "httpProxy":  "http://user:pass@example.com:3128",
+          "httpsProxy": "https://my-proxy.example.com:3129",
+          "noProxy":    "intra.mycorp.example.com",
+          "ftpProxy":   "http://user:pass@example.com:3128",
+          "allProxy":   "socks://example.com:1234"
+        },
+        "https://manager1.mycorp.example.com:2377": {
+          "httpProxy":  "http://user:pass@example.com:3128",
+          "httpsProxy": "https://my-proxy.example.com:3129"
+        }
+      }
+    }
+    ```
+
+    #### Experimental features
+
+    Experimental features provide early access to future product functionality.
+    These features are intended for testing and feedback, and they may change
+    between releases without warning or can be removed from a future release.
+
+    Starting with Docker 20.10, experimental CLI features are enabled by default,
+    and require no configuration to enable them.
+
+    #### Notary
+
+    If using your own notary server and a self-signed certificate or an internal
+    Certificate Authority, you need to place the certificate at
+    `tls/<registry_url>/ca.crt` in your Docker config directory.
+
+    Alternatively you can trust the certificate globally by adding it to your system's
+    list of root Certificate Authorities.
 cname:
     - docker attach
     - docker build
@@ -120,7 +454,7 @@ clink:
 options:
     - option: config
       value_type: string
-      default_value: /root/.docker
+      default_value: /Users/david/.docker
       description: Location of client config files
       deprecated: false
       hidden: false
@@ -164,6 +498,7 @@ options:
       shorthand: H
       value_type: list
       description: Daemon socket to connect to
+      details_url: '#host'
       deprecated: false
       hidden: false
       experimental: false
@@ -193,7 +528,7 @@ options:
       swarm: false
     - option: tlscacert
       value_type: string
-      default_value: /root/.docker/ca.pem
+      default_value: /Users/david/.docker/ca.pem
       description: Trust certs signed only by this CA
       deprecated: false
       hidden: false
@@ -203,7 +538,7 @@ options:
       swarm: false
     - option: tlscert
       value_type: string
-      default_value: /root/.docker/cert.pem
+      default_value: /Users/david/.docker/cert.pem
       description: Path to TLS certificate file
       deprecated: false
       hidden: false
@@ -213,7 +548,7 @@ options:
       swarm: false
     - option: tlskey
       value_type: string
-      default_value: /root/.docker/key.pem
+      default_value: /Users/david/.docker/key.pem
       description: Path to TLS key file
       deprecated: false
       hidden: false
@@ -231,6 +566,63 @@ options:
       experimentalcli: false
       kubernetes: false
       swarm: false
+examples: |-
+    ### Specify daemon host (-H, --host) {#host}
+
+    You can use the `-H`, `--host` flag to specify a socket to use when you invoke
+    a `docker` command. You can use the following protocols:
+
+    | Scheme                                 | Description               | Example                          |
+    |----------------------------------------|---------------------------|----------------------------------|
+    | `unix://[<path>]`                      | Unix socket (Linux only)  | `unix:///var/run/docker.sock`    |
+    | `tcp://[<IP or host>[:port]]`          | TCP connection            | `tcp://174.17.0.1:2376`          |
+    | `ssh://[username@]<IP or host>[:port]` | SSH connection            | `ssh://user@192.168.64.5`        |
+    | `npipe://[<name>]`                     | Named pipe (Windows only) | `npipe:////./pipe/docker_engine` |
+
+    If you don't specify the `-H` flag, and you're not using a custom
+    [context](/engine/context/working-with-contexts),
+    commands use the following default sockets:
+
+    - `unix:///var/run/docker.sock` on macOS and Linux
+    - `npipe:////./pipe/docker_engine` on Windows
+
+    To achieve a similar effect without having to specify the `-H` flag for every
+    command, you could also [create a context](/reference/cli/docker/context/create/),
+    or alternatively, use the
+    [`DOCKER_HOST` environment variable](#environment-variables).
+
+    For more information about the `-H` flag, see
+    [Daemon socket option](/reference/cli/dockerd/#daemon-socket-option).
+
+    #### Using TCP sockets
+
+    The following example shows how to invoke `docker ps` over TCP, to a remote
+    daemon with IP address `174.17.0.1`, listening on port `2376`:
+
+    ```console
+    $ docker -H tcp://174.17.0.1:2376 ps
+    ```
+
+    > **Note**
+    >
+    > By convention, the Docker daemon uses port `2376` for secure TLS connections,
+    > and port `2375` for insecure, non-TLS connections.
+
+    #### Using SSH sockets
+
+    When you use SSH invoke a command on a remote daemon, the request gets forwarded
+    to the `/var/run/docker.sock` Unix socket on the SSH host.
+
+    ```console
+    $ docker -H ssh://user@192.168.64.5 ps
+    ```
+
+    You can optionally specify the location of the socket by appending a path
+    component to the end of the SSH address.
+
+    ```console
+    $ docker -H ssh://user@192.168.64.5/var/run/docker.sock ps
+    ```
 deprecated: false
 hidden: false
 experimental: false

--- a/data/engine-cli/docker_container_attach.yaml
+++ b/data/engine-cli/docker_container_attach.yaml
@@ -190,7 +190,7 @@ examples: |-
 
     These `a`, `ctrl-a`, `X`, or `ctrl-\\` values are all examples of valid key
     sequences. To configure a different configuration default key sequence for all
-    containers, see [**Configuration file** section](/engine/reference/commandline/cli/#configuration-files).
+    containers, see [**Configuration file** section](/reference/cli/docker/#configuration-files).
 deprecated: false
 hidden: false
 experimental: false

--- a/data/engine-cli/docker_container_cp.yaml
+++ b/data/engine-cli/docker_container_cp.yaml
@@ -129,7 +129,7 @@ examples: |-
     $ docker cp CONTAINER:/var/logs/ /tmp/app_logs
     ```
 
-    Copy a file from container to stdout. Please note `cp` command produces a tar stream
+    Copy a file from container to stdout. Note `cp` command produces a tar stream
 
     ```console
     $ docker cp CONTAINER:/var/logs/app.log - | tar x -O | grep "ERROR"

--- a/data/engine-cli/docker_container_create.yaml
+++ b/data/engine-cli/docker_container_create.yaml
@@ -866,7 +866,8 @@ options:
     - option: rm
       value_type: bool
       default_value: "false"
-      description: Automatically remove the container when it exits
+      description: |
+        Automatically remove the container and its associated anonymous volumes when it exits
       deprecated: false
       hidden: false
       experimental: false

--- a/data/engine-cli/docker_container_logs.yaml
+++ b/data/engine-cli/docker_container_logs.yaml
@@ -26,7 +26,7 @@ long: |-
     a given date. You can specify the date as an RFC 3339 date, a UNIX
     timestamp, or a Go duration string (e.g. `1m30s`, `3h`). Besides RFC3339 date
     format you may also use RFC3339Nano, `2006-01-02T15:04:05`,
-    `2006-01-02T15:04:05.999999999`, `2006-01-02Z07:00`, and `2006-01-02`. The local
+    `2006-01-02T15:04:05.999999999`, `2006-01-02T07:00`, and `2006-01-02`. The local
     timezone on the client will be used if you do not provide either a `Z` or a
     `+-00:00` timezone offset at the end of the timestamp. When providing Unix
     timestamps enter seconds[.nanoseconds], where seconds is the number of seconds

--- a/data/engine-cli/docker_container_prune.yaml
+++ b/data/engine-cli/docker_container_prune.yaml
@@ -65,7 +65,7 @@ examples: |-
     timestamps, or Go duration strings (e.g. `10m`, `1h30m`) computed
     relative to the daemon machine’s time. Supported formats for date
     formatted time stamps include RFC3339Nano, RFC3339, `2006-01-02T15:04:05`,
-    `2006-01-02T15:04:05.999999999`, `2006-01-02Z07:00`, and `2006-01-02`. The local
+    `2006-01-02T15:04:05.999999999`, `2006-01-02T07:00`, and `2006-01-02`. The local
     timezone on the daemon will be used if you do not provide either a `Z` or a
     `+-00:00` timezone offset at the end of the timestamp. When providing Unix
     timestamps enter seconds[.nanoseconds], where seconds is the number of seconds

--- a/data/engine-cli/docker_container_run.yaml
+++ b/data/engine-cli/docker_container_run.yaml
@@ -900,7 +900,8 @@ options:
     - option: rm
       value_type: bool
       default_value: "false"
-      description: Automatically remove the container when it exits
+      description: |
+        Automatically remove the container and its associated anonymous volumes when it exits
       details_url: '#rm'
       deprecated: false
       hidden: false
@@ -1189,14 +1190,7 @@ examples: |-
     2. Install `htop` in the container:
 
        ```console
-       / # apk add htop
-       fetch https://dl-cdn.alpinelinux.org/alpine/v3.18/main/aarch64/APKINDEX.tar.gz
-       fetch https://dl-cdn.alpinelinux.org/alpine/v3.18/community/aarch64/APKINDEX.tar.gz
-       (1/3) Installing ncurses-terminfo-base (6.4_p20230506-r0)
-       (2/3) Installing libncursesw (6.4_p20230506-r0)
-       (3/3) Installing htop (3.2.2-r1)
-       Executing busybox-1.36.1-r2.trigger
-       OK: 9 MiB in 18 packages
+       / # apk add --quiet htop
        ```
 
     3. Invoke the `htop` command.
@@ -1682,7 +1676,24 @@ examples: |-
 
     To start a container and connect it to a network, use the `--network` option.
 
-    The following commands create a network named `my-net` and adds a `busybox` container
+    If you want to add a running container to a network use the `docker network connect` subcommand.
+
+    You can connect multiple containers to the same network. Once connected, the
+    containers can communicate using only another container's IP address
+    or name. For `overlay` networks or custom plugins that support multi-host
+    connectivity, containers connected to the same multi-host network but launched
+    from different Engines can also communicate in this way.
+
+    > **Note**
+    >
+    > The default bridge network only allows containers to communicate with each other using
+    > internal IP addresses. User-created bridge networks provide DNS resolution between
+    > containers using container names.
+
+    You can disconnect a container from a network using the `docker network
+    disconnect` command.
+
+    The following commands create a network named `my-net` and add a `busybox` container
     to the `my-net` network.
 
     ```console
@@ -1699,24 +1710,56 @@ examples: |-
     $ docker run -itd --network=my-net --ip=192.0.2.69 busybox
     ```
 
-    If you want to add a running container to a network use the `docker network connect` subcommand.
+    To connect the container to more than one network, repeat the `--network` option.
 
-    You can connect multiple containers to the same network. Once connected, the
-    containers can communicate using only another container's IP address
-    or name. For `overlay` networks or custom plugins that support multi-host
-    connectivity, containers connected to the same multi-host network but launched
-    from different Engines can also communicate in this way.
+    ```console
+    $ docker network create --subnet 192.0.2.0/24 my-net1
+    $ docker network create --subnet 192.0.3.0/24 my-net2
+    $ docker run -itd --network=my-net1 --network=my-net2 busybox
+    ```
+
+    To specify options when connecting to more than one network, use the extended syntax
+    for the `--network` flag. Comma-separated options that can be specified in the extended
+    `--network` syntax are:
+
+    | Option          | Top-level Equivalent                  | Description                                     |
+    |-----------------|---------------------------------------|-------------------------------------------------|
+    | `name`          |                                       | The name of the network (mandatory)             |
+    | `alias`         | `--network-alias`                     | Add network-scoped alias for the container      |
+    | `ip`            | `--ip`                                | IPv4 address (e.g., 172.30.100.104)             |
+    | `ip6`           | `--ip6`                               | IPv6 address (e.g., 2001:db8::33)               |
+    | `mac-address`   | `--mac-address`                       | Container MAC address (e.g., 92:d0:c6:0a:29:33) |
+    | `link-local-ip` | `--link-local-ip`                     | Container IPv4/IPv6 link-local addresses        |
+    | `driver-opt`    | `docker network connect --driver-opt` | Network driver options                          |
+
+    ```console
+    $ docker network create --subnet 192.0.2.0/24 my-net1
+    $ docker network create --subnet 192.0.3.0/24 my-net2
+    $ docker run -itd --network=name=my-net1,ip=192.0.2.42 --network=name=my-net2,ip=192.0.3.42 busybox
+    ```
+
+    `sysctl` settings that start with `net.ipv4.`, `net.ipv6.` or `net.mpls.` can be
+    set per-interface using `driver-opt` label `com.docker.network.endpoint.sysctls`.
+    The interface name must be the string `IFNAME`.
+
+    To set more than one `sysctl` for an interface, quote the whole `driver-opt` field,
+    remembering to escape the quotes for the shell if necessary. For example, if the
+    interface to `my-net` is given name `eth0`, the following example sets sysctls
+    `net.ipv4.conf.eth0.log_martians=1` and `net.ipv4.conf.eth0.forwarding=0`, and
+    assigns the IPv4 address `192.0.2.42`.
+
+    ```console
+    $ docker network create --subnet 192.0.2.0/24 my-net
+    $ docker run -itd --network=name=my-net,\"driver-opt=com.docker.network.endpoint.sysctls=net.ipv4.conf.IFNAME.log_martians=1,net.ipv4.conf.IFNAME.forwarding=0\",ip=192.0.2.42 busybox
+    ```
 
     > **Note**
     >
-    > The default bridge network only allow containers to communicate with each other using
-    > internal IP addresses. User-created bridge networks provide DNS resolution between
-    > containers using container names.
+    > Network drivers may restrict the sysctl settings that can be modified and, to protect
+    > the operation of the network, new restrictions may be added in the future.
 
-    You can disconnect a container from a network using the `docker network
-    disconnect` command.
-
-    For more information on connecting a container to a network when using the `run` command, see the ["*Docker network overview*"](/network/).
+    For more information on connecting a container to a network when using the `run` command,
+    see the [Docker network overview](/network/).
 
     ### Mount volumes from container (--volumes-from) {#volumes-from}
 
@@ -1795,7 +1838,7 @@ examples: |-
 
     These `a`, `ctrl-a`, `X`, or `ctrl-\\` values are all examples of valid key
     sequences. To configure a different configuration default key sequence for all
-    containers, see [**Configuration file** section](/engine/reference/commandline/cli/#configuration-files).
+    containers, see [**Configuration file** section](/reference/cli/docker/#configuration-files).
 
     ### Add host device to container (--device) {#device}
 
@@ -1870,17 +1913,19 @@ examples: |-
 
     > **Note**
     >
-    > This is experimental feature and as such doesn't represent a stable API.
+    > The CDI feature is experimental, and potentially subject to change.
+    > CDI is currently only supported for Linux containers.
 
-    Container Device Interface (CDI) is a
-    [standardized](https://github.com/cncf-tags/container-device-interface/blob/main/SPEC.md)
-    mechanism for container runtimes to create containers which are able to
-    interact with third party devices.
+    [Container Device Interface
+    (CDI)](https://github.com/cncf-tags/container-device-interface/blob/main/SPEC.md)
+    is a standardized mechanism for container runtimes to create containers which
+    are able to interact with third party devices.
 
-    With CDI, device configurations are defined using a JSON file. In addition to
-    enabling the container to interact with the device node, it also lets you
-    specify additional configuration for the device, such as kernel modules, host
-    libraries, and environment variables.
+    With CDI, device configurations are declaratively defined using a JSON or YAML
+    file. In addition to enabling the container to interact with the device node,
+    it also lets you specify additional configuration for the device, such as
+    environment variables, host mounts (such as shared objects), and executable
+    hooks.
 
     You can reference a CDI device with the `--device` flag using the
     fully-qualified name of the device, as shown in the following example:
@@ -1892,10 +1937,10 @@ examples: |-
     This starts an `ubuntu` container with access to the specified CDI device,
     `vendor.com/class=device-name`, assuming that:
 
-    - A valid CDI specification (JSON file) for the requested device is available
-      on the system running the daemon, in one of the configured CDI specification
-      directories.
-    - The CDI feature has been enabled on the daemon side, see [Enable CDI
+    - A valid CDI specification (JSON or YAML file) for the requested device is
+      available on the system running the daemon, in one of the configured CDI
+      specification directories.
+    - The CDI feature has been enabled in the daemon; see [Enable CDI
       devices](/reference/cli/dockerd/#enable-cdi-devices).
 
     ### Attach to STDIN/STDOUT/STDERR (-a, --attach) {#attach}

--- a/data/engine-cli/docker_create.yaml
+++ b/data/engine-cli/docker_create.yaml
@@ -849,7 +849,8 @@ options:
     - option: rm
       value_type: bool
       default_value: "false"
-      description: Automatically remove the container when it exits
+      description: |
+        Automatically remove the container and its associated anonymous volumes when it exits
       deprecated: false
       hidden: false
       experimental: false

--- a/data/engine-cli/docker_image_prune.yaml
+++ b/data/engine-cli/docker_image_prune.yaml
@@ -99,7 +99,7 @@ examples: |-
     timestamps, or Go duration strings (e.g. `10m`, `1h30m`) computed
     relative to the daemon machine’s time. Supported formats for date
     formatted time stamps include RFC3339Nano, RFC3339, `2006-01-02T15:04:05`,
-    `2006-01-02T15:04:05.999999999`, `2006-01-02Z07:00`, and `2006-01-02`. The local
+    `2006-01-02T15:04:05.999999999`, `2006-01-02T07:00`, and `2006-01-02`. The local
     timezone on the daemon will be used if you do not provide either a `Z` or a
     `+-00:00` timezone offset at the end of the timestamp.  When providing Unix
     timestamps enter seconds[.nanoseconds], where seconds is the number of seconds

--- a/data/engine-cli/docker_image_push.yaml
+++ b/data/engine-cli/docker_image_push.yaml
@@ -49,6 +49,18 @@ options:
       experimentalcli: false
       kubernetes: false
       swarm: false
+    - option: platform
+      value_type: string
+      description: |-
+        Push a platform-specific manifest as a single-platform image to the registry.
+        'os[/arch[/variant]]': Explicit platform (eg. linux/amd64)
+      deprecated: false
+      hidden: false
+      min_api_version: "1.46"
+      experimental: false
+      experimentalcli: false
+      kubernetes: false
+      swarm: false
     - option: quiet
       shorthand: q
       value_type: bool

--- a/data/engine-cli/docker_network_connect.yaml
+++ b/data/engine-cli/docker_network_connect.yaml
@@ -120,6 +120,26 @@ examples: |-
     $ docker network connect --alias db --alias mysql multi-host-network container2
     ```
 
+    ### Set sysctls for a container's interface (--driver-opt) {#sysctl}
+
+    `sysctl` settings that start with `net.ipv4.` and `net.ipv6.` can be set per-interface
+    using `--driver-opt` label `com.docker.network.endpoint.sysctls`. The name of the
+    interface must be replaced by `IFNAME`.
+
+    To set more than one `sysctl` for an interface, quote the whole value of the
+    `driver-opt` field, remembering to escape the quotes for the shell if necessary.
+    For example, if the interface to `my-net` is given name `eth3`, the following example
+    sets `net.ipv4.conf.eth3.log_martians=1` and `net.ipv4.conf.eth3.forwarding=0`.
+
+    ```console
+    $ docker network connect --driver-opt=\"com.docker.network.endpoint.sysctls=net.ipv4.conf.IFNAME.log_martians=1,net.ipv4.conf.IFNAME.forwarding=0\" multi-host-network container2
+    ```
+
+    > **Note**
+    >
+    > Network drivers may restrict the sysctl settings that can be modified and, to protect
+    > the operation of the network, new restrictions may be added in the future.
+
     ### Network implications of stopping, pausing, or restarting containers
 
     You can pause, restart, and stop containers that are connected to a network.

--- a/data/engine-cli/docker_network_create.yaml
+++ b/data/engine-cli/docker_network_create.yaml
@@ -173,7 +173,7 @@ options:
     - option: ipv6
       value_type: bool
       default_value: "false"
-      description: Enable IPv6 networking
+      description: Enable or disable IPv6 networking
       deprecated: false
       hidden: false
       experimental: false
@@ -321,7 +321,7 @@ examples: |-
     | `--gateway`  | -              | IPv4 or IPv6 Gateway for the master subnet |
     | `--ip-range` | `--fixed-cidr` | Allocate IPs from a range                  |
     | `--internal` | -              | Restrict external access to the network    |
-    | `--ipv6`     | `--ipv6`       | Enable IPv6 networking                     |
+    | `--ipv6`     | `--ipv6`       | Enable or disable IPv6 networking          |
     | `--subnet`   | `--bip`        | Subnet for network                         |
 
     For example, let's use `-o` or `--opt` options to specify an IP address binding

--- a/data/engine-cli/docker_network_prune.yaml
+++ b/data/engine-cli/docker_network_prune.yaml
@@ -64,7 +64,7 @@ examples: |-
     timestamps, or Go duration strings (e.g. `10m`, `1h30m`) computed
     relative to the daemon machine’s time. Supported formats for date
     formatted time stamps include RFC3339Nano, RFC3339, `2006-01-02T15:04:05`,
-    `2006-01-02T15:04:05.999999999`, `2006-01-02Z07:00`, and `2006-01-02`. The local
+    `2006-01-02T15:04:05.999999999`, `2006-01-02T07:00`, and `2006-01-02`. The local
     timezone on the daemon will be used if you do not provide either a `Z` or a
     `+-00:00` timezone offset at the end of the timestamp.  When providing Unix
     timestamps enter seconds[.nanoseconds], where seconds is the number of seconds

--- a/data/engine-cli/docker_push.yaml
+++ b/data/engine-cli/docker_push.yaml
@@ -27,6 +27,18 @@ options:
       experimentalcli: false
       kubernetes: false
       swarm: false
+    - option: platform
+      value_type: string
+      description: |-
+        Push a platform-specific manifest as a single-platform image to the registry.
+        'os[/arch[/variant]]': Explicit platform (eg. linux/amd64)
+      deprecated: false
+      hidden: false
+      min_api_version: "1.46"
+      experimental: false
+      experimentalcli: false
+      kubernetes: false
+      swarm: false
     - option: quiet
       shorthand: q
       value_type: bool

--- a/data/engine-cli/docker_run.yaml
+++ b/data/engine-cli/docker_run.yaml
@@ -869,7 +869,8 @@ options:
     - option: rm
       value_type: bool
       default_value: "false"
-      description: Automatically remove the container when it exits
+      description: |
+        Automatically remove the container and its associated anonymous volumes when it exits
       deprecated: false
       hidden: false
       experimental: false

--- a/data/engine-cli/docker_service_logs.yaml
+++ b/data/engine-cli/docker_service_logs.yaml
@@ -42,7 +42,7 @@ long: |-
     a given date. You can specify the date as an RFC 3339 date, a UNIX
     timestamp, or a Go duration string (e.g. `1m30s`, `3h`). Besides RFC3339 date
     format you may also use RFC3339Nano, `2006-01-02T15:04:05`,
-    `2006-01-02T15:04:05.999999999`, `2006-01-02Z07:00`, and `2006-01-02`. The local
+    `2006-01-02T15:04:05.999999999`, `2006-01-02T07:00`, and `2006-01-02`. The local
     timezone on the client will be used if you do not provide either a `Z` or a
     `+-00:00` timezone offset at the end of the timestamp. When providing Unix
     timestamps enter seconds[.nanoseconds], where seconds is the number of seconds

--- a/data/engine-cli/docker_swarm_unlock-key.yaml
+++ b/data/engine-cli/docker_swarm_unlock-key.yaml
@@ -59,7 +59,7 @@ examples: |-
 
         SWMKEY-1-fySn8TY4w5lKcWcJPIpKufejh9hxx5KYwx6XZigx3Q4
 
-    Please remember to store this key in a password manager, since without it you
+    Remember to store this key in a password manager, since without it you
     will not be able to restart the manager.
     ```
 
@@ -76,7 +76,7 @@ examples: |-
 
         SWMKEY-1-7c37Cc8654o6p38HnroywCi19pllOnGtbdZEgtKxZu8
 
-    Please remember to store this key in a password manager, since without it you
+    Remember to store this key in a password manager, since without it you
     will not be able to restart the manager.
     ```
 

--- a/data/engine-cli/docker_swarm_unlock.yaml
+++ b/data/engine-cli/docker_swarm_unlock.yaml
@@ -29,7 +29,7 @@ inherited_options:
 examples: |-
     ```console
     $ docker swarm unlock
-    Please enter unlock key:
+    Enter unlock key:
     ```
 deprecated: false
 hidden: false

--- a/data/engine-cli/docker_system_events.yaml
+++ b/data/engine-cli/docker_system_events.yaml
@@ -129,7 +129,7 @@ long: |-
     relative to the client machine’s time. If you do not provide the `--since` option,
     the command returns only new and/or live events. Supported formats for date
     formatted time stamps include RFC3339Nano, RFC3339, `2006-01-02T15:04:05`,
-    `2006-01-02T15:04:05.999999999`, `2006-01-02Z07:00`, and `2006-01-02`. The local
+    `2006-01-02T15:04:05.999999999`, `2006-01-02T07:00`, and `2006-01-02`. The local
     timezone on the client will be used if you do not provide either a `Z` or a
     `+-00:00` timezone offset at the end of the timestamp. When providing Unix
     timestamps enter seconds[.nanoseconds], where seconds is the number of seconds

--- a/data/engine-cli/docker_system_prune.yaml
+++ b/data/engine-cli/docker_system_prune.yaml
@@ -147,7 +147,7 @@ examples: |-
     timestamps, or Go duration strings (e.g. `10m`, `1h30m`) computed
     relative to the daemon machine’s time. Supported formats for date
     formatted time stamps include RFC3339Nano, RFC3339, `2006-01-02T15:04:05`,
-    `2006-01-02T15:04:05.999999999`, `2006-01-02Z07:00`, and `2006-01-02`. The local
+    `2006-01-02T15:04:05.999999999`, `2006-01-02T07:00`, and `2006-01-02`. The local
     timezone on the daemon will be used if you do not provide either a `Z` or a
     `+-00:00` timezone offset at the end of the timestamp. When providing Unix
     timestamps enter seconds[.nanoseconds], where seconds is the number of seconds

--- a/data/engine-cli/docker_trust_revoke.yaml
+++ b/data/engine-cli/docker_trust_revoke.yaml
@@ -101,7 +101,7 @@ examples: |-
 
     ```console
     $ docker trust revoke example/trust-demo
-    Please confirm you would like to delete all signature data for example/trust-demo? [y/N] y
+    Confirm you would like to delete all signature data for example/trust-demo? [y/N] y
     Enter passphrase for delegation key with ID 27d42a8:
     Successfully deleted signature for example/trust-demo
     ```

--- a/data/engine-cli/docker_volume_create.yaml
+++ b/data/engine-cli/docker_volume_create.yaml
@@ -194,7 +194,7 @@ examples: |-
     ```
 
     If you specify a volume name already in use on the current driver, Docker
-    assumes you want to re-use the existing volume and doesn't return an error.
+    assumes you want to reuse the existing volume and doesn't return an error.
 
     ### Driver-specific options (-o, --opt) {#opt}
 

--- a/data/redirects.yml
+++ b/data/redirects.yml
@@ -140,7 +140,7 @@
   - /go/daemon-access/
 "/engine/deprecated/#deprecated-engine-features-1":
   - /go/deprecated/
-"/engine/reference/commandline/cli/#experimental-features":
+"/reference/cli/docker/#experimental-features":
   - /go/experimental/
 "/reference/cli/docker/login/#credential-stores":
   - /go/credential-store/

--- a/data/toc.yaml
+++ b/data/toc.yaml
@@ -1627,8 +1627,6 @@ Manuals:
       title: Start containers automatically
   - sectiontitle: CLI
     section:
-    - path: /engine/reference/commandline/cli/
-      title: Use the Docker CLI
     - path: /config/completion/
       title: Completion
     - path: /config/filter/

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -282,8 +282,6 @@ module:
           target: content/engine/deprecated.md
         - source: docs/reference/run.md
           target: content/engine/reference/run.md
-        - source: docs/reference/commandline/cli.md
-          target: content/engine/reference/commandline/cli.md
         - source: docs/reference/dockerd.md
           target: content/reference/cli/dockerd.md
 


### PR DESCRIPTION
## Description

Moves information about config, env vars, and other how-tos about the Docker CLI to the base command reference page.

https://deploy-preview-19794--docsdocker.netlify.app/reference/cli/docker/

## Related issues or tickets

Needs:

- https://github.com/docker/cli-docs-tool/pull/53
- https://github.com/docker/cli/pull/5010

## Reviews

- [ ] Technical review
- [ ] Editorial review
- [ ] Product review