### PR TITLE
fix(typo): AS instead of as

### DIFF
--- a/content/build/building/multi-stage.md
+++ b/content/build/building/multi-stage.md
@@ -69,7 +69,7 @@ Dockerfile are re-ordered later, the `COPY` doesn't break.
 
 ```dockerfile
 # syntax=docker/dockerfile:1
-FROM golang:{{% param "example_go_version" %}} as build
+FROM golang:{{% param "example_go_version" %}} AS build
 WORKDIR /src
 COPY <<EOF /src/main.go
 package main


### PR DESCRIPTION
<!--Delete sections as needed -->

## Description
Use `AS` instead of `as` in the dockerfile for the `Name your build stages` that cause a warning when building: 
```
WARN: FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 1)
```

## Related issues or tickets

<!-- Related issues, pull requests, or Jira tickets -->

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Technical review
- [ ] Editorial review
- [ ] Product review