### PR TITLE
redirects: add alias for old ecs integration page

### DIFF
--- a/content/cloud/_index.md
+++ b/content/cloud/_index.md
@@ -11,6 +11,7 @@ aliases:
 - /cloud/ecs-architecture/
 - /cloud/aci-compose-features/
 - /cloud/aci-container-features/
+- /engine/context/ecs-integration/
 ---
 
 Docker Compose's integration for Amazon's Elastic Container Service and Azure Container Instances has retired. The integration documentation is no longer available through the Docker Docs site. 


### PR DESCRIPTION
This page was linked to from https://github.com/docker-archive/compose-cli/blob/c156ce6da4c2b317174d42daf1b019efa87e9f92/docs/README.md

Signed-off-by: David Karlsson <35727626+dvdksn@users.noreply.github.com>
