### PR TITLE
Updated path to fit the java spring tutorial

### DIFF
--- a/content/language/java/containerize.md
+++ b/content/language/java/containerize.md
@@ -96,7 +96,7 @@ In the terminal, press `ctrl`+`c` to stop the application.
 ### Run the application in the background
 
 You can run the application detached from the terminal by adding the `-d`
-option. Inside the `docker-php-sample` directory, run the following command
+option. Inside the `spring-petclinic` directory, run the following command
 in a terminal.
 
 ```console


### PR DESCRIPTION
<!--Delete sections as needed -->

## Description

In the java containerize tutorial was a path from the php tutorial. The path was updated.

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Technical review
- [ ] Editorial review
- [ ] Product review