### PR TITLE
desktop: fix a couple versions in release notes

### DIFF
--- a/content/desktop/release-notes.md
+++ b/content/desktop/release-notes.md
@@ -46,11 +46,10 @@ For frequently asked questions about Docker Desktop releases, see [FAQs](faqs/re
 
 ### Upgrades
 
-- [Docker Compose v2.26.0](https://github.com/docker/compose/releases/tag/v2.26.0)
+- [Docker Compose v2.26.1](https://github.com/docker/compose/releases/tag/v2.26.1)
 - [Docker Scout CLI v1.6.3](https://github.com/docker/scout-cli/releases/tag/v1.6.3)
 - [Docker Engine v26.0.0](https://docs.docker.com/engine/release-notes/26.0/#2600)
 - [Buildx v0.13.1](https://github.com/docker/buildx/releases/tag/v0.13.1)
-- [Docker Scout CLI v1.6.0](https://github.com/docker/scout-cli/releases/tag/v1.6.0)
 - [Kubernetes v1.29.2](https://github.com/kubernetes/kubernetes/releases/tag/v1.29.2)
 - [cri-dockerd v0.3.11](https://github.com/Mirantis/cri-dockerd/releases/tag/v0.3.11)
 - Docker Debug v0.0.27


### PR DESCRIPTION
## Description
Fix a couple small issues on the 4.29.0 Desktop release notes:
* Compose shipped with v2.26.1, not v2.26.0
* Scout CLI was in here twice
 
## Related issues or tickets
n/a

## Reviews
@aevesdocker 