### PR TITLE
Do not use for loops for package removal on debian-based systems

### DIFF
--- a/content/engine/install/debian.md
+++ b/content/engine/install/debian.md
@@ -59,7 +59,7 @@ conflicts with the versions bundled with Docker Engine.
 Run the following command to uninstall all conflicting packages:
 
 ```console
-$ for pkg in docker.io docker-doc docker-compose podman-docker containerd runc; do sudo apt-get remove $pkg; done
+$ sudo apt-get remove docker.io docker-doc docker-compose podman-docker containerd runc
 ```
 
 `apt-get` might report that you have none of these packages installed.

--- a/content/engine/install/raspberry-pi-os.md
+++ b/content/engine/install/raspberry-pi-os.md
@@ -61,7 +61,7 @@ conflicts with the versions bundled with Docker Engine.
 Run the following command to uninstall all conflicting packages:
 
 ```console
-$ for pkg in docker.io docker-doc docker-compose podman-docker containerd runc; do sudo apt-get remove $pkg; done
+$ sudo apt-get remove docker.io docker-doc docker-compose podman-docker containerd runc
 ```
 
 `apt-get` might report that you have none of these packages installed.

--- a/content/engine/install/ubuntu.md
+++ b/content/engine/install/ubuntu.md
@@ -70,7 +70,7 @@ conflicts with the versions bundled with Docker Engine.
 Run the following command to uninstall all conflicting packages:
 
 ```console
-$ for pkg in docker.io docker-doc docker-compose docker-compose-v2 podman-docker containerd runc; do sudo apt-get remove $pkg; done
+$ sudo apt-get remove docker.io docker-doc docker-compose docker-compose-v2 podman-docker containerd runc
 ```
 
 `apt-get` might report that you have none of these packages installed.


### PR DESCRIPTION
<!--Delete sections as needed -->

## Description

<!-- Tell us what you did and why -->
In the docker engine installation instructions, it is advised to remove unofficial packages in the following way:

```shell
for pkg in <packages>; do sudo apt-get remove $pkg; done
``` 

This invokes apt-get many times, resulting in having to confirm every uninstallation.

This PR changes such instructions to the following, easier-to-read and easier-to-execute format:

```shell
sudo apt-get remove <packages>
``` 

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Technical review
- [ ] Editorial review
- [ ] Product review