### PR TITLE
build(fix): cache backends require containerd with docker worker

### DIFF
--- a/content/build/cache/backends/_index.md
+++ b/content/build/cache/backends/_index.md
@@ -17,9 +17,9 @@ An external cache becomes almost essential in CI/CD build environments. Such
 environments usually have little-to-no persistence between runs, but it's still
 important to keep the runtime of image builds as low as possible.
 
-The default `docker` driver supports the `inline` and `local` cache backends.
-Other cache backends require you to select a different
-[driver](../../drivers/index.md).
+The default `docker` driver supports the `inline`, `local`, `registry`, and
+`gha` cache backends, but only if you have enabled the [containerd image store](/desktop/containerd.md).
+Other cache backends require you to select a different [driver](../../drivers/_index.md).
 
 > **Warning**
 >

--- a/content/build/cache/backends/registry.md
+++ b/content/build/cache/backends/registry.md
@@ -39,7 +39,6 @@ The following table describes the available CSV parameters that you can pass to
 | Name                | Option                  | Type                    | Default | Description                                                          |
 | ------------------- | ----------------------- | ----------------------- | ------- | -------------------------------------------------------------------- |
 | `ref`               | `cache-to`,`cache-from` | String                  |         | Full name of the cache image to import.                              |
-| `dest`              | `cache-to`              | String                  |         | Path of the local directory where cache gets exported to.            |
 | `mode`              | `cache-to`              | `min`,`max`             | `min`   | Cache layers to export, see [cache mode][1].                         |
 | `oci-mediatypes`    | `cache-to`              | `true`,`false`          | `true`  | Use OCI media types in exported manifests, see [OCI media types][2]. |
 | `compression`       | `cache-to`              | `gzip`,`estargz`,`zstd` | `gzip`  | Compression type, see [cache compression][3].                        |

--- a/content/build/drivers/_index.md
+++ b/content/build/drivers/_index.md
@@ -27,10 +27,13 @@ The following table outlines some differences between drivers.
 | Feature                      |  `docker`   | `docker-container` | `kubernetes` |      `remote`      |
 | :--------------------------- | :---------: | :----------------: | :----------: | :----------------: |
 | **Automatically load image** |     ✅      |                    |              |                    |
-| **Cache export**             | Inline only |         ✅         |      ✅      |         ✅         |
+| **Cache export**             |     ✓\*     |         ✅         |      ✅      |         ✅         |
 | **Tarball output**           |             |         ✅         |      ✅      |         ✅         |
 | **Multi-arch images**        |             |         ✅         |      ✅      |         ✅         |
 | **BuildKit configuration**   |             |         ✅         |      ✅      | Managed externally |
+
+\* _The `docker` driver doesn't support all cache export options.
+See [Cache storage backends](../cache/backends/_index.md) for more information._
 
 ## Loading to local image store
 


### PR DESCRIPTION

## Description

- **build(cache): containerd required for cache backends with docker worker**
- **build(cache): removed dest parameter for registry backend**

## Related issues or tickets

https://dockercommunity.slack.com/archives/C7S7A40MP/p1719577061277029
