### PR TITLE
Fixed incorrect package names for ubuntu in documentation to install the Compose plugin

### DIFF
--- a/content/compose/install/linux.md
+++ b/content/compose/install/linux.md
@@ -41,19 +41,19 @@ For Compose standalone, see [Install Compose Standalone](standalone.md).
 
         ```console
         $ sudo apt-get update
-        $ sudo apt-get install docker-compose-plugin
+        $ sudo apt-get install docker-compose
         ```
     * For RPM-based distros, run:
 
         ```console
         $ sudo yum update
-        $ sudo yum install docker-compose-plugin
+        $ sudo yum install docker-compose
         ```
 
 3.  Verify that Docker Compose is installed correctly by checking the version.
 
     ```console
-    $ docker compose version
+    $ docker-compose version
     ```
 
     Expected output:
@@ -72,13 +72,13 @@ To update the Compose plugin, run the following commands:
 
     ```console
     $ sudo apt-get update
-    $ sudo apt-get install docker-compose-plugin
+    $ sudo apt-get install docker-compose
     ```
 * For RPM-based distros, run:
 
     ```console
     $ sudo yum update
-    $ sudo yum install docker-compose-plugin
+    $ sudo yum install docker-compose
     ```
 
 ## Install the plugin manually


### PR DESCRIPTION
In [Docker Docs](https://docs.docker.com/compose/install/linux/#install-using-the-repository), I found an issue:
1. Incorrect package name in Install Docker Compose using the repository section 
 ` sudo apt-get install docker-compose-plugin` is incorrect.

<!--Delete sections as needed -->
# 1. First issue:
```
 sudo apt-get update
 sudo apt-get install docker-compose-plugin
```

## Description
- The Package name is incorrect so raises an error: 

```
E: Unable to locate package docker-compose-plugin
```
 
![Screenshot from 2024-05-08 16-16-43](https://github.com/docker/docs/assets/108977462/834fab6f-8e11-4769-927b-4fc0bc009e5a)


<!-- Tell us what you did and why -->
That's why I edited this line  and added correct package name :
```
 sudo apt-get update
 sudo apt-get install docker-compose
```

**Now this works fine** and if I run 
`docker-compose version` then I get version info as well.
![image](https://github.com/docker/docs/assets/108977462/e778fdcc-b179-4cae-82d8-cea21688c300)


## Related issues or tickets

<!-- Related issues, pull requests, or Jira tickets -->

## Reviews

<!-- Notes for reviewers here -->
I changed package name to fix the above error.
<!-- List applicable reviews (optionally @tag reviewers) -->

- [x] Technical review
- [x] Editorial review
- [ ] Product review