### PR TITLE
document proxyEnableKerberosNTLM config

### DIFF
--- a/content/desktop/settings/windows.md
+++ b/content/desktop/settings/windows.md
@@ -234,6 +234,8 @@ Kerberos and NTLM proxy authentication are available for Business subscribers wi
 
 Developers are no longer interrupted by prompts for proxy credentials as authentication is centralized. This also reduces the risk of account lockouts due to incorrect sign in attempts.
 
+If your proxy offers multiple authentication schemes in 407(Proxy Authentication Required) response, Docker Desktop selects the strongest authentication scheme (Kerberos, NTLM, Basic, in that order strongest to weakest). If your proxy server returns Kerberos, NTLM and Basic authentication schemes, but your Kerberos/NTLM environment is not set up correctly, this may cause Docker Desktop fail to successfully authenticate with the proxy, as it attempts to use the strongest authentication scheme. To overcome this until your Kerberos/NTLM environment is fixed, you can fallback to Basic authentication scheme by setting `proxyEnableKerberosNTLM` to false in settings.json file located under %APPDATA%/Docker/ directory. Quit Docker Desktop application and start it again to effect this change. `proxyEnableKerberosNTLM` is available in Docker Desktop 4.31 and later releases.
+
 > **Note**
 >
 > Docker Desktop also supports the use of [SOCKS5 proxies](../networking.md#socks5-proxy-support).


### PR DESCRIPTION
<!--Delete sections as needed -->

## Description
Adds description for the config proxyEnableKerberosNTLM to the docs. This config is available in 4.31, so we should merge this after 4.31 is released.

<!-- Tell us what you did and why -->

## Related issues or tickets
https://docker.atlassian.net/browse/SEG-575

<!-- Related issues, pull requests, or Jira tickets -->

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Technical review
- [x] Editorial review
- [ ] Product review