### PR TITLE
engine: Add release notes for v25.0.6

### DIFF
--- a/content/engine/release-notes/25.0.md
+++ b/content/engine/release-notes/25.0.md
@@ -14,6 +14,33 @@ For more information about:
 - Deprecated and removed features, see [Deprecated Engine Features](../deprecated.md).
 - Changes to the Engine API, see [Engine API version history](../api/version-history.md).
 
+## 25.0.6
+{{< release-date date="2024-07-25" >}}
+
+For a full list of pull requests and changes in this release, refer to the relevant GitHub milestones:
+
+- [docker/cli, 25.0.6 milestone](https://github.com/docker/cli/issues?q=is%3Aclosed+milestone%3A25.0.6)
+- [moby/moby, 25.0.6 milestone](https://github.com/moby/moby/issues?q=is%3Aclosed+milestone%3A25.0.6)
+
+### Security
+
+This release contains a fix for [CVE-2024-41110](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2024-41110) / [GHSA-v23v-6jw2-98fq](https://github.com/moby/moby/security/advisories/GHSA-v23v-6jw2-98fq) that impacted setups [using authorization plugins (AuthZ)](https://docs.docker.com/engine/extend/plugins_authorization/) for access control.
+
+### Bug fixes and enhancements
+
+- Remove erroneous platform from image config OCI descriptor in docker save output. [moby/moby#47695](https://github.com/moby/moby/pull/47695)
+- Fix a nil dereference when getting image history for images having layers without the `Created` value set. [moby/moby#47759](https://github.com/moby/moby/pull/47759)
+- apparmor: Allow confined runc to kill containers. [moby/moby#47830](https://github.com/moby/moby/pull/47830)
+- Fix an issue where rapidly promoting a Swarm node after another node was demoted could cause the promoted node to fail its promotion. [moby/moby#47869](https://github.com/moby/moby/pull/47869)
+- Don't depend on containerd `platform.Parse` to return a typed error. [moby/moby#47890](https://github.com/moby/moby/pull/47890)
+- builder/mobyexporter: Add missing nil check. [moby/moby#47987](https://github.com/moby/moby/pull/47987)
+
+### Packaging updates
+
+- Update AWS SDK Go v2 to v1.24.1 for AWS CloudWatch logging driver. [moby/moby#47724](https://github.com/moby/moby/pull/47724)
+- Update Go runtime to 1.21.12, which contains security fixes for [CVE-2024-24791](https://github.com/advisories/GHSA-hw49-2p59-3mhj). [moby/moby#48146](https://github.com/moby/moby/pull/48146)
+- Update Containerd (static binaries only) to v1.7.20. [moby/moby#48199](https://github.com/moby/moby/pull/48199)
+
 ## 25.0.5
 
 {{< release-date date="2024-03-19" >}}


### PR DESCRIPTION
<!--Delete sections as needed -->

## Description
Add release notes for docker engine v25.0.6 https://github.com/moby/moby/releases/tag/v25.0.6
