### PR TITLE
Fix typo "Container" => "Containers"

### DIFF
--- a/content/guides/getting-started/get-docker-desktop.md
+++ b/content/guides/getting-started/get-docker-desktop.md
@@ -75,7 +75,7 @@ For this container, the frontend is accessible on port `8080`. To open the websi
 ## Manage containers using Docker Desktop
 
 
-1. Open Docker Desktop and select the **Container** field on the left sidebar.
+1. Open Docker Desktop and select the **Containers** field on the left sidebar.
 2. You can view information about your container including logs, and files, and even access the shell by selecting the **Exec** tab.
 
    ![Screenshot of exec into the running container in Docker Desktop](images/exec-into-docker-container.webp?border=true)


### PR DESCRIPTION


<!--Delete sections as needed -->

## Description

Fix typo on https://docs.docker.com/guides/getting-started/get-docker-desktop/. On Docker Desktop 4.31.1, the option appears as "Containers":

![Screenshot 2024-07-07 100706](https://github.com/docker/docs/assets/992997/60d2ea61-b589-41c2-81f6-d37ad83a7340)

<!-- Tell us what you did and why -->

## Related issues or tickets

None?

<!-- Related issues, pull requests, or Jira tickets -->

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Technical review
- [ ] Editorial review
- [ ] Product review