### PR TITLE
remove beta label from debug

### DIFF
--- a/content/desktop/use-desktop/container.md
+++ b/content/desktop/use-desktop/container.md
@@ -86,11 +86,6 @@ and select the **System default** option under **Choose your terminal**.
 
 #### Open the integrated terminal in debug mode
 
-> **Beta feature**
->
-> The debug mode feature is currently in [Beta](../../release-lifecycle.md/#beta).
-{ .experimental }
-
 Debug mode requires a [Pro, Team, or Business subcription](/subscription/details/). Debug mode has several advantages, such as:
 
 - A customizable toolbox. The toolbox comes with many standard Linux tools

--- a/content/reference/cli/docker/debug.md
+++ b/content/reference/cli/docker/debug.md
@@ -6,7 +6,3 @@ layout: cli
 aliases:
 - /engine/reference/commandline/debug/
 ---
-
-> **Beta feature**
->
-> Docker Debug is currently in [Beta](../../../release-lifecycle.md#beta).

--- a/data/toc.yaml
+++ b/data/toc.yaml
@@ -555,7 +555,7 @@ Reference:
       - path: /reference/cli/docker/context/use/
         title: docker context use
   - path: /reference/cli/docker/debug/
-    title: docker debug (Beta)
+    title: docker debug
   - path: /reference/cli/docker/exec/
     title: docker exec
   - sectiontitle: docker image


### PR DESCRIPTION
<!--Delete sections as needed -->

## Description

Removed beta label from Docker Debug.

## Related issues or tickets

ENGDOCS-2122

## Reviews

- [ ] Editorial review