### PR TITLE
Add Underscores (`_`) and slashes (`/`) to valid label content

### DIFF
--- a/content/config/labels-custom-metadata.md
+++ b/content/config/labels-custom-metadata.md
@@ -30,7 +30,7 @@ all previous values.
 ### Key format recommendations
 
 A label key is the left-hand side of the key-value pair. Keys are alphanumeric
-strings which may contain periods (`.`), underscores (`_`), and hyphens (`-`). Most Docker users use
+strings which may contain periods (`.`), underscores (`_`), slashes (`/`), and hyphens (`-`). Most Docker users use
 images created by other organizations, and the following guidelines help to
 prevent inadvertent duplication of labels across objects, especially if you plan
 to use labels as a mechanism for automation.

--- a/content/config/labels-custom-metadata.md
+++ b/content/config/labels-custom-metadata.md
@@ -30,7 +30,7 @@ all previous values.
 ### Key format recommendations
 
 A label key is the left-hand side of the key-value pair. Keys are alphanumeric
-strings which may contain periods (`.`) and hyphens (`-`). Most Docker users use
+strings which may contain periods (`.`), underscores (`_`), and hyphens (`-`). Most Docker users use
 images created by other organizations, and the following guidelines help to
 prevent inadvertent duplication of labels across objects, especially if you plan
 to use labels as a mechanism for automation.


### PR DESCRIPTION
## Description

We're building a tool that wraps container creation and found that Docker can also work with underscores as well as slashes in labels.



## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Technical review
- [ ] Editorial review
- [ ] Product review