### PR TITLE
hugo: return keywords as sliceArray

### DIFF
--- a/assets/js/src/search.js
+++ b/assets/js/src/search.js
@@ -15,7 +15,15 @@ async function initializeIndex() {
     keys: [
       { name: "title", weight: 2 },
       { name: "description", weight: 1 },
-      { name: "keywords", weight: 1 },
+      {
+        name: "keywords",
+        weight: 1,
+        getFn: (page) => {
+          return Array.isArray(page.keywords)
+            ? page.keywords.join(" ")
+            : page.keywords;
+        },
+      },
       { name: "tags", weight: 1 },
     ],
     minMatchCharLength: 1,

--- a/layouts/partials/meta.html
+++ b/layouts/partials/meta.html
@@ -13,7 +13,7 @@
 <meta name="description" content="{{ $description }}" />
 <meta
   name="keywords"
-  content="{{- partial "utils/keywords.html" . -}}"
+  content="{{- delimit (partialCached "utils/keywords.html" . .) ", " -}}"
 />
 <link rel="canonical" href="{{ .Permalink }}" />
 

--- a/layouts/partials/utils/keywords.html
+++ b/layouts/partials/utils/keywords.html
@@ -1,11 +1,11 @@
 {{ $keywords := "" }}
 {{ if .Keywords }}
-  {{ $keywords = delimit .Keywords " " }}
+  {{ $keywords = collections.Apply .Keywords "strings.Trim" "." ", " }}
 {{ else }}
   {{ with .File }}
     {{ with (index (site.Data.frontmatter) .Path) }}
       {{ with .keywords }}
-        {{ $keywords = strings.Replace (strings.Trim . "\n") "\n" " " }}
+        {{ $keywords = collections.Apply (strings.Split (strings.Replace . "\n" " ") ",") "strings.Trim" "." " " }}
       {{ end }}
     {{ end }}
   {{ end }}


### PR DESCRIPTION
## Description

Return keywords as sliceArray from keyword util template.

Handle concatenation on consuming side (in templates, scripts)

[metadata.json](https://deploy-preview-20024--docsdocker.netlify.app/metadata.json)

## Related issues or tickets

Fixes docker/for-win#14071
