### PR TITLE
ci: use @reviewdog branch of vale-action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,7 +40,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
-      - uses: errata-ai/vale-action@38bf078c328061f59879b347ca344a718a736018
+      - uses: errata-ai/vale-action@reviewdog
         env:
           PIP_BREAK_SYSTEM_PACKAGES: 1
         with:


### PR DESCRIPTION
Using the reviewdog branch of vale-action truncates the raw
output section, allegedly (per the #testthedocs channel in WtD slack)

Signed-off-by: David Karlsson <35727626+dvdksn@users.noreply.github.com>
