### PR TITLE
docs: update directory name in r language guide

### DIFF
--- a/content/language/r/containerize.md
+++ b/content/language/r/containerize.md
@@ -25,11 +25,11 @@ Clone the sample application to use with this guide. Open a terminal, change dir
 $ git clone https://github.com/mfranzon/r-docker-dev.git
 ```
 
-You should now have the following contents in your `r-docker`
+You should now have the following contents in your `r-docker-dev`
 directory.
 
 ```text
-├── r-docker/
+├── r-docker-dev/
 │ ├── src/
 │ │ └── app.R
 │ ├── src_db/
@@ -46,7 +46,7 @@ To learn more about the files in the repository, see the following:
 
 ## Run the application
 
-Inside the `r-docker` directory, run the following command in a
+Inside the `r-docker-dev` directory, run the following command in a
 terminal.
 
 ```console
@@ -60,7 +60,7 @@ In the terminal, press `ctrl`+`c` to stop the application.
 ### Run the application in the background
 
 You can run the application detached from the terminal by adding the `-d`
-option. Inside the `r-docker` directory, run the following command
+option. Inside the `r-docker-dev` directory, run the following command
 in a terminal.
 
 ```console


### PR DESCRIPTION
<!--Delete sections as needed -->

## Description

- Update the incorrect directory name from '**r-docker**' to '**r-docker-dev**'. After cloning, the directory name on the local system will be 'r-docker-dev', as clearly visible with the repo git URL in 'https://github.com/mfranzon/r-docker-dev.git'.

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [x] Technical review
- [ ] Editorial review
- [ ] Product review