### PR TITLE
Fix URL used for images in twitter/og previews

### DIFF
--- a/layouts/_default/hub-api-baseof.html
+++ b/layouts/_default/hub-api-baseof.html
@@ -11,7 +11,7 @@
   <!-- favicon -->
   {{ partialCached "favicon.html" "favicon" }}
   <!-- make the latest API version the canonical page as that's what we want users to be using mostly -->
-  <link rel="canonical" href="{{ site.BaseURL }}/docker-hub/api/latest/" />
+  <link rel="canonical" href="{{ "/docker-hub/api/latest/" | relURL }}" />
   <style>
     body {
       margin: 0;

--- a/layouts/index.robots.txt
+++ b/layouts/index.robots.txt
@@ -2,7 +2,7 @@
 User-agent: *
 
 
-Sitemap: {{ site.BaseURL }}/sitemap.xml
+Sitemap: {{ "sitemap.xml" | absURL }}
 {{- else -}}
 # Disable all indexing on staging websites and Netlify previews to prevent
 # them showing up in search results.

--- a/layouts/partials/meta.html
+++ b/layouts/partials/meta.html
@@ -35,7 +35,7 @@
 <meta name="twitter:url" content="https://twitter.com/docker_docs" />
 <meta
   name="twitter:image:src"
-  content="{{ site.BaseURL }}/assets/images/thumbnail.webp"
+  content="{{ site.BaseURL }}assets/images/thumbnail.webp"
 />
 <meta name="twitter:image:alt" content="Docker Documentation" />
 <meta property="og:title" content="{{ $title }}" />
@@ -49,7 +49,7 @@
 <meta
   property="og:image"
   itemprop="image primaryImageOfPage"
-  content="{{ site.BaseURL }}/assets/images/thumbnail.webp"
+  content="{{ site.BaseURL }}assets/images/thumbnail.webp"
 />
 <meta property="og:locale" content="en_US" />
 <meta property="og:url" content="{{ .Permalink }}" />

--- a/layouts/partials/meta.html
+++ b/layouts/partials/meta.html
@@ -35,7 +35,7 @@
 <meta name="twitter:url" content="https://twitter.com/docker_docs" />
 <meta
   name="twitter:image:src"
-  content="{{ site.BaseURL }}assets/images/thumbnail.webp"
+  content="{{ "assets/images/thumbnail.webp" | absURL }}"
 />
 <meta name="twitter:image:alt" content="Docker Documentation" />
 <meta property="og:title" content="{{ $title }}" />
@@ -49,7 +49,7 @@
 <meta
   property="og:image"
   itemprop="image primaryImageOfPage"
-  content="{{ site.BaseURL }}assets/images/thumbnail.webp"
+  content="{{ "assets/images/thumbnail.webp" | absURL }}"
 />
 <meta property="og:locale" content="en_US" />
 <meta property="og:url" content="{{ .Permalink }}" />


### PR DESCRIPTION
## Description

When using docs in Twitter/other locations, the preview cards aren't pulling an image due to an invalid URL in the `meta` tag. Example here:

```html
<meta name=twitter:image:src content="https://docs.docker.com//assets/images/thumbnail.webp">
```

The additional `/` is causing the image to 404. This PR removes the extra slash.
