### PR TITLE
guides: remove use-case new badge

### DIFF
--- a/data/toc.yaml
+++ b/data/toc.yaml
@@ -187,7 +187,7 @@ Guides:
     - title: "Test your deployment"
       path: /language/php/deploy/
 
-- sectiontitle: Use-case guides {{< badge color=violet text=New >}}
+- sectiontitle: Use-case guides
   section:
     - path: /guides/use-case/
       title: Overview


### PR DESCRIPTION

## Description

Removed the new badge from the use-case guides in the left nav. It's been there for over two months.

## Reviews

- [ ] Editorial review
