### PR TITLE
Update Java Version From 3.3.0-m3 to 3.3.2 in docker guides.

### DIFF
--- a/content/guides/docker-concepts/building-images/multi-stage-builds.md
+++ b/content/guides/docker-concepts/building-images/multi-stage-builds.md
@@ -48,7 +48,7 @@ In this hands-on guide, you'll unlock the power of multi-stage builds to create 
 
 1. [Download and install](https://www.docker.com/products/docker-desktop/) Docker Desktop.
 
-2. Open this [pre-initialized project](https://start.spring.io/#!type=maven-project&language=java&platformVersion=3.3.0-M3&packaging=jar&jvmVersion=21&groupId=com.example&artifactId=spring-boot-docker&name=spring-boot-docker&description=Demo%20project%20for%20Spring%20Boot&packageName=com.example.spring-boot-docker&dependencies=web) to generate a ZIP file. Here’s how that looks:
+2. Open this [pre-initialized project](https://start.spring.io/#!type=maven-project&language=java&platformVersion=3.3.2&packaging=jar&jvmVersion=21&groupId=com.example&artifactId=spring-boot-docker&name=spring-boot-docker&description=Demo%20project%20for%20Spring%20Boot&packageName=com.example.spring-boot-docker&dependencies=web) to generate a ZIP file. Here’s how that looks:
 
 
     ![A screenshot of Spring Initializr tool selected with Java 21, Spring Web and Spring Boot 3.3.0](images/spring-initializr.webp?border=true)


### PR DESCRIPTION
# Address unavailable Spring Boot version (3.3.0-M3) in Docker documentation

## Description
When i click the link to spring installer. is show a warning `Spring Boot 3.3.0-M3 is not available, 3.3.2 has been selected.`. so i chaged the url in the docker docs to version `3.3.2`. 

## Reviews
- [ ] Editorial review