### PR TITLE
fixes to windows-install

### DIFF
--- a/content/desktop/install/windows-install.md
+++ b/content/desktop/install/windows-install.md
@@ -63,11 +63,6 @@ For more information on setting up WSL 2 with Docker Desktop, see [WSL](../wsl/_
 >
 > Docker only supports Docker Desktop on Windows for those versions of Windows that are still within [Microsoft’s servicing timeline](https://support.microsoft.com/en-us/help/13853/windows-lifecycle-fact-sheet). Docker Desktop is not supported on server versions of Windows, such as Windows Server 2019 or Windows Server 2022. For more information on how to run containers on Windows Server, see [Microsoft's official documentation](https://learn.microsoft.com/virtualization/windowscontainers/quick-start/set-up-environment).
 
-> **Should I use Hyper-V or WSL?**
->
-> Docker Desktop's functionality remains consistent on both WSL and Hyper-V, without a preference for either architecture. Hyper-V and WSL have their own advantages and disadvantages, depending on your specific set up and your planned use case. 
-{ .tip }
-
 {{< /tab >}}
 {{< tab name="Hyper-V backend and Windows containers" >}}
 
@@ -96,10 +91,15 @@ For more information on setting up WSL 2 with Docker Desktop, see [WSL](../wsl/_
 
 > **Note**
 >
-> Docker only supports Docker Desktop on Windows for those versions of Windows that are still within [Microsoft’s servicing timeline](https://support.microsoft.com/en-us/help/13853/windows-lifecycle-fact-sheet).
+> Docker only supports Docker Desktop on Windows for those versions of Windows that are still within [Microsoft’s servicing timeline](https://support.microsoft.com/en-us/help/13853/windows-lifecycle-fact-sheet). Docker Desktop is not supported on server versions of Windows, such as Windows Server 2019 or Windows Server 2022. For more information on how to run containers on Windows Server, see [Microsoft's official documentation](https://learn.microsoft.com/virtualization/windowscontainers/quick-start/set-up-environment).
 
 {{< /tab >}}
 {{< /tabs >}}
+
+> **Should I use Hyper-V or WSL?**
+>
+> Docker Desktop's functionality remains consistent on both WSL and Hyper-V, without a preference for either architecture. Hyper-V and WSL have their own advantages and disadvantages, depending on your specific set up and your planned use case. 
+{ .tip }
 
 Containers and images created with Docker Desktop are shared between all
 user accounts on machines where it is installed. This is because all Windows
@@ -133,11 +133,7 @@ For more information on Windows containers, refer to the following documentation
 
 > **Note**
 >
-> When you switch to Windows containers, **Settings** only shows those tabs that are active and apply to your Windows containers. These are:
->
->  * [General](../settings/windows.md#general)
->  * [Proxies](../settings/windows.md#proxies)
->  * [Daemon](../settings/windows.md#docker-engine)
+> When you switch to Windows containers, **Settings** only shows those tabs that are active and apply to your Windows containers.
 
 If you set proxies or daemon configuration in Windows containers mode, these
 apply only on Windows containers. If you switch back to Linux containers,


### PR DESCRIPTION
## Description

This is a follow up from https://github.com/docker/docs/pull/20056.
I realized the second tab (Hyper-V and Windows containers) did not have the same note I updated into the initial PR.
I also reviewed the remaining documentation to check for errors. Here's what this PR does:

- Added a support statement for Docker Desktop on Windows Server and provided a link to users for more information - this time into the second tab on system requirements.
- Moved a tip to outside of the tab - the tip is relevant regardless of the choice, so should not be in the tab.
- Removed part of the statement on what are the menu options under settings for Windows containers. This was outdated and newer versions of Docker Desktop show more information.
