### PR TITLE
centos 8 eol

### DIFF
--- a/content/engine/install/centos.md
+++ b/content/engine/install/centos.md
@@ -1,8 +1,7 @@
 ---
 description: Learn how to install Docker Engine on CentOS. These instructions cover
   the different installation methods, how to uninstall, and next steps.
-keywords: install docker centos, centos install docker, docker install centos, yum
-  install docker, install docker centos 7, install docker centos 8, centos docker-ce
+keywords: requirements, yum, installation, centos, install, uninstall, docker engine, upgrade, update
 title: Install Docker Engine on CentOS
 toc_max: 4
 aliases:
@@ -29,7 +28,6 @@ To install Docker Engine, you need a maintained version of one of the following
 CentOS versions:
 
 - CentOS 7 (EOL: [June 30, 2024](https://blog.centos.org/2023/04/end-dates-are-coming-for-centos-stream-8-and-centos-linux-7/#centos-linux-7-end-of-life-june-30-2024))
-- CentOS 8 (stream) (EOL: [May 31, 2024](https://blog.centos.org/2023/04/end-dates-are-coming-for-centos-stream-8-and-centos-linux-7/#centos-stream-8-end-of-builds-may-31-2024))
 - CentOS 9 (stream)
 
 The `centos-extras` repository must be enabled. This repository is enabled by
@@ -118,17 +116,17 @@ $ sudo yum-config-manager --add-repo {{% param "download-url-base" %}}/docker-ce
    ```console
    $ yum list docker-ce --showduplicates | sort -r
 
-   docker-ce.x86_64    3:25.0.0-1.el8    docker-ce-stable
-   docker-ce.x86_64    3:24.0.7-1.el8    docker-ce-stable
+   docker-ce.x86_64    3:25.0.0-1.el9    docker-ce-stable
+   docker-ce.x86_64    3:24.0.7-1.el9    docker-ce-stable
    <...>
    ```
 
    The list returned depends on which repositories are enabled, and is specific
-   to your version of CentOS (indicated by the `.el8` suffix in this example).
+   to your version of CentOS (indicated by the `.el9` suffix in this example).
 
    Install a specific version by its fully qualified package name, which is
    the package name (`docker-ce`) plus the version string (2nd column),
-   separated by a hyphen (`-`). For example, `docker-ce-3:25.0.0-1.el8`.
+   separated by a hyphen (`-`). For example, `docker-ce-3:25.0.0-1.el9`.
 
    Replace `<VERSION_STRING>` with the desired version and then run the following
    command to install:

--- a/content/engine/install/centos.md
+++ b/content/engine/install/centos.md
@@ -116,8 +116,8 @@ $ sudo yum-config-manager --add-repo {{% param "download-url-base" %}}/docker-ce
    ```console
    $ yum list docker-ce --showduplicates | sort -r
 
-   docker-ce.x86_64    3:25.0.0-1.el9    docker-ce-stable
-   docker-ce.x86_64    3:24.0.7-1.el9    docker-ce-stable
+   docker-ce.x86_64    3:26.1.3-1.el9    docker-ce-stable
+   docker-ce.x86_64    3:26.1.2-1.el9    docker-ce-stable
    <...>
    ```
 
@@ -126,7 +126,7 @@ $ sudo yum-config-manager --add-repo {{% param "download-url-base" %}}/docker-ce
 
    Install a specific version by its fully qualified package name, which is
    the package name (`docker-ce`) plus the version string (2nd column),
-   separated by a hyphen (`-`). For example, `docker-ce-3:25.0.0-1.el9`.
+   separated by a hyphen (`-`). For example, `docker-ce-3:26.1.2-1.el9`.
 
    Replace `<VERSION_STRING>` with the desired version and then run the following
    command to install:

--- a/content/engine/security/rootless.md
+++ b/content/engine/security/rootless.md
@@ -127,12 +127,10 @@ testuser:231072:65536
 
 - Known to work on openSUSE 15 and SLES 15.
 {{< /tab >}}
-{{< tab name="CentOS 8, RHEL 8, and Fedora" >}}
+{{< tab name="CentOS 9 (stream), RHEL 8, and Fedora" >}}
 - Installing `fuse-overlayfs` is recommended. Run `sudo dnf install -y fuse-overlayfs`.
 
 - You might need `sudo dnf install -y iptables`.
-
-- Known to work on CentOS 8, RHEL 8, and Fedora 34.
 {{< /tab >}}
 {{< tab name="CentOS 7 and RHEL 7" >}}
 - Add `user.max_user_namespaces=28633` to `/etc/sysctl.conf` (or 


### PR DESCRIPTION
## Description

- **engine: remove centos 8 (EOL)**
- **engine(centos-install): bump docker-ce example versions**
