### PR TITLE
macvlan: Add ipv6 flag for ipv6 exmple

### DIFF
--- a/content/network/drivers/macvlan.md
+++ b/content/network/drivers/macvlan.md
@@ -115,7 +115,7 @@ $ docker network create -d macvlan \
     --subnet=192.168.216.0/24 --subnet=192.168.218.0/24 \
     --gateway=192.168.216.1 --gateway=192.168.218.1 \
     --subnet=2001:db8:abc8::/64 --gateway=2001:db8:abc8::10 \
-     -o parent=eth0.218 \
+     -o parent=eth0.218 --ipv6 \
      -o macvlan_mode=bridge macvlan216
 ```
 


### PR DESCRIPTION
<!--Delete sections as needed -->

## Description

I added the --ipv6 flag for the IPv6 example because it did not work for me without it
<!-- Tell us what you did and why -->

## Related issues or tickets

<!-- Related issues, pull requests, or Jira tickets -->

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Technical review