### PR TITLE
docs: remove note since issue #4696 was fixed

### DIFF
--- a/content/build/buildkit/_index.md
+++ b/content/build/buildkit/_index.md
@@ -237,11 +237,6 @@ We appreciate any feedback you submit by [opening an issue here](https://github.
    "@
    ```
 
-   > **Note**
-   >
-   > For a consistent experience, use forward-slashes `/` for paths, e.g. `C:/` instead of `C:\`.
-   > Support for Windows-style paths is tracked in [moby/buildkit#4696](https://github.com/moby/buildkit/issues/4696).
-
 10. Build and push the image to a registry.
 
     ```console


### PR DESCRIPTION
Issue raised by the note in the docs has been closed refer to [buildkit#4696](https://github.com/moby/buildkit/issues/4696)

## Related issues

* moby/buildkit#4894