### PR TITLE
Update line number in documentation for todos.ejs file

### DIFF
--- a/content/guides/walkthroughs/multi-container-apps.md
+++ b/content/guides/walkthroughs/multi-container-apps.md
@@ -78,7 +78,7 @@ To run Compose Watch and see the real-time changes:
    ```console
    $ docker compose watch
    ```
-2. Open `app/views/todos.ejs` in a text or code editor, then change the text on line 18.
+2. Open `app/views/todos.ejs` in a text or code editor, then change the text on line 21.
 3. Save the changes in `app/views/todos.ejs`.
 4. View your application at [http://localhost:3000](http://localhost:3000) to see the changes in real-time.
 


### PR DESCRIPTION
Open `app/views/todos.ejs` in a text or code editor, then change the text on line 18.

This pull request corrects an error in the documentation where the line number for editing text in the todos.ejs file was incorrectly stated as line 18. The correct line number is 21. This small change ensures accuracy and clarity for developers following the documentation.

![image](https://github.com/docker/docs/assets/125583651/fd2b6ab6-1e6c-466f-b97c-a4a75c813b5e)
