### PR TITLE
docs: fix links to docker-run

### DIFF
--- a/content/compose/compose-file/05-services.md
+++ b/content/compose/compose-file/05-services.md
@@ -1497,7 +1497,7 @@ Optionally, limit the number of restart retries the Docker daemon attempts.
 ```
 
 You can find more detailed information on restart policies in the
-[Restart Policies (--restart)](/engine/reference/run/#restart-policies---restart)
+[Restart Policies (--restart)](../../reference/cli/docker/container/run.md#restart)
 section of the Docker run reference page.
 
 ## runtime
@@ -1599,7 +1599,7 @@ security_opt:
   - label:role:ROLE
 ```
 
-For further default labeling schemes you can override, see [Security configuration](https://docs.docker.com/engine/reference/run/#security-configuration).
+For further default labeling schemes you can override, see [Security configuration](../../reference/cli/docker/container/run.md#security-opt).
 
 ## shm_size
 
@@ -1661,7 +1661,7 @@ sysctls:
 You can only use sysctls that are namespaced in the kernel. Docker does not
 support changing sysctls inside a container that also modify the host system.
 For an overview of supported sysctls, refer to [configure namespaced kernel
-parameters (sysctls) at runtime](https://docs.docker.com/engine/reference/commandline/run/#sysctl).
+parameters (sysctls) at runtime](../../reference/cli/docker/container/run.md#sysctl).
 
 ## tmpfs
 


### PR DESCRIPTION
<!--Delete sections as needed -->

## Description
It seems that the location of `docker run` CLI reference has been moved. These URLs are pointing to a page that does not contain the expected content.
<!-- Tell us what you did and why -->

## Related issues or tickets
Didn't find any.
<!-- Related issues, pull requests, or Jira tickets -->

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Technical review
- [ ] Editorial review
- [ ] Product review