### PR TITLE
scout: update and add push stub

### DIFF
--- a/content/reference/cli/docker/scout/push.md
+++ b/content/reference/cli/docker/scout/push.md
@@ -1,0 +1,14 @@
+---
+datafolder: scout-cli
+datafile: docker_scout_push
+title: docker scout push
+layout: cli
+---
+
+<!--
+This page is automatically generated from Docker's source code. If you want to
+suggest a change to the text that appears here, open a ticket in the source
+repository on GitHub:
+
+https://github.com/docker/scout-cli
+-->

--- a/data/toc.yaml
+++ b/data/toc.yaml
@@ -684,6 +684,8 @@ Reference:
       title: docker scout integration list
     - path: /reference/cli/docker/scout/policy/
       title: docker scout policy
+    - path: /reference/cli/docker/scout/push/
+      title: docker scout push
     - path: /reference/cli/docker/scout/quickview/
       title: docker scout quickview
     - path: /reference/cli/docker/scout/recommendations/


### PR DESCRIPTION
<!--Delete sections as needed -->

## Description

- ~Update scout-cli to v1.6.4~ syntax issue in latest v1.6, so I will carry an update in a separate pr
- Add stub file for `docker scout push`

https://deploy-preview-19807--docsdocker.netlify.app/reference/cli/docker/scout/push/
