### PR TITLE
guides: use "Try it out" consistently in concept headings

### DIFF
--- a/content/guides/docker-concepts/building-images/multi-stage-builds.md
+++ b/content/guides/docker-concepts/building-images/multi-stage-builds.md
@@ -42,7 +42,7 @@ This Dockerfile uses two stages:
 - The final stage uses a smaller base image suitable for running your application. It copies the compiled artifacts (a JAR file, for example) from the build stage. Finally, it defines the runtime configuration (using `CMD` or `ENTRYPOINT`) for starting your application.
 
 
-## Try it now
+## Try it out
 
 In this hands-on guide, you'll unlock the power of multi-stage builds to create lean and efficient Docker images for a sample Java application. You'll use a simple “Hello World” Spring Boot-based application built with Maven as your example.
 

--- a/content/guides/docker-concepts/the-basics/what-is-a-container.md
+++ b/content/guides/docker-concepts/the-basics/what-is-a-container.md
@@ -36,7 +36,7 @@ A container is simply an isolated process with all of the files it needs to run.
 > Quite often, you will see containers and VMs used together. As an example, in a cloud environment, the provisioned machines are typically VMs. However, instead of provisioning one machine to run one application, a VM with a container runtime can run multiple containerized applications, increasing resource utilization and reducing costs.
 
 
-## Try it now
+## Try it out
 
 In this hands-on, you will see how to run a Docker container using the Docker Desktop GUI.
 

--- a/content/guides/docker-concepts/the-basics/what-is-a-registry.md
+++ b/content/guides/docker-concepts/the-basics/what-is-a-registry.md
@@ -26,7 +26,7 @@ A _registry_ is a centralized location that stores and manages container images,
 >
 > You can create one private repository and unlimited public repositories using the free version of Docker Hub. For more information, visit the [Docker Hub subscription page](https://www.docker.com/pricing/).
 
-## Try it now
+## Try it out
 
 In this hands-on, you will learn how to build and push a Docker image to the Docker Hub repository.
 

--- a/content/guides/docker-concepts/the-basics/what-is-an-image.md
+++ b/content/guides/docker-concepts/the-basics/what-is-an-image.md
@@ -36,7 +36,7 @@ Docker Hub provides a variety of Docker-supported and endorsed images known as D
 
 For example, [Redis](https://hub.docker.com/_/redis) and [Memcached](https://hub.docker.com/_/memcached) are a few popular ready-to-go Docker Official Images. You can download these images and have these services up and running in a matter of seconds. There are also base images, like the [Node.js](https://hub.docker.com/_/node) Docker image, that you can use as a starting point and add your own files and configurations.
 
-## Try it now
+## Try it out
 
 {{< tabs group=concept-usage persist=true >}}
 {{< tab name="Using the GUI" >}}


### PR DESCRIPTION
## Description

Concepts used a mix of "Try it out" and "Try it now". I've changed it to "Try it out" everywhere.
