### PR TITLE
Fix incorrect reference to "line 18" - make it "line 21" (correct)

### DIFF
--- a/content/guides/walkthroughs/multi-container-apps.md
+++ b/content/guides/walkthroughs/multi-container-apps.md
@@ -78,7 +78,7 @@ To run Compose Watch and see the real-time changes:
    ```console
    $ docker compose watch
    ```
-2. Open `app/views/todos.ejs` in a text or code editor, then change the text on line 18.
+2. Open `app/views/todos.ejs` in a text or code editor, then change the text on line 21.
 3. Save the changes in `app/views/todos.ejs`.
 4. View your application at [http://localhost:3000](http://localhost:3000) to see the changes in real-time.
 


### PR DESCRIPTION
The file `app/views/todos.ejs/` must have been changed since these instructions were written. The instructions say to change text on line 18, but that is just a `<div>` tag. The text to be changed is actually now on line 21.

<!--Delete sections as needed -->

## Description

<!-- Tell us what you did and why -->

## Related issues or tickets

<!-- Related issues, pull requests, or Jira tickets -->

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Technical review
- [ ] Editorial review
- [ ] Product review