### PR TITLE
`env` can be omitted in docker build --secret

### DIFF
--- a/content/build/building/secrets.md
+++ b/content/build/building/secrets.md
@@ -68,7 +68,7 @@ as a file in the build container at `/run/secrets/kube`.
 $ docker build --secret id=kube,env=KUBECONFIG .
 ```
 
-When you secrets from environment variables, you can omit the `id` parameter
+When you secrets from environment variables, you can omit the `env` parameter
 to bind the secret to a file with the same name as the variable.
 In the following example, the value of the `API_TOKEN` variable
 is mounted to `/run/secrets/API_TOKEN` in the build container.


### PR DESCRIPTION
<!--Delete sections as needed -->

## Description
In the example, the full command is `$ docker build --secret id=kube,env=KUBECONFIG .`,
Then the `env` is omitted and the command becomes `$ docker build --secret id=API_TOKEN .`

I believe the **id** is a typo and should be replace by **env**
## Related issues or tickets

<!-- Related issues, pull requests, or Jira tickets -->

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Technical review
- [ ] Editorial review
- [ ] Product review