### PR TITLE
vendor: mention `dst` and `destination` options too

### DIFF
--- a/_vendor/github.com/moby/buildkit/frontend/dockerfile/docs/reference.md
+++ b/_vendor/github.com/moby/buildkit/frontend/dockerfile/docs/reference.md
@@ -682,29 +682,29 @@ The supported mount types are:
 This mount type allows binding files or directories to the build container. A
 bind mount is read-only by default.
 
-| Option           | Description                                                                          |
-| ---------------- | ------------------------------------------------------------------------------------ |
-| `target`[^1]     | Mount path.                                                                          |
-| `source`         | Source path in the `from`. Defaults to the root of the `from`.                       |
-| `from`           | Build stage or image name for the root of the source. Defaults to the build context. |
-| `rw`,`readwrite` | Allow writes on the mount. Written data will be discarded.                           |
+| Option                             | Description                                                                          |
+| ----------------                   | ------------------------------------------------------------------------------------ |
+| `target`, `dst`, `destination`[^1] | Mount path.                                                                          |
+| `source`                           | Source path in the `from`. Defaults to the root of the `from`.                       |
+| `from`                             | Build stage or image name for the root of the source. Defaults to the build context. |
+| `rw`,`readwrite`                   | Allow writes on the mount. Written data will be discarded.                           |
 
 ### RUN --mount=type=cache
 
 This mount type allows the build container to cache directories for compilers
 and package managers.
 
-| Option          | Description                                                                                                                                                                                                                                                                |
-| --------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `id`            | Optional ID to identify separate/different caches. Defaults to value of `target`.                                                                                                                                                                                          |
-| `target`[^1]    | Mount path.                                                                                                                                                                                                                                                                |
-| `ro`,`readonly` | Read-only if set.                                                                                                                                                                                                                                                          |
-| `sharing`       | One of `shared`, `private`, or `locked`. Defaults to `shared`. A `shared` cache mount can be used concurrently by multiple writers. `private` creates a new mount if there are multiple writers. `locked` pauses the second writer until the first one releases the mount. |
-| `from`          | Build stage to use as a base of the cache mount. Defaults to empty directory.                                                                                                                                                                                              |
-| `source`        | Subpath in the `from` to mount. Defaults to the root of the `from`.                                                                                                                                                                                                        |
-| `mode`          | File mode for new cache directory in octal. Default `0755`.                                                                                                                                                                                                                |
-| `uid`           | User ID for new cache directory. Default `0`.                                                                                                                                                                                                                              |
-| `gid`           | Group ID for new cache directory. Default `0`.                                                                                                                                                                                                                             |
+| Option                             | Description                                                                                                                                                                                                                                                                |
+| ---------------                    | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `id`                               | Optional ID to identify separate/different caches. Defaults to value of `target`.                                                                                                                                                                                          |
+| `target`, `dst`, `destination`[^1] | Mount path.                                                                                                                                                                                                                                                                |
+| `ro`,`readonly`                    | Read-only if set.                                                                                                                                                                                                                                                          |
+| `sharing`                          | One of `shared`, `private`, or `locked`. Defaults to `shared`. A `shared` cache mount can be used concurrently by multiple writers. `private` creates a new mount if there are multiple writers. `locked` pauses the second writer until the first one releases the mount. |
+| `from`                             | Build stage to use as a base of the cache mount. Defaults to empty directory.                                                                                                                                                                                              |
+| `source`                           | Subpath in the `from` to mount. Defaults to the root of the `from`.                                                                                                                                                                                                        |
+| `mode`                             | File mode for new cache directory in octal. Default `0755`.                                                                                                                                                                                                                |
+| `uid`                              | User ID for new cache directory. Default `0`.                                                                                                                                                                                                                              |
+| `gid`                              | Group ID for new cache directory. Default `0`.                                                                                                                                                                                                                             |
 
 Contents of the cache directories persists between builder invocations without
 invalidating the instruction cache. Cache mounts should only be used for better
@@ -743,24 +743,24 @@ case.
 
 This mount type allows mounting `tmpfs` in the build container.
 
-| Option       | Description                                           |
-| ------------ | ----------------------------------------------------- |
-| `target`[^1] | Mount path.                                           |
-| `size`       | Specify an upper limit on the size of the filesystem. |
+| Option                             | Description                                           |
+| ------------                       | ----------------------------------------------------- |
+| `target`, `dst`, `destination`[^1] | Mount path.                                           |
+| `size`                             | Specify an upper limit on the size of the filesystem. |
 
 ### RUN --mount=type=secret
 
 This mount type allows the build container to access secure files such as
 private keys without baking them into the image.
 
-| Option     | Description                                                                                       |
-| ---------- | ------------------------------------------------------------------------------------------------- |
-| `id`       | ID of the secret. Defaults to basename of the target path.                                        |
-| `target`   | Mount path. Defaults to `/run/secrets/` + `id`.                                                   |
-| `required` | If set to `true`, the instruction errors out when the secret is unavailable. Defaults to `false`. |
-| `mode`     | File mode for secret file in octal. Default `0400`.                                               |
-| `uid`      | User ID for secret file. Default `0`.                                                             |
-| `gid`      | Group ID for secret file. Default `0`.                                                            |
+| Option                         | Description                                                                                       |
+| ----------                     | ------------------------------------------------------------------------------------------------- |
+| `id`                           | ID of the secret. Defaults to basename of the target path.                                        |
+| `target`, `dst`, `destination` | Mount path. Defaults to `/run/secrets/` + `id`.                                                   |
+| `required`                     | If set to `true`, the instruction errors out when the secret is unavailable. Defaults to `false`. |
+| `mode`                         | File mode for secret file in octal. Default `0400`.                                               |
+| `uid`                          | User ID for secret file. Default `0`.                                                             |
+| `gid`                          | Group ID for secret file. Default `0`.                                                            |
 
 #### Example: access to S3
 
@@ -781,14 +781,14 @@ $ docker buildx build --secret id=aws,src=$HOME/.aws/credentials .
 This mount type allows the build container to access SSH keys via SSH agents,
 with support for passphrases.
 
-| Option     | Description                                                                                    |
-| ---------- | ---------------------------------------------------------------------------------------------- |
-| `id`       | ID of SSH agent socket or key. Defaults to "default".                                          |
-| `target`   | SSH agent socket path. Defaults to `/run/buildkit/ssh_agent.${N}`.                             |
-| `required` | If set to `true`, the instruction errors out when the key is unavailable. Defaults to `false`. |
-| `mode`     | File mode for socket in octal. Default `0600`.                                                 |
-| `uid`      | User ID for socket. Default `0`.                                                               |
-| `gid`      | Group ID for socket. Default `0`.                                                              |
+| Option                         | Description                                                                                    |
+| ----------                     | ---------------------------------------------------------------------------------------------- |
+| `id`                           | ID of SSH agent socket or key. Defaults to "default".                                          |
+| `target`, `dst`, `destination` | SSH agent socket path. Defaults to `/run/buildkit/ssh_agent.${N}`.                             |
+| `required`                     | If set to `true`, the instruction errors out when the key is unavailable. Defaults to `false`. |
+| `mode`                         | File mode for socket in octal. Default `0600`.                                                 |
+| `uid`                          | User ID for socket. Default `0`.                                                               |
+| `gid`                          | Group ID for socket. Default `0`.                                                              |
 
 #### Example: access to GitLab
 


### PR DESCRIPTION
All of these options are valid https://github.com/moby/moby/blob/27b322e56bc04da8e431fe792c742f7b52df9c46/vendor/github.com/moby/buildkit/frontend/dockerfile/instructions/commands_runmount.go#L196 and should be mentioned.

Partially fixes #20441.

Signed-off-by: Arkadiusz Drabczyk <arkadiusz@drabczyk.org>

## Description

All of these options are valid https://github.com/moby/moby/blob/27b322e56bc04da8e431fe792c742f7b52df9c46/vendor/github.com/moby/buildkit/frontend/dockerfile/instructions/commands_runmount.go#L196 and should be mentioned.

## Related issues or tickets

https://github.com/docker/docs/issues/20441

## Reviews

- [x] Technical review
- [x] Editorial review
- [ ] Product review
