### PR TITLE
css: fix rendering issue for code with numbered lines

### DIFF
--- a/assets/css/code.css
+++ b/assets/css/code.css
@@ -22,13 +22,13 @@
       padding: 0 4px;
     }
 
-    table code {
+    table:not(.lntable) code {
       overflow-wrap: unset;
       white-space: nowrap;
     }
 
     /* Indented code blocks */
-    :not(.highlight) > pre {
+    pre:not(.chroma) {
       @apply my-4 overflow-x-auto p-3;
       font-size: 0.875em;
       border: 1px solid;


### PR DESCRIPTION
## Description

Fixes an issue with css being incorrectly applied to codeblocks with linenumbers

Before:

<img width="602" alt="image" src="https://github.com/docker/docs/assets/35727626/b6af175a-f064-47d5-ae7f-68e75f1719e7">

After:

<img width="808" alt="image" src="https://github.com/docker/docs/assets/35727626/49e5944b-6b53-4aa1-9c3c-0d59fd9ba184">

