### PR TITLE
fix: update glossary.yaml location

### DIFF
--- a/content/glossary.md
+++ b/content/glossary.md
@@ -12,5 +12,5 @@ aliases:
 
 <!--
 To edit/add/remove glossary entries, visit the YAML file at:
-https://github.com/docker/docs/blob/main/_data/glossary.yaml
+https://github.com/docker/docs/blob/main/data/glossary.yaml
 -->


### PR DESCRIPTION
<!--Delete sections as needed -->

## Description

Commit a0d21ade2f3344c61c32a4c42e43d9fd59e4a37c moved the location of `glossary.yaml`. This PR adjusts the sources to this change.

## Related issues or tickets

<!-- Related issues, pull requests, or Jira tickets -->

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Technical review
- [ ] Editorial review
- [ ] Product review