### PR TITLE
(Fixed) Incorrect command to remove old versions docker(centos)

### DIFF
--- a/content/engine/install/centos.md
+++ b/content/engine/install/centos.md
@@ -39,14 +39,14 @@ Uninstall any such older versions before attempting to install a new version,
 along with associated dependencies.
 
 ```console
-$ sudo yum remove docker \
-                  docker-client \
-                  docker-client-latest \
-                  docker-common \
-                  docker-latest \
-                  docker-latest-logrotate \
-                  docker-logrotate \
-                  docker-engine
+$ sudo yum remove docker-ce \
+                     docker-client \
+                     docker-client-latest \
+                     docker-common \
+                     docker-latest \
+                     docker-latest-logrotate \
+                     docker-logrotate \
+                     docker-engine
 ```
 
 `yum` might report that you have none of these packages installed.


### PR DESCRIPTION
Fixes #20460


## Description

Updated the command to remove old versions docker from `sudo yum remove docker` to `sudo yum remove docker-ce`

## Related issues or tickets

Issue #20460 

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Technical review
- [ ] Editorial review
- [ ] Product review