### PR TITLE
Move Docker Build Cloud to its own top-level section

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,6 +5,8 @@
 
 /content/build/ @crazy-max @dvdksn
 
+/content/build-cloud/ @dvdksn
+
 /content/compose/ @aevesdocker
 
 /content/desktop/ @aevesdocker

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -13,6 +13,11 @@ area/build:
           - _vendor/github.com/docker/buildx/**
           - content/engine/commandline/build*
 
+area/build-cloud:
+  - changed-files:
+      - any-glob-to-any-file:
+          - content/build-cloud/**
+
 area/compose:
   - changed-files:
       - any-glob-to-any-file:

--- a/content/_index.md
+++ b/content/_index.md
@@ -36,6 +36,17 @@ grid:
         url: "/build/building/packaging/"
       - text: "Release notes"
         url: "/build/release-notes/"
+  - title: Docker Build Cloud
+    icon: cloud
+    description: |
+      Run your builds in the cloud.
+    links:
+      - text: "Overview"
+        url: "/build-cloud/"
+      - text: "Setup"
+        url: "/build-cloud/setup/"
+      - text: "Optimization"
+        url: "/build-cloud/optimization/"
   - title: Docker Compose
     icon: polyline
     description: |

--- a/content/build-cloud/_index.md
+++ b/content/build-cloud/_index.md
@@ -5,6 +5,7 @@ keywords: build, cloud, cloud build, remote builder
 aliases:
   - /build/hydrobuild/
   - /build/cloud/faq/
+  - /build/cloud/
 ---
 
 Docker Build Cloud is a service that lets you build your container images
@@ -51,7 +52,7 @@ data between cloud builders.
 ## Get Docker Build Cloud
 
 To get started with Docker Build Cloud,
-[create a Docker account](../../docker-id/_index.md)
+[create a Docker account](/docker-id/_index.md)
 and sign up for the starter plan on the
 [Docker Build Cloud Dashboard](https://build.docker.com/).
 
@@ -64,6 +65,6 @@ Once you've signed up and created a builder, continue by
 [setting up the builder in your local environment](./setup.md).
 
 For more information about the available subscription plans, see
-[Docker Build Cloud subscriptions and features](../../subscription/build-cloud/build-details.md).
+[Docker Build Cloud subscriptions and features](/subscription/build-cloud/build-details.md).
 For information about roles and permissions related to Docker Build Cloud, see
-[Roles and Permissions](../../security/for-admins/roles-and-permissions.md#docker-build-cloud).
+[Roles and Permissions](/security/for-admins/roles-and-permissions.md#docker-build-cloud).

--- a/content/build-cloud/ci.md
+++ b/content/build-cloud/ci.md
@@ -4,6 +4,7 @@ description: Speed up your continuous integration pipelines with Docker Build Cl
 keywords: build, cloud build, ci, gha, gitlab, buildkite, jenkins, circle ci
 aliases:
   - /hydrobuild/ci/
+  - /build/cloud/ci/
 ---
 
 Using Docker Build Cloud in CI can speed up your build pipelines, which means less time
@@ -37,7 +38,7 @@ See [Loading build results](./usage/#loading-build-results) for details.
 >
 > Version 4.0.0 and later of `docker/build-push-action` and
 > `docker/bake-action` builds images with [provenance attestations by
-> default](../ci/github-actions/attestations.md#default-provenance). Docker
+> default](/build/ci/github-actions/attestations.md#default-provenance). Docker
 > Build Cloud automatically attempts to load images to the local image store if
 > you don't explicitly push them to a registry.
 >

--- a/content/build-cloud/optimization.md
+++ b/content/build-cloud/optimization.md
@@ -4,6 +4,7 @@ description: Building remotely is different from building locally. Here's how to
 keywords: build, cloud build, optimize, remote, local, cloud
 aliases:
   - /hydrobuild/optimization/
+  - /build/cloud/optimization/
 ---
 
 Docker Build Cloud runs your builds remotely, and not on the machine where you

--- a/content/build-cloud/setup.md
+++ b/content/build-cloud/setup.md
@@ -4,6 +4,7 @@ description: How to get started with Docker Build Cloud
 keywords: build, cloud build
 aliases:
   - /hydrobuild/setup/
+  - /build/cloud/setup/
 ---
 
 Before you can start using Docker Build Cloud, you must add the builder to your local

--- a/content/build-cloud/usage.md
+++ b/content/build-cloud/usage.md
@@ -4,6 +4,7 @@ description: Invoke your cloud builds with the Buildx CLI client
 keywords: build, cloud build, usage, cli, buildx, client
 aliases:
   - /hydrobuild/usage/
+  - /build/cloud/usage/
 ---
 
 To build using Docker Build Cloud, invoke a build command and specify the name of the
@@ -66,7 +67,7 @@ $ docker compose build
 
 In addition to `docker buildx use`, you can also use the `docker compose build
 --builder` flag or the [`BUILDX_BUILDER` environment
-variable](../building/variables.md#buildx_builder) to select the cloud builder.
+variable](/build/building/variables.md#buildx_builder) to select the cloud builder.
 
 ## Loading build results
 
@@ -142,7 +143,7 @@ The traffic is encrypted and secrets are never stored in the build cache.
 >
 > If you're misusing build arguments to pass credentials, authentication
 > tokens, or other secrets, you should refactor your build to pass the secrets using
-> [secret mounts](../../reference/cli/docker/buildx/build.md#secret) instead.
+> [secret mounts](/reference/cli/docker/buildx/build.md#secret) instead.
 > Build arguments are stored in the cache and their values are exposed through attestations.
 > Secret mounts don't leak outside of the build and are never included in attestations.
 {.warning}

--- a/content/build/_index.md
+++ b/content/build/_index.md
@@ -17,10 +17,6 @@ grid:
     architectures.
   icon: content_copy
   link: /build/building/multi-platform/
-- title: Build Cloud
-  description: Build your images faster in the cloud.
-  icon: /assets/images/logo-build-cloud.svg
-  link: /build/cloud/
 - title: Architecture
   description: Explore BuildKit, the open source build engine.
   icon: construction

--- a/content/build/building/multi-platform.md
+++ b/content/build/building/multi-platform.md
@@ -151,7 +151,7 @@ $ docker build \
   --push .
 ```
 
-For more information, see [Docker Build Cloud](../cloud/_index.md).
+For more information, see [Docker Build Cloud](/build-cloud/_index.md).
 
 ### Cross-compilation
 

--- a/content/build/ci/github-actions/build-summary.md
+++ b/content/build/ci/github-actions/build-summary.md
@@ -104,7 +104,7 @@ contain a link to download the build record archive.
 
 Build summaries are currently not supported for:
 
-- Builds using [Docker Build Cloud](/build/cloud/_index.md). Support for Docker
+- Builds using [Docker Build Cloud](/build-cloud/_index.md). Support for Docker
   Build Cloud is planned for a future release.
 - Repositories hosted on GitHub Enterprise Servers. Summaries can only be
   viewed for repositories hosted on GitHub.com.

--- a/content/desktop/use-desktop/builds.md
+++ b/content/desktop/use-desktop/builds.md
@@ -15,7 +15,7 @@ You can switch to **Active builds** to view any ongoing builds.
 
 ![Build UI screenshot active builds](../images/build-ui-active-builds.webp)
 
-If you're connected to a cloud builder through [Docker Build Cloud](../../build/cloud/_index.md),
+If you're connected to a cloud builder through [Docker Build Cloud](../../build-cloud/_index.md),
 the Builds view also lists any active or completed cloud builds by other team members
 connected to the same cloud builder.
 

--- a/content/manuals.md
+++ b/content/manuals.md
@@ -41,7 +41,7 @@ services:
 - title: Build Cloud
   description: Build your images faster in the cloud.
   icon: /assets/images/logo-build-cloud.svg
-  link: /build/cloud/
+  link: /build-cloud/
 admin:
 - title: Administration
   description: Centralized observability for companies and organizations.

--- a/data/toc.yaml
+++ b/data/toc.yaml
@@ -1913,18 +1913,6 @@ Manuals:
           title: Kubernetes driver
         - path: /build/drivers/remote/
           title: Remote driver
-    - sectiontitle: Build Cloud {{< badge color=violet text=New >}}
-      section:
-        - path: /build/cloud/
-          title: Overview
-        - path: /build/cloud/setup/
-          title: Setup
-        - path: /build/cloud/usage/
-          title: Usage
-        - path: /build/cloud/ci/
-          title: Build Cloud in CI
-        - path: /build/cloud/optimization/
-          title: Optimize for cloud builds
     - sectiontitle: Exporters
       section:
         - path: /build/exporters/
@@ -2057,6 +2045,18 @@ Manuals:
             title: Reproducible builds
     - path: /build/release-notes/
       title: Release notes
+- sectiontitle: Docker Build Cloud
+  section:
+    - path: /build-cloud/
+      title: Overview
+    - path: /build-cloud/setup/
+      title: Setup
+    - path: /build-cloud/usage/
+      title: Usage
+    - path: /build-cloud/ci/
+      title: Continuous integration
+    - path: /build-cloud/optimization/
+      title: Optimization
 - sectiontitle: Docker Compose
   section:
   - path: /compose/


### PR DESCRIPTION

## Description

Moves dbc from a subsection of build to its own section, and adds a tile on the landing page.
