### PR TITLE
engine: rhel x86_64/aarch64 experimental support

### DIFF
--- a/content/engine/install/_index.md
+++ b/content/engine/install/_index.md
@@ -41,16 +41,18 @@ through Docker Desktop. For instructions on how to install Docker Desktop, see:
 
 ## Supported platforms
 
-| Platform                                       | x86_64 / amd64    | arm64 / aarch64   | arm (32-bit)             | ppc64le         | s390x           |
-| :--------------------------------------------- | :---------------- | :---------------- | :----------------------- | :-------------- | :-------------- |
-| [CentOS](centos.md)                            | [✅](centos.md)   | [✅](centos.md)   |                          | [✅](centos.md) |                 |
-| [Debian](debian.md)                            | [✅](debian.md)   | [✅](debian.md)   | [✅](debian.md)          | [✅](debian.md) |                 |
-| [Fedora](fedora.md)                            | [✅](fedora.md)   | [✅](fedora.md)   |                          | [✅](fedora.md) |                 |
-| [Raspberry Pi OS (32-bit)](raspberry-pi-os.md) |                   |                   | [✅](raspberry-pi-os.md) |                 |                 |
-| [RHEL (s390x)](rhel.md)                        |                   |                   |                          |                 | [✅](rhel.md)   |
-| [SLES](sles.md)                                |                   |                   |                          |                 | [✅](sles.md)   |
-| [Ubuntu](ubuntu.md)                            | [✅](ubuntu.md)   | [✅](ubuntu.md)   | [✅](ubuntu.md)          | [✅](ubuntu.md) | [✅](ubuntu.md) |
-| [Binaries](binaries.md)                        | [✅](binaries.md) | [✅](binaries.md) | [✅](binaries.md)        |                 |                 |
+| Platform                                       | x86_64 / amd64 | arm64 / aarch64 | arm (32-bit) | ppc64le | s390x |
+| :--------------------------------------------- | :------------: | :-------------: | :----------: | :-----: | :---: |
+| [CentOS](centos.md)                            |       ✅       |       ✅        |              |   ✅    |       |
+| [Debian](debian.md)                            |       ✅       |       ✅        |      ✅      |   ✅    |       |
+| [Fedora](fedora.md)                            |       ✅       |       ✅        |              |   ✅    |       |
+| [Raspberry Pi OS (32-bit)](raspberry-pi-os.md) |                |                 |      ✅      |         |       |
+| [RHEL](rhel.md)                                |       🚧       |       🚧        |              |         |  ✅   |
+| [SLES](sles.md)                                |                |                 |              |         |  ✅   |
+| [Ubuntu](ubuntu.md)                            |       ✅       |       ✅        |      ✅      |   ✅    |  ✅   |
+| [Binaries](binaries.md)                        |       ✅       |       ✅        |      ✅      |         |       |
+
+🚧 = Experimental
 
 ### Other Linux distros
 

--- a/content/engine/install/rhel.md
+++ b/content/engine/install/rhel.md
@@ -2,8 +2,8 @@
 description: Learn how to install Docker Engine on RHEL. These instructions cover
   the different installation methods, how to uninstall, and next steps.
 keywords: requirements, apt, installation, rhel, rpm, install, install docker engine, uninstall, upgrade,
-  update, s390x, ibm-z
-title: Install Docker Engine on RHEL (s390x)
+  update
+title: Install Docker Engine on RHEL
 toc_max: 4
 aliases:
 - /ee/docker-ee/rhel/
@@ -16,15 +16,15 @@ aliases:
 download-url-base: https://download.docker.com/linux/rhel
 ---
 
-> **Note**
+> **Experimental**
 >
-> The installation instructions on this page refer to packages for RHEL on the
-> **s390x** architecture (IBM Z). Other architectures, including x86_64, aren't
-> yet supported for RHEL.
->
-> For other architectures, you may be able to install the CentOS packages.
-> Refer to [Install Docker Engine on CentOS](centos.md).
-{ .warning }
+> Support for Docker Engine on RHEL x86_64 and aarch64 is experimental.
+{ .experimental }
+
+> **Docker Desktop for Linux** is also available for RHEL.
+> 
+> To get access, join the [Early Access Program](https://www.docker.com/docker-desktop-preview-program/).
+{ .restricted }
 
 To get started with Docker Engine on RHEL, make sure you
 [meet the prerequisites](#prerequisites), and then follow the
@@ -37,9 +37,9 @@ To get started with Docker Engine on RHEL, make sure you
 To install Docker Engine, you need a maintained version of one of the following
 RHEL versions:
 
-- RHEL 7 on s390x (IBM Z) (EOL: [June 30, 2024](https://www.ibm.com/blog/announcement/ibm-is-announcing-red-hat-enterprise-linux-7-is-going-end-of-support-on-30-june-2024/))
-- RHEL 8 on s390x (IBM Z)
-- RHEL 9 on s390x (IBM Z)
+- RHEL 7 (s390x only) (EOL: [June 30, 2024](https://www.ibm.com/blog/announcement/ibm-is-announcing-red-hat-enterprise-linux-7-is-going-end-of-support-on-30-june-2024/))
+- RHEL 8
+- RHEL 9
 
 ### Uninstall old versions
 
@@ -185,27 +185,43 @@ download the `.rpm` file for your release and install it manually. You need to
 download a new file each time you want to upgrade Docker Engine.
 
 <!-- markdownlint-disable-next-line -->
-1. Go to [{{% param "download-url-base" %}}/]({{% param "download-url-base" %}}/)
-   and choose your version of RHEL. Then go to `s390x/stable/Packages/`
-   and download the `.rpm` file for the Docker version you want to install.
+1. Go to [{{% param "download-url-base" %}}/]({{% param "download-url-base" %}}/).
 
-2. Install Docker Engine, changing the following path to the path where you downloaded
-   the Docker package.
+2. Select your RHEL version in the list.
+
+3. Select the applicable architecture (`x86_64`, `aarch64`, or `s390x`), and
+   then go to `stable/Packages/`.
+
+4. Download the following `deb` files for the Docker Engine, CLI, containerd,
+   and Docker Compose packages:
+
+   - `containerd.io_<version>_<arch>.deb`
+   - `docker-ce_<version>_<arch>.deb`
+   - `docker-ce-cli_<version>_<arch>.deb`
+   - `docker-buildx-plugin_<version>_<arch>.deb`
+   - `docker-compose-plugin_<version>_<arch>.deb`
+
+5. Install Docker Engine, changing the following path to the path where you downloaded
+   the packages.
 
    ```console
-   $ sudo yum install /path/to/package.rpm
+   $ sudo yum install ./containerd.io_<version>_<arch>.rpm \
+     ./docker-ce_<version>_<arch>.rpm \
+     ./docker-ce-cli_<version>_<arch>.rpm \
+     ./docker-buildx-plugin_<version>_<arch>.rpm \
+     ./docker-compose-plugin_<version>_<arch>.rpm
    ```
 
    Docker is installed but not started. The `docker` group is created, but no
    users are added to the group.
 
-3. Start Docker.
+6. Start Docker.
 
    ```console
    $ sudo systemctl start docker
    ```
 
-4. Verify that the Docker Engine installation is successful by running the
+7. Verify that the Docker Engine installation is successful by running the
    `hello-world` image.
 
    ```console

--- a/data/toc.yaml
+++ b/data/toc.yaml
@@ -1482,7 +1482,7 @@ Manuals:
     - path: /engine/install/fedora/
       title: Fedora
     - path: /engine/install/rhel/
-      title: RHEL (s390x)
+      title: RHEL
     - path: /engine/install/sles/
       title: SLES
     - path: /engine/install/ubuntu/


### PR DESCRIPTION
## Description

This PR updates the docker-ce installation instruction to call out experimental support for x86_64 and aarch64 on rhel
