### PR TITLE
docs: Update grammer and semantics in file-watch.md

### DIFF
--- a/content/compose/file-watch.md
+++ b/content/compose/file-watch.md
@@ -15,7 +15,7 @@ For many projects, this allows for a hands-off development workflow once Compose
 * Directories are watched recursively
 * Glob patterns aren't supported
 * Rules from `.dockerignore` apply
-  * Use `ignore` to defined additional paths to be ignored (same syntax)
+  * Use `ignore` option to define additional paths to be ignored (same syntax)
   * Temporary/backup files for common IDEs (Vim, Emacs, JetBrains, & more) are ignored automatically
   * `.git` directories are ignored automatically
 
@@ -41,7 +41,7 @@ Each rule requires, a `path` pattern and `action` to take when a modification is
 the `action`, additional fields might be accepted or required. 
 
 Watch mode can be used with many different languages and frameworks.
-The specific paths and rules will vary project to project, but the concepts remain the same. 
+The specific paths and rules will vary from project to project, but the concepts remain the same. 
 
 ### Prerequisites
 


### PR DESCRIPTION
## Description

> Add minor patches to correct the docs for `compose watch`.

<!-- Tell us what you did and why -->
I updated a sentence containing grammar errors to improve the documentation for future readers.
Given the following sentence: **"Use `ignore` to defined additional paths to be ignored (same syntax)"**
The following patches were made:
- Modify `defined` to `define`, the correct verb tense in the given context.
- Specify `ignore` as an option for better clarity for first-time readers.


## Related issues or tickets

After an extensive search: `N/A`.

## Reviews

<!-- Notes for reviewers here -->
The following [`CONTRIBUTOR`](https://github.com/docker/docs/blob/35219d69ec6ac6fd7270ec5be318f8edff67afe3/CONTRIBUTING.md#editing-content) guidelines were followed:
1. Include a single file change in this PR.
2. Use an editor without automatic reformatting to avoid whitespace or line-wrapping changes.

<!-- List applicable reviews (optionally @tag reviewers) -->
- [ ] Technical review
- [ ] Editorial review
- [ ] Product review