### PR TITLE
fix: pass heading text through md renderer

### DIFF
--- a/layouts/_default/_markup/render-heading.html
+++ b/layouts/_default/_markup/render-heading.html
@@ -1,6 +1,6 @@
 {{ partial "heading.html" (dict
   "level" .Level
-  "text" (.Text | plainify | safeHTML)
+  "text" (.Text | safeHTML)
   "id" (.Attributes.id | default .Anchor)
   "class" .Attributes.class
   )

--- a/layouts/partials/pagemeta.html
+++ b/layouts/partials/pagemeta.html
@@ -30,7 +30,7 @@
     {{- range . }}
       {{- if and (ge .Level $min) (le .Level $max) }}
         <li>
-          <a class="link lg:no-underline" href="#{{ .ID }}">{{ .Title }}</a>
+          <a class="link lg:no-underline" href="#{{ .ID }}">{{ markdownify .Title }}</a>
         </li>
       {{- end }}
       {{- with .Headings }}

--- a/layouts/partials/toc-cli.html
+++ b/layouts/partials/toc-cli.html
@@ -13,7 +13,7 @@
           {{ else }}
             href="#{{ $text | anchorize }}"
           {{ end }}
-          >{{ plainify $text }}</a>
+          >{{ markdownify $text }}</a>
       </li>
     {{ end }}
   </ul>


### PR DESCRIPTION
Headings were incorrectly rendered on page and in the toc because they werent passed through the markdown renderer (and in some cases were plainified)

See slack: https://docker.slack.com/archives/C04300R4G5U/p1714652943156239

## Before:

![image](https://github.com/docker/docs/assets/35727626/367a0411-e59e-48b0-bf0c-42c4e87b062c)

<hr>

<img width="314" alt="image" src="https://github.com/docker/docs/assets/35727626/bc13201a-7307-44f3-aaa5-37a6ece625fc">
<img width="441" alt="image" src="https://github.com/docker/docs/assets/35727626/1d5b0f4f-f119-418a-988b-15c1b753d82a">

(src for the above 👇🏻)
<img width="750" alt="image" src="https://github.com/docker/docs/assets/35727626/d869dcb7-dadd-42ac-8580-069fc56d8409">


## After:

<img width="356" alt="image" src="https://github.com/docker/docs/assets/35727626/6ab6ec23-bea9-4889-a8a9-a41977376619">

<img width="730" alt="image" src="https://github.com/docker/docs/assets/35727626/971d9030-ebcc-4c77-aea0-a4531eabdfa9">

