### PR TITLE
scout: base image policy config for health scores

### DIFF
--- a/content/scout/policy/scores.md
+++ b/content/scout/policy/scores.md
@@ -108,12 +108,19 @@ The policies that influence the score, and their respective weights, are as foll
 | [Fixable critical and high vulnerabilities](./_index.md#fixable-critical-and-high-vulnerabilities)        | 20     |
 | [High-profile vulnerabilities](./_index.md#high-profile-vulnerabilities)                                  | 20     |
 | [Supply chain attestations](./_index.md#supply-chain-attestations)                                        | 15     |
-| [Unapproved base images](./_index.md#unapproved-base-images)                                              | 15     |
+| [Unapproved base images](./_index.md#unapproved-base-images) \*                                           | 15     |
 | [Outdated base images](./_index.md#outdated-base-images)                                                  | 10     |
 | [Default non-root user](./_index.md#default-non-root-user)                                                | 5      |
-| AGPL v3-licensed software \*                                                                              | 5      |
+| AGPL v3-licensed software \*\*                                                                            | 5      |
 
-\* _The **AGPL v3-licensed software** policy is a subset of the
+\* _The **Unapproved base images** policy used for health score evaluation also
+checks that the tags of Docker Official Images use supported tags and, where
+applicable, that the Linux distro that the image uses is a supported distro
+version. This is a policy configuration option that's enabled by default for
+health score evaluation. For more information, refer to the
+[Unapproved base images](/scout/policy/#unapproved-base-images) policy._
+
+\*\* _The **AGPL v3-licensed software** policy is a subset of the
 [Copyleft licenses](./_index.md#copyleft-licenses) policy._
 
 ### Evaluation


### PR DESCRIPTION
The Unapproved base images policy enables the optional configurations by
default when used in health score evaluation.

Signed-off-by: David Karlsson <35727626+dvdksn@users.noreply.github.com>
