### PR TITLE
scout: add CISA Vulnrichment advisory

### DIFF
--- a/content/scout/advisory-db-sources.md
+++ b/content/scout/advisory-db-sources.md
@@ -26,6 +26,7 @@ Docker Scout uses the following package repositories and security trackers:
 - [Bitnami Vulnerability Database](https://github.com/bitnami/vulndb)
 - [CISA Known Exploited Vulnerability
   Catalog](https://www.cisa.gov/known-exploited-vulnerabilities-catalog)
+- [CISA Vulnrichment](https://github.com/cisagov/vulnrichment)
 - [Debian Security Bug Tracker](https://security-tracker.debian.org/tracker/)
 - [Exploit Prediction Scoring System (EPSS)](https://api.first.org/epss/)
 - [GitHub Advisory Database](https://github.com/advisories/)


### PR DESCRIPTION
## Description

Docker Scout: Add CISA Vulnrichment (https://github.com/cisagov/vulnrichment) advisory

## Related issues or tickets

https://docker.slack.com/archives/C04C69EM70C/p1715337771890229?thread_ts=1715336381.924809&cid=C04C69EM70C
