### PR TITLE
docs: Inlude example for build secrets

### DIFF
--- a/content/compose/use-secrets.md
+++ b/content/compose/use-secrets.md
@@ -84,7 +84,25 @@ In the advanced example above:
 >
 > The `_FILE` environment variables demonstrated here are a convention used by some images, including Docker Official Images like [mysql](https://hub.docker.com/_/mysql) and [postgres](https://hub.docker.com/_/postgres).
 
+### Build Secrets
+
+In the following example, the `npm_token` secret will be available at build time. It's value will be taken from the `NPM_TOKEN` environment variable.
+
+```yaml
+services:
+  myapp:
+    build:
+      secrets:
+        - npm_token
+      context: .
+
+secrets:
+  npm_token:
+    environment: NPM_TOKEN
+```
+
 ## Resources
 
 - [Secrets top-level element](compose-file/09-secrets.md)
 - [Secrets attribute for services top-level element](compose-file/05-services.md#secrets)
+- [Build Secrets](https://docs.docker.com/build/building/secrets/)


### PR DESCRIPTION
<!--Delete sections as needed -->

## Description

I had a hard time figuring out how to define build secrets in the compose file. Even though it was really obvious once I found out how to do it, this small example can save minutes for other developers as they try to figure out how to do it.

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Technical review
- [ ] Editorial review
- [ ] Product review