### PR TITLE
engine: louder notice about sles being s390x only

### DIFF
--- a/content/engine/install/sles.md
+++ b/content/engine/install/sles.md
@@ -3,7 +3,7 @@ description: Learn how to install Docker Engine on SLES. These instructions cove
   the different installation methods, how to uninstall, and next steps.
 keywords: requirements, apt, installation, install docker engine, centos, rpm, sles, install, uninstall,
   upgrade, update, s390x, ibm-z
-title: Install Docker Engine on SLES
+title: Install Docker Engine on SLES (s390x)
 toc_max: 4
 aliases:
 - /ee/docker-ee/sles/
@@ -24,16 +24,18 @@ aliases:
 download-url-base: https://download.docker.com/linux/sles
 ---
 
+> **Note**
+>
+> The installation instructions on this page refer to packages for SLES on the
+> **s390x** architecture (IBM Z). Other architectures, including x86_64, aren't
+> supported for SLES.
+{ .warning }
+
 To get started with Docker Engine on SLES, make sure you
 [meet the prerequisites](#prerequisites), and then follow the
 [installation steps](#installation-methods).
 
 ## Prerequisites
-
-> **Note**
->
-> We currently only provide packages for SLES on s390x (IBM Z). Other architectures
-> are not yet supported for SLES.
 
 ### OS requirements
 


### PR DESCRIPTION
The SLES installation instruction has gotten a low CSAT score, likely because it's only for the s390x architecture, and people are mistakingly assuming it works for x86. I amplified the notice about this instruction being applicable only for s390x/IBM Z mainframes.
