### PR TITLE
Update rootless.md

### DIFF
--- a/content/engine/security/rootless.md
+++ b/content/engine/security/rootless.md
@@ -437,6 +437,7 @@ For example:
 ## Troubleshooting
 
 ### Unable to install with systemd when systemd is present on the system
+
 ``` console
 $ dockerd-rootless-setuptool.sh install
 [INFO] systemd not detected, dockerd-rootless.sh needs to be started manually:

--- a/content/engine/security/rootless.md
+++ b/content/engine/security/rootless.md
@@ -436,8 +436,12 @@ For example:
 
 ## Troubleshooting
 
-### Errors installing the Docker daemon
-
+### Unable to install with systemd when systemd is present on the system
+``` console
+$ dockerd-rootless-setuptool.sh install
+[INFO] systemd not detected, dockerd-rootless.sh needs to be started manually:
+...
+```
 `rootlesskit` cannot detect systemd properly if you switch to your user via `sudo su`. For users which cannot be logged-in, you must use the `machinectl` command which is part of the `systemd-container` package. After installing `systemd-container` switch to `myuser` with the following command:
 ``` console
 $ sudo machinectl shell myuser@

--- a/content/engine/security/rootless.md
+++ b/content/engine/security/rootless.md
@@ -170,7 +170,7 @@ testuser:231072:65536
 > If the system-wide Docker daemon is already running, consider disabling it:
 >```console
 >$ sudo systemctl disable --now docker.service docker.socket
->$ sudo systemctl stop docker.service docker.socket
+>$ sudo rm /var/run/docker.sock
 >```
 > Should you choose not to shut down the `docker` service and socket, you will need to use the `--force`
 > parameter in the next section. There are no known issues, but until you shutdown and disable you're

--- a/content/engine/security/rootless.md
+++ b/content/engine/security/rootless.md
@@ -172,8 +172,8 @@ testuser:231072:65536
 >$ sudo systemctl stop docker.service docker.socket
 >```
 > Should you choose not to shut down the docker service and socket, you will need to use the `--force`
-> parameter in the next section.  There are no known issues, but until you shutdown and disable you're
-> still running rooted Docker. 
+> parameter in the next section. There are no known issues, but until you shutdown and disable you're
+> still running rootful Docker. 
 
 {{< tabs >}}
 {{< tab name="With packages (RPM/DEB)" >}}

--- a/content/engine/security/rootless.md
+++ b/content/engine/security/rootless.md
@@ -73,7 +73,8 @@ testuser:231072:65536
   profile for `rootlesskit` manually:
 
   1. Create and install the currently logged-in user's AppArmor profile:
-     ``` console
+
+     ```console
      $ filename=$(echo $HOME/bin/rootlesskit | sed -e s@^/@@ -e s@/@.@g)
      $ cat <<EOF > ~/${filename}
      abi <abi/4.0>,

--- a/content/engine/security/rootless.md
+++ b/content/engine/security/rootless.md
@@ -438,7 +438,7 @@ For example:
 
 ### Errors installing the Docker daemon
 
-The `rootlesskit` cannot detect Systemd properly if you switch to your user via `sudo su`.  For users which cannot be logged-in, you must utilize the `machinectl` command which is a part of the `systemd-container` package. After installing `systemd-container` switch to "myuser" with the following command:
+`rootlesskit` cannot detect systemd properly if you switch to your user via `sudo su`. For users which cannot be logged-in, you must use the `machinectl` command which is part of the `systemd-container` package. After installing `systemd-container` switch to `myuser` with the following command:
 ``` console
 $ sudo machinectl shell myuser@
 ```

--- a/content/engine/security/rootless.md
+++ b/content/engine/security/rootless.md
@@ -436,6 +436,7 @@ For example:
 ## Troubleshooting
 
 ### Errors installing the Docker daemon
+
 The `rootlesskit` cannot detect Systemd properly if you switch to your user via `sudo su`.  For users which cannot be logged-in, you must utilize the `machinectl` command which is a part of the `systemd-container` package. After installing `systemd-container` switch to "myuser" with the following command:
 ``` console
 $ sudo machinectl shell myuser@

--- a/content/engine/security/rootless.md
+++ b/content/engine/security/rootless.md
@@ -172,7 +172,7 @@ testuser:231072:65536
 >$ sudo systemctl disable --now docker.service docker.socket
 >$ sudo systemctl stop docker.service docker.socket
 >```
-> Should you choose not to shut down the docker service and socket, you will need to use the `--force`
+> Should you choose not to shut down the `docker` service and socket, you will need to use the `--force`
 > parameter in the next section. There are no known issues, but until you shutdown and disable you're
 > still running rootful Docker. 
 

--- a/content/engine/security/rootless.md
+++ b/content/engine/security/rootless.md
@@ -53,6 +53,8 @@ testuser:231072:65536
 {{< tabs >}}
 {{< tab name="Ubuntu" >}}
 - Install `dbus-user-session` package if not installed. Run `sudo apt-get install -y dbus-user-session` and relogin.
+- Install `uidmap` package if not installed.  Run `sudo apt-get install -y uidmap`.
+- If running in a terminal where the user was not directly logged into, you will need to install `systemd-container` with `sudo apt-get install -y systemd-container`, then switch to TheUser with the command `sudo machinectl shell TheUser@`.
 
 - `overlay2` storage driver  is enabled by default
   ([Ubuntu-specific kernel patch](https://kernel.ubuntu.com/git/ubuntu/ubuntu-bionic.git/commit/fs/overlayfs?id=3b7da90f28fe1ed4b79ef2d994c81efbc58f1144)).
@@ -70,21 +72,21 @@ testuser:231072:65536
   script](https://get.docker.com/rootless), however, you must add an AppArmor
   profile for `rootlesskit` manually:
 
-  1. Add the AppArmor profile to `/etc/apparmor.d/usr.local.bin.rootlesskit`:
-
-     ```console
-     $ cat <<EOF > /etc/apparmor.d/$(echo $HOME/bin/rootlesskit | sed -e s@^/@@ -e s@/@.@g)
+  1. Create and install the currently logged-in user's AppArmor profile:
+     ``` console
+     $ filename=$(echo $HOME/bin/rootlesskit | sed -e s@^/@@ -e s@/@.@g)
+     $ cat <<EOF > ~/${filename}
      abi <abi/4.0>,
      include <tunables/global>
 
      "$HOME/bin/rootlesskit" flags=(unconfined) {
        userns,
 
-       include if exists <local/$(echo $HOME/bin/rootlesskit | sed -e s@^/@@ -e s@/@.@g)>
+       include if exists <local/${filename}>
      }
      EOF
+     $ sudo mv ~/${filename} /etc/apparmor.d/${filename}
      ```
-
   2. Restart AppArmor.
 
      ```console
@@ -167,7 +169,11 @@ testuser:231072:65536
 > If the system-wide Docker daemon is already running, consider disabling it:
 >```console
 >$ sudo systemctl disable --now docker.service docker.socket
+>$ sudo systemctl stop docker.service docker.socket
 >```
+> Should you choose not to shut down the docker service and socket, you will need to use the `--force`
+> parameter in the next section.  There are no known issues, but until you shutdown and disable you're
+> still running rooted Docker. 
 
 {{< tabs >}}
 {{< tab name="With packages (RPM/DEB)" >}}
@@ -428,6 +434,13 @@ For example:
   `docker run --user 2000 --ulimit nproc=100 <IMAGE> <COMMAND>`
 
 ## Troubleshooting
+
+### Errors installing the Docker daemon
+The `rootlesskit` cannot detect Systemd properly if you switch to your user via `sudo su`.  For users which cannot be logged-in, you must utilize the `machinectl` command which is a part of the `systemd-container` package. After installing `systemd-container` switch to "myuser" with the following command:
+``` console
+$ sudo machinectl shell myuser@
+```
+Where `myuser@` is your desired username and @ signifies this machine.
 
 ### Errors when starting the Docker daemon
 


### PR DESCRIPTION
I just accomplished install via both manual and docker-ce-rootless-extras packages on Ubuntu 24.04.  There were some pain points which I hope to address here and make this run more smoothly for others. 

* As a `$` user, you cannot `cat<< EOF > /etc/apparmor.d`.  The existing command should never work because you cannot be the user and access the apparmor folder at the same time. So we create the file and then move the file.  This separates into creation which should be done as a user, and moving which requires sudo access.  If the move command fails, that's a basic issue which can be resolved by an admin. 
* I added missing apt-get commands which may be required on Ubuntu.  I noticed `dbus-user-session` is a default package in Ubuntu and it was mentioned. So i took the liberty to add uidmap which is absolutely required, and systemd-container may be necessary for accessing via non-login terminals.
* The command `sudo systemctl disable --now docker.service docker.socket` was insufficient and requires a reboot to activate.  The `sudo systemctl stop docker.service docker.socket` will immediately shut down the docker service. 
* I added a note about not shutting down the docker service.
* Troubleshooting now includes an installation error where the user was a pure service account without login capabilities. `systemd-container` and `machinectl` is required when not logging in via terminal with user/pass.

<!--Delete sections as needed -->

## Description

<!-- Tell us what you did and why -->

## Related issues or tickets

<!-- Related issues, pull requests, or Jira tickets -->

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Technical review
- [ ] Editorial review
- [ ] Product review