### PR TITLE
vendor: moby, cli 26.1.2

### DIFF
--- a/_vendor/modules.txt
+++ b/_vendor/modules.txt
@@ -1,4 +1,4 @@
-# github.com/moby/moby v26.1.0+incompatible
+# github.com/moby/moby v26.1.2+incompatible
 # github.com/moby/buildkit v0.13.1
 # github.com/docker/buildx v0.14.0
 # github.com/docker/cli v26.1.0+incompatible

--- a/_vendor/modules.txt
+++ b/_vendor/modules.txt
@@ -1,6 +1,6 @@
 # github.com/moby/moby v26.1.2+incompatible
 # github.com/moby/buildkit v0.13.1
 # github.com/docker/buildx v0.14.0
-# github.com/docker/cli v26.1.0+incompatible
+# github.com/docker/cli v26.1.3-0.20240513184838-60f2d38d5341+incompatible
 # github.com/docker/compose/v2 v2.27.0
 # github.com/docker/scout-cli v1.8.0

--- a/data/engine-cli/docker_container_run.yaml
+++ b/data/engine-cli/docker_container_run.yaml
@@ -2331,6 +2331,7 @@ examples: |-
     | `--security-opt="seccomp=unconfined"`     | Turn off seccomp confinement for the container                                                                                                                                                                   |
     | `--security-opt="seccomp=builtin"`        | Use the default (built-in) seccomp profile for the container. This can be used to enable seccomp for a container running on a daemon with a custom default profile set, or with seccomp disabled ("unconfined"). |
     | `--security-opt="seccomp=profile.json"`   | White-listed syscalls seccomp Json file to be used as a seccomp filter                                                                                                                                           |
+    | `--security-opt="systempaths=unconfined"` | Turn off confinement for system paths (masked paths, read-only paths) for the container                                                                                                                           |
 
     The `--security-opt` flag lets you override the default labeling scheme for a
     container. Specifying the level in the following command allows you to share

--- a/data/engine-cli/docker_swarm_init.yaml
+++ b/data/engine-cli/docker_swarm_init.yaml
@@ -270,6 +270,12 @@ examples: |-
 
     If unspecified, the IP address or interface of the advertise address is used.
 
+    Setting `--data-path-addr` does not restrict which interfaces or source IP
+    addresses the VXLAN socket is bound to. Similar to `--advertise-addr`, the
+    purpose of this flag is to inform other members of the swarm about which
+    address to use for control plane traffic. To restrict access to the VXLAN port
+    of the node, use firewall rules.
+
     ### Configure port number for data traffic (--data-path-port) {#data-path-port}
 
     The `--data-path-port` flag allows you to configure the UDP port number to use

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/docker/compose/v2 v2.27.0 // indirect
 	github.com/docker/scout-cli v1.8.0 // indirect
 	github.com/moby/buildkit v0.13.1 // indirect
-	github.com/moby/moby v26.1.0+incompatible // indirect
+	github.com/moby/moby v26.1.2+incompatible // indirect
 )
 
 replace (
@@ -19,5 +19,5 @@ replace (
 	github.com/docker/compose/v2 => github.com/docker/compose/v2 v2.27.0
 	github.com/docker/scout-cli => github.com/docker/scout-cli v1.8.0
 	github.com/moby/buildkit => github.com/moby/buildkit v0.13.0-rc3.0.20240424175633-5fce077ed0e0
-	github.com/moby/moby => github.com/moby/moby v26.1.0+incompatible
+	github.com/moby/moby => github.com/moby/moby v26.1.2+incompatible
 )

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ toolchain go1.21.1
 
 require (
 	github.com/docker/buildx v0.14.0 // indirect
-	github.com/docker/cli v26.1.0+incompatible // indirect
+	github.com/docker/cli v26.1.3-0.20240513184838-60f2d38d5341+incompatible // indirect
 	github.com/docker/compose/v2 v2.27.0 // indirect
 	github.com/docker/scout-cli v1.8.0 // indirect
 	github.com/moby/buildkit v0.13.1 // indirect
@@ -15,7 +15,7 @@ require (
 
 replace (
 	github.com/docker/buildx => github.com/docker/buildx v0.14.0
-	github.com/docker/cli => github.com/docker/cli v26.1.0+incompatible
+	github.com/docker/cli => github.com/docker/cli v26.1.3-0.20240513184838-60f2d38d5341+incompatible
 	github.com/docker/compose/v2 => github.com/docker/compose/v2 v2.27.0
 	github.com/docker/scout-cli => github.com/docker/scout-cli v1.8.0
 	github.com/moby/buildkit => github.com/moby/buildkit v0.13.0-rc3.0.20240424175633-5fce077ed0e0

--- a/go.sum
+++ b/go.sum
@@ -255,6 +255,8 @@ github.com/moby/moby v26.0.0+incompatible h1:2n9/cIWkxiEI1VsWgTGgXhxIWUbv42PyxEP
 github.com/moby/moby v26.0.0+incompatible/go.mod h1:fDXVQ6+S340veQPv35CzDahGBmHsiclFwfEygB/TWMc=
 github.com/moby/moby v26.1.0+incompatible h1:mjepCwMH0KpCgPvrXjqqyCeTCHgzO7p9TwZ2nQMI2qU=
 github.com/moby/moby v26.1.0+incompatible/go.mod h1:fDXVQ6+S340veQPv35CzDahGBmHsiclFwfEygB/TWMc=
+github.com/moby/moby v26.1.2+incompatible h1:yOGzOkmMRtkhyySHHRH9dWOK/rlrmZR/cVnMGqlynzw=
+github.com/moby/moby v26.1.2+incompatible/go.mod h1:fDXVQ6+S340veQPv35CzDahGBmHsiclFwfEygB/TWMc=
 github.com/moby/sys/symlink v0.1.0/go.mod h1:GGDODQmbFOjFsXvfLVn3+ZRxkch54RkSiGqsZeMYowQ=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/morikuni/aec v1.0.0/go.mod h1:BbKIizmSmc5MMPqRYbxO4ZU0S0+P200+tUnFx7PXmsc=

--- a/go.sum
+++ b/go.sum
@@ -98,6 +98,8 @@ github.com/docker/cli v26.0.0+incompatible h1:90BKrx1a1HKYpSnnBFR6AgDq/FqkHxwlUy
 github.com/docker/cli v26.0.0+incompatible/go.mod h1:JLrzqnKDaYBop7H2jaqPtU4hHvMKP+vjCwu2uszcLI8=
 github.com/docker/cli v26.1.0+incompatible h1:+nwRy8Ocd8cYNQ60mozDDICICD8aoFGtlPXifX/UQ3Y=
 github.com/docker/cli v26.1.0+incompatible/go.mod h1:JLrzqnKDaYBop7H2jaqPtU4hHvMKP+vjCwu2uszcLI8=
+github.com/docker/cli v26.1.3-0.20240513184838-60f2d38d5341+incompatible h1:9bTMRZTbwJvSrosCeCWS9o9cxtBxxpwOiwlrJZwSWb8=
+github.com/docker/cli v26.1.3-0.20240513184838-60f2d38d5341+incompatible/go.mod h1:JLrzqnKDaYBop7H2jaqPtU4hHvMKP+vjCwu2uszcLI8=
 github.com/docker/compose-cli v1.0.35 h1:uZyEHLalfqBS2PiTpA1LAULyJmuQ+YtZg7nG4Xl3/Cc=
 github.com/docker/compose-cli v1.0.35/go.mod h1:mSXI4hFLpRU3EtI8NTo32bNwI0UXSr8jnq+/rYjGAUU=
 github.com/docker/compose/v2 v2.22.0 h1:3rRz4L7tPU75wRsV8JZh2/aTgerQvPa1cpzZN+tHqUY=


### PR DESCRIPTION
- **vendor: github.com/moby/moby v26.1.2**
- **vendor: github.com/docker/cli v26.1.2**
