### PR TITLE
redirects: remove old preview redirect

### DIFF
--- a/data/redirects.yml
+++ b/data/redirects.yml
@@ -604,8 +604,6 @@
   - /feedback/gha-build-summary/
 
 # Docker Scout
-"https://deploy-preview-19873--docsdocker.netlify.app/scout/dashboard/#notification-settings":
-  - /go/scout-notifications/
 "/scout/":
   - /go/scout/
   - /go/docker-scout/


### PR DESCRIPTION
This redirect was now duplicated and is redefined here https://github.com/docker/docs/blob/56b0337867138b12a915dfcca5901ae0de1db62e/data/redirects.yml#L651-L652