### PR TITLE
fix typo in example startup-order.md

### DIFF
--- a/content/compose/startup-order.md
+++ b/content/compose/startup-order.md
@@ -39,7 +39,7 @@ services:
   db:
     image: postgres
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER} -d ${POSTGRES_DB}'"]
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER} -d ${POSTGRES_DB}"]
       interval: 10s
       retries: 5
       start_period: 30s


### PR DESCRIPTION
## Description 
There was an additional ' character that was appended to the database name in this example when copy-pasted

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Technical review
- [ ] Editorial review
- [ ] Product review