### PR TITLE
build: remove checkout, use vars for username

### DIFF
--- a/content/build/ci/github-actions/annotations.md
+++ b/content/build/ci/github-actions/annotations.md
@@ -38,7 +38,7 @@ jobs:
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          username: ${{ vars.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Extract metadata
@@ -80,7 +80,7 @@ jobs:
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          username: ${{ vars.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Extract metadata
@@ -133,7 +133,7 @@ jobs:
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          username: ${{ vars.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Extract metadata

--- a/content/build/ci/github-actions/annotations.md
+++ b/content/build/ci/github-actions/annotations.md
@@ -19,7 +19,7 @@ with [build-push-action] and [bake-action].
 {{< tabs >}}
 {{< tab name="build-push-action" >}}
 
-```yaml {hl_lines=35}
+```yaml {hl_lines=32}
 name: ci
 
 on:
@@ -32,9 +32,6 @@ jobs:
   docker:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -117,7 +114,7 @@ want to annotate. For example, setting `DOCKER_METADATA_ANNOTATIONS_LEVELS` to
 The following example creates annotations on both the image index and
 manifests.
 
-```yaml {hl_lines=31}
+```yaml {hl_lines=28}
 name: ci
 
 on:
@@ -130,9 +127,6 @@ jobs:
   docker:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 

--- a/content/build/ci/github-actions/attestations.md
+++ b/content/build/ci/github-actions/attestations.md
@@ -68,7 +68,7 @@ jobs:
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          username: ${{ vars.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Extract metadata
@@ -114,7 +114,7 @@ jobs:
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          username: ${{ vars.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Extract metadata

--- a/content/build/ci/github-actions/attestations.md
+++ b/content/build/ci/github-actions/attestations.md
@@ -62,9 +62,6 @@ jobs:
   docker:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -83,7 +80,6 @@ jobs:
       - name: Build and push image
         uses: docker/build-push-action@v6
         with:
-          context: .
           push: true
           provenance: mode=max
           tags: ${{ steps.meta.outputs.tags }}
@@ -112,9 +108,6 @@ jobs:
   docker:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -133,7 +126,6 @@ jobs:
       - name: Build and push image
         uses: docker/build-push-action@v6
         with:
-          context: .
           sbom: true
           push: true
           tags: ${{ steps.meta.outputs.tags }}

--- a/content/build/ci/github-actions/build-summary.md
+++ b/content/build/ci/github-actions/build-summary.md
@@ -80,7 +80,6 @@ variable in the YAML configuration for your build step:
         env:
           DOCKER_BUILD_NO_SUMMARY: true
         with:
-          context: .
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
 ```

--- a/content/build/ci/github-actions/cache.md
+++ b/content/build/ci/github-actions/cache.md
@@ -34,7 +34,7 @@ jobs:
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          username: ${{ vars.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       
       - name: Build and push
@@ -67,7 +67,7 @@ jobs:
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          username: ${{ vars.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       
       - name: Build and push
@@ -112,7 +112,7 @@ jobs:
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          username: ${{ vars.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       
       - name: Build and push
@@ -244,7 +244,7 @@ jobs:
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          username: ${{ vars.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       
       - name: Build and push

--- a/content/build/ci/github-actions/cache.md
+++ b/content/build/ci/github-actions/cache.md
@@ -28,9 +28,6 @@ jobs:
   docker:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       
@@ -43,7 +40,6 @@ jobs:
       - name: Build and push
         uses: docker/build-push-action@v6
         with:
-          context: .
           push: true
           tags: user/app:latest
           cache-from: type=registry,ref=user/app:latest
@@ -65,9 +61,6 @@ jobs:
   docker:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       
@@ -80,7 +73,6 @@ jobs:
       - name: Build and push
         uses: docker/build-push-action@v6
         with:
-          context: .
           push: true
           tags: user/app:latest
           cache-from: type=registry,ref=user/app:buildcache
@@ -114,9 +106,6 @@ jobs:
   docker:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       
@@ -129,7 +118,6 @@ jobs:
       - name: Build and push
         uses: docker/build-push-action@v6
         with:
-          context: .
           push: true
           tags: user/app:latest
           cache-from: type=gha
@@ -176,9 +164,6 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
 
@@ -210,7 +195,6 @@ jobs:
       - name: Build and push
         uses: docker/build-push-action@v6
         with:
-          context: .
           cache-from: type=gha
           cache-to: type=gha,mode=max
           file: build/package/Dockerfile
@@ -246,9 +230,6 @@ jobs:
   docker:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       
@@ -269,7 +250,6 @@ jobs:
       - name: Build and push
         uses: docker/build-push-action@v6
         with:
-          context: .
           push: true
           tags: user/app:latest
           cache-from: type=local,src=/tmp/.buildx-cache

--- a/content/build/ci/github-actions/configure-builder.md
+++ b/content/build/ci/github-actions/configure-builder.md
@@ -49,9 +49,6 @@ jobs:
   buildx:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
         with:
@@ -59,8 +56,6 @@ jobs:
       
       - name: Build
         uses: docker/build-push-action@v6
-        with:
-          context: .
 ```
 
 Logs will be available at the end of a job:
@@ -88,9 +83,6 @@ jobs:
   buildx:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
         with:
@@ -126,9 +118,6 @@ jobs:
   buildx:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
         with:
@@ -312,9 +301,6 @@ jobs:
   docker:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      
       - name: Set up builder1
         uses: docker/setup-buildx-action@v3
         id: builder1
@@ -327,13 +313,11 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           builder: ${{ steps.builder1.outputs.name }}
-          context: .
           target: mytarget1
       
       - name: Build against builder2
         uses: docker/build-push-action@v6
         with:
           builder: ${{ steps.builder2.outputs.name }}
-          context: .
           target: mytarget2
 ```

--- a/content/build/ci/github-actions/copy-image-registries.md
+++ b/content/build/ci/github-actions/copy-image-registries.md
@@ -26,7 +26,7 @@ jobs:
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          username: ${{ vars.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       
       - name: Login to GitHub Container Registry

--- a/content/build/ci/github-actions/copy-image-registries.md
+++ b/content/build/ci/github-actions/copy-image-registries.md
@@ -17,9 +17,6 @@ jobs:
   docker:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
       
@@ -42,7 +39,6 @@ jobs:
       - name: Build and push
         uses: docker/build-push-action@v6
         with:
-          context: .
           platforms: linux/amd64,linux/arm64
           push: true
           tags: |

--- a/content/build/ci/github-actions/export-docker.md
+++ b/content/build/ci/github-actions/export-docker.md
@@ -17,17 +17,12 @@ jobs:
   docker:
     runs-on: ubuntu-latest
     steps:
-      
-      - name: Checkout
-        uses: actions/checkout@v4
-      
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       
       - name: Build
         uses: docker/build-push-action@v6
         with:
-          context: .
           load: true
           tags: myimage:latest
       

--- a/content/build/ci/github-actions/local-registry.md
+++ b/content/build/ci/github-actions/local-registry.md
@@ -22,9 +22,6 @@ jobs:
         ports:
           - 5000:5000
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
       
@@ -36,7 +33,6 @@ jobs:
       - name: Build and push to local registry
         uses: docker/build-push-action@v6
         with:
-          context: .
           push: true
           tags: localhost:5000/name/app:latest
       

--- a/content/build/ci/github-actions/manage-tags-labels.md
+++ b/content/build/ci/github-actions/manage-tags-labels.md
@@ -54,7 +54,7 @@ jobs:
         if: github.event_name != 'pull_request'
         uses: docker/login-action@v3
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          username: ${{ vars.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       
       - name: Login to GHCR

--- a/content/build/ci/github-actions/manage-tags-labels.md
+++ b/content/build/ci/github-actions/manage-tags-labels.md
@@ -26,9 +26,6 @@ jobs:
   docker:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@v5
@@ -71,7 +68,6 @@ jobs:
       - name: Build and push
         uses: docker/build-push-action@v6
         with:
-          context: .
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/content/build/ci/github-actions/multi-platform.md
+++ b/content/build/ci/github-actions/multi-platform.md
@@ -24,9 +24,6 @@ jobs:
   docker:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
       
@@ -42,7 +39,6 @@ jobs:
       - name: Build and push
         uses: docker/build-push-action@v6
         with:
-          context: .
           platforms: linux/amd64,linux/arm64
           push: true
           tags: user/app:latest
@@ -90,9 +86,6 @@ jobs:
           platform=${{ matrix.platform }}
           echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV
       
-      - name: Checkout
-        uses: actions/checkout@v4
-      
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@v5
@@ -115,7 +108,6 @@ jobs:
         id: build
         uses: docker/build-push-action@v6
         with:
-          context: .
           platforms: ${{ matrix.platform }}
           labels: ${{ steps.meta.outputs.labels }}
           outputs: type=image,name=${{ env.REGISTRY_IMAGE }},push-by-digest=true,name-canonical=true,push=true

--- a/content/build/ci/github-actions/multi-platform.md
+++ b/content/build/ci/github-actions/multi-platform.md
@@ -33,7 +33,7 @@ jobs:
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          username: ${{ vars.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       
       - name: Build and push
@@ -101,7 +101,7 @@ jobs:
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          username: ${{ vars.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       
       - name: Build and push by digest
@@ -150,7 +150,7 @@ jobs:
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          username: ${{ vars.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       
       - name: Create manifest list and push
@@ -286,7 +286,7 @@ jobs:
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          username: ${{ vars.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       
       - name: Build
@@ -340,7 +340,7 @@ jobs:
       - name: Login to DockerHub
         uses: docker/login-action@v3
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          username: ${{ vars.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       
       - name: Create manifest list and push

--- a/content/build/ci/github-actions/named-contexts.md
+++ b/content/build/ci/github-actions/named-contexts.md
@@ -31,16 +31,12 @@ jobs:
   docker:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       
       - name: Build
         uses: docker/build-push-action@v6
         with:
-          context: .
           build-contexts: |
             alpine=docker-image://alpine:{{% param "example_alpine_version" %}}
           tags: myimage:latest
@@ -70,9 +66,6 @@ jobs:
   docker:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
         with:
@@ -81,15 +74,13 @@ jobs:
       - name: Build base image
         uses: docker/build-push-action@v6
         with:
-          context: ./base
-          file: ./base/Dockerfile
+          context: "{{defaultContext}}:base"
           load: true
           tags: my-base-image:latest
       
       - name: Build
         uses: docker/build-push-action@v6
         with:
-          context: .
           build-contexts: |
             alpine=docker-image://my-base-image:latest
           tags: myimage:latest
@@ -124,9 +115,6 @@ jobs:
         ports:
           - 5000:5000
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
       
@@ -139,15 +127,13 @@ jobs:
       - name: Build base image
         uses: docker/build-push-action@v6
         with:
-          context: ./base
-          file: ./base/Dockerfile
+          context: "{{defaultContext}}:base"
           tags: localhost:5000/my-base-image:latest
           push: true
       
       - name: Build
         uses: docker/build-push-action@v6
         with:
-          context: .
           build-contexts: |
             alpine=docker-image://localhost:5000/my-base-image:latest
           tags: myimage:latest

--- a/content/build/ci/github-actions/push-multi-registries.md
+++ b/content/build/ci/github-actions/push-multi-registries.md
@@ -26,7 +26,7 @@ jobs:
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          username: ${{ vars.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       
       - name: Login to GitHub Container Registry

--- a/content/build/ci/github-actions/push-multi-registries.md
+++ b/content/build/ci/github-actions/push-multi-registries.md
@@ -17,9 +17,6 @@ jobs:
   docker:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
       
@@ -42,7 +39,6 @@ jobs:
       - name: Build and push
         uses: docker/build-push-action@v6
         with:
-          context: .
           platforms: linux/amd64,linux/arm64
           push: true
           tags: |

--- a/content/build/ci/github-actions/reproducible-builds.md
+++ b/content/build/ci/github-actions/reproducible-builds.md
@@ -31,16 +31,12 @@ jobs:
   docker:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       
       - name: Build
         uses: docker/build-push-action@v6
         with:
-          context: .
           tags: user/app:latest
         env:
           SOURCE_DATE_EPOCH: 0
@@ -91,9 +87,6 @@ jobs:
   docker:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       
@@ -103,7 +96,6 @@ jobs:
       - name: Build
         uses: docker/build-push-action@v6
         with:
-          context: .
           tags: user/app:latest
         env:
           SOURCE_DATE_EPOCH: ${{ env.TIMESTAMP }}

--- a/content/build/ci/github-actions/secrets.md
+++ b/content/build/ci/github-actions/secrets.md
@@ -42,9 +42,6 @@ jobs:
   docker:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
       
@@ -54,7 +51,6 @@ jobs:
       - name: Build
         uses: docker/build-push-action@v6
         with:
-          context: .
           platforms: linux/amd64,linux/arm64
           tags: user/app:latest
           secrets: |
@@ -174,9 +170,6 @@ jobs:
   docker:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-      
       - name: Set up SSH
         uses: MrSquaare/ssh-setup-action@2d028b70b5e397cf8314c6eaea229a6c3e34977a # v3.1.0
         with:
@@ -187,7 +180,6 @@ jobs:
       - name: Build and push
         uses: docker/build-push-action@v6
         with:
-          context: .
           ssh: default
           push: true
           tags: user/app:latest
@@ -207,7 +199,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       
       - name: Set up SSH
         uses: MrSquaare/ssh-setup-action@2d028b70b5e397cf8314c6eaea229a6c3e34977a # v3.1.0

--- a/content/build/ci/github-actions/share-image-jobs.md
+++ b/content/build/ci/github-actions/share-image-jobs.md
@@ -21,16 +21,12 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       
       - name: Build and export
         uses: docker/build-push-action@v6
         with:
-          context: .
           tags: myimage:latest
           outputs: type=docker,dest=/tmp/myimage.tar
       

--- a/content/build/ci/github-actions/test-before-push.md
+++ b/content/build/ci/github-actions/test-before-push.md
@@ -35,7 +35,7 @@ jobs:
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          username: ${{ vars.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       
       - name: Build and export to Docker

--- a/content/build/ci/github-actions/test-before-push.md
+++ b/content/build/ci/github-actions/test-before-push.md
@@ -26,9 +26,6 @@ jobs:
   docker:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
       
@@ -44,7 +41,6 @@ jobs:
       - name: Build and export to Docker
         uses: docker/build-push-action@v6
         with:
-          context: .
           load: true
           tags: ${{ env.TEST_TAG }}
       
@@ -55,7 +51,6 @@ jobs:
       - name: Build and push
         uses: docker/build-push-action@v6
         with:
-          context: .
           platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ env.LATEST_TAG }}

--- a/content/build/ci/github-actions/update-dockerhub-desc.md
+++ b/content/build/ci/github-actions/update-dockerhub-desc.md
@@ -27,7 +27,7 @@ jobs:
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          username: ${{ vars.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       
       - name: Build and push
@@ -39,7 +39,7 @@ jobs:
       - name: Update repo description
         uses: peter-evans/dockerhub-description@e98e4d1628a5f3be2be7c231e50981aee98723ae # v4.0.0
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          username: ${{ vars.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
           repository: user/app
 ```

--- a/content/build/ci/github-actions/update-dockerhub-desc.md
+++ b/content/build/ci/github-actions/update-dockerhub-desc.md
@@ -18,9 +18,6 @@ jobs:
   docker:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
       
@@ -36,7 +33,6 @@ jobs:
       - name: Build and push
         uses: docker/build-push-action@v6
         with:
-          context: .
           push: true
           tags: user/app:latest
       

--- a/content/build/cloud/ci.md
+++ b/content/build/cloud/ci.md
@@ -63,8 +63,6 @@ jobs:
   docker:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
       - name: Log in to Docker Hub
         uses: docker/login-action@v3
         with:
@@ -80,11 +78,10 @@ jobs:
       - name: Build and push
         uses: docker/build-push-action@v6
         with:
-          context: .
           tags: "<IMAGE>"
           # For pull requests, export results to the build cache.
           # Otherwise, push to a registry.
-          outputs: ${{ github.event_name == 'pull_request' && 'type=cacheonly' || 'type=registry,push=true' }}
+          outputs: ${{ github.event_name == 'pull_request' && 'type=cacheonly' || 'type=registry' }}
 ```
 
 {{< /tab >}}

--- a/content/build/cloud/ci.md
+++ b/content/build/cloud/ci.md
@@ -66,7 +66,7 @@ jobs:
       - name: Log in to Docker Hub
         uses: docker/login-action@v3
         with:
-          username: ${{ secrets.DOCKER_USER }}
+          username: ${{ vars.DOCKER_USER }}
           password: ${{ secrets.DOCKER_PAT }}
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/content/includes/gha-tutorial.md
+++ b/content/includes/gha-tutorial.md
@@ -78,9 +78,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       -
-        name: Checkout
-        uses: actions/checkout@v4
-      -
         name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
@@ -93,8 +90,6 @@ jobs:
         name: Build and push
         uses: docker/build-push-action@v6
         with:
-          context: .
-          file: ./Dockerfile
           push: true
           tags: ${{ secrets.DOCKERHUB_USERNAME }}/clockbox:latest
 ```
@@ -102,18 +97,15 @@ jobs:
 
 The previous YAML snippet contains a sequence of steps that:
 
-1. Checks out the repository on the build machine.
-2. Signs in to Docker Hub, using the
+1. Signs in to Docker Hub, using the
    [Docker Login](https://github.com/marketplace/actions/docker-login) action and your Docker Hub credentials.
-3. Creates a BuildKit builder instance using the
+2. Creates a BuildKit builder instance using the
    [Docker Setup Buildx](https://github.com/marketplace/actions/docker-setup-buildx) action.
-4. Builds the container image and pushes it to the Docker Hub repository, using
+3. Builds the container image and pushes it to the Docker Hub repository, using
    [Build and push Docker images](https://github.com/marketplace/actions/build-and-push-docker-images).
 
    The `with` key lists a number of input parameters that configures the step:
 
-   - `context`: the [build context](/build/building/context/).
-   - `file`: filepath to the Dockerfile.
    - `push`: tells the action to upload the image to a registry after building
      it.
    - `tags`: tags that specify where to push the image.
@@ -135,9 +127,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       -
-        name: Checkout
-        uses: actions/checkout@v4
-      -
         name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
@@ -150,8 +139,6 @@ jobs:
         name: Build and push
         uses: docker/build-push-action@v6
         with:
-          context: .
-          file: ./Dockerfile
           push: true
           tags: ${{ secrets.DOCKERHUB_USERNAME }}/clockbox:latest
 ```

--- a/content/includes/gha-tutorial.md
+++ b/content/includes/gha-tutorial.md
@@ -10,7 +10,7 @@ To follow this tutorial, you need a Docker ID and a GitHub account.
 
 ### Step one: Create the repository
 
-Create a GitHub repository and configure the Docker Hub secrets.
+Create a GitHub repository and configure the Docker Hub credentials.
 
 1. Create a new GitHub repository using
    [this template repository](https://github.com/dvdksn/clockbox/generate).
@@ -20,16 +20,16 @@ Create a GitHub repository and configure the Docker Hub secrets.
 
 2. Open the repository **Settings**, and go to **Secrets and variables** > **Actions**.
 
-3. Create a new secret named `DOCKERHUB_USERNAME` and your Docker ID as value.
+3. Create a new **Repository variable** named `DOCKER_USERNAME` and your Docker ID as value.
 
 4. Create a new
    [Personal Access Token (PAT)](/security/for-developers/access-tokens/#create-an-access-token)
    for Docker Hub. You can name this token `clockboxci`.
 
-5. Add the PAT as a second secret in your GitHub repository, with the name
+5. Add the PAT as a **Repository secret** in your GitHub repository, with the name
    `DOCKERHUB_TOKEN`.
 
-With your repository created, and secrets configured, you're now ready for
+With your repository created, and credentials configured, you're now ready for
 action!
 
 ### Step two: Set up the workflow
@@ -81,7 +81,7 @@ jobs:
         name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          username: ${{ vars.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       -
         name: Set up Docker Buildx
@@ -91,7 +91,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           push: true
-          tags: ${{ secrets.DOCKERHUB_USERNAME }}/clockbox:latest
+          tags: ${{ vars.DOCKERHUB_USERNAME }}/clockbox:latest
 ```
 
 
@@ -130,7 +130,7 @@ jobs:
         name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          username: ${{ vars.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       -
         name: Set up Docker Buildx
@@ -140,7 +140,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           push: true
-          tags: ${{ secrets.DOCKERHUB_USERNAME }}/clockbox:latest
+          tags: ${{ vars.DOCKERHUB_USERNAME }}/clockbox:latest
 ```
 
 

--- a/content/language/cpp/configure-ci-cd.md
+++ b/content/language/cpp/configure-ci-cd.md
@@ -18,18 +18,18 @@ In this section, you'll learn how to set up and use GitHub Actions to build and 
 
 ## Step one: Create the repository
 
-Create a GitHub repository, configure the Docker Hub secrets, and push your source code.
+Create a GitHub repository, configure the Docker Hub credentials, and push your source code.
 
 1. [Create a new repository](https://github.com/new) on GitHub.
 
 2. Open the repository **Settings**, and go to **Secrets and variables** >
    **Actions**.
 
-3. Create a new **Repository secrets** named `DOCKER_USERNAME` and your Docker ID as value.
+3. Create a new **Repository variable** named `DOCKER_USERNAME` and your Docker ID as value.
 
 4. Create a new [Personal Access Token (PAT)](../../security/for-developers/access-tokens.md/#create-an-access-token) for Docker Hub. You can name this token `docker-tutorial`. Make sure access permissions include Read and Write.
 
-5. Add the PAT as a second **Repository secrets** in your GitHub repository, with the name
+5. Add the PAT as a **Repository secret** in your GitHub repository, with the name
    `DOCKERHUB_TOKEN`.
 
 6. In your local repository on your machine, run the following command to change
@@ -79,7 +79,7 @@ to Docker Hub.
            name: Login to Docker Hub
            uses: docker/login-action@v3
            with:
-             username: ${{ secrets.DOCKER_USERNAME }}
+             username: ${{ vars.DOCKER_USERNAME }}
              password: ${{ secrets.DOCKERHUB_TOKEN }}
          -
            name: Set up Docker Buildx
@@ -90,7 +90,7 @@ to Docker Hub.
            with:
              platforms: linux/amd64,linux/arm64
              push: true
-             tags: ${{ secrets.DOCKER_USERNAME }}/${{ github.event.repository.name }}:latest
+             tags: ${{ vars.DOCKER_USERNAME }}/${{ github.event.repository.name }}:latest
    ```
 
    For more information about the YAML syntax for `docker/build-push-action`,

--- a/content/language/cpp/configure-ci-cd.md
+++ b/content/language/cpp/configure-ci-cd.md
@@ -76,9 +76,6 @@ to Docker Hub.
        runs-on: ubuntu-latest
        steps:
          -
-           name: Checkout
-           uses: actions/checkout@v4
-         -
            name: Login to Docker Hub
            uses: docker/login-action@v3
            with:
@@ -91,15 +88,13 @@ to Docker Hub.
            name: Build and push
            uses: docker/build-push-action@v6
            with:
-             context: .
              platforms: linux/amd64,linux/arm64
              push: true
              tags: ${{ secrets.DOCKER_USERNAME }}/${{ github.event.repository.name }}:latest
    ```
 
-   If your Dockerfile is in a different directory, update the `context` with the path to the directory containing the Dockerfile. 
-
-   For more information about the YAML syntax used here, see [Workflow syntax for GitHub Actions](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions).
+   For more information about the YAML syntax for `docker/build-push-action`,
+   refer to the [GitHub Action README](https://github.com/docker/build-push-action/blob/master/README.md).
 
 ## Step three: Run the workflow
 

--- a/content/language/dotnet/configure-ci-cd.md
+++ b/content/language/dotnet/configure-ci-cd.md
@@ -18,18 +18,18 @@ In this section, you'll learn how to set up and use GitHub Actions to build and 
 
 ## Step one: Create the repository
 
-Create a GitHub repository, configure the Docker Hub secrets, and push your source code.
+Create a GitHub repository, configure the Docker Hub credentials, and push your source code.
 
 1. [Create a new repository](https://github.com/new) on GitHub.
 
 2. Open the repository **Settings**, and go to **Secrets and variables** >
    **Actions**.
 
-3. Create a new secret named `DOCKER_USERNAME` and your Docker ID as value.
+3. Create a new **Repository variable** named `DOCKER_USERNAME` and your Docker ID as value.
 
-4. Create a new [Personal Access Token (PAT)](../../security/for-developers/access-tokens.md/#create-an-access-token) for Docker Hub. You can name this token `tutorial-docker`. Make sure access permissions include Read and Write.
+4. Create a new [Personal Access Token (PAT)](../../security/for-developers/access-tokens.md/#create-an-access-token) for Docker Hub. You can name this token `docker-tutorial`. Make sure access permissions include Read and Write.
 
-5. Add the PAT as a second secret in your GitHub repository, with the name
+5. Add the PAT as a **Repository secret** in your GitHub repository, with the name
    `DOCKERHUB_TOKEN`.
 
 6. In your local repository on your machine, run the following command to change
@@ -87,7 +87,7 @@ to Docker Hub.
            name: Login to Docker Hub
            uses: docker/login-action@v3
            with:
-             username: ${{ secrets.DOCKER_USERNAME }}
+             username: ${{ vars.DOCKER_USERNAME }}
              password: ${{ secrets.DOCKERHUB_TOKEN }}
          -
            name: Set up Docker Buildx
@@ -105,7 +105,7 @@ to Docker Hub.
              platforms: linux/amd64,linux/arm64
              push: true
              target: final
-             tags: ${{ secrets.DOCKER_USERNAME }}/${{ github.event.repository.name }}:latest
+             tags: ${{ vars.DOCKER_USERNAME }}/${{ github.event.repository.name }}:latest
    ```
 
    For more information about the YAML syntax for `docker/build-push-action`,

--- a/content/language/dotnet/configure-ci-cd.md
+++ b/content/language/dotnet/configure-ci-cd.md
@@ -84,9 +84,6 @@ to Docker Hub.
        runs-on: ubuntu-latest
        steps:
          -
-           name: Checkout
-           uses: actions/checkout@v4
-         -
            name: Login to Docker Hub
            uses: docker/login-action@v3
            with:
@@ -99,23 +96,20 @@ to Docker Hub.
            name: Build and test
            uses: docker/build-push-action@v6
            with:
-             context: .
              target: build
              load: true
          -
            name: Build and push
            uses: docker/build-push-action@v6
            with:
-             context: .
              platforms: linux/amd64,linux/arm64
              push: true
              target: final
              tags: ${{ secrets.DOCKER_USERNAME }}/${{ github.event.repository.name }}:latest
    ```
 
-   If your Dockerfile is in a different directory, update the `context` with the path to the directory containing the Dockerfile.
-
-   For more information about the YAML syntax used here, see [Workflow syntax for GitHub Actions](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions).
+   For more information about the YAML syntax for `docker/build-push-action`,
+   refer to the [GitHub Action README](https://github.com/docker/build-push-action/blob/master/README.md).
 
 ## Step three: Run the workflow
 

--- a/content/language/golang/configure-ci-cd.md
+++ b/content/language/golang/configure-ci-cd.md
@@ -18,18 +18,18 @@ In this section, you'll learn how to set up and use GitHub Actions to build and 
 
 ## Step one: Create the repository
 
-Create a GitHub repository, configure the Docker Hub secrets, and push your source code.
+Create a GitHub repository, configure the Docker Hub credentials, and push your source code.
 
 1. [Create a new repository](https://github.com/new) on GitHub.
 
 2. Open the repository **Settings**, and go to **Secrets and variables** >
    **Actions**.
 
-3. Create a new **Repository secrets** named `DOCKER_USERNAME` and your Docker ID as value.
+3. Create a new **Repository variable** named `DOCKER_USERNAME` and your Docker ID as value.
 
 4. Create a new [Personal Access Token (PAT)](../../security/for-developers/access-tokens.md/#create-an-access-token) for Docker Hub. You can name this token `docker-tutorial`. Make sure access permissions include Read and Write.
 
-5. Add the PAT as a second **Repository secrets** in your GitHub repository, with the name
+5. Add the PAT as a **Repository secret** in your GitHub repository, with the name
    `DOCKERHUB_TOKEN`.
 
 6. In your local repository on your machine, run the following command to change
@@ -79,7 +79,7 @@ to Docker Hub.
            name: Login to Docker Hub
            uses: docker/login-action@v3
            with:
-             username: ${{ secrets.DOCKER_USERNAME }}
+             username: ${{ vars.DOCKER_USERNAME }}
              password: ${{ secrets.DOCKERHUB_TOKEN }}
          -
            name: Set up Docker Buildx
@@ -90,7 +90,7 @@ to Docker Hub.
            with:
              platforms: linux/amd64,linux/arm64
              push: true
-             tags: ${{ secrets.DOCKER_USERNAME }}/${{ github.event.repository.name }}:latest
+             tags: ${{ vars.DOCKER_USERNAME }}/${{ github.event.repository.name }}:latest
    ```
 
    For more information about the YAML syntax for `docker/build-push-action`,

--- a/content/language/golang/configure-ci-cd.md
+++ b/content/language/golang/configure-ci-cd.md
@@ -76,9 +76,6 @@ to Docker Hub.
        runs-on: ubuntu-latest
        steps:
          -
-           name: Checkout
-           uses: actions/checkout@v4
-         -
            name: Login to Docker Hub
            uses: docker/login-action@v3
            with:
@@ -91,15 +88,13 @@ to Docker Hub.
            name: Build and push
            uses: docker/build-push-action@v6
            with:
-             context: .
              platforms: linux/amd64,linux/arm64
              push: true
              tags: ${{ secrets.DOCKER_USERNAME }}/${{ github.event.repository.name }}:latest
    ```
 
-   If your Dockerfile is in a different directory, update the `context` with the path to the directory containing the Dockerfile. 
-
-   For more information about the YAML syntax used here, see [Workflow syntax for GitHub Actions](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions).
+   For more information about the YAML syntax for `docker/build-push-action`,
+   refer to the [GitHub Action README](https://github.com/docker/build-push-action/blob/master/README.md).
 
 ## Step three: Run the workflow
 

--- a/content/language/java/configure-ci-cd.md
+++ b/content/language/java/configure-ci-cd.md
@@ -79,9 +79,6 @@ to Docker Hub.
        runs-on: ubuntu-latest
        steps:
          -
-           name: Checkout
-           uses: actions/checkout@v4
-         -
            name: Login to Docker Hub
            uses: docker/login-action@v3
            with:
@@ -94,23 +91,20 @@ to Docker Hub.
            name: Build and test
            uses: docker/build-push-action@v6
            with:
-             context: .
              target: test
              load: true
          -
            name: Build and push
            uses: docker/build-push-action@v6
            with:
-             context: .
              platforms: linux/amd64,linux/arm64
              push: true
              target: final
              tags: ${{ secrets.DOCKER_USERNAME }}/${{ github.event.repository.name }}:latest
    ```
-   
-   If your Dockerfile is in a different directory, update the `context` with the path to the directory containing the Dockerfile.
 
-   For more information about the YAML syntax used here, see [Workflow syntax for GitHub Actions](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions).
+   For more information about the YAML syntax for `docker/build-push-action`,
+   refer to the [GitHub Action README](https://github.com/docker/build-push-action/blob/master/README.md).
 
 ## Step three: Run the workflow
 

--- a/content/language/java/configure-ci-cd.md
+++ b/content/language/java/configure-ci-cd.md
@@ -18,18 +18,18 @@ In this section, you'll learn how to set up and use GitHub Actions to build and 
 
 ## Step one: Create the repository
 
-Create a GitHub repository, configure the Docker Hub secrets, and push your source code.
+Create a GitHub repository, configure the Docker Hub credentials, and push your source code.
 
 1. [Create a new repository](https://github.com/new) on GitHub.
 
 2. Open the repository **Settings**, and go to **Secrets and variables** >
    **Actions**.
 
-3. Create a new secret named `DOCKER_USERNAME` and your Docker ID as value.
+3. Create a new **Repository variable** named `DOCKER_USERNAME` and your Docker ID as value.
 
 4. Create a new [Personal Access Token (PAT)](../../security/for-developers/access-tokens.md/#create-an-access-token) for Docker Hub. You can name this token `docker-tutorial`. Make sure access permissions include Read and Write.
 
-5. Add the PAT as a second secret in your GitHub repository, with the name
+5. Add the PAT as a **Repository secret** in your GitHub repository, with the name
    `DOCKERHUB_TOKEN`.
 
 6. In your local repository on your machine, run the following command to change
@@ -82,7 +82,7 @@ to Docker Hub.
            name: Login to Docker Hub
            uses: docker/login-action@v3
            with:
-             username: ${{ secrets.DOCKER_USERNAME }}
+             username: ${{ vars.DOCKER_USERNAME }}
              password: ${{ secrets.DOCKERHUB_TOKEN }}
          -
            name: Set up Docker Buildx
@@ -100,7 +100,7 @@ to Docker Hub.
              platforms: linux/amd64,linux/arm64
              push: true
              target: final
-             tags: ${{ secrets.DOCKER_USERNAME }}/${{ github.event.repository.name }}:latest
+             tags: ${{ vars.DOCKER_USERNAME }}/${{ github.event.repository.name }}:latest
    ```
 
    For more information about the YAML syntax for `docker/build-push-action`,

--- a/content/language/nodejs/configure-ci-cd.md
+++ b/content/language/nodejs/configure-ci-cd.md
@@ -18,20 +18,18 @@ In this section, you'll learn how to set up and use GitHub Actions to build and 
 
 ## Step one: Create the repository
 
-Create a GitHub repository, configure the Docker Hub secrets, and push your source code.
+Create a GitHub repository, configure the Docker Hub credentials, and push your source code.
 
 1. [Create a new repository](https://github.com/new) on GitHub.
 
 2. Open the repository **Settings**, and go to **Secrets and variables** >
    **Actions**.
 
-3. Create a new secret named `DOCKER_USERNAME` and your Docker ID as value.
+3. Create a new **Repository variable** named `DOCKER_USERNAME` and your Docker ID as value.
 
-4. Create a new [Personal Access Token
-   (PAT)](/security/for-developers/access-tokens/#create-an-access-token) for Docker Hub. You
-   can name this token `node-docker`. Make sure access permissions include Read and Write.
+4. Create a new [Personal Access Token (PAT)](../../security/for-developers/access-tokens.md/#create-an-access-token) for Docker Hub. You can name this token `docker-tutorial`. Make sure access permissions include Read and Write.
 
-5. Add the PAT as a second **Repository secrets** in your GitHub repository, with the name
+5. Add the PAT as a **Repository secret** in your GitHub repository, with the name
    `DOCKERHUB_TOKEN`.
 
 6. In your local repository on your machine, run the following command to change
@@ -81,7 +79,7 @@ to Docker Hub.
            name: Login to Docker Hub
            uses: docker/login-action@v3
            with:
-             username: ${{ secrets.DOCKER_USERNAME }}
+             username: ${{ vars.DOCKER_USERNAME }}
              password: ${{ secrets.DOCKERHUB_TOKEN }}
          -
            name: Set up Docker Buildx
@@ -99,7 +97,7 @@ to Docker Hub.
              platforms: linux/amd64,linux/arm64/v8
              push: true
              target: prod
-             tags: ${{ secrets.DOCKER_USERNAME }}/${{ github.event.repository.name }}:latest
+             tags: ${{ vars.DOCKER_USERNAME }}/${{ github.event.repository.name }}:latest
    ```
    
    For more information about the YAML syntax for `docker/build-push-action`,

--- a/content/language/nodejs/configure-ci-cd.md
+++ b/content/language/nodejs/configure-ci-cd.md
@@ -78,9 +78,6 @@ to Docker Hub.
        runs-on: ubuntu-latest
        steps:
          -
-           name: Checkout
-           uses: actions/checkout@v4
-         -
            name: Login to Docker Hub
            uses: docker/login-action@v3
            with:
@@ -93,23 +90,20 @@ to Docker Hub.
            name: Build and test
            uses: docker/build-push-action@v6
            with:
-             context: .
              target: test
              load: true
          -
            name: Build and push
            uses: docker/build-push-action@v6
            with:
-             context: .
              platforms: linux/amd64,linux/arm64/v8
              push: true
              target: prod
              tags: ${{ secrets.DOCKER_USERNAME }}/${{ github.event.repository.name }}:latest
    ```
-
-   If your Dockerfile is in a different directory, update the `context` with the path to the directory containing the Dockerfile.
-
-   For more information about the YAML syntax used here, see [Workflow syntax for GitHub Actions](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions).
+   
+   For more information about the YAML syntax for `docker/build-push-action`,
+   refer to the [GitHub Action README](https://github.com/docker/build-push-action/blob/master/README.md).
 
 ## Step three: Run the workflow
 

--- a/content/language/php/configure-ci-cd.md
+++ b/content/language/php/configure-ci-cd.md
@@ -18,18 +18,18 @@ In this section, you'll learn how to set up and use GitHub Actions to build and 
 
 ## Step one: Create the repository
 
-Create a GitHub repository, configure the Docker Hub secrets, and push your source code.
+Create a GitHub repository, configure the Docker Hub credentials, and push your source code.
 
 1. [Create a new repository](https://github.com/new) on GitHub.
 
 2. Open the repository **Settings**, and go to **Secrets and variables** >
    **Actions**.
 
-3. Create a new secret named `DOCKER_USERNAME` and your Docker ID as value.
+3. Create a new **Repository variable** named `DOCKER_USERNAME` and your Docker ID as value.
 
-4. Create a new [Personal Access Token (PAT)](../../security/for-developers/access-tokens.md/#create-an-access-token) for Docker Hub. You can name this token `tutorial-docker`. Make sure access permissions include Read and Write.
+4. Create a new [Personal Access Token (PAT)](../../security/for-developers/access-tokens.md/#create-an-access-token) for Docker Hub. You can name this token `docker-tutorial`. Make sure access permissions include Read and Write.
 
-5. Add the PAT as a second secret in your GitHub repository, with the name
+5. Add the PAT as a **Repository secret** in your GitHub repository, with the name
    `DOCKERHUB_TOKEN`.
 
 6. In your local repository on your machine, run the following command to change
@@ -87,7 +87,7 @@ to Docker Hub.
            name: Login to Docker Hub
            uses: docker/login-action@v3
            with:
-             username: ${{ secrets.DOCKER_USERNAME }}
+             username: ${{ vars.DOCKER_USERNAME }}
              password: ${{ secrets.DOCKERHUB_TOKEN }}
          -
            name: Set up Docker Buildx
@@ -105,7 +105,7 @@ to Docker Hub.
              platforms: linux/amd64,linux/arm64
              push: true
              target: final
-             tags: ${{ secrets.DOCKER_USERNAME }}/${{ github.event.repository.name }}:latest
+             tags: ${{ vars.DOCKER_USERNAME }}/${{ github.event.repository.name }}:latest
    ```
 
    For more information about the YAML syntax for `docker/build-push-action`,

--- a/content/language/php/configure-ci-cd.md
+++ b/content/language/php/configure-ci-cd.md
@@ -84,9 +84,6 @@ to Docker Hub.
        runs-on: ubuntu-latest
        steps:
          -
-           name: Checkout
-           uses: actions/checkout@v4
-         -
            name: Login to Docker Hub
            uses: docker/login-action@v3
            with:
@@ -99,23 +96,20 @@ to Docker Hub.
            name: Build and test
            uses: docker/build-push-action@v6
            with:
-             context: .
              target: test
              load: true
          -
            name: Build and push
            uses: docker/build-push-action@v6
            with:
-             context: .
              platforms: linux/amd64,linux/arm64
              push: true
              target: final
              tags: ${{ secrets.DOCKER_USERNAME }}/${{ github.event.repository.name }}:latest
    ```
-   
-   If your Dockerfile is in a different directory, update the `context` with the path to the directory containing the Dockerfile.
 
-   For more information about the YAML syntax used here, see [Workflow syntax for GitHub Actions](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions).
+   For more information about the YAML syntax for `docker/build-push-action`,
+   refer to the [GitHub Action README](https://github.com/docker/build-push-action/blob/master/README.md).
 
 ## Step three: Run the workflow
 

--- a/content/language/python/configure-ci-cd.md
+++ b/content/language/python/configure-ci-cd.md
@@ -18,18 +18,18 @@ In this section, you'll learn how to set up and use GitHub Actions to build and 
 
 ## Step one: Create the repository
 
-Create a GitHub repository, configure the Docker Hub secrets, and push your source code.
+Create a GitHub repository, configure the Docker Hub credentials, and push your source code.
 
 1. [Create a new repository](https://github.com/new) on GitHub.
 
 2. Open the repository **Settings**, and go to **Secrets and variables** >
    **Actions**.
 
-3. Create a new secret named `DOCKER_USERNAME` and your Docker ID as value.
+3. Create a new **Repository variable** named `DOCKER_USERNAME` and your Docker ID as value.
 
-4. Create a new [Personal Access Token (PAT)](../../security/for-developers/access-tokens.md/#create-an-access-token) for Docker Hub. You can name this token `python-docker`. Make sure access permissions include Read and Write.
+4. Create a new [Personal Access Token (PAT)](../../security/for-developers/access-tokens.md/#create-an-access-token) for Docker Hub. You can name this token `docker-tutorial`. Make sure access permissions include Read and Write.
 
-5. Add the PAT as a second secret in your GitHub repository, with the name
+5. Add the PAT as a **Repository secret** in your GitHub repository, with the name
    `DOCKERHUB_TOKEN`.
 
 6. In your local repository on your machine, run the following command to change
@@ -79,7 +79,7 @@ to Docker Hub.
            name: Login to Docker Hub
            uses: docker/login-action@v3
            with:
-             username: ${{ secrets.DOCKER_USERNAME }}
+             username: ${{ vars.DOCKER_USERNAME }}
              password: ${{ secrets.DOCKERHUB_TOKEN }}
          -
            name: Set up Docker Buildx
@@ -90,7 +90,7 @@ to Docker Hub.
            with:
              platforms: linux/amd64,linux/arm64
              push: true
-             tags: ${{ secrets.DOCKER_USERNAME }}/${{ github.event.repository.name }}:latest
+             tags: ${{ vars.DOCKER_USERNAME }}/${{ github.event.repository.name }}:latest
    ```
       
    For more information about the YAML syntax for `docker/build-push-action`,

--- a/content/language/python/configure-ci-cd.md
+++ b/content/language/python/configure-ci-cd.md
@@ -76,9 +76,6 @@ to Docker Hub.
        runs-on: ubuntu-latest
        steps:
          -
-           name: Checkout
-           uses: actions/checkout@v4
-         -
            name: Login to Docker Hub
            uses: docker/login-action@v3
            with:
@@ -91,15 +88,13 @@ to Docker Hub.
            name: Build and push
            uses: docker/build-push-action@v6
            with:
-             context: .
              platforms: linux/amd64,linux/arm64
              push: true
              tags: ${{ secrets.DOCKER_USERNAME }}/${{ github.event.repository.name }}:latest
    ```
-   
-   If your Dockerfile is in a different directory, update the `context` with the path to the directory containing the Dockerfile.
-
-   For more information about the YAML syntax used here, see [Workflow syntax for GitHub Actions](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions).
+      
+   For more information about the YAML syntax for `docker/build-push-action`,
+   refer to the [GitHub Action README](https://github.com/docker/build-push-action/blob/master/README.md).
 
 ## Step three: Run the workflow
 

--- a/content/language/r/configure-ci-cd.md
+++ b/content/language/r/configure-ci-cd.md
@@ -76,9 +76,6 @@ to Docker Hub.
        runs-on: ubuntu-latest
        steps:
          -
-           name: Checkout
-           uses: actions/checkout@v4
-         -
            name: Login to Docker Hub
            uses: docker/login-action@v3
            with:
@@ -91,13 +88,13 @@ to Docker Hub.
            name: Build and push
            uses: docker/build-push-action@v6
            with:
-             context: .
              platforms: linux/amd64,linux/arm64
              push: true
              tags: ${{ secrets.DOCKER_USERNAME }}/${{ github.event.repository.name }}:latest
    ```
 
-   For more information about the YAML syntax used here, see [Workflow syntax for GitHub Actions](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions).
+   For more information about the YAML syntax for `docker/build-push-action`,
+   refer to the [GitHub Action README](https://github.com/docker/build-push-action/blob/master/README.md).
 
 ## Step three: Run the workflow
 

--- a/content/language/r/configure-ci-cd.md
+++ b/content/language/r/configure-ci-cd.md
@@ -18,18 +18,18 @@ In this section, you'll learn how to set up and use GitHub Actions to build and 
 
 ## Step one: Create the repository
 
-Create a GitHub repository, configure the Docker Hub secrets, and push your source code.
+Create a GitHub repository, configure the Docker Hub credentials, and push your source code.
 
 1. [Create a new repository](https://github.com/new) on GitHub.
 
 2. Open the repository **Settings**, and go to **Secrets and variables** >
    **Actions**.
 
-3. Create a new secret named `DOCKER_USERNAME` and your Docker ID as value.
+3. Create a new **Repository variable** named `DOCKER_USERNAME` and your Docker ID as value.
 
-4. Create a new [Personal Access Token (PAT)](../../security/for-developers/access-tokens.md/#create-an-access-token) for Docker Hub. You can name this token `r-docker`.
+4. Create a new [Personal Access Token (PAT)](../../security/for-developers/access-tokens.md/#create-an-access-token) for Docker Hub. You can name this token `docker-tutorial`. Make sure access permissions include Read and Write.
 
-5. Add the PAT as a second secret in your GitHub repository, with the name
+5. Add the PAT as a **Repository secret** in your GitHub repository, with the name
    `DOCKERHUB_TOKEN`.
 
 6. In your local repository on your machine, run the following command to change
@@ -79,7 +79,7 @@ to Docker Hub.
            name: Login to Docker Hub
            uses: docker/login-action@v3
            with:
-             username: ${{ secrets.DOCKER_USERNAME }}
+             username: ${{ vars.DOCKER_USERNAME }}
              password: ${{ secrets.DOCKERHUB_TOKEN }}
          -
            name: Set up Docker Buildx
@@ -90,7 +90,7 @@ to Docker Hub.
            with:
              platforms: linux/amd64,linux/arm64
              push: true
-             tags: ${{ secrets.DOCKER_USERNAME }}/${{ github.event.repository.name }}:latest
+             tags: ${{ vars.DOCKER_USERNAME }}/${{ github.event.repository.name }}:latest
    ```
 
    For more information about the YAML syntax for `docker/build-push-action`,

--- a/content/language/rust/configure-ci-cd.md
+++ b/content/language/rust/configure-ci-cd.md
@@ -18,18 +18,18 @@ In this section, you'll learn how to set up and use GitHub Actions to build and 
 
 ## Step one: Create the repository
 
-Create a GitHub repository, configure the Docker Hub secrets, and push your source code.
+Create a GitHub repository, configure the Docker Hub credentials, and push your source code.
 
 1. [Create a new repository](https://github.com/new) on GitHub.
 
 2. Open the repository **Settings**, and go to **Secrets and variables** >
    **Actions**.
 
-3. Create a new secret named `DOCKER_USERNAME` and your Docker ID as value.
+3. Create a new **Repository variable** named `DOCKER_USERNAME` and your Docker ID as value.
 
-4. Create a new [Personal Access Token (PAT)](../../security/for-developers/access-tokens.md/#create-an-access-token) for Docker Hub. You can name this token `rust-docker`. Make sure access permissions include Read and Write.
+4. Create a new [Personal Access Token (PAT)](../../security/for-developers/access-tokens.md/#create-an-access-token) for Docker Hub. You can name this token `docker-tutorial`. Make sure access permissions include Read and Write.
 
-5. Add the PAT as a second secret in your GitHub repository, with the name
+5. Add the PAT as a **Repository secret** in your GitHub repository, with the name
    `DOCKERHUB_TOKEN`.
 
 6. In your local repository on your machine, run the following command to change
@@ -79,7 +79,7 @@ to Docker Hub.
            name: Login to Docker Hub
            uses: docker/login-action@v3
            with:
-             username: ${{ secrets.DOCKER_USERNAME }}
+             username: ${{ vars.DOCKER_USERNAME }}
              password: ${{ secrets.DOCKERHUB_TOKEN }}
          -
            name: Set up Docker Buildx
@@ -89,7 +89,7 @@ to Docker Hub.
            uses: docker/build-push-action@v6
            with:
              push: true
-             tags: ${{ secrets.DOCKER_USERNAME }}/${{ github.event.repository.name }}:latest
+             tags: ${{ vars.DOCKER_USERNAME }}/${{ github.event.repository.name }}:latest
    ```
    
    For more information about the YAML syntax for `docker/build-push-action`,

--- a/content/language/rust/configure-ci-cd.md
+++ b/content/language/rust/configure-ci-cd.md
@@ -76,9 +76,6 @@ to Docker Hub.
        runs-on: ubuntu-latest
        steps:
          -
-           name: Checkout
-           uses: actions/checkout@v4
-         -
            name: Login to Docker Hub
            uses: docker/login-action@v3
            with:
@@ -91,14 +88,12 @@ to Docker Hub.
            name: Build and push
            uses: docker/build-push-action@v6
            with:
-             context: .
              push: true
              tags: ${{ secrets.DOCKER_USERNAME }}/${{ github.event.repository.name }}:latest
    ```
    
-   If your Dockerfile is in a different directory, update the `context` with the path to the directory containing the Dockerfile.
-
-   For more information about the YAML syntax used here, see [Workflow syntax for GitHub Actions](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions).
+   For more information about the YAML syntax for `docker/build-push-action`,
+   refer to the [GitHub Action README](https://github.com/docker/build-push-action/blob/master/README.md).
 
 ## Step three: Run the workflow
 

--- a/content/scout/integrations/ci/gha.md
+++ b/content/scout/integrations/ci/gha.md
@@ -55,11 +55,6 @@ jobs:
       pull-requests: write
 
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ env.SHA }}
-
       - name: Setup Docker buildx
         uses: docker/setup-buildx-action@v3
 
@@ -90,7 +85,6 @@ jobs:
         id: build-and-push
         uses: docker/build-push-action@v6
         with:
-          context: .
           sbom: ${{ github.event_name != 'pull_request' }}
           provenance: ${{ github.event_name != 'pull_request' }}
           push: ${{ github.event_name != 'pull_request' }}
@@ -103,11 +97,10 @@ jobs:
 
 This creates workflow steps to:
 
-1. Check out the repository.
-2. Set up Docker buildx.
-3. Authenticate to the registry.
-4. Extract metadata from Git reference and GitHub events.
-5. Build and push the Docker image to the registry.
+1. Set up Docker buildx.
+2. Authenticate to the registry.
+3. Extract metadata from Git reference and GitHub events.
+4. Build and push the Docker image to the registry.
 
 > **Note**
 >

--- a/content/scout/policy/ci.md
+++ b/content/scout/policy/ci.md
@@ -94,9 +94,6 @@ jobs:
 
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
       - name: Setup Docker buildx
         uses: docker/setup-buildx-action@v3
 
@@ -117,7 +114,6 @@ jobs:
         id: build-and-push
         uses: docker/build-push-action@v4
         with:
-          context: .
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           sbom: ${{ github.event_name != 'pull_request' }}


### PR DESCRIPTION
## Description

- Removes the checkout action for build-push-action and instead uses the default Git context
- Updates CI examples to use `vars` for Docker username as opposed to `secrets`

The use of `vars` prevents username from being redacted in build summaries, in situations where the image reference contains the username.
