### PR TITLE
docs: Fix typo in service name

### DIFF
--- a/content/language/r/deploy.md
+++ b/content/language/r/deploy.md
@@ -38,7 +38,7 @@ spec:
         service: shiny
     spec:
       containers:
-       - name: shimy-service
+       - name: shiny-service
          image: DOCKER_USERNAME/REPO_NAME
          imagePullPolicy: Always
          env:


### PR DESCRIPTION
The container is named `shimy-service` instead of `shiny-service`

## Description

I noticed a typo while working through the tutorial, so I fixed it.

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Technical review
- [ ] Editorial review
- [ ] Product review