### PR TITLE
fix GitHub Actions YAML file block

### DIFF
--- a/content/scout/integrations/ci/gha.md
+++ b/content/scout/integrations/ci/gha.md
@@ -124,26 +124,26 @@ With this setup out of the way, you can add the following steps to run the
 image comparison:
 
 ```yaml
-# You can skip this step if Docker Hub is your registry
-# and you already authenticated before
-- name: Authenticate to Docker
-  uses: docker/login-action@v3
-  with:
-    username: ${{ secrets.DOCKER_USER }}
-    password: ${{ secrets.DOCKER_PAT }}
+      # You can skip this step if Docker Hub is your registry
+      # and you already authenticated before
+      - name: Authenticate to Docker
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USER }}
+          password: ${{ secrets.DOCKER_PAT }}
 
-# Compare the image built in the pull request with the one in production
-- name: Docker Scout
-  id: docker-scout
-  if: ${{ github.event_name == 'pull_request' }}
-  uses: docker/scout-action@v1
-  with:
-    command: compare
-    image: ${{ steps.meta.outputs.tags }}
-    to-env: production
-    ignore-unchanged: true
-    only-severities: critical,high
-    github-token: ${{ secrets.GITHUB_TOKEN }}
+      # Compare the image built in the pull request with the one in production
+      - name: Docker Scout
+        id: docker-scout
+        if: ${{ github.event_name == 'pull_request' }}
+        uses: docker/scout-action@v1
+        with:
+          command: compare
+          image: ${{ steps.meta.outputs.tags }}
+          to-env: production
+          ignore-unchanged: true
+          only-severities: critical,high
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 ```
 
 The compare command analyzes the image and evaluates policy compliance, and

--- a/content/scout/integrations/ci/gha.md
+++ b/content/scout/integrations/ci/gha.md
@@ -54,51 +54,51 @@ jobs:
     permissions:
       pull-requests: write
 
-steps:
-  - name: Checkout repository
-    uses: actions/checkout@v4
-    with:
-      ref: ${{ env.SHA }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ env.SHA }}
 
-  - name: Setup Docker buildx
-    uses: docker/setup-buildx-action@v3
+      - name: Setup Docker buildx
+        uses: docker/setup-buildx-action@v3
 
-  # Authenticate to the container registry
-  - name: Authenticate to registry ${{ env.REGISTRY }}
-    uses: docker/login-action@v3
-    with:
-      registry: ${{ env.REGISTRY }}
-      username: ${{ secrets.REGISTRY_USER }}
-      password: ${{ secrets.REGISTRY_TOKEN }}
+      # Authenticate to the container registry
+      - name: Authenticate to registry ${{ env.REGISTRY }}
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ secrets.REGISTRY_USER }}
+          password: ${{ secrets.REGISTRY_TOKEN }}
 
-  # Extract metadata (tags, labels) for Docker
-  - name: Extract Docker metadata
-    id: meta
-    uses: docker/metadata-action@v5
-    with:
-      images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-      labels: |
-        org.opencontainers.image.revision=${{ env.SHA }}
-      tags: |
-        type=edge,branch=$repo.default_branch
-        type=semver,pattern=v{{version}}
-        type=sha,prefix=,suffix=,format=short
+      # Extract metadata (tags, labels) for Docker
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          labels: |
+            org.opencontainers.image.revision=${{ env.SHA }}
+          tags: |
+            type=edge,branch=$repo.default_branch
+            type=semver,pattern=v{{version}}
+            type=sha,prefix=,suffix=,format=short
 
-  # Build and push Docker image with Buildx
-  # (don't push on PR, load instead)
-  - name: Build and push Docker image
-    id: build-and-push
-    uses: docker/build-push-action@v5
-    with:
-      context: .
-      sbom: ${{ github.event_name != 'pull_request' }}
-      provenance: ${{ github.event_name != 'pull_request' }}
-      push: ${{ github.event_name != 'pull_request' }}
-      load: ${{ github.event_name == 'pull_request' }}
-      tags: ${{ steps.meta.outputs.tags }}
-      labels: ${{ steps.meta.outputs.labels }}
-      cache-from: type=gha
-      cache-to: type=gha,mode=max
+      # Build and push Docker image with Buildx
+      # (don't push on PR, load instead)
+      - name: Build and push Docker image
+        id: build-and-push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          sbom: ${{ github.event_name != 'pull_request' }}
+          provenance: ${{ github.event_name != 'pull_request' }}
+          push: ${{ github.event_name != 'pull_request' }}
+          load: ${{ github.event_name == 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 ```
 
 This creates workflow steps to:


### PR DESCRIPTION
<!--Delete sections as needed -->

## Description

<!-- Tell us what you did and why -->
1. Indent the `steps` key two levels to move it from the top level
into the `build` job key, since it should be `jobs.build.steps` as specified
in [Workflow syntax for GitHub Actions](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idsteps)
2. Indent the step setting keys to the appropriate level

## Related issues or tickets

<!-- Related issues, pull requests, or Jira tickets -->

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Technical review
- [ ] Editorial review