### PR TITLE
Fix deprecated types.ImagePullOptions usage and replace with image.PullOptions

### DIFF
--- a/content/engine/api/sdk/_index.md
+++ b/content/engine/api/sdk/_index.md
@@ -82,6 +82,7 @@ import (
 	"os"
 
 	"github.com/docker/docker/api/types"
+        "github.com/docker/docker/api/types/image"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/client"
 	"github.com/docker/docker/pkg/stdcopy"
@@ -95,7 +96,7 @@ func main() {
     }
     defer cli.Close()
 
-    reader, err := cli.ImagePull(ctx, "docker.io/library/alpine", types.ImagePullOptions{})
+    reader, err := cli.ImagePull(ctx, "docker.io/library/alpine", image.PullOptions{})
     if err != nil {
         panic(err)
     }

--- a/content/engine/api/sdk/_index.md
+++ b/content/engine/api/sdk/_index.md
@@ -82,8 +82,8 @@ import (
 	"os"
 
 	"github.com/docker/docker/api/types"
-        "github.com/docker/docker/api/types/image"
 	"github.com/docker/docker/api/types/container"
+        "github.com/docker/docker/api/types/image"
 	"github.com/docker/docker/client"
 	"github.com/docker/docker/pkg/stdcopy"
 )


### PR DESCRIPTION
<!--Delete sections as needed -->

## Description

While going through golang docker sdk docs, I found that as per https://github.com/moby/moby/blob/v26.0.0/api/types/types_deprecated.go#L7-L35 , the types.ImagePullOptions has been deprecated and on usage throws `undefined: types.ImagePullOptions` error as below:

<img width="1120" alt="Screenshot 2024-06-28 at 12 34 29 AM" src="https://github.com/docker/docs/assets/29746985/845a18f9-1862-4715-99ad-2bc622b8d420">

Fixed the issue by using images.PullOptions which is the correct replacement as mentioned by the same docs above.



## Related issues or tickets

<!-- Related issues, pull requests, or Jira tickets -->

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Technical review
- [ ] Editorial review
- [ ] Product review