### PR TITLE
fix: make term table full width

### DIFF
--- a/layouts/tag/term.html
+++ b/layouts/tag/term.html
@@ -11,7 +11,7 @@
       <span class="text-gray-light dark:text-gray-dark">Pages with this tag:</span>
       {{ partial "pagination.html" . }}
     </div>
-    <table>
+    <table style="display: table">
       <thead>
         <tr>
           <th width="50%">Title</th>


### PR DESCRIPTION
## Description

Force display:table on term pages for tags

before: https://docs.docker.com/tags/faq/
after: https://deploy-preview-19887--docsdocker.netlify.app/tags/faq/

Signed-off-by: David Karlsson <35727626+dvdksn@users.noreply.github.com>

## Related issues or tickets

https://docker.slack.com/archives/C04300R4G5U/p1714065448301229?thread_ts=1714064880.288539&cid=C04300R4G5U
