### PR TITLE
recommend use of up --watch and document watch command as an alternative

### DIFF
--- a/content/compose/file-watch.md
+++ b/content/compose/file-watch.md
@@ -49,7 +49,6 @@ In order to work properly, `watch` relies on common executables. Make sure your 
 * stat
 * mkdir
 * rmdir
-* tar
 
 `watch` also requires that the container's `USER` can write to the target path so it can update files. A common pattern is for 
 initial content to be copied into the container using the `COPY` instruction in a Dockerfile. To ensure such files are owned 
@@ -142,7 +141,7 @@ services:
           path: package.json
 ```
 
-In this example, when running `docker compose watch`, a container for the `web` service is launched using an image built from the `Dockerfile` in the project's root.
+In this example, when running `docker compose up --watch`, a container for the `web` service is launched using an image built from the `Dockerfile` in the project's root.
 The `web` service runs `npm start` for its command, which then launches a development version of the application with Hot Module Reload enabled in the bundler (Webpack, Vite, Turbopack, etc).
 
 After the service is up, the watch mode starts monitoring the target directories and files.
@@ -159,7 +158,7 @@ This pattern can be followed for many languages and frameworks, such as Python w
 ## Use `watch`
 
 1. Add `watch` sections to one or more services in `compose.yaml`.
-2. Run `docker compose watch` to build and launch a Compose project and start the file watch mode.
+2. Run `docker compose up --watch` to build and launch a Compose project and start the file watch mode.
 3. Edit service source files using your preferred IDE or editor.
 
 > **Looking for a sample project to test things out?**
@@ -168,6 +167,14 @@ This pattern can be followed for many languages and frameworks, such as Python w
 > or [local setup for Docker docs](https://github.com/docker/docs/blob/main/CONTRIBUTING.md)
 > for a demonstration of Compose `watch`.
 { .tip }
+
+
+> **Watch command
+>
+> Watch can also be used with the dedicated `docker compose watch` command if you don't want to 
+> get application logs mixed with (re)build logs and filesystem sync events.
+{ .tip }
+
 
 ## Feedback
 


### PR DESCRIPTION
## Description

document compose watch feature relying on `--watch` flag, and document `watch` command as an alternative

## Related issues or tickets

https://github.com/docker/compose/issues/11089#issuecomment-2079515066

## Reviews

- [ ] Technical review
- [ ] Editorial review
- [ ] Product review