### PR TITLE
Add note regarding IPv6 and address 127.0.0.1 for host networking

### DIFF
--- a/content/network/drivers/host.md
+++ b/content/network/drivers/host.md
@@ -85,13 +85,14 @@ $ nc localhost 80
 
 ### Limitations
 
-The host network feature of Docker Desktop works on layer 4. This means that
+- The host network feature of Docker Desktop works on layer 4. This means that
 unlike with Docker on Linux, network protocols that operate below TCP or UDP are
 not supported.
-
-Also, the feature doesn't work with Enhanced Container Isolation enabled, since
+- This feature doesn't work with Enhanced Container Isolation enabled, since
 isolating your containers from the host and allowing them access to the host
 network contradict each other.
+- IPv6 is not yet supported. Services need to use IPv4 and bind to address
+  127.0.0.1 in the container to be visible on the host.
 
 ## Next steps
 


### PR DESCRIPTION
## Description

Add note regarding IPv6 and address 127.0.0.1 for host networking

## Related issues or tickets

https://github.com/docker/for-mac/issues/7261

## Reviews

- [ ] Technical review
- [ ] Editorial review
- [ ] Product review