### PR TITLE
Networking overview - DNS fixes

### DIFF
--- a/content/network/_index.md
+++ b/content/network/_index.md
@@ -174,22 +174,6 @@ configuration.
 | `--dns-opt`    | A key-value pair representing a DNS option and its value. See your operating system's documentation for `resolv.conf` for valid options.                                                                                                                            |
 | `--hostname`   | The hostname a container uses for itself. Defaults to the container's ID if not specified.                                                                                                                                                                          |
 
-### Nameservers with IPv6 addresses
-
-If the `/etc/resolv.conf` file on the host system contains one or more
-nameserver entries with an IPv6 address, those nameserver entries get copied
-over to `/etc/resolv.conf` in containers that you run.
-
-For containers using musl libc (in other words, Alpine Linux), this results in
-a race condition for hostname lookup. As a result, hostname resolution might
-sporadically fail if the external IPv6 DNS server wins the race condition
-against the embedded DNS server.
-
-It's rare that the external DNS server is faster than the embedded one. But
-things like garbage collection, or large numbers of concurrent DNS requests,
-can sometimes result in a round trip to the external server being faster than local
-resolution.
-
 ### Custom hosts
 
 Your container will have lines in `/etc/hosts` which define the hostname of the

--- a/content/network/_index.md
+++ b/content/network/_index.md
@@ -167,12 +167,12 @@ You can configure DNS resolution on a per-container basis, using flags for the
 The following table describes the available `docker run` flags related to DNS
 configuration.
 
-| Flag           | Description                                                                                                                                                                                                                                                         |
-| -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `--dns`        | The IP address of a DNS server. To specify multiple DNS servers, use multiple `--dns` flags. If the container can't reach any of the IP addresses you specify, it uses Google's public DNS server at `8.8.8.8`. This allows containers to resolve internet domains. |
-| `--dns-search` | A DNS search domain to search non-fully qualified hostnames. To specify multiple DNS search prefixes, use multiple `--dns-search` flags.                                                                                                                            |
-| `--dns-opt`    | A key-value pair representing a DNS option and its value. See your operating system's documentation for `resolv.conf` for valid options.                                                                                                                            |
-| `--hostname`   | The hostname a container uses for itself. Defaults to the container's ID if not specified.                                                                                                                                                                          |
+| Flag           | Description                                                                                                                                                                                                                                           |
+| -------------- |-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `--dns`        | The IP address of a DNS server. To specify multiple DNS servers, use multiple `--dns` flags. DNS requests will be forwarded from the container's network namespace so, for example, `--dns=127.0.0.1` refers to the container's own loopback address. |
+| `--dns-search` | A DNS search domain to search non-fully qualified hostnames. To specify multiple DNS search prefixes, use multiple `--dns-search` flags.                                                                                                              |
+| `--dns-opt`    | A key-value pair representing a DNS option and its value. See your operating system's documentation for `resolv.conf` for valid options.                                                                                                              |
+| `--hostname`   | The hostname a container uses for itself. Defaults to the container's ID if not specified.                                                                                                                                                            |
 
 ### Custom hosts
 


### PR DESCRIPTION
## Description

Two DNS-related tweaks to the network-overview page ...

Since 26.0.0, IPv6 nameservers in the host's /etc/resolv.conf file have been treated the same as IPv4 nameservers:
- The internal DNS server will use them as upstream servers, they won't be left in the container's resolv.conf. (So, there's no longer any race between the internal server and IPv6 upstream servers when using musl-libc.)

A '--dns' server will not be replaced by default DNS:
-  Google's DNS servers are currently used by containers on the default bridge network, when none of the host's /etc/resolv.conf nameservers are usable (host loopback addresses that the container can't see). _That should change in 27.0, the internal DNS server will be used for the default network too._
- But, if a server is supplied via the --dns option, it'll just appear in the container's resolv.conf (on the default bridge) or as an upstream server (for the internal resolver).
- So, fix the networking-intro page's description, noting that requests to --dns servers happen in the container's namespace.

## Related issues or tickets

https://github.com/moby/moby/pull/47512 - Add IPv6 nameserver to the internal DNS's upstreams.

## Reviews

@dvdksn, @akerouanton