### PR TITLE
Update docker hub API list repository tags sample response

### DIFF
--- a/content/docker-hub/api/latest.yaml
+++ b/content/docker-hub/api/latest.yaml
@@ -1825,8 +1825,9 @@ components:
           type: integer
           description: "tag ID"
         images:
-          type: object
-          $ref: '#/components/schemas/image'
+          type: array
+          items:
+            $ref: '#/components/schemas/image'
         creator:
           type: integer
           description: "ID of the user that pushed the tag"


### PR DESCRIPTION
The sample response for `/v2/namespaces/{namespace}/repositories/{repository}/tags` was wrong. The `images` tag should actually contain an array of `image` objects, not a singular `image` object.


## Related issues or tickets

Fixes #20552 

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Technical review
- [ ] Editorial review
- [ ] Product review