### PR TITLE
hub: change "My Account" to "Account settings"

### DIFF
--- a/content/admin/convert-account.md
+++ b/content/admin/convert-account.md
@@ -50,7 +50,7 @@ Consider the following effects of converting your account:
 
 1. Ensure you have removed your user account from any company or teams or organizations. Also make sure that you have a new Docker ID before you convert an account. See the [Prerequisites](#prerequisites) section for details.
 
-2. In the top-right of Docker Hub, select your account name and then from the drop-down menu, select **My Account**.
+2. In the top-right of Docker Hub, select your account name and then from the drop-down menu, select **Account settings**.
 
 3. From the **Convert Account** tab, select **Convert to Organization**.
 

--- a/content/admin/deactivate-account.md
+++ b/content/admin/deactivate-account.md
@@ -42,7 +42,7 @@ Before deactivating your Docker account, ensure that you meet the following requ
 
 Once you have completed all the steps above, you can deactivate your account. 
 
-1. Select your account name in the top-right of Docker Hub and from the drop-down menu, select **My Account**.
+1. Select your account name in the top-right of Docker Hub and from the drop-down menu, select **Account settings**.
 2. From the **Deactivate Account** tab, select **Deactivate account**. 
 
 > This cannot be undone. Be sure you've gathered all the data you need from your account before deactivating it.

--- a/content/docker-hub/builds/link-source.md
+++ b/content/docker-hub/builds/link-source.md
@@ -25,7 +25,7 @@ If you are linking a source code provider to create autobuilds for a team, follo
 
 1. Sign in to Docker Hub.
 
-2. Select **My Account** in the top-right drop-down navigation, then select the **Linked Accounts** tab.
+2. Select **Account settings** in the top-right drop-down navigation, then select the **Linked Accounts** tab.
 
 3. Select **Link provider** for the source provider you want to link.
 
@@ -97,7 +97,7 @@ To revoke Docker Hub's access to an organization's GitHub repositories:
 To revoke Docker Hub's access to your GitHub account, you must unlink it both
 from Docker Hub, and from your GitHub account.
 
-1. Select **My Account** in the top-right drop-down navigation, then open
+1. Select **Account settings** in the top-right drop-down navigation, then open
 the **Linked Accounts** section.
 
 2. Select the plug icon next to the source provider you want to remove.
@@ -119,7 +119,7 @@ code provider.
 
 1. Sign in to Docker Hub using your Docker ID.
 
-2. Select **My Account** in the top-right drop-down navigation, then select the **Linked Accounts** tab.
+2. Select **Account settings** in the top-right drop-down navigation, then select the **Linked Accounts** tab.
 
 3. Select **Link provider** for the source provider you want to link.
 
@@ -135,7 +135,7 @@ unlink it both from Docker Hub, and from your Bitbucket account.
 
 1. Sign in to Docker Hub.
 
-2. Select **My Account** in the top-right drop-down navigation, then open
+2. Select **Account settings** in the top-right drop-down navigation, then open
 the **Linked Accounts** section.
 
 3. Select the **Plug** icon next to the source provider you want to remove.

--- a/content/security/for-developers/2fa/_index.md
+++ b/content/security/for-developers/2fa/_index.md
@@ -26,7 +26,7 @@ Authenticator with a registered YubiKey.
 ## Enable two-factor authentication
 
 1. Sign in to your Docker Hub account. 
-2. Select your avatar and then from the drop-down menu, select **My Account**. 
+2. Select your avatar and then from the drop-down menu, select **Account settings**. 
 3. Select the **Security** tab and then select **Enable Two-Factor Authentication**.
 4. Enter your account password, then select **Confirm**.
 5. Save your recovery code and store it somewhere safe. You can use your recovery code to recover your account in the event you lose access to your authenticator app.

--- a/content/security/for-developers/2fa/disable-2fa.md
+++ b/content/security/for-developers/2fa/disable-2fa.md
@@ -14,7 +14,7 @@ aliases:
 { .warning }
 
 1. Sign in to your Docker Hub account. 
-2. Select your avatar and then from the drop-down menu, select **My Account**.
+2. Select your avatar and then from the drop-down menu, select **Account settings**.
 3. Navigate to the **Security** tab and select **Manage Two-Factor Authentication**.
 4. Enter your password, then select **Confirm**.
 5. Select **Disable 2FA**.

--- a/content/security/for-developers/2fa/new-recovery-code.md
+++ b/content/security/for-developers/2fa/new-recovery-code.md
@@ -11,7 +11,7 @@ If you have lost your two-factor authentication recovery code and still have
 access to your Docker Hub account, you can generate a new recovery code.
 
 1. Sign in to your Docker Hub account. 
-2. Select your avatar and then from the drop-down menu, select **My Account**.
+2. Select your avatar and then from the drop-down menu, select **Account settings**.
 3. Navigate to the **Security** tab and select **Manage Two-Factor Authentication**.
 4. Enter your password, then select **Confirm**.
 

--- a/content/security/for-developers/access-tokens.md
+++ b/content/security/for-developers/access-tokens.md
@@ -26,7 +26,7 @@ any time.
 
 1. Sign in to [Docker Hub](https://hub.docker.com).
 
-2. Select your avatar in the top-right corner and from the drop-down menu select **My Account**.
+2. Select your avatar in the top-right corner and from the drop-down menu select **Account settings**.
 
 3. Select the **Security** tab and then **New Access Token**.
 
@@ -63,7 +63,7 @@ When prompted for a password, enter your personal access token instead of a pass
 
 You can rename, activate, deactivate, or delete a token as needed.
 
-1. Access your tokens under **My Account > Security**.
+1. Access your tokens under **Account settings > Security**.
    This page shows an overview of all your tokens, and lists if the token was generated manually or if it was [auto-generated](#auto-generated-tokens). You can also view the number
    of tokens that are activated and deactivated in the toolbar.
 


### PR DESCRIPTION
I tried to follow instructions, and it looks like this item under the avatar dropdown is renamed to "Account settings"; the "My profile" menu-item brings me to my (public) profile page.

<img width="364" alt="Screenshot 2024-06-11 at 10 24 30" src="https://github.com/docker/docs/assets/1804568/b2ec5585-7228-4874-91cb-aa0134918351">


## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Technical review
- [ ] Editorial review
- [ ] Product review
