### PR TITLE
Fix: compose postgre auth error

### DIFF
--- a/content/language/nodejs/develop.md
+++ b/content/language/nodejs/develop.md
@@ -232,6 +232,8 @@ services:
     environment:
       - POSTGRES_DB=example
       - POSTGRES_PASSWORD_FILE=/run/secrets/db-password
+      - POSTGRES_HOST_AUTH_METHOD=md5
+      - PGDATA=/var/lib/postgresql/data/pgdata 
     expose:
       - 5432
     healthcheck:


### PR DESCRIPTION
## Description

When attempting to run a `Docker Compose` setup with `todo-app server` and `postgres` containers, authentication failures happens for `Postgre` container. (Docker docs: using containers for Node.js development)

I explained the details and applied a suggestion solving the issue. 

## Related issues or tickets

The details are available in the issue I created: Auth Error With Postgre Container Using Docker Compose #19865 

## Reviews

Notes for the reviewer: With the code changes I provided, I've been able to run the containers and application. I'd appreciate code review. 

**My Environment**:
- Operating System: MacOS (M1 - Apple Silicon Chip)
- Docker version 26.0.0
- Docker Compose version v2.26.1-desktop.1