### PR TITLE
Add note that Docker Debug containers are not protected by ECI.

### DIFF
--- a/content/desktop/hardened-desktop/enhanced-container-isolation/limitations.md
+++ b/content/desktop/hardened-desktop/enhanced-container-isolation/limitations.md
@@ -78,6 +78,12 @@ Containers launched by the Docker Desktop Dev Environments feature are not yet
 protected either. We expect to improve on this in future versions of Docker
 Desktop.
 
+### Docker Debug containers are not yet protected
+
+[Docker Debug](https://docs.docker.com/reference/cli/docker/debug/) containers
+are not yet protected by ECI. We expect to improve on this in future versions of
+Docker Desktop.
+
 ### Use in production
 
 In general users should not experience differences between running a container


### PR DESCRIPTION
<!--Delete sections as needed -->

## Description

Adds a short note in the Enhanced Container Isolation (ECI) limitations section indicting that Docker Debug containers are not protected by ECI.

## Related issues or tickets

https://docker.atlassian.net/browse/POS-2505

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Technical review
- [X] Editorial review
- [ ] Product review