### PR TITLE
Fix FromAsCasing warning

### DIFF
--- a/content/language/python/containerize.md
+++ b/content/language/python/containerize.md
@@ -77,7 +77,7 @@ Create a file named `Dockerfile` with the following contents.
 # Want to help us make this template better? Share your feedback here: https://forms.gle/ybq9Krt8jtBL3iCk7
 
 ARG PYTHON_VERSION=3.11.4
-FROM python:${PYTHON_VERSION}-slim as base
+FROM python:${PYTHON_VERSION}-slim AS base
 
 # Prevents Python from writing pyc files.
 ENV PYTHONDONTWRITEBYTECODE=1


### PR DESCRIPTION
Hello! :) 
## Description

Change:

FROM python:${PYTHON_VERSION}-slim as base

To:

FROM python:${PYTHON_VERSION}-slim AS base

To get rid of warning which shows up on image build:

=> WARN: FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 3)
 1 warning found (use --debug to expand):
 - FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 3)

## Related issues or tickets

<!-- Related issues, pull requests, or Jira tickets -->

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Technical review
- [ ] Editorial review
- [ ] Product review