### PR TITLE
Add -y flag to Docker installation command in documentation, Remove i…

### DIFF
--- a/content/engine/install/ubuntu.md
+++ b/content/engine/install/ubuntu.md
@@ -143,7 +143,7 @@ Docker from the repository.
    To install the latest version, run:
 
    ```console
-   $ sudo apt-get install docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+   $ sudo apt-get install docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin -y
    ```
   
    {{< /tab >}}


### PR DESCRIPTION
- Added the -y flag to the `sudo apt-get install` command in the Docker installation guide.
- This change automates the confirmation step during the package installation process, removing the pause that requires user confirmation and improving the user experience by eliminating the need for manual input to resume installation.

## Description

The current process causes a pause during installation, requiring user confirmation. By adding the -y flag, the installation process becomes fully automated, assuming the user is already aware of and agrees to the installation of Docker.
