### PR TITLE
align beta callout wording

### DIFF
--- a/content/desktop/use-desktop/container.md
+++ b/content/desktop/use-desktop/container.md
@@ -86,10 +86,9 @@ and select the **System default** option under **Choose your terminal**.
 
 #### Open the integrated terminal in debug mode
 
-> **Beta**
+> **Beta feature**
 >
-> The debug mode feature is in [Beta](../../release-lifecycle.md/#beta). Docker
-> recommends that you don't use this feature in production environments.
+> The debug mode feature is currently in [Beta](../../release-lifecycle.md/#beta).
 { .experimental }
 
 Debug mode requires a [Pro, Team, or Business subcription](/subscription/details/). Debug mode has several advantages, such as:

--- a/content/desktop/use-desktop/volumes.md
+++ b/content/desktop/use-desktop/volumes.md
@@ -96,10 +96,9 @@ To empty a volume:
 
 ## Export a volume
 
-> **Beta**
+> **Beta feature**
 >
-> The export volume feature is in [Beta](../../release-lifecycle.md/#beta).
-> Docker recommends that you don't use this feature in production environments.
+> The export volume feature is currently in [Beta](../../release-lifecycle.md/#beta).
 { .experimental }
 
 You can export the content of a volume to a local file, a local image, or an to
@@ -128,10 +127,9 @@ To export a volume:
 
 ## Import a volume
 
-> **Beta**
+> **Beta feature**
 >
-> The import volume feature is in [Beta](../../release-lifecycle.md/#beta).
-> Docker recommends that you don't use this feature in production environments.
+> The import volume feature is currently in [Beta](../../release-lifecycle.md/#beta).
 { .experimental }
 
 You can import a local file, a local image, or an image from Docker Hub. Any

--- a/content/reference/cli/docker/debug.md
+++ b/content/reference/cli/docker/debug.md
@@ -7,6 +7,6 @@ aliases:
 - /engine/reference/commandline/debug/
 ---
 
-> **Beta**
+> **Beta feature**
 >
-> Docker Debug is currently in [Beta](../../../release-lifecycle.md#beta). Docker recommends that you do not use this in production environments.
+> Docker Debug is currently in [Beta](../../../release-lifecycle.md#beta).


### PR DESCRIPTION
## Description

Removed the mention of production environments as it doesn't really make sense for a local development feature. Aligned wording with the [Scout beta callout](https://docs.docker.com/scout/policy/remediation/).

## Related issues or tickets

ENGDOCS-2063

## Reviews

- [ ] Editorial review
