### PR TITLE
Update note on Windows Arm installer for Docker Desktop 4.32

### DIFF
--- a/content/desktop/install/windows-install.md
+++ b/content/desktop/install/windows-install.md
@@ -109,9 +109,7 @@ For more information on setting up WSL 2 with Docker Desktop, see [WSL](../wsl/_
 
 > **Important**
 >
-> The installer and the [privileged service](../windows/permission-requirements.md#privileged-helper) are still built for `x86_64`. These are not performance critical components and currently run with [`x86` emulation](https://learn.microsoft.com/en-us/windows/arm/apps-on-arm-x86-emulation#wow64-apis).
-> 
-> Also, the following features are not supported:
+> The following features are not supported:
 > - Hyper-V backend
 > - Windows containers
 { .important }


### PR DESCRIPTION
<!--Delete sections as needed -->

## Description

Removes the note regarding the installer and privileged service on Arm, since it is not applicabel starting with Docker Desktop 4.32

## Related issues or tickets

<!-- Related issues, pull requests, or Jira tickets -->

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Technical review
- [ ] Editorial review
- [ ] Product review