### PR TITLE
build: add beta badge to build summary

### DIFF
--- a/data/toc.yaml
+++ b/data/toc.yaml
@@ -1946,7 +1946,7 @@ Manuals:
           - path: /build/ci/github-actions/
             title: Introduction
           - path: /build/ci/github-actions/build-summary/
-            title: Build summary
+            title: Build summary {{< badge color=blue text=Beta >}}
           - path: /build/ci/github-actions/configure-builder/
             title: Configuring your builder
           - path: /build/ci/github-actions/multi-platform/


### PR DESCRIPTION
## Description

Add beta badge to build summary in the sidebar.

@dvdksn @colinhemmings Let me know if that makes sense

<img width="302" alt="image" src="https://github.com/docker/docs/assets/35727626/8181fecc-b0cc-4ee3-98a1-3e7ea146cc67">

## Related issues or tickets

<!-- Related issues, pull requests, or Jira tickets -->

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Technical review
- [x] Editorial review
- [x] Product review