### PR TITLE
engine, desktop: remove Ubuntu 23.10 (Mantic Minotaur) (EOL: July 11, 2024)

### DIFF
--- a/content/desktop/install/ubuntu.md
+++ b/content/desktop/install/ubuntu.md
@@ -28,7 +28,7 @@ _For checksums, see [Release notes](../release-notes.md)_
 To install Docker Desktop successfully, you must:
 
 - Meet the [system requirements](linux-install.md#system-requirements)
-- Have a 64-bit version of either the LTS version Ubuntu Jammy Jellyfish 22.04, or the current non-LTS version (Ubuntu Mantic Minotaur 23.10). Docker Desktop is supported on `x86_64` (or `amd64`) architecture.
+- Have a 64-bit version of either the LTS version Ubuntu Jammy Jellyfish 22.04, or the current non-LTS version. Docker Desktop is supported on `x86_64` (or `amd64`) architecture.
    > **Note**
    >
    > The latest Ubuntu 24.04 LTS is not yet supported. Docker Desktop will fail to start. Due to a change in how the latest Ubuntu release restricts the unprivileged namespaces, `sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0` needs to be run at least once. Refer to the [Ubuntu Blog](https://ubuntu.com/blog/ubuntu-23-10-restricted-unprivileged-user-namespaces) for more details.

--- a/content/engine/install/ubuntu.md
+++ b/content/engine/install/ubuntu.md
@@ -50,7 +50,6 @@ To install Docker Engine, you need the 64-bit version of one of these Ubuntu
 versions:
 
 - Ubuntu Noble 24.04 (LTS)
-- Ubuntu Mantic 23.10 (EOL: [July 12, 2024](https://wiki.ubuntu.com/Releases))
 - Ubuntu Jammy 22.04 (LTS)
 - Ubuntu Focal 20.04 (LTS)
 


### PR DESCRIPTION
Ubuntu 23.10 reached EOL on July 11, 2024: https://fridge.ubuntu.com/2024/07/17/ubuntu-23-10-mantic-minotaur-reached-end-of-life-on-july-11-2024/


<!--Delete sections as needed -->

## Description

<!-- Tell us what you did and why -->

## Related issues or tickets

<!-- Related issues, pull requests, or Jira tickets -->

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Technical review
- [ ] Editorial review
- [ ] Product review