### PR TITLE
Fix odd table of contents entry on volumes page

### DIFF
--- a/content/storage/volumes.md
+++ b/content/storage/volumes.md
@@ -99,7 +99,7 @@ If you need to specify volume driver options, you must use `--mount`.
 The examples below show both the `--mount` and `-v` syntax where possible, with
 `--mount` first.
 
-### Differences between `-v` and `--mount` behavior 
+### Differences between -v and --mount behavior 
 
 As opposed to bind mounts, all options for volumes are available for both
 `--mount` and `-v` flags.


### PR DESCRIPTION
## Description

The code block in the title was causing the table of contents to display oddly

![image](https://github.com/docker/docs/assets/289860/0b4f47ba-0a71-4857-84b9-6a1d6af9e4ae)

A more proper fix would be to update the table of contents code to strip out the code tags, however the html generation is already stripping the code blocks out of the html title, so stripping the code blocks from the markdown seems the easiest solution

## Related issues or tickets

<!-- Related issues, pull requests, or Jira tickets -->

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Technical review
- [ ] Editorial review
- [ ] Product review