### PR TITLE
lint: enable markdownlint MD022 / blanks-around-headings

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,5 +1,6 @@
 {
   "default": false,
+  "blanks-around-headings": true,
   "hr-style": true,
   "heading-start-left": true,
   "single-h1": true,

--- a/content/admin/organization/members.md
+++ b/content/admin/organization/members.md
@@ -45,6 +45,7 @@ To add a member to a team:
    > **Note**
    >
    > The invitee must first accept the invitation to join the organization before being added to the team.
+
 ### Remove a member from a team
 
 To remove a member from a specific team:

--- a/content/compose/compose-file/05-services.md
+++ b/content/compose/compose-file/05-services.md
@@ -872,6 +872,7 @@ external_links:
 `extra_hosts` adds hostname mappings to the container network interface configuration (`/etc/hosts` for Linux).
 
 ### Short syntax
+
 Short syntax uses plain strings in a list. Values must set hostname and IP address for additional hosts in the form of `HOSTNAME=IP`.
 
 ```yml
@@ -897,6 +898,7 @@ extra_hosts:
 ```
 
 ### Long syntax
+
 Alternatively, `extra_hosts` can be set as a mapping between hostname(s) and IP(s)
 
 ```yml

--- a/content/compose/compose-file/compose-file-v3.md
+++ b/content/compose/compose-file/compose-file-v3.md
@@ -595,6 +595,7 @@ credential_spec:
 ```
 
 #### Example gMSA configuration
+
 When configuring a gMSA credential spec for a service, you only need
 to specify a credential spec with `config`, as shown in the following example:
 

--- a/content/compose/environment-variables/env-file.md
+++ b/content/compose/environment-variables/env-file.md
@@ -15,6 +15,7 @@ For more information, see [Environment variables precedence](envvars-precedence.
 { .important }
 
 ## Syntax
+
 The following syntax rules apply to environment files:
 
 - Lines beginning with `#` are processed as comments and ignored.
@@ -42,6 +43,7 @@ The following syntax rules apply to environment files:
   - `VAR=some\tvalue` -> `some\tvalue`
 
 ### Interpolation
+
 Compose supports interpolation in environment files.
 Interpolation is applied for unquoted and double-quoted values.
 Both braced (`${VAR}`) and unbraced (`$VAR`) expressions are supported.

--- a/content/compose/environment-variables/set-environment-variables.md
+++ b/content/compose/environment-variables/set-environment-variables.md
@@ -104,6 +104,7 @@ web:
 See [`environment` attribute](../compose-file/05-services.md#environment) for more examples on how to use it. 
 
 #### Additional information 
+
 - You can choose not to set a value and pass the environment variables from your shell straight through to your containers. It works in the same way as `docker run -e VARIABLE ...`:
   ```yaml
   web:
@@ -132,7 +133,9 @@ web:
   env_file:
     - web-variables.env
 ```
+
 #### Additional information 
+
 - If multiple files are specified, they are evaluated in order and can override values set in previous files.
 - Environment variables declared in the `.env` file cannot then be referenced again separately in the Compose file.
 - If you use both the `env_file` and `environment` attribute, environment variables set by `environment` take precedence.
@@ -188,6 +191,7 @@ $ docker compose --env-file ./config/.env.dev up
 ```
 
 #### Additional information 
+
 - This method is useful if you want to temporarily override an `.env` file that is already referenced in your `compose.yml` file. For example you may have different `.env` files for production ( `.env.prod`) and testing (`.env.test`).
   In the following example, there are two environment files, `.env` and `.env.dev`. Both have different values set for `TAG`. 
 
@@ -246,6 +250,7 @@ Similar to `docker run --env`, you can set environment variables temporarily wit
 ```console
 $ docker compose run -e DEBUG=1 web python console.py
 ```
+
 #### Additional information 
 
 - You can also pass a variable from the shell by not giving it a value:
@@ -257,6 +262,7 @@ $ docker compose run -e DEBUG=1 web python console.py
   The value of the `DEBUG` variable in the container is taken from the value for the same variable in the shell in which Compose is run.
 
 ## Further resources
+
 - [Understand environment variable precedence](envvars-precedence.md).
 - [Set or change predefined environment variables](envvars.md)
 - [Explore best practices](best-practices.md)

--- a/content/compose/install/standalone.md
+++ b/content/compose/install/standalone.md
@@ -12,6 +12,7 @@ aliases:
 On this page you can find instructions on how to install Compose standalone on Linux or Windows Server, from the command line.
 
 ### On Linux
+
 > **Compose standalone**
 >
 > Note that Compose standalone uses the `-compose` syntax instead of the current standard syntax `compose`.  

--- a/content/compose/intro/features-uses.md
+++ b/content/compose/intro/features-uses.md
@@ -63,6 +63,7 @@ For details on using production-oriented features, see
 [Compose in production](../production.md).
 
 ## What's next?
+
 - [Learn about the history of Compose](history.md)
 - [Understand how Compose works](../compose-application-model.md)
 - [Try Compose](../gettingstarted.md)

--- a/content/compose/migrate.md
+++ b/content/compose/migrate.md
@@ -131,6 +131,7 @@ Yes. You can still download and install Compose V1 packages, but you won't get s
 { .warning }
 
 ## Additional Resources
+
 - [docker-compose V1 on PyPI](https://pypi.org/project/docker-compose/1.29.2/)
 - [docker/compose V1 on Docker Hub](https://hub.docker.com/r/docker/compose)
 - [docker-compose V1 source on GitHub](https://github.com/docker/compose/releases/tag/1.29.2)

--- a/content/compose/release-notes.md
+++ b/content/compose/release-notes.md
@@ -12,26 +12,31 @@ aliases:
 For more detailed information, see the [release notes in the Compose repo](https://github.com/docker/compose/releases/).
 
 ## 2.26.0
+
 {{< release-date date="2024-03-29" >}}
 
 ### Update
+
 - Dependencies upgrade: opencontainers/image-spec v1.1.0
 
 ### Bug fixes and enhancements
+
 - Added image pull failure reason in output
 - Fixed crash when running up with `--no-build` and `--watch`
 - Fixed crash when no TTY available and menu enabled
 - Improved legibility of menu actions
 
-
 ## 2.26.0
+
 {{< release-date date="2024-03-22" >}}
 
 ### Update
+
 - Dependencies upgrade: bump compose-go v2.0.2
 - Dependencies upgrade: bump docker v26.0.0
 
 ### Bug fixes and enhancements
+
 - Reduced timeout of the Otel tracing command
 - Fixed `config --format json`
 - Fixed documentation on default build image name
@@ -40,23 +45,26 @@ For more detailed information, see the [release notes in the Compose repo](https
 - Introduced `config --variables` to list Compose model variables
 - Added a navigation menu within `docker compose up`
 
-
 ## 2.25.0
+
 {{< release-date date="2024-03-15" >}}
 
-
 ### Update
+
 - Dependencies upgrade: bump compose-go v2.0.0
 
 ### Bug fixes and enhancements
+
 - Restored `config` hebaviour until `--no-interpolate` is set
 - Fixed service name shell completion
 - Added `--watch` flag to `up` command
 
 ## 2.24.7
+
 {{< release-date date="2024-03-06" >}}
 
 ### Update
+
 - Dependencies upgrade: bump golang to 1.21.8
 - Dependencies upgrade: bump compose-go to 2.0.0-rc8
 - Dependencies upgrade: bump docker to v24.0.4
@@ -77,74 +85,92 @@ For more detailed information, see the [release notes in the Compose repo](https
 - Compose now respects `COMPOSE_REMOVE_ORPHANS` on `up`
 
 ## 2.24.6
+
 {{< release-date date="2024-02-15" >}}
 
 ### Update
+
 - Dependencies upgrade: bump cli to 25.0.3
 - Dependencies upgrade: bump compose-go to 2.0.0-rc.7
 
 ### Bug fixes and enhancements
+
 - Fixed issue of `.env` file loading when project file is set via `COMPOSE_FILE` variable
 - Aligned `ps --status=exited` behaviour with the Docker CLI behaviour
 - Fixed a deadlock when collecting large logs
 
 ## 2.24.5
+
 {{< release-date date="2024-01-30" >}}
 
 ### Bug fixes and enhancements
+
 - Fixed "failed to solve: changes out of order" errors when building images on Windows.
 
 ## 2.24.4
+
 {{< release-date date="2024-01-29" >}}
 
 ### Update
+
 - Dependencies upgrade: bump cli to 25.0.1
 - Dependencies upgrade: bump docker to 25.0.1
 - Dependencies upgrade: bump compose-go to 2.0.0-rc.3
 
 ### Bug fixes and enhancements
+
 - Fixed issue when checking external network existence when swarm is enabled.
 - Added support for `storage_opt` attribute.
 
 ## 2.24.3
+
 {{< release-date date="2024-01-24" >}}
 
 This release fixes a build issue with Docker Desktop for Windows introduced in Compose v2.24.0.
 
 ### Update
+
 - Compose now uses a custom version of `fsutils` library.
 
 ## 2.24.2
+
 {{< release-date date="2024-01-22" >}}
 
 ### Update
+
 - Dependencies upgrade: bump cli to 25.0.0 GA
 - Dependencies upgrade: bump compose-go to 2.0.0-rc.2
 
 ## 2.24.1
+
 {{< release-date date="2024-01-18" >}}
 
 ### Update
+
 - Dependencies upgrade: bump cli to 25.0.0-rc3
 - Dependencies upgrade: bump docker to 25.0.0-rc3
 - Dependencies upgrade: bump compose-go to 2.0.0-rc.1
 - Dependencies upgrade: bump containerd to 1.7.12
 
 ### Bug fixes and enhancements
+
 - Reworked the display of container status during `up`
 - Fixed the engine version required to use `healthcheck.start_interval`
 - Removed `watch` subcommand from the `alpha` command
 - Fixed a bug when handling received signals
 
 ## 2.24.0
+
 {{< release-date date="2024-01-11" >}}
 
 ### Update
+
 - Dependencies upgrade: bump cli to 25.0.0-beta.3
 - Dependencies upgrade: bump compose-go to 2.0.0-beta.3
 - Dependencies upgrade: bump golang to 1.21.6 
 
 ### Bug fixes and enhancements
+
 - Introduced `docker compose attach` to attach local standard input, output, and error streams to a service's running container.
 - Introduced `docker compose stats` to display a live stream of container(s) resource usage statistics.
 - Introduced `docker compose ps --orphans` to include/exclude services not declared.
@@ -163,33 +189,41 @@ This release fixes a build issue with Docker Desktop for Windows introduced in C
 - Fixed `docker compose up` teardown when command context is cancelled.
 
 ## 2.23.3
+
 {{< release-date date="2023-11-22" >}}
 
 ### Update
+
 - Dependencies upgrade: bump buildx to v0.12.0
 
 ## 2.23.2
+
 {{< release-date date="2023-11-21" >}}
 
 ### Update
+
 - Dependencies upgrade: bump buildkit 0.12.3 
 - Dependencies upgrade: bump docker 24.0.7 
 - Dependencies upgrade: bump cli 24.0.7 
 - Dependencies upgrade: bump 1.20.2
 
 ### Bug fixes and enhancements
+
 - Compose now supports `builds.tags` with `push` command.
 - Compose Watch now re-builds service images at startup.
 - Now `--remove-orphans` doesn't manage disabled services as orphaned.
 - Compose displays `Building` output log only if there is at least one service to build.
 
 ## 2.23.1
+
 {{< release-date date="2023-11-16" >}}
 
 ### Update
+
 - Dependencies upgrade: bump compose-go to v1.20.1
 
 ### Bug fixes and enhancements
+
 - Aligned Compose with OCI artifact best practices.
 - Introduced `--resolve-image-digests` so users can seal service images by digest when publishing a Compose application.
 - Improved Compose Watch configuration logging.
@@ -204,13 +238,16 @@ This release fixes a build issue with Docker Desktop for Windows introduced in C
 - Stripped project prefix from docker-compose up output.
 
 ## 2.23.0
+
 {{< release-date date="2023-10-18" >}}
 
 ### Update
+
 - Dependencies upgrade: bump compose-go to v1.20.0
 - Dependencies upgrade: bump containerd to 1.7.7
 
 ### Bug fixes and enhancements
+
 - Added dry-run support for publish command
 - Added `COMPOSE_ENV_FILES` env variable to pass a list of env files
 - Added `sync+restart` action to `compose watch`
@@ -220,6 +257,7 @@ This release fixes a build issue with Docker Desktop for Windows introduced in C
 - Fixed an issue when the pull policy provided was invalid
 
 ## 2.22.0
+
 {{< release-date date="2023-09-21" >}}
 
 > **Note**
@@ -228,11 +266,13 @@ This release fixes a build issue with Docker Desktop for Windows introduced in C
 > For more information, see [File watch](./file-watch.md).
 
 ### Update
+
 - Dependencies upgrade: bump golang to 1.21.1
 - Dependencies upgrade: bump compose-go to v1.19.0
 - Dependencies upgrade: bump buildkit to v0.12.2
 
 ### Bug fixes and enhancements
+
 - Added experimental support for the `publish` command.
 - The command `watch` now builds and launches the project during startup.
 - Added `policy` option to the `--pull` flag.
@@ -243,6 +283,7 @@ This release fixes a build issue with Docker Desktop for Windows introduced in C
 - Passed BuildOptions to `up` and `run` commands.
 
 ## 2.21.0
+
 {{< release-date date="2023-08-30" >}}
 
 > **Note**
@@ -250,9 +291,11 @@ This release fixes a build issue with Docker Desktop for Windows introduced in C
 > The format of `docker compose ps` and `docker compose ps --format=json` changed to better align with `docker ps` output. See [compose#10918](https://github.com/docker/compose/pull/10918).
 
 ### Update
+
 - Dependencies upgrade: bump compose-go to v1.18.3
 
 ### Bug fixes and enhancements
+
 - Changed `docker compose ps` and `docker compose ps --format=json` output to align with Docker CLI.
 - Added support for multi-document YAML files.
 - Added support for loading remote Compose files from Git repos with `include` (experimental).
@@ -262,14 +305,17 @@ This release fixes a build issue with Docker Desktop for Windows introduced in C
 - Fixed `.env` overrides when using `include`.
 
 ## 2.20.3
+
 {{< release-date date="2023-08-11" >}}
 
 ### Update
+
 - Dependencies upgrade: bump golang to 1.21.0
 - Dependencies upgrade: bump compose-go to v1.18.1
 - Dependencies upgrade: bump buildkit to v0.12.1
 
 ### Bug fixes and enhancements
+
 - Improved speed and reliability of `watch` sync.
 - Added builder's name on the first build line.
 - Improved shell completion for `--project-directory` and `--profile`.
@@ -277,32 +323,39 @@ This release fixes a build issue with Docker Desktop for Windows introduced in C
 - Removed unnecessary warning when an option dependency exists successfully.
 
 ## 2.20.2
+
 {{< release-date date="2023-07-19" >}}
 
 ### Bug fixes and enhancements
+
 - Added support for the `depends_on.required` attribute.
 - Fixed an issue where build tries to push unnamed service images.
 - Fixed a bug which meant the target secret path on Windows was not checked.
 - Fixed a bug resolving build context path for services using `extends.file`.
 
 ## 2.20.1
+
 {{< release-date date="2023-07-18" >}}
 
 ### Update
+
 - Dependencies upgrade: bump golang to 1.20.6
 - Dependencies upgrade: bump buildx to v0.11.2
 - Dependencies upgrade: bump buildkit to v0.12
 - Dependencies upgrade: bump docker-cli to v24.0.5-dev
 
 ## 2.20.0
+
 {{< release-date date="2023-07-11" >}}
 
 ### Update
+
 - Dependencies upgrade: bump docker/cli-docs-tools to v0.6.0
 - Dependencies upgrade: bump docker to v24.0.4
 - Dependencies upgrade: bump buildx to v0.11.1
 
 ### Bug fixes and enhancements
+
 * Introduced the `wait` command.
 * Added support of `--builder` and `BUILDX_BUILDER` to the `build` command.
 * Added support for the `include` and `attach` attributes from the Compose Specification.
@@ -316,26 +369,32 @@ This release fixes a build issue with Docker Desktop for Windows introduced in C
 * Improved some test speeds.
 
 ## 2.19.1
+
 {{< release-date date="2023-06-29" >}}
 
 ### Update
+
 - Dependencies upgrade: bump compose-go to v1.15.1
 
 ### Bug fixes and enhancements
+
 - Fixed sporadic "container not connected to network" errors on `compose up`.
 - Fixed "please specify build context" errors on `compose build`.
 - Compose now warns if using a bind mount in a service `watch` configuration.
 
 ## 2.19.0
+
 {{< release-date date="2023-06-21" >}}
 
 ### Update
+
 - Dependencies upgrade: bump compose-go to v1.15.0
 - Dependencies upgrade: bump buildx to v0.11.0
 - Dependencies upgrade: bump docker to v24.0.2
 - Dependencies upgrade: bump golang to 1.20.5
 
 ### Bug fixes and enhancements
+
 - Introduced the ability to select a single service to be stopped by `compose down`.
 - Added `--progress` as top-level flag to configure progress UI style.
 - Introduced `run --cap-add` to run maintenance commands using service image.
@@ -365,20 +424,25 @@ This release fixes a build issue with Docker Desktop for Windows introduced in C
 - Added more ignore rules to dependabot.
 
 ## 2.18.1
+
 {{< release-date date="2023-05-17" >}}
 
 ### Bug fixes and enhancements
+
 - Fixed "Image not found" errors when building images
 
 ## 2.18.0
+
 {{< release-date date="2023-05-16" >}}
 
 ### Update
+
 - Dependencies upgrade: bump compose-go to v1.13.5
 - Dependencies upgrade: bump buildkit to v0.11.6
 - Dependencies upgrade: bump docker to v23.0.5
 
 ### Bug fixes and enhancements
+
 - Added dry run support using `--dry-run`
 - Added the first (alpha) implementation of the `viz` sub-command
 - Introduced `--no-path-resolution` to skip relative path to be resolved
@@ -400,40 +464,52 @@ This release fixes a build issue with Docker Desktop for Windows introduced in C
 - Compose now reports that the external network is not found when Swarm is disabled
 
 ## 2.17.2
+
 {{< release-date date="2023-03-26" >}}
 
 ### Update
+
 - Dependencies upgrade: bump compose-go to v1.13.2
 
 ### Bug fixes and enhancements
+
 - Fixed invalid project name error for directories with uppercase characters or `.` in the name. Fixed [compose#10405](https://github.com/docker/compose/issues/10405)
 
 ## 2.17.1
+
 {{< release-date date="2023-03-24" >}}
+
 ### Update
+
 - Dependencies upgrade: bump buildkit to v0.11.5
 - Dependencies upgrade: bump compose-go to v1.13.1
 - Dependencies upgrade: bump golang to 1.20.2
 
 ### Bug fixes and enhancements
+
 - Fixed panic on `alpha watch` command. Pull Request [compose#10393](https://github.com/docker/compose/pull/10393)
 - Prevented conflicts for services named `extensions`. Fixed [compose-go#247](https://github.com/compose-spec/compose-go/issues/247)
 - Compose now validates project names more consistently. Fixed [compose-go#363](https://github.com/compose-spec/compose-go/issues/363)
 
 ## 2.17.0
+
 {{< release-date date="2023-03-23" >}}
+
 ### Upgrade notes
+
 - Project name validation is more strictly enforced. Project names can only include letters, numbers, `_`, `-` and must be lowercase and start with a letter or number.
 - Boolean fields in YAML must be either `true` or `false`. Deprecated YAML 1.1 values such as "on" or "no" are not supported.
 - Duplicate YAML merge keys (`<<`) are rejected.
 
 ### Update
+
 - Dependencies upgrade: bump buildkit to v0.11.4
 - Dependencies upgrade: bump buildx to v0.10.4
 - Dependencies upgrade: bump containerd to 1.6.18
 - Dependencies upgrade: bump compose-go to v1.13.0
 
 ### Bug fixes and enhancements
+
 * Introduced `--wait-timeout` on `up` command. Fixed [compose#10269](https://github.com/docker/compose/issues/10269)
 * Made `compose service --hash` output sort by service name. Pull Request [compose#10278](https://github.com/docker/compose/pull/10278)
 * Compose now renders a compact TUI progress report to monitor layers download. Pull Request [compose#10281](https://github.com/docker/compose/pull/10281)
@@ -463,8 +539,11 @@ This release fixes a build issue with Docker Desktop for Windows introduced in C
 * Compose now supports Dry Run mode for `restart` command. Pull Request [compose#10339](https://github.com/docker/compose/issues/10339)
 
 ## 2.16.0
+
 {{< release-date date="2023-02-08" >}}
+
 ### Update
+
 - Dependencies upgrade: bump docker to v23.0.0
 - Dependencies upgrade: bump docker-cli to v23.0.0
 - Dependencies upgrade: bump buildkit to v0.11.2
@@ -473,6 +552,7 @@ This release fixes a build issue with Docker Desktop for Windows introduced in C
 - Dependencies upgrade: bump golang to 1.20
 
 ### Bug fixes and enhancements
+
 * Introduced `--remove-orphans` for the `compose create` command. Fixed [compose#9718](https://github.com/docker/compose/issues/9718)
 * Shortened the TTY output when the terminal is too small. Fixed [compose#9962](https://github.com/docker/compose/issues/9962)
 * Added `remove-orphans` functionality to run. Fixed [compose#9718](https://github.com/docker/compose/issues/9718#issuecomment-1209448445)
@@ -501,23 +581,31 @@ This release fixes a build issue with Docker Desktop for Windows introduced in C
 * Compose now supports Dry Run mode for `cp` command.Fixed [compose#10235](https://github.com/docker/compose/issues/10235)
 
 ## 2.15.1
+
 {{< release-date date="2023-01-09" >}}
+
 ### Update
+
 - Dependencies upgrade to fix Golan CVE-2022-27664 and CVE-2022-32149
 
 ### Bug fixes and enhancements
+
 * Added support for UTS namespace. Fixed [compose#8408](https://github.com/docker/compose/issues/8408)
 * Fixed filtering issue when no filter set. Fixed [roadmap#418](https://github.com/docker/roadmap/issues/418)
 * Fixed concurrent map writes issue during build step. Pull Request [compose#10151](https://github.com/docker/compose/pull/10151)
 * Fixed issue when stdin is not a terminal. Fixed [compose#9739](https://github.com/docker/compose/issues/9739)
 
 ## 2.15.0
+
 {{< release-date date="2023-01-05" >}}
+
 ### Update
+
 - Dependencies upgrade: bump compose-go to v1.8.1
 - Dependencies upgrade: bump cli-docs-tool to 0.5.1
 
 ### Bug fixes and enhancements
+
 * Added support of the `privileged` attribute in the `service.build` section. Pull Request [compose#10112](https://github.com/docker/compose/pull/10112)
 * Introduced `--ignore-buildable` to ignore buildable images on pull. Fixed [compose#8805](https://github.com/docker/compose/issues/8805)
 * Introduceed `--no-attach` to ignore some service outputs. Fixed [compose#8546](https://github.com/docker/compose/issues/8546)
@@ -532,11 +620,15 @@ This release fixes a build issue with Docker Desktop for Windows introduced in C
 * Compose limits build concurrency according to `--parallel`. Fixed [compose#9091](https://github.com/docker/compose/issues/9091)
 
 ## 2.14.2
+
 {{< release-date date="2022-12-20" >}}
+
 ### Update
+
 - Dependencies upgrade: bump containerd to 1.6.14
 
 ### Bug fixes and enhancements
+
 * Compose now uses DOCKER_DEFAULT_PLATFORM to determine the platform when creating a container. Fixed [compose#10041](https://github.com/docker/compose/pull/10041)
 * Compose now detects when dependency failed to start. Fixed [compose#9732](https://github.com/docker/compose/pull/9732)
 * Fixed WCOW volume mounts.  Fixed [compose#9577](https://github.com/docker/compose/pull/9577)
@@ -547,13 +639,16 @@ This release fixes a build issue with Docker Desktop for Windows introduced in C
 * Updated projectOptions to be public by renaming it to ProjectOptions. Fixed [compose#100102](https://github.com/docker/compose/pull/100102)
 
 ## 2.14.1
+
 {{< release-date date="2022-12-15" >}}
 
 ### Updates
+
 - Dependencies upgrade: bump Go to 1.19.4
 - Dependencies upgrade: bump containerd to 1.6.12
 
 ### Bug fixes and enhancements
+
 - Added `--parallel` to limit concurrent engine calls. Pull Request [compose#10030](https://github.com/docker/compose/pull/10030)
 - Distinguished stdout and stderr in `up` logs. Fixed [compose#8098](https://github.com/docker/compose/issues/8098)
 - Aligned `compose ps` output with `docker ps`. Fixed [compose#6867](https://github.com/docker/compose/issues/6867)
@@ -570,13 +665,16 @@ This release fixes a build issue with Docker Desktop for Windows introduced in C
 - Load project from files when explicitly set by user. Fixed [compose#9554](https://github.com/docker/compose/pull/9554) 
 
 ## 2.14.0
+
 {{< release-date date="2022-12-02" >}}
 
 ### Updates
+
 - Dependencies upgrade: bump compose-go to [v1.8.0](https://github.com/compose-spec/compose-go/releases/tag/v1.8.0)
 - Dependencies upgrade: bump Go to 1.19.3
 
 ### Bug fixes and enhancements
+
 - Added `oom_score_adj` field to service definition. Pull Request [compose#10019](https://github.com/docker/compose/issues/10019)
 - Added mode field for tmpfs mount permissions. Pull Request [compose#10031](https://github.com/docker/compose/issues/10031)
 - Compose now only stops services started by `up` when interrupted. Fixed [compose#10028](https://github.com/docker/compose/issues/10028)
@@ -588,14 +686,17 @@ This release fixes a build issue with Docker Desktop for Windows introduced in C
 - Fixed `run` for services using `network_mode: service:NAME`. Fixed [compose#10036](https://github.com/docker/compose/issues/10036)
 
 ## 2.13.0
+
 {{< release-date date="2022-11-23" >}}
 
 ### Updates
+
 - Dependencies upgrade: bump containerd to 1.6.10
 - Dependencies upgrade: bump docker-credential-helpers to v0.7.0
 - Update CI dependencies. Pull Request [compose#9982](https://github.com/docker/compose/pull/9982)
 
 ### Bug fixes and enhancements
+
 - Added a `no-consistency` option to `convert` command. Fixed [compose#9963](https://github.com/docker/compose/issues/9963)
 - Added a `build` option to `run` command. Fixed [compose#10003](https://github.com/docker/compose/issues/10003)
 - Fixed mapping `restart_policy.condition` to engine supported values. Fixed [compose#8756](https://github.com/docker/compose/issues/8756), [docs#15936](https://github.com/docker/docs/pull/15936)
@@ -607,33 +708,39 @@ This release fixes a build issue with Docker Desktop for Windows introduced in C
 - Removed usage of the deprecated dependency `gotest.tools` v2. Pull Request [compose#9935](https://github.com/docker/compose/pull/9935)
 - Excluded issues labeled with `kind/feature` from stale bot process. Fixed [compose#9988](https://github.com/docker/compose/pull/9988)
 
-
 ## 2.12.2
+
 {{< release-date date="2022-10-21" >}}
 
 ### Updates
+
 - Updated Docker Engine API to restore compatibility with Golang 1.18 needed for Linux packaging. Pull Request [compose#9940](https://github.com/docker/compose/pull/9940)
 
 For the full change log or additional information, check the [Compose repository 2.12.2 release page](https://github.com/docker/compose/releases/tag/v2.12.2).
 
 ## 2.12.1
+
 {{< release-date date="2022-10-21" >}}
 
 ### Security
+
 - Updated Docker Engine API to apply fix of [CVE-2022-39253](https://nvd.nist.gov/vuln/detail/CVE-2022-39253). Pull Request [compose#9934](https://github.com/docker/compose/pull/9934)
 
 For the full change log or additional information, check the [Compose repository 2.12.1 release page](https://github.com/docker/compose/releases/tag/v2.12.1).
 
 ## 2.12.0
+
 {{< release-date date="2022-10-18" >}}
 
 ### Updates
+
 - CI update to the documentation repository path
 - Upgraded to compose-go from [1.5.1 to 1.6.0](https://github.com/compose-spec/compose-go/releases/tag/v1.6.0)
 
 - Updated to go 1.19.2 to address CVE-2022-2879, CVE-2022-2880, CVE-2022-41715
 
 ### Bug fixes and enhancements
+
 - Added a `quiet` option when pushing an image. Fixed [compose#9089](https://github.com/docker/compose/issues/9089)
 - Fixed a misleading error message for `port` command. Pull Request [compose#9909](https://github.com/docker/compose/pull/9909)
 - Fixed a bug to prevent failure when Compose tries to remove a non-existing container. Fixed by [compose#9896](https://github.com/docker/compose/pull/9896/)
@@ -642,6 +749,7 @@ For the full change log or additional information, check the [Compose repository
 For the full change log or additional information, check the [Compose repository 2.12.0 release page](https://github.com/docker/compose/releases/tag/v2.12.0).
 
 ## 2.11.2
+
 {{< release-date date="2022-09-27" >}}
 
 > **Note**     
@@ -650,9 +758,11 @@ For the full change log or additional information, check the [Compose repository
 > - Setting `DOCKER_HOST` via `.env` files is not supported in Compose v2
 
 ### Updates
+
 - Upgraded to compose-go from [1.5.1 to 1.6.0](https://github.com/compose-spec/compose-go/releases/tag/v1.6.0)
 
 ### Bug fixes and enhancements
+
 - Fixed a bug to prevent "invalid template" errors on valid environment variable values. Fixes [compose##9806](https://github.com/docker/compose/issues/9806), [compose##9746](https://github.com/docker/compose/issues/9746), [compose##9704](https://github.com/docker/compose/issues/9704), [compose##9294](https://github.com/docker/compose/issues/9294)
 - Fixed a bug to ensure new images from `docker compose build` are used. Fixes [compose#9856](https://github.com/docker/compose/issues/9856)
 - Fixed cross-architecture builds when `DOCKER_DEFAULT_PLATFORM` not set. Fixes [compose#9864](https://github.com/docker/compose/pull/9864)
@@ -670,9 +780,11 @@ For the full change log or additional information, check the [Compose repository
 For the full change log or additional information, check the [Compose repository 2.11.2 release page](https://github.com/docker/compose/releases/tag/v2.11.2).
 
 ## 2.11.1
+
 {{< release-date date="2022-09-20" >}}
 
 ### Bug fixes and enhancements
+
 - Fixed a bug to keep `depends_on` condition when service has `volumes_from`. Fixes [compose#9843](https://github.com/docker/compose/issues/9843)
 - Fixed a bug to keep the platform defined at service level during build if no build platforms. Fixes [compose#9729](https://github.com/docker/compose/pull/9729#issuecomment-1246748144)
 - Fixed a bug to keep the platform defined via DOCKER_DEFAULT_PLATFORM during build if no build platforms provided. Fixes [compose#9853](https://github.com/docker/compose/issues/9853)
@@ -680,9 +792,11 @@ For the full change log or additional information, check the [Compose repository
 For the full change log or additional information, check the [Compose repository 2.11.1 release page](https://github.com/docker/compose/releases/tag/v2.11.1).
 
 ## 2.11.0
+
 {{< release-date date="2022-09-14" >}}
 
 ### Updates
+
 - Dependencies upgrade: bump Golang to 1.19.1
 - Dependencies upgrade: bump github.com/docker/go-units from 0.4.0 to 0.5.0
 - Dependencies upgrade: bump github.com/cnabio/cnab-to-oci from 0.3.6 to 0.3.7
@@ -692,6 +806,7 @@ For the full change log or additional information, check the [Compose repository
 - Dependencies upgrade: bump compose-go from [1.5.0 to 1.5.1](https://github.com/compose-spec/compose-go/releases/tag/v1.5.1)
 
 ### Bug fixes and enhancements
+
 - Added platforms build. Fixes [compose-spec#267](https://github.com/compose-spec/compose-spec/pull/267)
 - Logs now filter to services from current Compose file. Fixes [compose#9801](https://github.com/docker/compose/issues/9801)
 - Added an improved output warning when pulling images. Fixes [compose#9820](https://github.com/docker/compose/issues/9820)
@@ -706,6 +821,7 @@ For the full change log or additional information, check the [Compose repository
 For the full change log or additional information, check the [Compose repository 2.11.0 release page](https://github.com/docker/compose/releases/tag/v2.11.0).
 
 ## 2.10.2
+
 {{< release-date date="2022-08-26" >}}
 
 ### Bug fixes and enhancements
@@ -715,8 +831,8 @@ For the full change log or additional information, check the [Compose repository
 
 For the full change log or additional information, check the [Compose repository 2.10.2 release page](https://github.com/docker/compose/releases/tag/v2.10.2).
 
-
 ## 2.10.1
+
 {{< release-date date="2022-08-24" >}}
 
 ### Updates
@@ -724,6 +840,7 @@ For the full change log or additional information, check the [Compose repository
 - Dependencies update: Bumped github.com/moby/buildkit from [0.10.3 to 0.10.4](https://github.com/moby/buildkit/releases/tag/v0.10.4).
 
 ### Bug fixes and enhancements
+
 - Fixed image pulls being skipped when `pull_policy` was not set. Fixes [compose#9773](https://github.com/docker/compose/issues/9773).
 - Restored `.sha256` checksum files in release artifacts. Fixes [compose#9772](https://github.com/docker/compose/issues/9772).
 - Removed error message showing exit code when using --exit-code-from. Fixes [compose#9782](https://github.com/docker/compose/issues/9782).
@@ -732,15 +849,17 @@ For the full change log or additional information, check the [Compose repository
 
 For the full change log or additional information, check the [Compose repository 2.10.1 release page](https://github.com/docker/compose/releases/tag/v2.10.1).
 
-
 ## 2.10.0
+
 {{< release-date date="2022-08-19" >}}
 
 ### New
+
 - Applied newly loaded environment variables to `DockerCli` and `APIClient`. Fixes [compose#9210](https://github.com/docker/compose/issues/9210).
 - Added support for windows/arm64 and linux/riscv64.
 
 ### Updates
+
 - Updated Dockerfile syntax to latest stable and renamed docs Dockerfile.
 - Dependencies update: Upgraded BuildKit & docker/distribution.
 - Dependencies update: Updated Docker CLI version used in CI to v20.10.17.
@@ -750,6 +869,7 @@ For the full change log or additional information, check the [Compose repository
 - Dependencies update: Bumped github.com/cnabio/cnab-to-oci from [0.3.5 to 0.3.6](https://github.com/cnabio/cnab-to-oci/releases/tag/v0.3.6).
 
 ### Bug fixes and enhancements
+
 - Reverted environment variables precedence to OS over `.env` file. Fixes [compose#9737](https://github.com/docker/compose/issues/9737).
 - Updated usage strings for consistency.
 - Resolved environment variables case-insensitively on Windows. Fixes [compose#9431](https://github.com/docker/compose/issues/9431).
@@ -767,6 +887,7 @@ For the full change log or additional information, check the [Compose repository
 For the full change log, check the [Compose repository 2.10.0 release page](https://github.com/docker/compose/releases/tag/v2.10.0).
 
 ## 2.9.0
+
 {{< release-date date="2022-08-7" >}}
 
 > **Important**
@@ -780,6 +901,7 @@ For the full change log, check the [Compose repository 2.10.0 release page](http
 > This release reverts the breaking changes introduced in [Compose v2.8.0](#280) by [`compose-go v1.3.0`](https://github.com/compose-spec/compose-go/releases/tag/v1.3.0).
 
 ### Updates
+
 - Updated [`compose-go` to v1.4.0](https://github.com/compose-spec/compose-go/releases/tag/v1.4.0) as previous version introduced breaking changes. Fixes [compose#9700](https://github.com/docker/compose/issues/9700).
 
 ### Bug fixes and enhancements
@@ -791,6 +913,7 @@ For the full change log, check the [Compose repository 2.10.0 release page](http
 For the full change log or additional information, check the [Compose repository 2.9.0 release page](https://github.com/docker/compose/releases/tag/v2.9.0).
 
 ## 2.8.0
+
 {{< release-date date="2022-07-29" >}}
 
 > **Important**
@@ -823,6 +946,7 @@ In this release, Docker Compose recreates new resources (networks, volumes, secr
 For the full change log or additional information, check the [Compose repository 2.8.0 release page](https://github.com/docker/compose/releases/tag/v2.8.0).
 
 ## 2.7.0
+
 {{< release-date date="2022-07-20" >}}
 
 ### New
@@ -856,6 +980,7 @@ For the full change log or additional information, check the [Compose repository
 For the full change log or additional information, check the [Compose repository 2.7.0 release page](https://github.com/docker/compose/releases/tag/v2.7.0).
 
 ## 2.6.1
+
 {{< release-date date="2022-06-23" >}}
 
 ### New
@@ -899,8 +1024,8 @@ For the full change log or additional information, check the [Compose repository
 
 For the full change log or additional information, check the [Compose repository 2.6.1 release page](https://github.com/docker/compose/releases/tag/v2.6.1).
 
-
 ## 2.6.0
+
 {{< release-date date="2022-05-30" >}}
 
 ### New
@@ -925,8 +1050,8 @@ For the full change log or additional information, check the [Compose repository
 
 For the full change log or additional information, check the [Compose repository 2.6.0 release page](https://github.com/docker/compose/releases/tag/v2.6.0).
 
-
 ## 2.5.1
+
 {{< release-date date="2022-05-17" >}}
 
 ### Updates
@@ -944,8 +1069,8 @@ For the full change log or additional information, check the [Compose repository
 
 For the full change log or additional information, check the [Compose repository 2.5.1 release page](https://github.com/docker/compose/releases/tag/v2.5.1).
 
-
 ## 2.5.0
+
 {{< release-date date="2022-04-29" >}}
 
 ### Bug fixes and enhancements
@@ -967,6 +1092,7 @@ For the full change log or additional information, check the [Compose repository
 For the full change log or additional information, check the [Compose repository 2.5.0 release page](https://github.com/docker/compose/releases/tag/v2.5.0).
 
 ## 2.4.1
+
 {{< release-date date="2022-04-04" >}}
 
 ### Bug fixes and enhancements
@@ -979,6 +1105,7 @@ For the full change log or additional information, check the [Compose repository
 
 
 ## 2.4.0 
+
 {{< release-date date="2022-04-1" >}}
 
 ### Updates
@@ -1003,6 +1130,7 @@ For the full change log or additional information, check the [Compose repository
 
 
 ## 2.3.4 
+
 {{< release-date date="2022-03-25" >}}
 
 ### New
@@ -1017,6 +1145,7 @@ For the full change log or additional information, check the [Compose repository
 - Removed the need to get the original compose.yaml file to run 'docker compose kill'.
 
 ### Updates
+
 - Dependencies update: Bumped github.com/spf13/cobra from 1.3.0 to 1.4.0. Cobra library no longer requires Viper and all of its indirect dependencies [See cobra's release page](https://github.com/spf13/cobra/releases).
 - Dependencies update: Bumped buildx from v0.7.1 to v0.8.0.
 
@@ -1037,6 +1166,7 @@ For the full change log or additional information, check the [Compose repository
 For the releases later than 1.29.2 and earlier than 2.3.4, please check the [Compose repository release pages](https://github.com/docker/compose/releases).
 
 ## 1.29.2
+
 (2021-05-10)
 
 ### Miscellaneous
@@ -1046,6 +1176,7 @@ For the releases later than 1.29.2 and earlier than 2.3.4, please check the [Com
 - Bumped `py` to `1.10.0` in `requirements-indirect.txt`.
 
 ## 1.29.1
+
 (2021-04-13)
 
 ### Bugs
@@ -1059,6 +1190,7 @@ For the releases later than 1.29.2 and earlier than 2.3.4, please check the [Com
 - Removed extra scan suggestion on build.
 
 ## 1.29.0
+
 (2021-04-06)
 
 ### Features
@@ -1098,6 +1230,7 @@ For the releases later than 1.29.2 and earlier than 2.3.4, please check the [Com
 - Added `compose.yml` and `compose.yaml` to the default filename list.
 
 ## 1.28.5
+
 (2021-02-26)
 
 ### Bugs
@@ -1111,6 +1244,7 @@ For the releases later than 1.29.2 and earlier than 2.3.4, please check the [Com
 - Fixed the log fetching bug when service logging driver is set to 'none'.
 
 ## 1.28.4
+
 (2021-02-18)
 
 ### Bug fixes
@@ -1122,6 +1256,7 @@ For the releases later than 1.29.2 and earlier than 2.3.4, please check the [Com
 - Bumped Python to 3.7.10.
 
 ## 1.28.3
+
 (2021-02-17)
 
 ### Bug fixes
@@ -1143,6 +1278,7 @@ For the releases later than 1.29.2 and earlier than 2.3.4, please check the [Com
 For a list of PRs and issues fixed in this release, see [Compose 1.28.3](https://github.com/docker/compose/milestone/53?closed=1).
 
 ## 1.28.2
+
 (2021-01-26)
 
 ### Bug fixes
@@ -1156,6 +1292,7 @@ For a list of PRs and issues fixed in this release, see [Compose 1.28.3](https:/
 - CI setup update
 
 ## 1.28.0 
+
 (2021-01-20)
 
 ### Features
@@ -1219,6 +1356,7 @@ For a list of PRs and issues fixed in this release, see [Compose 1.28.3](https:/
 - Updated READMEs.
 
 ## 1.27.4
+
 (2020-09-24)
 
 ### Bug fixes
@@ -1230,6 +1368,7 @@ For a list of PRs and issues fixed in this release, see [Compose 1.28.3](https:/
 - Added protocol to the Docker socket address.
 
 ## 1.27.3
+
 (2020-09-16)
 
 ### Bug fixes
@@ -1245,6 +1384,7 @@ For a list of PRs and issues fixed in this release, see [Compose 1.28.3](https:/
 - Allowed strings for `cpus` fields.
 
 ## 1.27.2
+
 (2020-09-10)
 
 ### Bug fixes
@@ -1252,6 +1392,7 @@ For a list of PRs and issues fixed in this release, see [Compose 1.28.3](https:/
 - Fixed bug on `docker-compose run` container attach.
 
 ## 1.27.1
+
 (2020-09-10)
 
 ### Bug fixes
@@ -1265,6 +1406,7 @@ For a list of PRs and issues fixed in this release, see [Compose 1.28.3](https:/
 - Preserved the version number configured in the Compose file.
 
 ## 1.27.0
+
 (2020-09-07)
 
 ### Features
@@ -1308,6 +1450,7 @@ For a list of PRs and issues fixed in this release, see [Compose 1.28.3](https:/
 - Added script for Docs synchronization.
 
 ## 1.26.2
+
 (2020-07-02)
 
 ### Bug fixes
@@ -1315,6 +1458,7 @@ For a list of PRs and issues fixed in this release, see [Compose 1.28.3](https:/
 - Enforced `docker-py` 4.2.2 as minimum version when installing with pip.
 
 ## 1.26.1
+
 (2020-06-30)
 
 ### Features
@@ -1328,6 +1472,7 @@ For a list of PRs and issues fixed in this release, see [Compose 1.28.3](https:/
 - Fixed context load for non-docker endpoints.
 
 ## 1.26.0
+
 (2020-06-03)
 
 ### Features
@@ -1367,6 +1512,7 @@ For a list of PRs and issues fixed in this release, see [Compose 1.28.3](https:/
 - Fixed HTTPS connection when `DOCKER_HOST` is remote.
 
 ## 1.25.5
+
 (2020-04-10)
 
 ### Features
@@ -1378,6 +1524,7 @@ For a list of PRs and issues fixed in this release, see [Compose 1.28.3](https:/
   - Limited service scale to the size specified by the field `deploy.placement.max_replicas_per_node`.
 
 ## 1.25.4
+
 (2020-02-03)
 
 ### Bug fixes
@@ -1387,6 +1534,7 @@ For a list of PRs and issues fixed in this release, see [Compose 1.28.3](https:/
 - Fixed docker-compose exec for keys with no value on environment files.
 
 ## 1.25.3
+
 (2020-01-23)
 
 ### Bug fixes
@@ -1396,6 +1544,7 @@ For a list of PRs and issues fixed in this release, see [Compose 1.28.3](https:/
 - Updated the binary's sha256 on the release page.
 
 ## 1.25.2
+
 (2020-01-20)
 
 ### New features
@@ -1409,6 +1558,7 @@ For a list of PRs and issues fixed in this release, see [Compose 1.28.3](https:/
 - Fixed an issue that caused Docker Compose to render messages incorrectly when running commands outside a terminal.
 
 ## 1.25.1
+
 (2020-01-06)
 
 ### Bugfixes
@@ -1424,6 +1574,7 @@ For a list of PRs and issues fixed in this release, see [Compose 1.28.3](https:/
 - Docker Compose now reports images that cannot be pulled, however, are required to be built.
 
 ## 1.25.0
+
 (2019-11-18)
 
 ### New features
@@ -1509,11 +1660,13 @@ For a list of PRs and issues fixed in this release, see [Compose 1.28.3](https:/
 - Fixed the presentation of failed services on the `docker-compose start` command when containers are not available.
 
 ## 1.24.1
+
 (2019-06-24)
 
 This release contains minor improvements and bug fixes.
 
 ## 1.24.0
+
 (2019-03-28)
 
 ### Features
@@ -1566,6 +1719,7 @@ This release contains minor improvements and bug fixes.
 - Fixed release script and some typos on release documentation.
 
 ## 1.23.2
+
 (2018-11-28)
 
 ### Bug fixes
@@ -1590,6 +1744,7 @@ This release contains minor improvements and bug fixes.
   exception during validation.
 
 ## 1.23.1
+
 (2018-11-01)
 
 ### Bug fixes
@@ -1601,6 +1756,7 @@ This release contains minor improvements and bug fixes.
   vary depending on which subcommand was used.
 
 ## 1.23.0
+
 (2018-10-30)
 
 ### Important note
@@ -1676,6 +1832,7 @@ naming scheme accordingly before upgrading.
   longer suggests container names where service names are expected.
 
 ## 1.22.0
+
 (2018-07-17)
 
 ### New features
@@ -1730,6 +1887,7 @@ naming scheme accordingly before upgrading.
 - `docker-compose build` will no longer attempt to create image names starting with an invalid character
 
 ## 1.21.2
+
 (2018-05-03)
 
 ### Bug fixes
@@ -1738,6 +1896,7 @@ naming scheme accordingly before upgrading.
   from passing validation
 
 ## 1.21.1
+
 (2018-04-27)
 
 ### Bug fixes
@@ -1764,6 +1923,7 @@ naming scheme accordingly before upgrading.
   deployment.
 
 ## 1.21.0
+
 (2018-04-11)
 
 ### New features
@@ -1828,6 +1988,7 @@ naming scheme accordingly before upgrading.
   operations.
 
 ## 1.20.0
+
 (2018-03-20)
 
 ### New features
@@ -1915,6 +2076,7 @@ naming scheme accordingly before upgrading.
 - Fixed an encoding bug when streaming build progress
 
 ## 1.19.0
+
 (2018-02-07)
 
 ### Breaking changes
@@ -2008,6 +2170,7 @@ naming scheme accordingly before upgrading.
   to strings
 
 ## 1.18.0
+
 (2017-12-18)
 
 ### New features
@@ -2091,6 +2254,7 @@ naming scheme accordingly before upgrading.
   in `docker-compose up`
 
 ## 1.17.0
+
 (2017-11-01)
 
 ### New features
@@ -2149,6 +2313,7 @@ naming scheme accordingly before upgrading.
   created when running `up` commands concurrently.
 
 ## 1.16.0
+
 (2017-08-31)
 
 ### New features
@@ -2209,6 +2374,7 @@ naming scheme accordingly before upgrading.
   `0` as the value for the published port
 
 ## 1.15.0
+
 (2017-07-26)
 
 ### New features
@@ -2256,6 +2422,7 @@ naming scheme accordingly before upgrading.
   Windows Engine.
 
 ## 1.14.0
+
 (2017-06-19)
 
 ### New features
@@ -2311,6 +2478,7 @@ naming scheme accordingly before upgrading.
   contain invalid port definitions
 
 ## 1.13.0
+
 (2017-05-02)
 
 ### Breaking changes
@@ -2365,8 +2533,8 @@ naming scheme accordingly before upgrading.
 - Fixed a bug where recreating containers using a combination of `tmpfs` and
   `volumes` would result in an invalid config state
 
-
 ## 1.12.0
+
 (2017-04-04)
 
 ### New features
@@ -2464,6 +2632,7 @@ naming scheme accordingly before upgrading.
   COMPOSE_TLS_VERSION when used in combination with command-line TLS flags
 
 ## 1.11.2
+
 (2017-02-17)
 
 ### Bug fixes
@@ -2485,6 +2654,7 @@ naming scheme accordingly before upgrading.
   recognized in `.dockerignore` files.
 
 ## 1.11.1
+
 (2017-02-09)
 
 ### Bug fixes
@@ -2493,6 +2663,7 @@ naming scheme accordingly before upgrading.
   by the Compose parser
 
 ## 1.11.0
+
 (2017-02-08)
 
 ### New Features
@@ -2517,6 +2688,7 @@ naming scheme accordingly before upgrading.
   ignored when using multiple Compose files.
 
 ## 1.10.1
+
 (2017-02-01)
 
 ### Bug fixes
@@ -2540,6 +2712,7 @@ naming scheme accordingly before upgrading.
   when containers would stop or restart
 
 ## 1.10.0
+
 (2017-01-18)
 
 ### New Features
@@ -2586,8 +2759,8 @@ naming scheme accordingly before upgrading.
 - Fixed a bug where forward slashes in some .dockerignore patterns weren't
   being parsed correctly on Windows
 
-
 ## 1.9.0
+
 (2016-11-16)
 
 **Breaking changes**
@@ -2644,8 +2817,8 @@ naming scheme accordingly before upgrading.
 - Fixed an issue where Compose would incorrectly detect a configuration
   mismatch for overlay networks.
 
-
 ## 1.8.1
+
 (2016-09-22)
 
 ### Bug fixes
@@ -2686,8 +2859,8 @@ naming scheme accordingly before upgrading.
 - Fixed a bug where a misleading error would appear when encountering
   a connection timeout.
 
-
 ## 1.8.0
+
 (2016-06-14)
 
 ### Breaking Changes
@@ -2748,8 +2921,8 @@ naming scheme accordingly before upgrading.
 - `docker-compose create` and `docker-compose start` show more
   descriptive error messages when something goes wrong.
 
-
 ## 1.7.1
+
 (2016-05-04)
 
 ### Bug fixes
@@ -2789,8 +2962,8 @@ naming scheme accordingly before upgrading.
   which is indeed read from the current directory, instead of in the same
   location as the Compose file.
 
-
 ## 1.7.0
+
 (2016-04-13)
 
 ### Breaking Changes
@@ -2879,12 +3052,14 @@ naming scheme accordingly before upgrading.
     to fail.
 
 ## 1.6.2
+
 (2016-02-23)
 
 -   Fixed a bug where connecting to a TLS-enabled Docker Engine would fail with
     a certificate verification error.
 
 ## 1.6.1
+
 (2016-02-23)
 
 ### Bug fixes
@@ -2938,8 +3113,8 @@ naming scheme accordingly before upgrading.
 -   Corrected the warning message that is printed when a boolean value is used
     as a value in a mapping.
 
-
 ## 1.6.0
+
 (2016-01-15)
 
 ### Major Features
@@ -3018,7 +3193,6 @@ naming scheme accordingly before upgrading.
 
 -   Removed the `--allow-insecure-ssl` flag.
 
-
 ### Bug fixes
 
 -   Fixed a validation bug that prevented the use of a range of ports in
@@ -3054,8 +3228,8 @@ naming scheme accordingly before upgrading.
 -   Fixed a bug where attaching to a container would fail if it was using a
     non-standard logging driver (or none at all).
 
-
 ## 1.5.2
+
 (2015-12-03)
 
 -   Fixed a bug which broke the use of `environment` and `env_file` with
@@ -3076,8 +3250,8 @@ naming scheme accordingly before upgrading.
 
 -   Improved the validation of the `expose` option
 
-
 ## 1.5.1
+
 (2015-11-12)
 
 -   Add the `--force-rm` option to `build`.
@@ -3129,8 +3303,8 @@ naming scheme accordingly before upgrading.
 -   Improve validation error messages by including the filename as part of the
     error message.
 
-
 ## 1.5.0
+
 (2015-11-03)
 
 ### Breaking changes
@@ -3230,14 +3404,15 @@ https://github.com/docker/compose/blob/8cc8e61/docs/compose-file.md#variable-sub
 
 -   `docker-compose build` can now be run successfully against a Swarm cluster.
 
-
 ## 1.4.2
+
 (2015-09-22)
 
 -  Fixed a regression in the 1.4.1 release that would cause `docker-compose up`
    without the `-d` option to exit immediately.
 
 ## 1.4.1
+
 (2015-09-10)
 
 ### Bug fixes
@@ -3254,6 +3429,7 @@ https://github.com/docker/compose/blob/8cc8e61/docs/compose-file.md#variable-sub
 
 
 ## 1.4.0
+
 (2015-08-04)
 
 -   By default, `docker-compose up` now only recreates containers for services whose configuration has changed since they were created. This should result in a dramatic speed-up for many applications.
@@ -3293,6 +3469,7 @@ https://github.com/docker/compose/blob/8cc8e61/docs/compose-file.md#variable-sub
 Thanks @mnowster, @dnephin, @ekristen, @funkyfuture, @jeffk and @lukemarsden!
 
 ## 1.3.3
+
 (2015-07-15)
 
 ### Regression fixes
@@ -3301,6 +3478,7 @@ Thanks @mnowster, @dnephin, @ekristen, @funkyfuture, @jeffk and @lukemarsden!
 - Compose would sometimes crash depending on the formatting of container data returned from the Docker API.
 
 ## 1.3.2
+
 (2015-07-14)
 
 ### Bug fixes
@@ -3316,6 +3494,7 @@ Thanks @mnowster, @dnephin, @ekristen, @funkyfuture, @jeffk and @lukemarsden!
 Thanks @dano, @josephpage, @kevinsimper, @lieryan, @phemmer, @soulrebel and @sschepens!
 
 ## 1.3.1
+
 (2015-06-21)
 
 ### Bug fixes
@@ -3325,6 +3504,7 @@ Thanks @dano, @josephpage, @kevinsimper, @lieryan, @phemmer, @soulrebel and @ssc
 - If no network mode was specified, Compose would set it to "bridge", rather than allowing the Docker daemon to use its configured default network mode.
 
 ## 1.3.0
+
 (2015-06-18)
 
 ### Important notes
@@ -3370,6 +3550,7 @@ Several new configuration keys have been added to `docker-compose.yml`:
 Thanks @ahromis, @albers, @aleksandr-vin, @antoineco, @ccverak, @chernjie, @dnephin, @edmorley, @fordhurley, @josephpage, @KyleJamesWalker, @lsowen, @mchasal, @noironetworks, @sdake, @sdurrheimer, @sherter, @stephenlawrence, @thaJeztah, @thieman, @turtlemonvh, @twhiteman, @vdemeester, @xuxinkun and @zwily!
 
 ## 1.2.0
+
 (2015-04-16)
 
 - `docker-compose.yml` now supports an `extends` option, which enables a service to inherit configuration from another service in another configuration file. This is really good for sharing common configuration between apps, or for configuring the same app for different environments. Here's the [documentation](https://github.com/docker/compose/blob/master/docs/).
@@ -3393,6 +3574,7 @@ Thanks @ahromis, @albers, @aleksandr-vin, @antoineco, @ccverak, @chernjie, @dnep
 Thanks, @abesto, @albers, @alunduil, @dnephin, @funkyfuture, @gilclark, @IanVS, @KingsleyKelly, @knutwalker, @thaJeztah and @vmalloc!
 
 ## 1.1.0
+
 (2015-02-25)
 
 Fig has been renamed to Docker Compose, or just Compose for short. This has several implications for you:
@@ -3426,6 +3608,7 @@ Besides that, there’s a lot of new stuff in this release:
 Thanks @dnephin, @squebe, @jbalonso, @raulcd, @benlangfield, @albers, @ggtools, @bersace, @dtenenba, @petercv, @drewkett, @TFenby, @paulRbr, @Aigeruth and @salehe!
 
 ## 1.0.1
+
 (2014-11-04)
 
  - Added an `--allow-insecure-ssl` option to allow `fig up`, `fig run` and `fig pull` to pull from insecure registries.
@@ -3433,6 +3616,7 @@ Thanks @dnephin, @squebe, @jbalonso, @raulcd, @benlangfield, @albers, @ggtools, 
  - Fixed a bug where Fig couldn't build Dockerfiles with ADD statements pointing at URLs.
 
 ## 1.0.0
+
 (2014-10-16)
 
 The highlights:
@@ -3477,6 +3661,7 @@ Other things:
 Thanks @dnephin, @d11wtq, @marksteve, @rubbish, @jbalonso, @timfreund, @alunduil, @mieciu, @shuron, @moss, @suzaku and @chmouel! Whew.
 
 ## 0.5.2
+
 (2014-07-28)
 
  - Added a `--no-cache` option to `fig build`, which bypasses the cache just like `docker build --no-cache`.
@@ -3486,8 +3671,8 @@ Thanks @dnephin, @d11wtq, @marksteve, @rubbish, @jbalonso, @timfreund, @alunduil
 
 Thanks @dnephin and @marksteve!
 
-
 ## 0.5.1
+
 (2014-07-11)
 
  - If a service has a command defined, `fig run [service]` with no further arguments will run it.
@@ -3497,8 +3682,8 @@ Thanks @dnephin and @marksteve!
 
 Thanks @ryanbrainard and @d11wtq!
 
-
 ## 0.5.0
+
 (2014-07-11)
 
  - Fig now starts links when you run `fig run` or `fig up`.
@@ -3536,13 +3721,14 @@ Thanks @ryanbrainard and @d11wtq!
 
 Thanks to @d11wtq, @ryanbrainard, @rail44, @j0hnsmith, @binarin, @Elemecca, @mozz100 and @marksteve for their help with this release!
 
-
 ## 0.4.2
+
 (2014-06-18)
 
  - Fix various encoding errors when using `fig run`, `fig up` and `fig build`.
 
 ## 0.4.1
+
 (2014-05-08)
 
  - Add support for Docker 0.11.0. (Thanks @marksteve!)
@@ -3550,6 +3736,7 @@ Thanks to @d11wtq, @ryanbrainard, @rail44, @j0hnsmith, @binarin, @Elemecca, @moz
  - Return correct exit code from `fig run`.
 
 ## 0.4.0
+
 (2014-04-29)
 
  - Support Docker 0.9 and 0.10
@@ -3562,12 +3749,14 @@ Thanks to @d11wtq, @ryanbrainard, @rail44, @j0hnsmith, @binarin, @Elemecca, @moz
  - Error message improvements
 
 ## 0.3.2
+
 (2014-03-05)
 
  - Added an `--rm` option to `fig run`. (Thanks @marksteve!)
  - Added an `expose` option to `fig.yml`.
 
 ## 0.3.1
+
 (2014-03-04)
 
  - Added contribution instructions. (Thanks @kvz!)
@@ -3575,6 +3764,7 @@ Thanks to @d11wtq, @ryanbrainard, @rail44, @j0hnsmith, @binarin, @Elemecca, @moz
  - Fixed a bug in `fig ps` on Docker 0.8.1 when there is a container with no command.
 
 ## 0.3.0
+
 (2014-03-03)
 
  - We now ship binaries for OS X and Linux. No more having to install with Pip!
@@ -3588,6 +3778,7 @@ Thanks to @d11wtq, @ryanbrainard, @rail44, @j0hnsmith, @binarin, @Elemecca, @moz
 Thanks @marksteve, @Gazler and @teozkr!
 
 ## 0.2.2
+
 (2014-02-17)
 
  - Resolve dependencies using Cormen/Tarjan topological sort
@@ -3598,11 +3789,13 @@ Thanks @marksteve, @Gazler and @teozkr!
 Thanks to @barnybug and @dustinlacewell for their work on this release.
 
 ## 0.2.1
+
 (2014-02-04)
 
  - General improvements to error reporting (#77, #79)
 
 ## 0.2.0
+
 (2014-01-31)
 
  - Link services to themselves so run commands can access the running service. (#67)
@@ -3613,17 +3806,20 @@ Thanks to @barnybug and @dustinlacewell for their work on this release.
 Big thanks to @cameronmaske, @mrchrisadams and @damianmoore for their help with this release.
 
 ## 0.1.4
+
 (2014-01-27)
 
  - Add a link alias without the project name. This makes the environment variables a little shorter: `REDIS_1_PORT_6379_TCP_ADDR`. (#54)
 
 ## 0.1.3
+
 (2014-01-23)
 
  - Fix ports sometimes being configured incorrectly. (#46)
  - Fix log output sometimes not displaying. (#47)
 
 ## 0.1.2
+
 (2014-01-22)
 
  - Add `-T` option to `fig run` to disable pseudo-TTY. (#34)
@@ -3631,11 +3827,13 @@ Big thanks to @cameronmaske, @mrchrisadams and @damianmoore for their help with 
  - Improve reliability, fix arrow keys and fix a race condition in `fig run`. (#34, #39, #40)
 
 ## 0.1.1
+
 (2014-01-17)
 
  - Fix bug where ports were not exposed correctly (#29). Thanks @dustinlacewell!
 
 ## 0.1.0
+
 (2014-01-16)
 
  - Containers are recreated on each `fig up`, ensuring config is up-to-date with `fig.yml` (#2)
@@ -3651,6 +3849,7 @@ Big thanks to @cameronmaske, @mrchrisadams and @damianmoore for their help with 
 Big thanks to @tomstuart, @EnTeQuAk, @schickling, @aronasorman and @GeoffreyPlitt.
 
 ## 0.0.2
+
 (2014-01-02)
 
  - Improve documentation
@@ -3660,6 +3859,7 @@ Big thanks to @tomstuart, @EnTeQuAk, @schickling, @aronasorman and @GeoffreyPlit
  - Add `fig build` command
 
 ## 0.0.1
+
 (2013-12-20)
 
 Initial release.

--- a/content/contribute/ui.md
+++ b/content/contribute/ui.md
@@ -26,6 +26,7 @@ When practical, state instructions in terms of what the user should accomplish, 
 
 
 ## Refer to UI elements
+
 Don't use UI elements as if they were English verbs or nouns.
 
 |Correct     |Incorrect    |

--- a/content/desktop/extensions-sdk/extensions/publish.md
+++ b/content/desktop/extensions-sdk/extensions/publish.md
@@ -20,6 +20,7 @@ Whenever you are [ready to publish](./DISTRIBUTION.md) your extension in the Mar
 >
 > The Docker manual review process for extensions is paused at the moment. Submit your extension through the [automated submission process](https://github.com/docker/extensions-submissions/issues/new?assignees=&labels=&template=1_automatic_review.yaml&title=%5BSubmission%5D%3A+)
 { .important }
+
 ### Before you submit
 
 Before you submit your extension, it must pass the [validation](validate.md) checks.

--- a/content/desktop/faqs/linuxfaqs.md
+++ b/content/desktop/faqs/linuxfaqs.md
@@ -86,6 +86,7 @@ a group with the new GID and adding our user to it, or by setting a recursive
 ACL (see `setfacl(1)`) for folders shared with the Docker Desktop VM.
 
 ### Where does Docker Desktop store Linux containers?
+
 Docker Desktop stores Linux containers and images in a single, large "disk image" file in the Linux filesystem. This is different from Docker on Linux, which usually stores containers and images in the `/var/lib/docker` directory on the host's filesystem.
 
 #### Where is the disk image file?

--- a/content/desktop/faqs/macfaqs.md
+++ b/content/desktop/faqs/macfaqs.md
@@ -25,6 +25,7 @@ runs in the background. The process does not consume any resources unless
 `Docker.app` connects to it, so it's safe to ignore.
 
 ### Where does Docker Desktop store Linux containers and images? 
+
 Docker Desktop stores Linux containers and images in a single, large "disk image" file in the Mac filesystem. This is different from Docker on Linux, which usually stores containers and images in the `/var/lib/docker` directory.
 
 #### Where is the disk image file?
@@ -178,6 +179,7 @@ Desktop `xhyve` virtual machine).
 >   under insecure registries, and does not send client certificates. Commands
 >   like `docker run` that attempt to pull from the registry produce error
 >   messages on the command line, as well as on the registry.
+
 #### Directory structures for certificates
 
 If you have this directory structure, you do not need to manually add the CA

--- a/content/desktop/hardened-desktop/enhanced-container-isolation/limitations.md
+++ b/content/desktop/hardened-desktop/enhanced-container-isolation/limitations.md
@@ -57,24 +57,29 @@ Windows hosts and access Docker from within (see Docker Desktop's WSL distro
 integration feature, enabled via the Dashboard's **Settings** > **Resources** > **WSL Integration**).
 
 ### Docker Build and Buildx have some restrictions
+
 With ECI enabled, Docker build `--network=host` and Docker Buildx entitlements
 (`network.host`, `security.insecure`) are not allowed. Builds that require
 these won't work properly.
 
 ### Kubernetes pods are not yet protected
+
 Kubernetes pods are not yet protected by ECI. A malicious or privileged pod can
 compromise the Docker Desktop Linux VM and bypass security controls.
 
 ### Extension containers are not yet protected
+
 Extension containers are also not yet protected by ECI. Ensure you extension
 containers come from trusted entities to avoid issues.
 
 ### Docker Desktop dev environments are not yet protected
+
 Containers launched by the Docker Desktop Dev Environments feature are not yet
 protected either. We expect to improve on this in future versions of Docker
 Desktop.
 
 ### Use in production
+
 In general users should not experience differences between running a container
 in Docker Desktop with ECI enabled, which uses the Sysbox runtime, and running
 that same container in production, through the standard OCI `runc` runtime.

--- a/content/desktop/hardened-desktop/settings-management/configure.md
+++ b/content/desktop/hardened-desktop/settings-management/configure.md
@@ -205,6 +205,7 @@ The following `admin-settings.json` code and table provides an example of the re
 
 
 ### Step three: Re-launch Docker Desktop
+
 >**Note**
 >
 >Administrators should test the changes made through the `admin-settings.json` file locally to see if the settings work as expected.

--- a/content/desktop/install/ubuntu.md
+++ b/content/desktop/install/ubuntu.md
@@ -34,6 +34,7 @@ To install Docker Desktop successfully, you must:
   ```console
   $ sudo apt install gnome-terminal
   ```
+
 ## Install Docker Desktop
 
 Recommended approach to install Docker Desktop on Ubuntu:

--- a/content/desktop/release-notes.md
+++ b/content/desktop/release-notes.md
@@ -310,9 +310,11 @@ For frequently asked questions about Docker Desktop releases, see [FAQs](faqs/re
 ### Known issues
 
 #### For all platforms
+
 - When using Setting Management, the settings that are not set in the `admin-settings.json` will be reset to default when Docker Desktop starts.
 
 #### For Mac
+
 - Updating to 4.27.0 from the **Software updates** sometimes hangs. As a workaround, use the 4.27.0 installer from this page.
 
 ## 4.26.1
@@ -516,6 +518,7 @@ For frequently asked questions about Docker Desktop releases, see [FAQs](faqs/re
 - **Switch to Windows containers** option in the tray menu may not show up on Windows. As a workaround, edit the [`settings.json` file](https://docs.docker.com/desktop/settings/windows/) and set `"displaySwitchWinLinContainers": true`.
 
 #### For all platforms
+
 - Docker operations, such as pulling images or logging in, fail with 'connection refused' or 'timeout' errors if the Swap file size is set to 0MB. As a workaround, configure the swap file size to a non-zero value in the **Resources** tab in **Settings**. 
 
 ## 4.24.2
@@ -611,11 +614,13 @@ For frequently asked questions about Docker Desktop releases, see [FAQs](faqs/re
 #### For Mac
 
 - Creating a container with the port 53 fails with the error address `already in use`. As a workaround, deactivate network acceleration by adding `"kernelForUDP": false`, in the `settings.json` file located at `~/Library/Group Containers/group.com.docker/settings.json`.
+
 ## 4.23.0
 
 {{< release-date date="2023-09-11" >}}
 
 ### Upgrades
+
 - [Compose v2.21.0](https://github.com/docker/compose/releases/tag/v2.21.0)
 - [Docker Engine v24.0.6](https://docs.docker.com/engine/release-notes/24.0/#2406)
 - [Docker Scout CLI v0.24.1](https://github.com/docker/scout-cli/releases/tag/v0.24.1).

--- a/content/desktop/use-desktop/container.md
+++ b/content/desktop/use-desktop/container.md
@@ -126,6 +126,7 @@ can also:
 - Download files and folders from the container straight to the host
 
 ## Additional resources
+
 - [What is a container](../../guides/walkthroughs/what-is-a-container.md)
 - [Run a container](../../guides/walkthroughs/run-a-container.md)
 - [Run multi-container applications](../../guides/walkthroughs/multi-container-apps.md)

--- a/content/desktop/use-desktop/images.md
+++ b/content/desktop/use-desktop/images.md
@@ -101,5 +101,6 @@ Hovering over an image tag reveals two options:
 - **View in Hub**: Open the Docker Hub page and display detailed information about the image.
 
 ## Additional resources
+
 - [Run Docker Hub images](../../guides/walkthroughs/run-hub-images.md)
 - [Publish your image](../../guides/walkthroughs/publish-your-image.md)

--- a/content/docker-hub/release-notes.md
+++ b/content/docker-hub/release-notes.md
@@ -201,6 +201,7 @@ to `hub.docker.com`. You can access the page at its new URL: [https://hub.docker
 ## 2019-10-21
 
 ### New features
+
 * **Beta:** Docker Hub now supports two-factor authentication (2FA). Enable it in your account settings, under the **[Security](https://hub.docker.com/settings/security)** section.
 
     > If you lose both your 2FA authentication device and recovery code, you may
@@ -208,6 +209,7 @@ to `hub.docker.com`. You can access the page at its new URL: [https://hub.docker
     { .important }
 
 ### Enhancements
+
 * As a security measure, when two-factor authentication is enabled, the Docker CLI requires a personal access token instead of a password to log in.
 
 ### Known Issues
@@ -218,6 +220,7 @@ to `hub.docker.com`. You can access the page at its new URL: [https://hub.docker
 ## 2019-10-02
 
 ### Enhancements
+
 * You can now manage teams and members straight from your [organization page](https://hub.docker.com/orgs).
 Each organization page now breaks down into these tabs:
   * **New:** Members - manage your members directly from this page (delete,

--- a/content/engine/security/rootless.md
+++ b/content/engine/security/rootless.md
@@ -161,6 +161,7 @@ testuser:231072:65536
 - NFS mounts as the docker "data-root" is not supported. This limitation is not specific to rootless mode.
 
 ## Install
+
 > **Note**
 >
 > If the system-wide Docker daemon is already running, consider disabling it:
@@ -377,6 +378,7 @@ Or add `net.ipv4.ip_unprivileged_port_start=0` to `/etc/sysctl.conf` (or
 `/etc/sysctl.d`) and run `sudo sysctl --system`.
 
 ### Limiting resources
+
 Limiting resources with cgroup-related `docker run` flags such as `--cpus`, `--memory`, `--pids-limit`
 is supported only when running with cgroup v2 and systemd.
 See [Changing cgroup version](../../config/containers/runmetrics.md) to enable cgroup v2.
@@ -409,6 +411,7 @@ EOF
 > Delegating `cpuset` requires systemd 244 or later.
 
 #### Limiting resources without cgroup
+
 Even when cgroup is not available, you can still use the traditional `ulimit` and [`cpulimit`](https://github.com/opsengine/cpulimit),
 though they work in process-granularity rather than in container-granularity,
 and can be arbitrarily disabled by the container process.
@@ -688,6 +691,7 @@ For more information about networking options for RootlessKit, see:
 - [Port drivers](https://github.com/rootless-containers/rootlesskit/blob/v2.0.0/docs/port.md)
 
 ### Tips for debugging
+
 **Entering into `dockerd` namespaces**
 
 The `dockerd-rootless.sh` script executes `dockerd` in its own user, mount, and network namespaces.

--- a/content/get-started/overview.md
+++ b/content/get-started/overview.md
@@ -189,6 +189,7 @@ the default registry configuration):
     stops but isn't removed. You can start it again or remove it.
 
 ## The underlying technology
+
 Docker is written in the [Go programming language](https://golang.org/) and takes
 advantage of several features of the Linux kernel to deliver its functionality.
 Docker uses a technology called `namespaces` to provide the isolated workspace

--- a/content/network/network-tutorial-macvlan.md
+++ b/content/network/network-tutorial-macvlan.md
@@ -217,6 +217,7 @@ be physically attached to the network.
     ```
 
 ## Other networking tutorials
+
 - [Standalone networking tutorial](network-tutorial-standalone.md)
 - [Overlay networking tutorial](network-tutorial-overlay.md)
 - [Host networking tutorial](network-tutorial-host.md)

--- a/content/samples/_index.md
+++ b/content/samples/_index.md
@@ -15,16 +15,21 @@ aliases:
 Learn how to containerize different types of services by walking through Official Docker samples.
 
 ## Databases
+
 [MariaDB](../samples/mariadb.md) \| [MongoDB](../samples/mongodb.md) \| [MS-SQL](../samples/ms-sql.md) \| [MySQL](../samples/mysql.md) \| [PostgreSQL](../samples/postgres.md) \| [Redis](../samples/redis.md)
 
 ## Frameworks
+
 [.NET](../samples/dotnet.md) \| [Angular](../samples/angular.md) \| [Django](../samples/django.md) \| [Express](../samples/express.md) \|[FastAPI](../samples/fastapi.md) \| [Flask](../samples/flask.md) \| [Node.js](../samples/nodejs.md) \| [React](../samples/react.md) \| [Rails](../samples/rails.md) \| [Spark](../samples/spark.md) \| [Spring Boot](../samples/spring.md) \| [Vue.js](../samples/vuejs.md)
 
 ## Languages
+
 [Go](../samples/go.md) \| [Java](../samples/java.md) \| [JavaScript](../samples/javascript.md) \| [PHP](../samples/php.md) \| [Python](../samples/python.md) \| [Ruby](../samples/ruby.md) \| [Rust](../samples/rust.md) \| [TypeScript](../samples/typescript.md)
 
 ## Platforms
+
 [Gitea](../samples/gitea.md) \| [Nextcloud](../samples/nextcloud.md) \| [Portainer](../samples/portainer.md) \|  [Prometheus](../samples/prometheus.md) \| [WordPress](../samples/wordpress.md)
 
 ## Other samples
+
 [AI/ML](../samples/ai-ml.md) \| [Cloudflared](../samples/cloudflared.md) \| [Elasticsearch / Logstash / Kibana](../samples/elasticsearch.md) \| [Minecraft](../samples/minecraft.md) \| [NGINX](../samples/nginx.md) \| [Pi-hole](../samples/pi-hole.md) \| [Plex](../samples/plex.md) \| [Traefik](../samples/traefik.md) \| [WireGuard](../samples/wireguard.md)

--- a/content/security/security-announcements.md
+++ b/content/security/security-announcements.md
@@ -46,31 +46,37 @@ If you are unable to update to an unaffected version promptly, follow these best
 ### Technical details and impact
 
 #### CVE-2024-21626 (High)
+
 In runc v1.1.11 and earlier, due to certain leaked file descriptors, an attacker can gain access to the host filesystem by causing a newly-spawned container process (from `runc exec`) to have a working directory in the host filesystem namespace, or by tricking a user to run a malicious image and allow a container process to gain access to the host filesystem through `runc run`. The attacks can also be adapted to overwrite semi-arbitrary host binaries, allowing for complete container escapes. Note that when using higher-level runtimes (such as Docker or Kubernetes), this vulnerability can be exploited by running a malicious container image without additional configuration or by passing specific workdir options when starting a container. The vulnerability can also be exploited from within Dockerfiles in the case of Docker.
 
 _The issue has been fixed in runc v1.1.12._
 
 #### CVE-2024-23651 (High)
+
 In BuildKit <= v0.12.4, two malicious build steps running in parallel sharing the same cache mounts with subpaths could cause a race condition, leading to files from the host system being accessible to the build container. This will only occur if a user is trying to build a Dockerfile of a malicious project.
 
 _The issue has been fixed in BuildKit v0.12.5._
 
 #### CVE-2024-23652 (High)
+
 In BuildKit <= v0.12.4, a malicious BuildKit frontend or Dockerfile using `RUN --mount` could trick the feature that removes empty files created for the mountpoints into removing a file outside the container from the host system. This will only occur if a user is using a malicious Dockerfile.
 
 _The issue has been fixed in BuildKit v0.12.5._
 
 #### CVE-2024-23653 (High)
+
 In addition to running containers as build steps, BuildKit also provides APIs for running interactive containers based on built images. In BuildKit <= v0.12.4, it is possible to use these APIs to ask BuildKit to run a container with elevated privileges. Normally, running such containers is only allowed if special `security.insecure` entitlement is enabled both by buildkitd configuration and allowed by the user initializing the build request.
 
 _The issue has been fixed in BuildKit v0.12.5._
 
 #### CVE-2024-23650 (Medium)
+
 In BuildKit <= v0.12.4, a malicious BuildKit client or frontend could craft a request that could lead to BuildKit daemon crashing with a panic.
 
 _The issue has been fixed in BuildKit v0.12.5._
 
 #### CVE-2024-24557 (Medium)
+
 In Moby <= v25.0.1 and <= v24.0.8, the classic builder cache system is prone to cache poisoning if the image is built FROM scratch. Also, changes to some instructions (most important being `HEALTHCHECK` and `ONBUILD`) would not cause a cache miss. An attacker with knowledge of the Dockerfile someone is using could poison their cache by making them pull a specially crafted image that would be considered a valid cache candidate for some build steps.
 
 _The issue has been fixed in Moby >= v25.0.2 and >= v24.0.9._
@@ -78,16 +84,19 @@ _The issue has been fixed in Moby >= v25.0.2 and >= v24.0.9._
 ### How are Docker products affected? 
 
 #### Docker Desktop
+
 Docker Desktop v4.27.0 and earlier are affected. Docker Desktop v4.27.1 was released on February 1 and includes runc, BuildKit, and dockerd binaries patches. In addition to updating to this new version, we encourage all Docker users to diligently use Docker images and Dockerfiles and ensure you only use trusted content in your builds.
 
 As always, you should check Docker Desktop system requirements for your operating system ([Windows](../desktop/install/windows-install.md#system-requirements), [Linux](../desktop/install/linux-install.md#general-system-requirements), [Mac](../desktop/install/mac-install.md#system-requirements)) before updating to ensure full compatibility.
 
 #### Docker Build Cloud
+
 Any new Docker Build Cloud builder instances will be provisioned with the latest Docker Engine and BuildKit versions and will, therefore, be unaffected by these CVEs. Updates have also been rolled out to existing Docker Build Cloud builders.
 
 _No other Docker products are affected by these vulnerabilities._
 
 ### Advisory links
+
 * Runc
   * [CVE-2024-21626](https://github.com/opencontainers/runc/security/advisories/GHSA-xr7r-f8xq-vfvv)
 * BuildKit


### PR DESCRIPTION
## Description

Headings should be surrounded by blank lines

Rationale: Aside from aesthetic reasons, some parsers, including kramdown, will not parse headings that don't have a blank line before, and will parse them as regular text.
