### PR TITLE
Update advisory-db-sources.md

### DIFF
--- a/content/scout/deep-dive/advisory-db-sources.md
+++ b/content/scout/deep-dive/advisory-db-sources.md
@@ -47,7 +47,7 @@ Docker Scout uses the following package repositories and security trackers:
 - [SUSE Security CVRF](http://ftp.suse.com/pub/projects/security/cvrf/)
 - [Ubuntu CVE Tracker](https://people.canonical.com/~ubuntu-security/cve/)
 - [Wolfi Security Feed](https://packages.wolfi.dev/os/security.json)
-- [Chainguard Security Feed](https://packages.cgr.dev/chainguard/security.json)
+- [Chainguard Security Feed](https://packages.cgr.dev/chainguard/osv/all.json)
 
 When you enable Docker Scout for your Docker organization,
 a new database instance is provisioned on the Docker Scout platform.


### PR DESCRIPTION
I have replaced the secdb advisory feed link  with the new OSV feed.

<!--Delete sections as needed -->

The current link to Chainguard's advisory feed still pointed to the old secdb feed which Scout doesn't use anymore. In this PR i propose updating the link to point to the new OSV feed.

<!-- Tell us what you did and why -->

## Related issues or tickets

<!-- Related issues, pull requests, or Jira tickets -->

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Technical review
- [ ] Editorial review
- [ ] Product review