### PR TITLE
build/buildkit: fix image name

### DIFF
--- a/content/build/buildkit/_index.md
+++ b/content/build/buildkit/_index.md
@@ -219,7 +219,7 @@ We appreciate any feedback you submit by [opening an issue here](https://github.
    ...
    ```
 
-9. Create a Dockerfile and build a `hello-world` image.
+9. Create a Dockerfile and build a `hello-buildkit` image.
 
    ```console
    > mkdir sample_dockerfile
@@ -246,5 +246,5 @@ We appreciate any feedback you submit by [opening an issue here](https://github.
 11. After pushing to the registry, run the image with `docker run`.
 
     ```console
-    > docker run <username>/hello-world
+    > docker run <username>/hello-buildkit
     ```


### PR DESCRIPTION
The title suggested a "hello-world" image, but we were building a "hello-buildkit" image, but then trying to run "hello-world".

<!--Delete sections as needed -->

## Description

<!-- Tell us what you did and why -->

## Related issues or tickets

<!-- Related issues, pull requests, or Jira tickets -->

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Technical review
- [ ] Editorial review
- [ ] Product review