### PR TITLE
fix missing word in secrets documentation

### DIFF
--- a/content/build/building/secrets.md
+++ b/content/build/building/secrets.md
@@ -69,7 +69,7 @@ as a file in the build container at `/run/secrets/kube`.
 $ docker build --secret id=kube,env=KUBECONFIG .
 ```
 
-When you secrets from environment variables, you can omit the `env` parameter
+When you use secrets from environment variables, you can omit the `env` parameter
 to bind the secret to a file with the same name as the variable.
 In the following example, the value of the `API_TOKEN` variable
 is mounted to `/run/secrets/API_TOKEN` in the build container.


### PR DESCRIPTION
Just a small writing mistake in the documentations, pretty self-explanatory.

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Technical review
- [ ] Editorial review
- [ ] Product review