### PR TITLE
scout release notes: indexing blocked in 1.6.0

### DIFF
--- a/content/scout/release-notes/cli.md
+++ b/content/scout/release-notes/cli.md
@@ -127,6 +127,8 @@ and the `docker/scout-action` [GitHub Action](https://github.com/docker/scout-ac
   uses the cache from Windows. That way, if an image has been indexed for
   instance by Docker Desktop there's no need anymore to re-index it on WSL2
   side.
+- Indexing is now blocked in the CLI if it has been disabled using
+  [Settings Management](../../desktop/hardened-desktop/settings-management/configure.md) feature.
 
 - Fix a panic that would occur when analyzing a single-image `oci-dir` input
 - Improve local attestation support with the containerd image store


### PR DESCRIPTION
<!--Delete sections as needed -->

## Description

Update docker scout v1.6.0 release notes to indicate indexing is blocked when disabled in settings management feature.

## Related issues or tickets

<!-- Related issues, pull requests, or Jira tickets -->

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Technical review
- [ ] Editorial review
- [ ] Product review