### PR TITLE
scout: high-profile vulns cisa kev

### DIFF
--- a/content/scout/policy/_index.md
+++ b/content/scout/policy/_index.md
@@ -139,7 +139,21 @@ The list includes the following vulnerabilities:
 - [CVE-2024-3094 (XZ backdoor)](https://scout.docker.com/v/CVE-2024-3094)
 
 You can configure the CVEs included in this list by creating a custom policy.
-For more information, see [Configure policies](./configure.md).
+Custom configuration options include:
+
+- Remove CVEs from the list
+
+  If you don't want to track a specific CVE that's
+  included in the default list, you can remove it from the custom policy.
+
+- Enable tracking of vulnerabilities from CISA's Known Exploited Vulnerabilities (KEV) catalog
+
+  If you want this policy to track all vulnerabilities from
+  [CISA's KEV catalog](https://www.cisa.gov/known-exploited-vulnerabilities-catalog),
+  in addition to Docker's curated list of high-profile vulnerabilities,
+  you can enable this option in the custom policy.
+
+For more information about how to configure policies, see [Configure policies](./configure.md).
 
 ### Supply chain attestations
 

--- a/content/scout/policy/scores.md
+++ b/content/scout/policy/scores.md
@@ -106,14 +106,18 @@ The policies that influence the score, and their respective weights, are as foll
 | Policy                                                                                                    | Points |
 | --------------------------------------------------------------------------------------------------------- | ------ |
 | [Fixable critical and high vulnerabilities](./_index.md#fixable-critical-and-high-vulnerabilities)        | 20     |
-| [High-profile vulnerabilities](./_index.md#high-profile-vulnerabilities)                                  | 20     |
+| [High-profile vulnerabilities](./_index.md#high-profile-vulnerabilities) \*                               | 20     |
 | [Supply chain attestations](./_index.md#supply-chain-attestations)                                        | 15     |
 | [Unapproved base images](./_index.md#unapproved-base-images)                                              | 15     |
 | [Outdated base images](./_index.md#outdated-base-images)                                                  | 10     |
 | [Default non-root user](./_index.md#default-non-root-user)                                                | 5      |
-| AGPL v3-licensed software \*                                                                              | 5      |
+| AGPL v3-licensed software \*\*                                                                            | 5      |
 
-\* _The **AGPL v3-licensed software** policy is a subset of the
+\* _The **High-profile vulnerabilities policy** also considers vulnerabilities from the
+[CISA Known Exploited Vulnerabilities catalog](https://www.cisa.gov/known-exploited-vulnerabilities-catalog).
+This is a configuration option for this policy, and for health score calculation, it is enabled by default._
+
+\*\* _The **AGPL v3-licensed software** policy is a subset of the
 [Copyleft licenses](./_index.md#copyleft-licenses) policy._
 
 ### Evaluation


### PR DESCRIPTION
## Description

Adds an option to configurate the High-profile vulns policy to track items from the CISA KEV catalog.

This option is enabled by default for health scores.
