### PR TITLE
Revert "scout: unlist the scout metrics exporter page"

### DIFF
--- a/content/scout/metrics-exporter.md
+++ b/content/scout/metrics-exporter.md
@@ -1,6 +1,5 @@
 ---
 title: Docker Scout metrics exporter
-sitemap: false
 description: |
   Learn how to scrape data from Docker Scout using Prometheus to create your own
   vulnerability and policy dashboards wiht Grafana

--- a/content/scout/release-notes/platform.md
+++ b/content/scout/release-notes/platform.md
@@ -15,6 +15,16 @@ Docker Scout platform, including the Dashboard. For CLI release notes, refer to
 Take a look at the [Docker Public Roadmap](https://github.com/docker/roadmap/projects/1)
 for what's coming next.
 
+## Q2 2024
+
+New features and enhancements released in the second quarter of 2024.
+
+### 2024-05-06
+
+New HTTP endpoint that lets you scrape data from Docker Scout with Prometheus,
+to create your own vulnerability and policy dashboards with Grafana. See
+[Docker Scout metrics exporter](../metrics-exporter.md)
+
 ## Q1 2024
 
 New features and enhancements released in the first quarter of 2024.

--- a/data/toc.yaml
+++ b/data/toc.yaml
@@ -1398,6 +1398,8 @@ Manuals:
         title: SBOM
       - path: /scout/env-vars/
         title: Environment variables
+      - path: /scout/metrics-exporter/
+        title: Metrics exporter
     - sectiontitle: Policy Evaluation
       section:
       - path: /scout/policy/


### PR DESCRIPTION
Public release of metrics exporter endpoint docs

(Reverts docker/docs#19914)