### PR TITLE
Add note that Windows containers are not supported

### DIFF
--- a/content/network/drivers/host.md
+++ b/content/network/drivers/host.md
@@ -93,6 +93,8 @@ isolating your containers from the host and allowing them access to the host
 network contradict each other.
 - IPv6 is not yet supported. Services need to use IPv4 and bind to address
   `127.0.0.1` in the container to be visible on the host.
+- Only Linux containers are supported. Host networking does not work with
+  Windows containers.
 
 ## Next steps
 


### PR DESCRIPTION
## Description

Add to the list of limitations that Windows containers are not supported by host networking.

## Related issues or tickets

https://github.com/docker/roadmap/issues/238

## Reviews

- [ ] Technical review
- [x] Editorial review
- [ ] Product review