### PR TITLE
Fixed INCORRECT syntax of checking version info of docker compose

### DIFF
--- a/content/compose/install/linux.md
+++ b/content/compose/install/linux.md
@@ -53,13 +53,13 @@ For Compose standalone, see [Install Compose Standalone](standalone.md).
 3.  Verify that Docker Compose is installed correctly by checking the version.
 
     ```console
-    $ docker compose version
+    $ docker-compose version
     ```
 
     Expected output:
 
     ```text
-    Docker Compose version vN.N.N
+    docker-compose version vN.N.N
     ```
 
     Where `vN.N.N` is placeholder text standing in for the latest version.
@@ -117,6 +117,6 @@ To update the Compose plugin, run the following commands:
 3. Test the installation.
 
     ```console
-    $ docker compose version
-    Docker Compose version {{% param "compose_version" %}}
+    $ docker-compose version
+    docker-compose version {{% param "compose_version" %}}
     ```


### PR DESCRIPTION
<!--Delete sections as needed -->
## Description
In [Docker Docs](https://docs.docker.com/compose/install/linux/#install-using-the-repository), I found incorrect syntax for checking version of docker compose after installation.

In step 3, the syntax is incorrect, so raises an error.
```console
docker compose version
```
This gives error of `docker: 'compose' is not a docker command. See 'docker --help'`

![image](https://github.com/docker/docs/assets/108977462/a045bcf4-0c2e-4263-a9aa-b59b600a0bf7)

<!-- Tell us what you did and why -->
So I  corrected the syntax in the docs. The correct syntax to check for version of docker compose is
```console
docker-compose version
```
**Now this works fine and gives version information.**

![image](https://github.com/docker/docs/assets/108977462/bc158ba7-0e48-400f-b2c5-8373ead2af93)



## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [x] Technical review
- [x] Editorial review
- [ ] Product review