### PR TITLE
engine: update distro-versions (Fedora 40, Ubuntu 24.04), add EOL dates and add V26.1 to API docs

### DIFF
--- a/content/engine/api/_index.md
+++ b/content/engine/api/_index.md
@@ -73,22 +73,22 @@ To see the highest version of the API your Docker daemon and client support, use
 ```console
 $ docker version
 Client: Docker Engine - Community
- Version:           26.0.0
+ Version:           26.1.0
  API version:       1.45
- Go version:        go1.21.8
- Git commit:        2ae903e
- Built:             Wed Mar 20 15:17:48 2024
- OS/Arch:           linux/amd64
+ Go version:        go1.21.9
+ Git commit:        9714adc
+ Built:             Mon Apr 22 17:05:41 2024
+ OS/Arch:           linux/arm64
  Context:           default
 
 Server: Docker Engine - Community
  Engine:
-  Version:          26.0.0
+  Version:          26.1.0
   API version:      1.45 (minimum version 1.24)
-  Go version:       go1.21.8
-  Git commit:       8b79278
-  Built:            Wed Mar 20 15:17:48 2024
-  OS/Arch:          linux/amd64
+  Go version:       go1.21.9
+  Git commit:       c8af8eb
+  Built:            Mon Apr 22 17:07:05 2024
+  OS/Arch:          linux/arm64
   Experimental:     false
   ...
 ```
@@ -127,6 +127,7 @@ You can specify the API version to use in any of the following ways:
 
 | Docker version | Maximum API version        | Change log                                               |
 |:---------------|:---------------------------|:---------------------------------------------------------|
+| 26.1           | [1.45](/engine/api/v1.45/) | [changes](/engine/api/version-history/#v145-api-changes) |
 | 26.0           | [1.45](/engine/api/v1.45/) | [changes](/engine/api/version-history/#v145-api-changes) |
 | 25.0           | [1.44](/engine/api/v1.44/) | [changes](/engine/api/version-history/#v144-api-changes) |
 | 24.0           | [1.43](/engine/api/v1.43/) | [changes](/engine/api/version-history/#v143-api-changes) |

--- a/content/engine/install/centos.md
+++ b/content/engine/install/centos.md
@@ -28,8 +28,8 @@ To get started with Docker Engine on CentOS, make sure you
 To install Docker Engine, you need a maintained version of one of the following
 CentOS versions:
 
-- CentOS 7
-- CentOS 8 (stream)
+- CentOS 7 (EOL: [June 30, 2024](https://blog.centos.org/2023/04/end-dates-are-coming-for-centos-stream-8-and-centos-linux-7/#centos-linux-7-end-of-life-june-30-2024))
+- CentOS 8 (stream) (EOL: [May 31, 2024](https://blog.centos.org/2023/04/end-dates-are-coming-for-centos-stream-8-and-centos-linux-7/#centos-stream-8-end-of-builds-may-31-2024))
 - CentOS 9 (stream)
 
 The `centos-extras` repository must be enabled. This repository is enabled by

--- a/content/engine/install/debian.md
+++ b/content/engine/install/debian.md
@@ -143,15 +143,15 @@ Docker from the repository.
    # List the available versions:
    $ apt-cache madison docker-ce | awk '{ print $3 }'
 
-   5:25.0.0-1~debian.12~bookworm
-   5:24.0.7-1~debian.12~bookworm
+   5:26.1.0-1~debian.12~bookworm
+   5:26.0.2-1~debian.12~bookworm
    ...
    ```
 
    Select the desired version and install:
 
    ```console
-   $ VERSION_STRING=5:25.0.0-1~debian.12~bookworm
+   $ VERSION_STRING=5:26.1.0-1~debian.12~bookworm
    $ sudo apt-get install docker-ce=$VERSION_STRING docker-ce-cli=$VERSION_STRING containerd.io docker-buildx-plugin docker-compose-plugin
    ```
   

--- a/content/engine/install/fedora.md
+++ b/content/engine/install/fedora.md
@@ -26,6 +26,7 @@ Fedora versions:
 
 - Fedora 38
 - Fedora 39
+- Fedora 40
 
 ### Uninstall old versions
 
@@ -112,17 +113,17 @@ $ sudo dnf config-manager --add-repo {{% param "download-url-base" %}}/docker-ce
    ```console
    $ dnf list docker-ce --showduplicates | sort -r
 
-   docker-ce.x86_64    3:25.0.0-1.fc39    docker-ce-stable
-   docker-ce.x86_64    3:24.0.7-1.fc39    docker-ce-stable
+   docker-ce.x86_64    3:26.1.0-1.fc40    docker-ce-stable
+   docker-ce.x86_64    3:26.0.2-1.fc40    docker-ce-stable
    <...>
    ```
 
    The list returned depends on which repositories are enabled, and is specific
-   to your version of Fedora (indicated by the `.fc39` suffix in this example).
+   to your version of Fedora (indicated by the `.fc40` suffix in this example).
 
    Install a specific version by its fully qualified package name, which is
    the package name (`docker-ce`) plus the version string (2nd column),
-   separated by a hyphen (`-`). For example, `docker-ce-3:25.0.0-1.fc39`.
+   separated by a hyphen (`-`). For example, `docker-ce-3:26.1.0-1.fc40`.
 
    Replace `<VERSION_STRING>` with the desired version and then run the following
    command to install:

--- a/content/engine/install/fedora.md
+++ b/content/engine/install/fedora.md
@@ -24,7 +24,7 @@ To get started with Docker Engine on Fedora, make sure you
 To install Docker Engine, you need a maintained version of one of the following
 Fedora versions:
 
-- Fedora 38
+- Fedora 38 (EOL: [May 14, 2024](https://fedorapeople.org/groups/schedule/f-38/f-38-key-tasks.html))
 - Fedora 39
 - Fedora 40
 

--- a/content/engine/install/rhel.md
+++ b/content/engine/install/rhel.md
@@ -38,7 +38,7 @@ To get started with Docker Engine on RHEL, make sure you
 To install Docker Engine, you need a maintained version of one of the following
 RHEL versions:
 
-- RHEL 7 on s390x (IBM Z)
+- RHEL 7 on s390x (IBM Z) (EOL: [June 30, 2024](https://www.ibm.com/blog/announcement/ibm-is-announcing-red-hat-enterprise-linux-7-is-going-end-of-support-on-30-june-2024/))
 - RHEL 8 on s390x (IBM Z)
 - RHEL 9 on s390x (IBM Z)
 
@@ -129,17 +129,17 @@ $ sudo yum-config-manager --add-repo {{% param "download-url-base" %}}/docker-ce
    ```console
    $ yum list docker-ce --showduplicates | sort -r
 
-   docker-ce.s390x    3:24.0.0-1.el8    docker-ce-stable
-   docker-ce.s390x    3:23.0.6-1.el8    docker-ce-stable
+   docker-ce.s390x    3:26.0.2-1.el9    docker-ce-stable
+   docker-ce.s390x    3:26.0.1-1.el9    docker-ce-stable
    <...>
    ```
 
    The list returned depends on which repositories are enabled, and is specific
-   to your version of RHEL (indicated by the `.el8` suffix in this example).
+   to your version of RHEL (indicated by the `.el9` suffix in this example).
 
    Install a specific version by its fully qualified package name, which is
    the package name (`docker-ce`) plus the version string (2nd column),
-   separated by a hyphen (`-`). For example, `docker-ce-3:25.0.0-1.el8`.
+   separated by a hyphen (`-`). For example, `docker-ce-3:26.0.1-1.el9`.
 
    Replace `<VERSION_STRING>` with the desired version and then run the following
    command to install:

--- a/content/engine/install/ubuntu.md
+++ b/content/engine/install/ubuntu.md
@@ -38,6 +38,7 @@ To get started with Docker Engine on Ubuntu, make sure you
 To install Docker Engine, you need the 64-bit version of one of these Ubuntu
 versions:
 
+- Ubuntu Noble 24.04 (LTS)
 - Ubuntu Mantic 23.10
 - Ubuntu Jammy 22.04 (LTS)
 - Ubuntu Focal 20.04 (LTS)
@@ -145,15 +146,15 @@ Docker from the repository.
    # List the available versions:
    $ apt-cache madison docker-ce | awk '{ print $3 }'
 
-   5:24.0.0-1~ubuntu.22.04~jammy
-   5:23.0.6-1~ubuntu.22.04~jammy
+   5:26.1.0-1~ubuntu.24.04~noble
+   5:26.0.2-1~ubuntu.24.04~noble
    ...
    ```
 
    Select the desired version and install:
 
    ```console
-   $ VERSION_STRING=5:24.0.0-1~ubuntu.22.04~jammy
+   $ VERSION_STRING=5:26.1.0-1~ubuntu.24.04~noble
    $ sudo apt-get install docker-ce=$VERSION_STRING docker-ce-cli=$VERSION_STRING containerd.io docker-buildx-plugin docker-compose-plugin
    ```
   

--- a/content/engine/install/ubuntu.md
+++ b/content/engine/install/ubuntu.md
@@ -39,7 +39,7 @@ To install Docker Engine, you need the 64-bit version of one of these Ubuntu
 versions:
 
 - Ubuntu Noble 24.04 (LTS)
-- Ubuntu Mantic 23.10
+- Ubuntu Mantic 23.10 (EOL: [July 12, 2024](https://wiki.ubuntu.com/Releases))
 - Ubuntu Jammy 22.04 (LTS)
 - Ubuntu Focal 20.04 (LTS)
 


### PR DESCRIPTION
<!--Delete sections as needed -->

## Description

<!-- Tell us what you did and why -->

## Related issues or tickets

fixes / addresses (internal tickets);

- fixes https://github.com/docker/runtime-team/issues/120
- fixes https://github.com/docker/runtime-team/issues/121
- relates to https://github.com/docker/runtime-team/issues/119

<!-- Related issues, pull requests, or Jira tickets -->

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Technical review
- [ ] Editorial review
- [ ] Product review