### PR TITLE
Define units for max-buffer-size

### DIFF
--- a/content/config/containers/logging/configure.md
+++ b/content/config/containers/logging/configure.md
@@ -151,7 +151,7 @@ The `mode` log option controls whether to use the `blocking` (default) or
 
 The `max-buffer-size` log option controls the size of the buffer used for
 intermediate message storage when `mode` is set to `non-blocking`. `max-buffer-size`
-defaults to 1 megabyte.
+defaults to 1 megabyte. This value is case-insensitive and allows one of the binary units of measure: `KiB`, `MiB`, `GiB`, `TiB`, or `PiB` (with `i` being optional). The shorthand format using only the first character is more common.
 
 The following example starts an Alpine container with log output in non-blocking
 mode and a 4 megabyte buffer:


### PR DESCRIPTION
<!--Delete sections as needed -->

## Description

This documents the units for `max-buffer-size`. Previously, the allowed sizes were not documented to make it clear this is the binary unit of measure, where 1 KiB = 1024 Bytes. This also clarifies that the `i` can be omitted from the binary unit specification, which surprised me as a user that this didn't change the size calculation.

The single-character lowercased examples also were not previously clear in the docs which units they referred to, so hopefully this adds clarity.

## Related issues or tickets

<!-- Related issues, pull requests, or Jira tickets -->

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Technical review
- [ ] Editorial review
- [ ] Product review