### PR TITLE
Make the specification of max-buffer-size discoverable.

### DIFF
--- a/content/engine/logging/configure.md
+++ b/content/engine/logging/configure.md
@@ -151,9 +151,11 @@ STDERR or STDOUT streams block.
 The `mode` log option controls whether to use the `blocking` (default) or
 `non-blocking` message delivery.
 
-The `max-buffer-size` log option controls the size of the buffer used for
-intermediate message storage when `mode` is set to `non-blocking`. `max-buffer-size`
-defaults to 1 megabyte.
+The `max-buffer-size` controls the size of the buffer used for
+intermediate message storage when `mode` is set to `non-blocking`.
+The default is `1m` meaning 1 megabyte (1 million bytes).
+See [here](https://pkg.go.dev/github.com/docker/go-units#FromHumanSize) for the allowed format strings,
+some examples are `1KiB` for 1024 bytes, `2g` for 2 billion bytes.
 
 The following example starts an Alpine container with log output in non-blocking
 mode and a 4 megabyte buffer:

--- a/content/engine/logging/configure.md
+++ b/content/engine/logging/configure.md
@@ -153,8 +153,8 @@ The `mode` log option controls whether to use the `blocking` (default) or
 
 The `max-buffer-size` controls the size of the buffer used for
 intermediate message storage when `mode` is set to `non-blocking`.
-The default is `1m` meaning 1 megabyte (1 million bytes).
-See [here](https://pkg.go.dev/github.com/docker/go-units#FromHumanSize) for the allowed format strings,
+The default is `1m` meaning 1 MB (1 million bytes).
+See [function `FromHumanSize()` in the `go-units` package](https://pkg.go.dev/github.com/docker/go-units#FromHumanSize) for the allowed format strings,
 some examples are `1KiB` for 1024 bytes, `2g` for 2 billion bytes.
 
 The following example starts an Alpine container with log output in non-blocking


### PR DESCRIPTION
## Description

It's not obvious what type of strings are accepted by `max-buffer-size` nor is it obvious what e.g. `4m` means. Four _minutes_? (to me, it looks like something accepted by [ParseDuration](https://pkg.go.dev/time#ParseDuration)).

Instead we should direct users to the relevant documentation to explain clearly what's allowed and what the units are.

Specifically in our case we were trying to understand how to configure the logging driver for our AWS tasks.

## Related issues or tickets

- Closes #20503 

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Technical review
- [ ] Editorial review
- [ ] Product review