### PR TITLE
Fix prune command in docker buildx du

### DIFF
--- a/data/buildx/docker_buildx_du.yaml
+++ b/data/buildx/docker_buildx_du.yaml
@@ -62,7 +62,7 @@ examples: |-
     Total:         10.36GB
     ```
 
-    If `RECLAIMABLE` is false, the `docker buildx du prune` command won't delete
+    If `RECLAIMABLE` is false, the `docker buildx prune` command won't delete
     the record, even if you use `--all`. That's because the record is actively in
     use by some component of the builder.
 


### PR DESCRIPTION
## Description
The command to prune data is `docker buildx prune`, not `docker buildx du prune` (which fails with `ERROR: "docker buildx du" accepts no arguments.`)
<!-- Tell us what you did and why -->

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Technical review
- [ ] Editorial review
- [ ] Product review