### PR TITLE
docs: Fix typo in extends.md

### DIFF
--- a/content/compose/multiple-compose-files/extends.md
+++ b/content/compose/multiple-compose-files/extends.md
@@ -57,7 +57,7 @@ services:
       - "/data"
 ```
 You get exactly the same result as if you wrote
-`docker-compose.yml` with the same `build`, `ports` and `volumes` configuration
+`docker-compose.yml` with the same `build`, `ports`, and `volumes` configuration
 values defined directly under `web`.
 
 To include the service `webapp` in the final project when extending services from another file, you need to explicitly include both services in your current Compose file. For example (note this is a non-normative example):
@@ -165,7 +165,7 @@ clearly visible when reading the current file. Defining these locally also
 ensures that changes to the referenced file don't break anything.
 
 `extends` is useful if you only need a single service to be shared and you are
-familiar with the file you're extending to, so you can to tweak the
+familiar with the file you're extending to, so you can tweak the
 configuration. But this isn’t an acceptable solution when you want to re-use
 someone else's unfamiliar configurations and you don’t know about its own
 dependencies.


### PR DESCRIPTION
## Description
> Add a minor patch to correct a typographical error in the compose [`extend`](https://docs.docker.com/compose/multiple-compose-files/extends/) docs.

<!-- Tell us what you did and why -->
The following patches were made to the `extends.md` file to fix a minor typographical error:
- The word "to" is incorrectly placed in the phrase "so you can to tweak the configuration."
   Remove `to` from the phrase `so you can to tweak the configuration`.
- Absence of comma between the word "ports" and the conjunction "and".
   Add a comma after "ports" to separate "ports" and "volumes" as distinct items in the list, making the sentence easier to read and understand.

### Additional
> Other related concerns or recommendations for reviewers/maintainers.

The terms `compose.yaml` and `docker-compose.yaml` are used interchangeably in reference to the base/local compose file for the project examples. It would be nice if only one (preferably `compose.yaml`) is used throughout the entire file for improved readability through consistency. 

## Related issues or tickets

<!-- Related issues, pull requests, or Jira tickets -->
After an extensive search: `N/A`.

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Technical review
- [ ] Editorial review
- [ ] Product review