### PR TITLE
Correct docker compose command for getting started guide

### DIFF
--- a/content/guides/getting-started/develop-with-containers.md
+++ b/content/guides/getting-started/develop-with-containers.md
@@ -39,7 +39,7 @@ In this hands-on guide, you'll learn how to develop with containers.
     To start the project using the CLI, run the following command:
 
    ```console
-   $ docker compose watch
+   $ docker compose up -d
    ```
 
    You will see an output that shows container images being pulled down, containers starting, and more. Don't worry if you don't understand it all at this point. But, within a moment or two, things should stabilize and finish.


### PR DESCRIPTION
## Description

The documented docker compose command `docker compose watch` wasn't working as I was following along the getting started guide. So, I found that the command in todo-app's GitHub repository is a little bit different: `docker compose up -d`, and worked as expected.