### PR TITLE
fix: conflicting http proxy configuration for daemon

### DIFF
--- a/content/config/containers/resource_constraints.md
+++ b/content/config/containers/resource_constraints.md
@@ -233,7 +233,9 @@ for real-time tasks per runtime period. For instance, with the default period of
 containers using the real-time scheduler can run for 950000 microseconds for every
 1000000-microsecond period, leaving at least 50000 microseconds available for
 non-real-time tasks. To make this configuration permanent on systems which use
-`systemd`, see [Control and configure Docker with systemd](../daemon/systemd.md).
+`systemd`, create a systemd unit file for the `docker` service. For an example,
+see the instruction on how to configure the daemon to use a proxy with a
+[systemd unit file](../daemon/proxy.md#systemd-unit-file).
 
 #### Configure individual containers
 

--- a/content/config/daemon/_index.md
+++ b/content/config/daemon/_index.md
@@ -127,4 +127,4 @@ documentation. Some places to go next include:
 - [Limit a container's resources](../containers/resource_constraints.md)
 - [Configure storage drivers](../../storage/storagedriver/select-storage-driver.md)
 - [Container security](../../engine/security/_index.md)
-- [Configure the Docker daemon to use a proxy](./systemd.md#httphttps-proxy)
+- [Configure the Docker daemon to use a proxy](./proxy.md)

--- a/content/config/daemon/proxy.md
+++ b/content/config/daemon/proxy.md
@@ -7,6 +7,7 @@ aliases:
   - /articles/systemd/
   - /engine/admin/systemd/
   - /engine/articles/systemd/
+  - /config/daemon/systemd/
 ---
 
 <a name="httphttps-proxy"><!-- included for deep-links to old section --></a>
@@ -60,6 +61,8 @@ environment to configure HTTP or HTTPS proxy behavior:
 - `https_proxy`
 - `NO_PROXY`
 - `no_proxy`
+
+### systemd unit file
 
 If you're running the Docker daemon as a systemd service, you can create a
 systemd drop-in file that sets the variables for the `docker` service.

--- a/content/config/daemon/systemd.md
+++ b/content/config/daemon/systemd.md
@@ -1,7 +1,7 @@
 ---
-description: Learn about controlling and configuring the Docker daemon using systemd
-keywords: dockerd, daemon, systemd, configuration, proxy, networking
-title: Configure the daemon with systemd
+description: Learn how to configure the Docker daemon to use an HTTP proxy
+keywords: dockerd, daemon, configuration, proxy, networking, http_proxy, https_proxy, no_proxy, systemd, environment variables
+title: Configure the daemon to use a proxy
 aliases:
   - /articles/host_integration/
   - /articles/systemd/
@@ -9,36 +9,29 @@ aliases:
   - /engine/articles/systemd/
 ---
 
-This page describes how to customize daemon settings when using systemd.
+<a name="httphttps-proxy"><!-- included for deep-links to old section --></a>
 
-## Custom Docker daemon options
+If your organization uses a proxy server to connect to the internet, you may
+need to configure the Docker daemon to use the proxy server. The daemon uses
+a proxy server to access images stored on Docker Hub and other registries,
+and to reach other nodes in a Docker swarm.
 
-Most configuration options for the Docker daemon are set using the `daemon.json`
-configuration file. See [Docker daemon configuration overview](./index.md) for
-more information.
+This page describes how to configure a proxy for the Docker daemon. For
+instructions on configuring proxy settings for the Docker CLI, see [Configure
+Docker to use a proxy server](../../network/proxy.md).
 
-## Manually create the systemd unit files
+There are two ways you can configure these settings:
 
-When installing the binary without a package manager, you may want to integrate
-Docker with systemd. For this, install the two unit files (`service` and
-`socket`) from
-[the GitHub repository](https://github.com/moby/moby/tree/master/contrib/init/systemd)
-to `/etc/systemd/system`.
+- [Configuring the daemon](#daemon-configuration) through a configuration file or CLI flags
+- Setting [environment variables](#environment-variables) on the system
 
-### Configure the Docker daemon to use a proxy server {#httphttps-proxy}
+Configuring the daemon directly takes precedence over environment variables.
 
-The Docker daemon uses the following environment variables in
-its start-up environment to configure HTTP or HTTPS proxy behavior:
+## Daemon configuration
 
-- `HTTP_PROXY`
-- `http_proxy`
-- `HTTPS_PROXY`
-- `https_proxy`
-- `NO_PROXY`
-- `no_proxy`
-
-In Docker Engine version 23.0 and later versions, you may also configure proxy
-behavior for the daemon in the [`daemon.json` file](./index.md#configure-the-docker-daemon):
+You may configure proxy behavior for the daemon in the `daemon.json` file,
+or using CLI flags for the `--http-proxy` or `--https-proxy` flags for the
+`dockerd` command. Configuration using `daemon.json` is recommended.
 
 ```json
 {
@@ -50,11 +43,26 @@ behavior for the daemon in the [`daemon.json` file](./index.md#configure-the-doc
 }
 ```
 
-These configurations override the default `docker.service` systemd file.
+After changing the configuration file, restart the daemon for the proxy configuration to take effect:
 
-If you're behind an HTTP or HTTPS proxy server, for example in corporate
-settings, the daemon proxy configurations must be specified in the systemd
-service file, not in the `daemon.json` file or using environment variables.
+```console
+$ sudo systemctl restart docker
+```
+
+## Environment variables
+
+The Docker daemon checks the following environment variables in its start-up
+environment to configure HTTP or HTTPS proxy behavior:
+
+- `HTTP_PROXY`
+- `http_proxy`
+- `HTTPS_PROXY`
+- `https_proxy`
+- `NO_PROXY`
+- `no_proxy`
+
+If you're running the Docker daemon as a systemd service, you can create a
+systemd drop-in file that sets the variables for the `docker` service.
 
 > **Note for rootless mode**
 >
@@ -62,12 +70,12 @@ service file, not in the `daemon.json` file or using environment variables.
 > in [rootless mode](../../engine/security/rootless.md). When running in
 > rootless mode, Docker is started as a user-mode systemd service, and uses
 > files stored in each users' home directory in
-> `~/.config/systemd/user/docker.service.d/`. In addition, `systemctl` must be
-> executed without `sudo` and with the `--user` flag. Select the _"rootless
-> mode"_ tab below if you are running Docker in rootless mode.
+> `~/.config/systemd/<user>/docker.service.d/`. In addition, `systemctl` must
+> be executed without `sudo` and with the `--user` flag. Select the "Rootless
+> mode" tab if you are running Docker in rootless mode.
 
 {{< tabs >}}
-{{< tab name="regular install" >}}
+{{< tab name="Regular install" >}}
 
 1. Create a systemd drop-in directory for the `docker` service:
 
@@ -154,7 +162,7 @@ service file, not in the `daemon.json` file or using environment variables.
    ```
 
 {{< /tab >}}
-{{< tab name="rootless mode" >}}
+{{< tab name="Rootless mode" >}}
 
 1. Create a systemd drop-in directory for the `docker` service:
 

--- a/content/config/daemon/troubleshoot.md
+++ b/content/config/daemon/troubleshoot.md
@@ -60,7 +60,7 @@ ExecStart=/usr/bin/dockerd
 ```
 
 There are other times when you might need to configure `systemd` with Docker,
-such as [configuring a HTTP or HTTPS proxy](systemd.md#httphttps-proxy).
+such as [configuring a HTTP or HTTPS proxy](./proxy.md).
 
 > **Note**
 >

--- a/content/engine/install/linux-postinstall.md
+++ b/content/engine/install/linux-postinstall.md
@@ -96,7 +96,7 @@ To create the `docker` group and add your user:
 
 ## Configure Docker to start on boot with systemd
 
-Many modern Linux distributions use [systemd](../../config/daemon/systemd.md) to
+Many modern Linux distributions use [systemd](https://systemd.io/) to
 manage which services start when the system boots. On Debian and Ubuntu, the
 Docker service starts on boot by default. To automatically start Docker and
 containerd on boot for other Linux distributions using systemd, run the
@@ -114,9 +114,10 @@ $ sudo systemctl disable docker.service
 $ sudo systemctl disable containerd.service
 ```
 
-If you need to add an HTTP proxy, set a different directory or partition for the
-Docker runtime files, or make other customizations, see
-[customize your systemd Docker daemon options](../../config/daemon/systemd.md).
+You can use systemd unit files to configure the Docker service on startup,
+for example to add an HTTP proxy, set a different directory or partition for the
+Docker runtime files, or other customizations. For an example, see
+[Configure the daemon to use a proxy](../../config/daemon/proxy.md#systemd-unit-file).
 
 ## Configure default logging driver
 

--- a/content/engine/release-notes/20.10.md
+++ b/content/engine/release-notes/20.10.md
@@ -405,7 +405,7 @@ to learn how to use the `docker scan` command to check if images are vulnerable.
 > longer used for TLS (`https://`) connections. Make sure you also set an `$HTTPS_PROXY`
 > environment variable for handling requests to `https://` URLs.
 >
-> Refer to the [HTTP/HTTPS proxy section](../../config/daemon/systemd.md#httphttps-proxy)
+> Refer to [Configure the daemon to use a proxy](../../config/daemon/proxy.md)
 > to learn how to configure the Docker Daemon to use a proxy server.
 { .important }
 
@@ -435,7 +435,7 @@ to learn how to use the `docker scan` command to check if images are vulnerable.
 > longer used for TLS (`https://`) connections. Make sure you also set an `$HTTPS_PROXY`
 > environment variable for handling requests to `https://` URLs.
 >
-> Refer to the [HTTP/HTTPS proxy section](../../config/daemon/systemd.md#httphttps-proxy)
+> Refer to the [HTTP/HTTPS proxy section](../../config/daemon/proxy.md#httphttps-proxy)
 > to learn how to configure the Docker Daemon to use a proxy server.
 { .important }
 
@@ -476,7 +476,7 @@ well as updated versions of the containerd.io package.
 > longer used for TLS (`https://`) connections. Make sure you also set an `$HTTPS_PROXY`
 > environment variable for handling requests to `https://` URLs.
 >
-> Refer to the [HTTP/HTTPS proxy section](../../config/daemon/systemd.md#httphttps-proxy)
+> Refer to the [HTTP/HTTPS proxy section](../../config/daemon/proxy.md#httphttps-proxy)
 > to learn how to configure the Docker Daemon to use a proxy server.
 { .important }
 
@@ -521,7 +521,7 @@ well as updated versions of the containerd.io package.
 > longer used for TLS (`https://`) connections. Make sure you also set an `$HTTPS_PROXY`
 > environment variable for handling requests to `https://` URLs.
 >
-> Refer to the [HTTP/HTTPS proxy section](../../config/daemon/systemd.md#httphttps-proxy)
+> Refer to the [HTTP/HTTPS proxy section](../../config/daemon/proxy.md#httphttps-proxy)
 > to learn how to configure the Docker Daemon to use a proxy server.
 { .important }
 

--- a/content/network/proxy.md
+++ b/content/network/proxy.md
@@ -14,7 +14,7 @@ For instructions on configuring Docker Desktop to use HTTP/HTTPS proxies, see
 [proxies on Linux](../desktop/settings/linux.md#proxies).
 
 If you're running Docker Engine without Docker Desktop, refer to
-[Configure the Docker daemon to use a proxy server](../config/daemon/systemd.md#httphttps-proxy)
+[Configure the Docker daemon to use a proxy](../config/daemon/proxy.md)
 to learn how to configure a proxy server for the Docker daemon (`dockerd`) itself.
 
 If your container needs to use an HTTP, HTTPS, or FTP proxy server, you can
@@ -79,7 +79,7 @@ These settings are used to configure proxy environment variables for containers
 only, and not used as proxy settings for the Docker CLI or the Docker Engine
 itself.
 Refer to the [environment variables](/engine/reference/commandline/cli/#environment-variables)
-and [configure the Docker daemon to use a proxy server](../config/daemon/systemd.md#httphttps-proxy)
+and [configure the Docker daemon to use a proxy server](../config/daemon/proxy.md#httphttps-proxy)
 sections for configuring proxy settings for the CLI and daemon.
 
 ### Run containers with a proxy configuration

--- a/data/toc.yaml
+++ b/data/toc.yaml
@@ -1637,8 +1637,8 @@ Manuals:
       title: Start the daemon
     - path: /config/daemon/
       title: Configure the daemon
-    - path: /config/daemon/systemd/
-      title: Configure with systemd
+    - path: /config/daemon/proxy/
+      title: HTTP proxy
     - path: /config/containers/live-restore/
       title: Live restore
     - path: /config/daemon/troubleshoot/


### PR DESCRIPTION
## Description

- **engine: rewrite dockerd systemd config to http proxy config**
- **engine: rename systemd.md to proxy.md, update links**

## Related issues or tickets

- Closes #17880
- Closes #19988
