### PR TITLE
engine: 26.1.0 release notes

### DIFF
--- a/content/engine/release-notes/25.0.md
+++ b/content/engine/release-notes/25.0.md
@@ -5,11 +5,6 @@ keywords: docker, docker engine, ce, whats new, release notes
 toc_min: 1
 toc_max: 2
 skip_read_time: true
-aliases:
-- /engine/release-notes/
-- /engine/release-notes/latest/
-- /release-notes/docker-ce/
-- /release-notes/docker-engine/
 ---
 
 This page describes the latest changes, additions, known issues, and fixes for Docker Engine version 25.0.

--- a/content/engine/release-notes/26.0.md
+++ b/content/engine/release-notes/26.0.md
@@ -5,11 +5,6 @@ keywords: docker, docker engine, ce, whats new, release notes
 toc_min: 1
 toc_max: 2
 skip_read_time: true
-aliases:
-- /engine/release-notes/
-- /engine/release-notes/latest/
-- /release-notes/docker-ce/
-- /release-notes/docker-engine/
 ---
 
 This page describes the latest changes, additions, known issues, and fixes for Docker Engine version 26.0.

--- a/content/engine/release-notes/26.1.md
+++ b/content/engine/release-notes/26.1.md
@@ -1,0 +1,61 @@
+---
+title: Docker Engine 26.1 release notes
+description: Learn about the new features, bug fixes, and breaking changes for Docker Engine
+keywords: docker, docker engine, ce, whats new, release notes
+toc_min: 1
+toc_max: 2
+skip_read_time: true
+aliases:
+- /engine/release-notes/
+- /engine/release-notes/latest/
+- /release-notes/docker-ce/
+- /release-notes/docker-engine/
+---
+
+This page describes the latest changes, additions, known issues, and fixes for Docker Engine version 26.1.
+
+For more information about:
+
+- Deprecated and removed features, see [Deprecated Engine Features](../deprecated.md).
+- Changes to the Engine API, see [Engine API version history](../api/version-history.md).
+
+## 26.1.0
+
+{{< release-date date="2024-04-22" >}}
+
+For a full list of pull requests and changes in this release, refer to the relevant GitHub milestones:
+
+- [docker/cli, 26.1.0 milestone](https://github.com/docker/cli/issues?q=is%3Aclosed+milestone%3A26.1.0)
+- [moby/moby, 26.1.0 milestone](https://github.com/moby/moby/issues?q=is%3Aclosed+milestone%3A26.1.0)
+- Deprecated and removed features, see [Deprecated Features](https://github.com/docker/cli/blob/v26.1.0/docs/deprecated.md).
+- Changes to the Engine API, see [API version history](https://github.com/moby/moby/blob/v26.1.0/docs/api/version-history.md).
+
+### New
+
+- Added configurable OpenTelemetry utilities and basic instrumentation to commands.
+  For more information, see [OpenTelemetry for the Docker CLI](https://docs.docker.com/config/otel). [docker/cli#4889](https://github.com/docker/cli/pull/4889)
+
+### Bug fixes and enhancements
+
+- Native Windows containers are configured with an internal DNS server for container name resolution, and external DNS servers for other lookups.
+  Not all resolvers, including `nslookup`, fall back to the external resolvers when they get a `SERVFAIL` answer from the internal server.
+  So, the internal DNS server can now be configured to forward requests to the external resolvers, by setting a `feature` option in the `daemon.json` file:
+
+  ```json
+  {
+    "features": {
+      "windows-dns-proxy": true
+    }
+  }
+  ```
+
+  [moby/moby#47584](https://github.com/moby/moby/pull/47584)
+
+  > **Note**
+  >
+  > - This will be the new default behavior in Docker Engine 27.0.
+  > - The `windows-dns-proxy` feature flag will be removed in a future release.
+
+- Swarm: Fix `Subpath` not being passed to the container config. [moby/moby#47711](https://github.com/moby/moby/pull/47711)
+- Classic builder: Fix cache miss on `WORKDIR <directory>/` build step (directory with a trailing slash). [moby/moby#47723](https://github.com/moby/moby/pull/47723)
+- containerd image store: Fix `docker images` failing when any image in the store has unexpected target. [moby/moby#47738](https://github.com/moby/moby/pull/47738)

--- a/data/toc.yaml
+++ b/data/toc.yaml
@@ -1742,10 +1742,12 @@ Manuals:
     title: Deprecated features
   - sectiontitle: Release notes
     section:
-    - path: /engine/release-notes/26.0/
-      title: Engine 26.0
+    - path: /engine/release-notes/26.1/
+      title: Engine 26.1
     - sectiontitle: Previous versions
       section:
+      - path: /engine/release-notes/26.0/
+        title: Engine 26.0
       - path: /engine/release-notes/25.0/
         title: Engine 25.0
       - path: /engine/release-notes/24.0/

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -95,7 +95,7 @@ params:
   docs_url: https://docs.docker.com
 
   latest_engine_api_version: "1.45"
-  docker_ce_version: "26.0.0"
+  docker_ce_version: "26.1.0"
   compose_version: "v2.26.1"
   compose_file_v3: "3.8"
   compose_file_v2: "2.4"


### PR DESCRIPTION
<!--Delete sections as needed -->

## Description

Add release notes for 26.1.0

## Related issues

- Needs https://github.com/docker/docs/pull/19776