### PR TITLE
Update ubuntu.md

### DIFF
--- a/content/engine/install/ubuntu.md
+++ b/content/engine/install/ubuntu.md
@@ -69,7 +69,7 @@ conflicts with the versions bundled with Docker Engine.
 Run the following command to uninstall all conflicting packages:
 
 ```console
-$ for pkg in docker.io docker-doc docker-compose docker-compose-v2 podman-docker containerd runc; do sudo apt-get remove $pkg; done
+$ for pkg in docker.io docker-doc docker-compose docker-compose-v2 podman-docker containerd runc wmdocker; do sudo apt-get remove $pkg; done
 ```
 
 `apt-get` might report that you have none of these packages installed.


### PR DESCRIPTION
<!--Delete sections as needed -->

## Description

Added wmdocker for removal that comes bundled with the default docker/docker.io install on Ubuntu server 22.04.3 LTS as well as serveral other versions.

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Technical review
- [ ] Editorial review
- [ ] Product review