### PR TITLE
The word "container" should be changed to "image" for factual correct…

### DIFF
--- a/content/get-started/05_persisting_data.md
+++ b/content/get-started/05_persisting_data.md
@@ -136,7 +136,7 @@ To start the todo app container with the volume mounted:
 
 1. Select the search box at the top of Docker Desktop.
 2. In the search window, select the **Images** tab.
-3. In the search box, specify the container name, `getting-started`.
+3. In the search box, specify the image name, `getting-started`.
 
    > **Tip**
    >


### PR DESCRIPTION
…ness.

The term "container" should be replaced with "image" for accuracy, as we are searching for a specific image from the local images to run a new container.

<!--the word "container "-->

## Description

<!-- replaced it with image because we are searching for an image and not a container -->

