### PR TITLE
Update rootless.md

### DIFF
--- a/content/engine/security/rootless.md
+++ b/content/engine/security/rootless.md
@@ -77,7 +77,7 @@ testuser:231072:65536
      abi <abi/4.0>,
      include <tunables/global>
 
-     $HOME/bin/rootlesskit flags=(unconfined) {
+     "$HOME/bin/rootlesskit" flags=(unconfined) {
        userns,
 
        include if exists <local/$(echo $HOME/bin/rootlesskit | sed -e s@^/@@ -e s@/@.@g)>


### PR DESCRIPTION
Adding quotes prevents the `$` from being omitted from the beginning of this line.  When a line starts with `$` it is assumed to be an included shell prompt by the formatter and so does get coped.

<!--Delete sections as needed -->

## Description

<!-- Tell us what you did and why -->

## Related issues or tickets

<!-- Related issues, pull requests, or Jira tickets -->

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Technical review
- [ ] Editorial review
- [ ] Product review