### PR TITLE
Add FastAPI example for python docs

### DIFF
--- a/content/language/python/containerize.md
+++ b/content/language/python/containerize.md
@@ -55,8 +55,8 @@ Let's get started!
 
 ? What application platform does your project use? Python
 ? What version of Python do you want to use? 3.11.4
-? What port do you want your app to listen on? 5000
-? What is the command to run your app? python3 -m uvicorn app:app --host=0.0.0.0 --port=5000
+? What port do you want your app to listen on? 8000
+? What is the command to run your app? python3 -m uvicorn app:app --host=0.0.0.0 --port=8000
 ```
 
 Create a file named `.gitignore` with the following contents.
@@ -174,10 +174,10 @@ USER appuser
 COPY . .
 
 # Expose the port that the application listens on.
-EXPOSE 5000
+EXPOSE 8000
 
 # Run the application.
-CMD python3 -m uvicorn app:app --host=0.0.0.0 --port=5000
+CMD python3 -m uvicorn app:app --host=0.0.0.0 --port=8000
 ```
 
 Create a file named `compose.yaml` with the following contents.
@@ -197,7 +197,7 @@ services:
     build:
       context: .
     ports:
-      - 5000:5000
+      - 8000:8000
 ```
 
 Create a file named `.dockerignore` with the following contents.
@@ -329,7 +329,7 @@ terminal.
 $ docker compose up --build
 ```
 
-Open a browser and view the application at [http://localhost:5000](http://localhost:5000). You should see a simple FastAPI application.
+Open a browser and view the application at [http://localhost:8000](http://localhost:8000). You should see a simple FastAPI application.
 
 In the terminal, press `ctrl`+`c` to stop the application.
 
@@ -343,9 +343,9 @@ in a terminal.
 $ docker compose up --build -d
 ```
 
-Open a browser and view the application at [http://localhost:5000](http://localhost:5000).
+Open a browser and view the application at [http://localhost:8000](http://localhost:8000).
 
-To see the OpenAPI docs you can go at [http://localhost:5000/docs](http://localhost:5000/docs)
+To see the OpenAPI docs you can go at [http://localhost:8000/docs](http://localhost:8000/docs)
 
 You should see a simple FastAPI application.
 

--- a/content/language/python/containerize.md
+++ b/content/language/python/containerize.md
@@ -55,7 +55,7 @@ Let's get started!
 
 ? What application platform does your project use? Python
 ? What version of Python do you want to use? 3.11.4
-? What port do you want your app to listen on? 8000
+? What port do you want your app to listen on? 5000
 ? What is the command to run your app? python3 -m uvicorn app:app --host=0.0.0.0 --port=5000
 ```
 

--- a/content/language/python/containerize.md
+++ b/content/language/python/containerize.md
@@ -18,12 +18,12 @@ This section walks you through containerizing and running a Python application.
 
 ## Get the sample application
 
-The sample application uses the popular [Flask](https://flask.palletsprojects.com/) framework.
+The sample application uses the popular [FastAPI](https://fastapi.tiangolo.com) framework.
 
 Clone the sample application to use with this guide. Open a terminal, change directory to a directory that you want to work in, and run the following command to clone the repository:
 
 ```console
-$ git clone https://github.com/docker/python-docker
+$ git clone https://github.com/estebanx64/python-docker-example
 ```
 
 ## Initialize Docker assets
@@ -35,9 +35,9 @@ feature to help streamline the process, or you can manually create the assets.
 {{< tabs >}}
 {{< tab name="Use Docker Init" >}}
 
-Inside the `python-docker` directory, run the `docker init` command. `docker
+Inside the `python-docker-example` directory, run the `docker init` command. `docker
 init` provides some default configuration, but you'll need to answer a few
-questions about your application. For example, this application uses Flask to
+questions about your application. For example, this application uses FastAPI to
 run. Refer to the following example to answer the prompts from `docker init` and
 use the same answers for your prompts.
 
@@ -56,7 +56,7 @@ Let's get started!
 ? What application platform does your project use? Python
 ? What version of Python do you want to use? 3.11.4
 ? What port do you want your app to listen on? 8000
-? What is the command to run your app? python3 -m flask run --host=0.0.0.0 --port=8000
+? What is the command to run your app? python3 -m uvicorn app:app --host=0.0.0.0 --port=5000
 ```
 
 {{< /tab >}}
@@ -115,10 +115,10 @@ USER appuser
 COPY . .
 
 # Expose the port that the application listens on.
-EXPOSE 8000
+EXPOSE 5000
 
 # Run the application.
-CMD python3 -m flask run --host=0.0.0.0 --port=8000
+CMD python3 -m uvicorn app:app --host=0.0.0.0 --port=5000
 ```
 
 Create a file named `compose.yaml` with the following contents.
@@ -138,40 +138,7 @@ services:
     build:
       context: .
     ports:
-      - 8000:8000
-
-# The commented out section below is an example of how to define a PostgreSQL
-# database that your application can use. `depends_on` tells Docker Compose to
-# start the database before your application. The `db-data` volume persists the
-# database data between container restarts. The `db-password` secret is used
-# to set the database password. You must create `db/password.txt` and add
-# a password of your choosing to it before running `docker compose up`.
-#     depends_on:
-#       db:
-#         condition: service_healthy
-#   db:
-#     image: postgres
-#     restart: always
-#     user: postgres
-#     secrets:
-#       - db-password
-#     volumes:
-#       - db-data:/var/lib/postgresql/data
-#     environment:
-#       - POSTGRES_DB=example
-#       - POSTGRES_PASSWORD_FILE=/run/secrets/db-password
-#     expose:
-#       - 5432
-#     healthcheck:
-#       test: [ "CMD", "pg_isready" ]
-#       interval: 10s
-#       timeout: 5s
-#       retries: 5
-# volumes:
-#   db-data:
-# secrets:
-#   db-password:
-#     file: db/password.txt
+      - 5000:5000
 ```
 
 Create a file named `.dockerignore` with the following contents.
@@ -212,17 +179,77 @@ Create a file named `.dockerignore` with the following contents.
 LICENSE
 README.md
 ```
+Create a file named `.gitignore` with the following contents.
+
+```text {collapse=true,title=".dockerignore"}
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
+__pypackages__/
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+```
+
 {{< /tab >}}
 {{< /tabs >}}
 
-You should now have the following contents in your `python-docker`
+You should now have the following contents in your `python-docker-example`
 directory.
 
 ```text
-├── python-docker/
+├── python-docker-example/
 │ ├── app.py
 │ ├── requirements.txt
 │ ├── .dockerignore
+│ ├── .gitignore
 │ ├── compose.yaml
 │ ├── Dockerfile
 │ └── README.md
@@ -231,34 +258,37 @@ directory.
 To learn more about the files, see the following:
  - [Dockerfile](../../reference/dockerfile.md)
  - [.dockerignore](../../reference/dockerfile.md#dockerignore-file)
+ - [.gitignore](https://git-scm.com/docs/gitignore)
  - [compose.yaml](../../compose/compose-file/_index.md)
 
 ## Run the application
 
-Inside the `python-docker` directory, run the following command in a
+Inside the `python-docker-example` directory, run the following command in a
 terminal.
 
 ```console
 $ docker compose up --build
 ```
 
-Open a browser and view the application at [http://localhost:8000](http://localhost:8000). You should see a simple Flask application.
+Open a browser and view the application at [http://localhost:5000](http://localhost:5000). You should see a simple FastAPI application.
 
 In the terminal, press `ctrl`+`c` to stop the application.
 
 ### Run the application in the background
 
 You can run the application detached from the terminal by adding the `-d`
-option. Inside the `python-docker` directory, run the following command
+option. Inside the `python-docker-example` directory, run the following command
 in a terminal.
 
 ```console
 $ docker compose up --build -d
 ```
 
-Open a browser and view the application at [http://localhost:8000](http://localhost:8000).
+Open a browser and view the application at [http://localhost:5000](http://localhost:5000).
 
-You should see a simple Flask application.
+To see the OpenAPI docs you can go at [http://localhost:5000/docs](http://localhost:5000/docs)
+
+You should see a simple FastAPI application.
 
 In the terminal, run the following command to stop the application.
 

--- a/content/language/python/containerize.md
+++ b/content/language/python/containerize.md
@@ -59,6 +59,65 @@ Let's get started!
 ? What is the command to run your app? python3 -m uvicorn app:app --host=0.0.0.0 --port=5000
 ```
 
+Create a file named `.gitignore` with the following contents.
+
+```text {collapse=true,title=".gitignore"}
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
+__pypackages__/
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+```
+
 {{< /tab >}}
 {{< tab name="Manually create assets" >}}
 
@@ -181,7 +240,7 @@ README.md
 ```
 Create a file named `.gitignore` with the following contents.
 
-```text {collapse=true,title=".dockerignore"}
+```text {collapse=true,title=".gitignore"}
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/content/language/python/containerize.md
+++ b/content/language/python/containerize.md
@@ -345,7 +345,7 @@ $ docker compose up --build -d
 
 Open a browser and view the application at [http://localhost:8000](http://localhost:8000).
 
-To see the OpenAPI docs you can go at [http://localhost:8000/docs](http://localhost:8000/docs)
+To see the OpenAPI docs you can go to [http://localhost:8000/docs](http://localhost:8000/docs).
 
 You should see a simple FastAPI application.
 

--- a/content/language/python/deploy.md
+++ b/content/language/python/deploy.md
@@ -180,7 +180,7 @@ To learn more about Kubernetes objects, see the [Kubernetes documentation](https
    secret/postgres-secret created
    ```
 
-   and let's deploy our python application
+   Now, deploy your python application.
 
    ```console
    kubectl apply -f docker-python-kubernetes.yaml

--- a/content/language/python/deploy.md
+++ b/content/language/python/deploy.md
@@ -162,6 +162,10 @@ In these Kubernetes YAML file, there are various objects, separated by the `---`
 
 To learn more about Kubernetes objects, see the [Kubernetes documentation](https://kubernetes.io/docs/home/).
 
+> **Note**
+>
+> * The `NodePort` service is good for development/testing purposes. For production you should implement an [ingress-controller](https://kubernetes.io/docs/concepts/services-networking/ingress-controllers/).
+
 ## Deploy and check your application
 
 1. In a terminal, navigate to `python-docker-dev-example` and deploy your database to

--- a/content/language/python/deploy.md
+++ b/content/language/python/deploy.md
@@ -129,7 +129,7 @@ spec:
         - name: POSTGRES_PORT
           value: "5432"
         ports:
-        - containerPort: 5001
+        - containerPort: 8001
 ---
 apiVersion: v1
 kind: Service
@@ -141,8 +141,8 @@ spec:
   selector:
     service: fastapi
   ports:
-  - port: 5001
-    targetPort: 5001
+  - port: 8001
+    targetPort: 8001
     nodePort: 30001
 ```
 
@@ -219,7 +219,7 @@ To learn more about Kubernetes objects, see the [Kubernetes documentation](https
    NAME                 TYPE        CLUSTER-IP     EXTERNAL-IP   PORT(S)          AGE
    kubernetes           ClusterIP   10.43.0.1      <none>        443/TCP          13h
    postgres             ClusterIP   10.43.209.25   <none>        5432/TCP         3m10s
-   service-entrypoint   NodePort    10.43.67.120   <none>        5001:30001/TCP   79s
+   service-entrypoint   NodePort    10.43.67.120   <none>        8001:30001/TCP   79s
    ```
 
    In addition to the default `kubernetes` service, you can see your `service-entrypoint` service, accepting traffic on port 30001/TCP and the internal `ClusterIP` `postgres` with the port `5432` open to accept connections from you python app.

--- a/content/language/python/develop.md
+++ b/content/language/python/develop.md
@@ -47,7 +47,7 @@ You'll need to clone a new repository to get a sample application that includes 
    
    ? What application platform does your project use? Python
    ? What version of Python do you want to use? 3.11.4
-   ? What port do you want your app to listen on? 8001
+   ? What port do you want your app to listen on? 5001
    ? What is the command to run your app? python3 -m uvicorn app:app --host=0.0.0.0 --port=5001
    ```
 

--- a/content/language/python/develop.md
+++ b/content/language/python/develop.md
@@ -51,12 +51,71 @@ You'll need to clone a new repository to get a sample application that includes 
    ? What is the command to run your app? python3 -m uvicorn app:app --host=0.0.0.0 --port=5001
    ```
 
+   Create a file named `.gitignore` with the following contents.
+   
+   ```text {collapse=true,title=".gitignore"}
+   # Byte-compiled / optimized / DLL files
+   __pycache__/
+   *.py[cod]
+   *$py.class
+   
+   # C extensions
+   *.so
+   
+   # Distribution / packaging
+   .Python
+   build/
+   develop-eggs/
+   dist/
+   downloads/
+   eggs/
+   .eggs/
+   lib/
+   lib64/
+   parts/
+   sdist/
+   var/
+   wheels/
+   share/python-wheels/
+   *.egg-info/
+   .installed.cfg
+   *.egg
+   MANIFEST
+   
+   # Unit test / coverage reports
+   htmlcov/
+   .tox/
+   .nox/
+   .coverage
+   .coverage.*
+   .cache
+   nosetests.xml
+   coverage.xml
+   *.cover
+   *.py,cover
+   .hypothesis/
+   .pytest_cache/
+   cover/
+   
+   # PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
+   __pypackages__/
+   
+   # Environments
+   .env
+   .venv
+   env/
+   venv/
+   ENV/
+   env.bak/
+   venv.bak/
+   ```
+   
    {{< /tab >}}
    {{< tab name="Manually create assets" >}}
-
+   
    If you don't have Docker Desktop installed or prefer creating the assets
    manually, you can create the following files in your project directory.
-
+   
    Create a file named `Dockerfile` with the following contents.
    
    ```dockerfile {collapse=true,title=Dockerfile}
@@ -206,7 +265,7 @@ You'll need to clone a new repository to get a sample application that includes 
    ```
    Create a file named `.gitignore` with the following contents.
    
-   ```text {collapse=true,title=".dockerignore"}
+   ```text {collapse=true,title=".gitignore"}
    # Byte-compiled / optimized / DLL files
    __pycache__/
    *.py[cod]

--- a/content/language/python/develop.md
+++ b/content/language/python/develop.md
@@ -47,8 +47,8 @@ You'll need to clone a new repository to get a sample application that includes 
    
    ? What application platform does your project use? Python
    ? What version of Python do you want to use? 3.11.4
-   ? What port do you want your app to listen on? 5001
-   ? What is the command to run your app? python3 -m uvicorn app:app --host=0.0.0.0 --port=5001
+   ? What port do you want your app to listen on? 8001
+   ? What is the command to run your app? python3 -m uvicorn app:app --host=0.0.0.0 --port=8001
    ```
 
    Create a file named `.gitignore` with the following contents.
@@ -166,10 +166,10 @@ You'll need to clone a new repository to get a sample application that includes 
    COPY . .
    
    # Expose the port that the application listens on.
-   EXPOSE 5001
+   EXPOSE 8001
    
    # Run the application.
-   CMD python3 -m uvicorn app:app --host=0.0.0.0 --port=5001
+   CMD python3 -m uvicorn app:app --host=0.0.0.0 --port=8001
    ```
    
    Create a file named `compose.yaml` with the following contents.
@@ -189,7 +189,7 @@ You'll need to clone a new repository to get a sample application that includes 
        build:
          context: .
        ports:
-         - 5001:5001
+         - 8001:8001
    
    # The commented out section below is an example of how to define a PostgreSQL
    # database that your application can use. `depends_on` tells Docker Compose to
@@ -341,7 +341,7 @@ services:
     build:
       context: .
     ports:
-      - 5001:5001
+      - 8001:8001
     environment:
       - POSTGRES_SERVER=db
       - POSTGRES_USER=postgres
@@ -422,7 +422,7 @@ Let's create an object with a post method
 
 ```console
 $ curl -X 'POST' \
-  'http://0.0.0.0:5001/heroes/' \
+  'http://0.0.0.0:8001/heroes/' \
   -H 'accept: application/json' \
   -H 'Content-Type: application/json' \
   -d '{
@@ -448,7 +448,7 @@ Let's make a get request with the next curl command:
 
 ```console
 curl -X 'GET' \
-  'http://0.0.0.0:5001/heroes/' \
+  'http://0.0.0.0:8001/heroes/' \
   -H 'accept: application/json'
 ```
 
@@ -480,7 +480,7 @@ services:
     build:
       context: .
     ports:
-      - 5001:5001
+      - 8001:8001
     environment:
       - POSTGRES_SERVER=db
       - POSTGRES_USER=postgres
@@ -529,7 +529,7 @@ $ docker compose watch
 In a terminal, curl the application to get a response.
 
 ```console
-$ curl http://localhost:5001
+$ curl http://localhost:8001
 Hello, Docker!
 ```
 
@@ -545,7 +545,7 @@ Open `python-docker-dev-example/app.py` in an IDE or text editor and update the 
 Save the changes to `app.py` and then wait a few seconds for the application to rebuild. Curl the application again and verify that the updated text appears.
 
 ```console
-$ curl http://localhost:5001
+$ curl http://localhost:8001
 Hello, Docker!!!
 ```
 


### PR DESCRIPTION
<!--Delete sections as needed -->

## Description
Provide an example with one of the most used and modern python apps/frameworks today `FastAPI` to replace the old Flask example

<!-- Tell us what you did and why -->
Replaced the old flask app by a new modern FastAPI since FastAPI is more popular nowadays, modern and use the latest python types features. This change was requested and approved by Craig and Eva

## Related issues or tickets
N/A

## Reviews

<!-- Notes for reviewers here -->
N/A
<!-- List applicable reviews (optionally @tag reviewers) -->
@craig-osterhout 
@usha-mandya

- [ ] Technical review
- [ ] Editorial review
- [ ] Product review