### PR TITLE
admin: clarify enforcing sign-in

### DIFF
--- a/content/desktop/hardened-desktop/enhanced-container-isolation/_index.md
+++ b/content/desktop/hardened-desktop/enhanced-container-isolation/_index.md
@@ -92,10 +92,14 @@ To enable Enhanced Container Isolation as a developer:
 
 #### As an admin
 
-To enable Enhanced Container Isolation as an admin, you first need to [enforce sign-in](../../../security/for-admins/enforce-sign-in/_index.md).
-This is because the Enhanced Container Isolation feature requires a Docker
-Business subscription and therefore your Docker Desktop users must authenticate
-to your organization for this configuration to take effect.
+To enable Enhanced Container Isolation as an admin, you first need to [enforce
+sign-in](../../../security/for-admins/enforce-sign-in/_index.md). This is
+because the Enhanced Container Isolation feature requires a Docker Business
+subscription and therefore your Docker Desktop users must authenticate to your
+organization for this configuration to take effect. Enforcing sign-in ensures
+that your Docker Desktop developers always authenticate to your organization,
+even though they can authenticate without it and the feature will take effect.
+Enforcing sign-in guarantees the feature always takes effect.
 
 Next, you must [create and configure the `admin-settings.json` file](../settings-management/configure.md) and specify:
 

--- a/content/desktop/hardened-desktop/settings-management/_index.md
+++ b/content/desktop/hardened-desktop/settings-management/_index.md
@@ -51,7 +51,15 @@ For more details on the syntax and options admins can set, see [Configure Settin
 
 ### How do I set up and enforce Settings Management?
 
-As an administrator, you first need to [configure a registry.json to enforce sign-in](../../../security/for-admins/enforce-sign-in/_index.md). This is because the Settings Management feature requires a Docker Business subscription and therefore your Docker Desktop developers must authenticate to your organization for this configuration to take effect.
+As an administrator, you first need to [configure a registry.json to enforce
+sign-in](../../../security/for-admins/enforce-sign-in/_index.md). This is
+because the Settings Management feature requires a Docker Business subscription
+and therefore your Docker Desktop developers must authenticate to your
+organization. Enforcing sign-in ensures that your Docker Desktop developers
+always authenticate to your organization, even though they can authenticate
+without it and the feature will take effect. Enforcing sign-in guarantees the
+feature always takes effect.
+
 
 Next, you must either manually [create and configure the admin-settings.json file](configure.md), or use the `--admin-settings` installer flag on [macOS](../../install/mac-install.md#install-from-the-command-line) or [Windows](../../install/windows-install.md#install-from-the-command-line) to automatically create the `admin-settings.json` and save it in the correct location.
 

--- a/content/desktop/hardened-desktop/settings-management/configure.md
+++ b/content/desktop/hardened-desktop/settings-management/configure.md
@@ -15,7 +15,15 @@ Settings Management is designed specifically for organizations who don’t give 
 ### Prerequisites
 
 - [Download and install Docker Desktop 4.13.0 or later](../../release-notes.md).
-- As an admin, you need to [configure a registry.json to enforce sign-in](../../../security/for-admins/enforce-sign-in/_index.md). This is because this feature requires a Docker Business subscription and therefore your Docker Desktop users must authenticate to your organization for this configuration to take effect.
+- As an admin, you need to [configure a registry.json to enforce
+  sign-in](../../../security/for-admins/enforce-sign-in/_index.md). This is
+  because this feature requires a Docker Business subscription and therefore
+  your Docker Desktop users must authenticate to your organization for this
+  configuration to take effect. Enforcing sign-in ensures that your Docker
+  Desktop developers always authenticate to your organization, even though they
+  can authenticate without it and the feature will take effect. Enforcing
+  sign-in guarantees the feature always takes effect.
+
 
 ### Step one: Create the `admin-settings.json` file and save it in the correct location
 

--- a/content/security/for-admins/image-access-management.md
+++ b/content/security/for-admins/image-access-management.md
@@ -18,7 +18,13 @@ For example, a developer, who is part of an organization, building a new contain
 
 ## Prerequisites
 
-You need to [configure a registry.json to enforce sign-in](enforce-sign-in/_index.md). For Image Access Management to take effect, Docker Desktop users must authenticate to your organization.
+You need to [configure a registry.json to enforce
+sign-in](enforce-sign-in/_index.md). For Image Access Management to take effect,
+Docker Desktop users must authenticate to your organization. Enforcing sign-in
+ensures that your Docker Desktop developers always authenticate to your
+organization, even though they can authenticate without it and the feature will
+take effect. Enforcing sign-in guarantees the feature always takes effect.
+
 
 ## Configure Image Access Management permissions
 

--- a/content/security/for-admins/registry-access-management.md
+++ b/content/security/for-admins/registry-access-management.md
@@ -26,9 +26,15 @@ Example registries administrators can allow include:
  - Nexus
  - Artifactory
 
-## Prerequisites 
+## Prerequisites
 
-You need to [configure a registry.json to enforce sign-in](enforce-sign-in/_index.md). For Registry Access Management to take effect, Docker Desktop users must authenticate to your organization.
+You need to [configure a registry.json to enforce
+sign-in](enforce-sign-in/_index.md). For Registry Access Management to take
+effect, Docker Desktop users must authenticate to your organization. Enforcing
+sign-in ensures that your Docker Desktop developers always authenticate to your
+organization, even though they can authenticate without it and the feature will
+take effect. Enforcing sign-in guarantees the feature always takes effect.
+
 
 ## Configure Registry Access Management permissions
 


### PR DESCRIPTION
## Description

Clarified enforcing sign-in's role as a prerequisite. The features can still be configured and used without enforcing sign-in for some atypical use-cases.

## Related issues or tickets

ENGDOCS-2164

## Reviews

- [ ] Editorial review
