### PR TITLE
fix: add release-notes tag to engine release note

### DIFF
--- a/content/engine/release-notes/26.1.md
+++ b/content/engine/release-notes/26.1.md
@@ -5,6 +5,8 @@ keywords: docker, docker engine, ce, whats new, release notes
 toc_min: 1
 toc_max: 2
 skip_read_time: true
+tags:
+  - Release notes
 aliases:
 - /engine/release-notes/
 - /engine/release-notes/latest/


### PR DESCRIPTION
## Description

The Docker Engine release notes weren't showing up under /tags/release-notes

Added the tag to 26.1 (current latest)

## Related issues or tickets

Hotjar feedback https://insights.hotjar.com/sites/3169877/feedback/responses/413330?frid=98317330&referer=slack
