### PR TITLE
busybox image is removed from the prune example

### DIFF
--- a/data/engine-cli/docker_image_prune.yaml
+++ b/data/engine-cli/docker_image_prune.yaml
@@ -161,7 +161,6 @@ examples: |-
     foo                 latest              2f287ac753da        14 seconds ago      3.98 MB
     alpine              latest              88e169ea8f46        8 days ago          3.98 MB
     debian              jessie              7b0a06c805e8        2 months ago        123 MB
-    busybox             latest              e02e811dd08f        2 months ago        1.09 MB
     golang              1.7.0               138c2e655421        4 months ago        670 MB
 
     $ docker image prune -a --force --filter "until=240h"
@@ -189,7 +188,6 @@ examples: |-
     REPOSITORY          TAG                 IMAGE ID            CREATED              SIZE
     foo                 latest              2f287ac753da        About a minute ago   3.98 MB
     alpine              latest              88e169ea8f46        8 days ago           3.98 MB
-    busybox             latest              e02e811dd08f        2 months ago         1.09 MB
     ```
 
     The following example removes images with the label `deprecated`:


### PR DESCRIPTION
The command should delete the images created before ten days ago, but this has not happened and no description has been provided, thus it will confuse the person who reads the document.

<!--Delete sections as needed -->

## Description

<!-- Tell us what you did and why -->

## Related issues or tickets

<!-- Related issues, pull requests, or Jira tickets -->

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Technical review
- [ ] Editorial review
- [ ] Product review