### PR TITLE
engine: fix typo: iptables6 -> ip6tables

### DIFF
--- a/content/engine/install/debian.md
+++ b/content/engine/install/debian.md
@@ -32,7 +32,7 @@ To get started with Docker Engine on Debian, make sure you
   [Docker and ufw](../../network/packet-filtering-firewalls.md#docker-and-ufw).
 - Docker is only compatible with `iptables-nft` and `iptables-legacy`.
   Firewall rules created with `nft` are not supported on a system with Docker installed.
-  Make sure that any firewall rulesets you use are created with `iptables` or `iptables6`,
+  Make sure that any firewall rulesets you use are created with `iptables` or `ip6tables`,
   and that you add them to the `DOCKER-USER` chain,
   see [Packet filtering and firewalls](../../network/packet-filtering-firewalls.md).
 

--- a/content/engine/install/raspberry-pi-os.md
+++ b/content/engine/install/raspberry-pi-os.md
@@ -38,7 +38,7 @@ To get started with Docker Engine on Raspberry Pi OS, make sure you
   [Docker and ufw](../../network/packet-filtering-firewalls.md#docker-and-ufw).
 - Docker is only compatible with `iptables-nft` and `iptables-legacy`.
   Firewall rules created with `nft` are not supported on a system with Docker installed.
-  Make sure that any firewall rulesets you use are created with `iptables` or `iptables6`,
+  Make sure that any firewall rulesets you use are created with `iptables` or `ip6tables`,
   and that you add them to the `DOCKER-USER` chain,
   see [Packet filtering and firewalls](../../network/packet-filtering-firewalls.md).
 

--- a/content/engine/install/ubuntu.md
+++ b/content/engine/install/ubuntu.md
@@ -40,7 +40,7 @@ To get started with Docker Engine on Ubuntu, make sure you
   [Docker and ufw](../../network/packet-filtering-firewalls.md#docker-and-ufw).
 - Docker is only compatible with `iptables-nft` and `iptables-legacy`.
   Firewall rules created with `nft` are not supported on a system with Docker installed.
-  Make sure that any firewall rulesets you use are created with `iptables` or `iptables6`,
+  Make sure that any firewall rulesets you use are created with `iptables` or `ip6tables`,
   and that you add them to the `DOCKER-USER` chain,
   see [Packet filtering and firewalls](../../network/packet-filtering-firewalls.md).
 


### PR DESCRIPTION
- Follow-up for https://github.com/docker/docs/pull/19618

## Description

's/iptables6/ip6tables/g'

## Related issues or tickets

<!-- Related issues, pull requests, or Jira tickets -->

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [x] Technical review
- [ ] Editorial review
- [ ] Product review