### PR TITLE
clarify variables and .env file usage for interpolation

### DIFF
--- a/content/compose/environment-variables/envvars-precedence.md
+++ b/content/compose/environment-variables/envvars-precedence.md
@@ -15,10 +15,11 @@ The order of precedence (highest to lowest) is as follows:
 1. Set using [`docker compose run -e` in the CLI](set-environment-variables.md#set-environment-variables-with-docker-compose-run---env)
 2. Substituted from your [shell](set-environment-variables.md#substitute-from-the-shell)
 3. Set using just the [`environment` attribute in the Compose file](set-environment-variables.md#use-the-environment-attribute)
-4. Use of the [`--env-file` argument](set-environment-variables.md#substitute-with---env-file) in the CLI
+4. Use of the [`docker compose run  --env-file` argument](set-environment-variables.md#substitute-with---env-file) in the CLI
 5. Use of the [`env_file` attribute](set-environment-variables.md#use-the-env_file-attribute) in the Compose file
 6. Set using an [`.env` file](set-environment-variables.md#substitute-with-an-env-file) placed at base of your project directory
-7. Set in a container image in the [ENV directive](../../reference/dockerfile.md#env).
+7. Set using an [`.env` file](set-environment-variables.md#substitute-with-an-env-file) placed at base of your project directory
+8. Set in a container image in the [ENV directive](../../reference/dockerfile.md#env).
    Having any `ARG` or `ENV` setting in a `Dockerfile` evaluates only if there is no Docker Compose entry for `environment`, `env_file` or `run --env`.
 
 ## Simple example

--- a/content/compose/environment-variables/envvars.md
+++ b/content/compose/environment-variables/envvars.md
@@ -28,10 +28,9 @@ This page contains information on how you can set or change the following pre-de
 ## Methods to override 
 
 You can set or change the pre-defined environment variables:
-- Within your Compose file using the [`environment` attribute](set-environment-variables.md#use-the-environment-attribute)
-- With an [environment file](env-file.md) 
 - From the command line
 - From your [shell](set-environment-variables.md#substitute-from-the-shell)
+- With an [environment file](env-file.md), either using an explicit `--env-file` flag, or relying on a default `.env` file in your working directory
 
 When changing or setting any environment variables, be aware of [Environment variable precedence](envvars-precedence.md).
 
@@ -76,6 +75,8 @@ The path separator can also be customized using `COMPOSE_PATH_SEPARATOR`.
 Example: `COMPOSE_FILE=docker-compose.yml:docker-compose.prod.yml`.  
 
 See also the [command-line options overview](../reference/index.md#command-options-overview-and-help) and [using `-f` to specify name and path of one or more Compose files](../reference/index.md#use--f-to-specify-name-and-path-of-one-or-more-compose-files).
+
+When `COMPOSE\_FILE` points to a distinct folder, and both target and working directory contains a `.env` file, both get loaded. The local one (which can define `COMPOSE\_FILE`) can be used to override values set by `.env` file sibling to the target compose file.
 
 ### COMPOSE\_PROFILES
 

--- a/content/compose/environment-variables/variables.md
+++ b/content/compose/environment-variables/variables.md
@@ -1,0 +1,28 @@
+---
+title: Ways to set variables for Compose file
+description: How to set, use, and manage variables in Compose files
+keywords: compose, orchestration, interpolation, env file
+---
+
+Compose allows to us variables for flexibility as described in [interpolation](env-file.md#interpolation). Values are resolved based on local environment variables and env files (not to confuse with [_container_'s environment](set-environment-variables.md)) as illustrated in this example:
+
+```yaml
+services:
+  web:
+    image: nginx:${TAG}
+```
+
+Variable syntax is the same used in env file as documented [here](env-file.md#interpolation)
+
+The order of precedence (highest to lowest) is as follows:
+1. Variables from your local shell
+2. Set using an `.env` file placed in your working directory
+3. Set using an `.env` file placed at base of your project directory, if distinct from working directory
+
+The two latter are only relevant when compose is not ran with `--env-file` flag, as this disables load of a default
+`.env` file. 
+
+Working directory (a.k.a `pwd`) and project directory are distinct when:
+- `COMPOSE_FILE` variable is set, and points to a compose file in a ditinct folder
+- `docker compose` is ran with `--file` flag pointing to a compose file in a ditinct folder
+- Working directory does not contain a default `compose.yaml` file, and Compose finds one in a parent folder, which becomes the project directory.


### PR DESCRIPTION
## Description

clarify variables and .env file usage for interpolation, especially after https://github.com/docker/compose/pull/11824 was merged so this becomes an official feature

## Related issues or tickets

https://docker.atlassian.net/browse/COMP-582

## Reviews

- [ ] Technical review
- [ ] Editorial review
- [ ] Product review