### PR TITLE
ci: bump runner to ubuntu-24.04

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,6 +41,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: errata-ai/vale-action@38bf078c328061f59879b347ca344a718a736018
+        env:
+          PIP_BREAK_SYSTEM_PACKAGES: 1
         with:
           files: content
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ permissions:
 
 jobs:
   build:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       -
         name: Checkout
@@ -37,7 +37,7 @@ jobs:
 
   vale:
     if: ${{ github.event_name == 'pull_request' }}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - uses: errata-ai/vale-action@38bf078c328061f59879b347ca344a718a736018
@@ -45,7 +45,7 @@ jobs:
           files: content
 
   validate:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:
@@ -74,7 +74,7 @@ jobs:
   # build-releaser job will just build _releaser app used for Netlify and
   # AWS deployment in publish workflow. it's just to be sure it builds correctly.
   build-releaser:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       -
         name: Checkout

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,7 +19,7 @@ permissions:
 
 jobs:
   publish:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     if: github.repository_owner == 'docker'
     steps:
       -

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   labeler:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   main-to-published:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     if: github.repository_owner == 'docker'
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/validate-upstream.yml
+++ b/.github/workflows/validate-upstream.yml
@@ -25,7 +25,7 @@ on:
 
 jobs:
   run:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       -
         name: Checkout


### PR DESCRIPTION
Ubuntu 24.04 runners are GA

Vale currently breaks on these runners. Ref:

- https://github.com/errata-ai/vale-action/issues/128