### PR TITLE
Update the CI/CD config to build and push multi-platform image

### DIFF
--- a/content/language/nodejs/configure-ci-cd.md
+++ b/content/language/nodejs/configure-ci-cd.md
@@ -101,6 +101,7 @@ to Docker Hub.
            uses: docker/build-push-action@v5
            with:
              context: .
+             platforms: linux/amd64,linux/arm64/v8
              push: true
              target: prod
              tags: ${{ secrets.DOCKER_USERNAME }}/${{ github.event.repository.name }}:latest


### PR DESCRIPTION
## Description

The default CI/CD configuration builds and pushes the image to Dockerhub for `linux/amd64` (OS/ARCH) platform. This causes the `ImagePullBackOff` or `ErrImagePull` errors at the next section when deploying the application to Kubernetes, because I use arm64 architecture. 

https://docs.docker.com/language/nodejs/configure-ci-cd/

**Solution:**
`platforms: linux/amd64,linux/arm64/v8`: Added this to step `Build and push` at CI/CD configuration.

## Related issue

Details in the issue: #20008
