### PR TITLE
hub: remove webhook callback_url

### DIFF
--- a/content/docker-hub/webhooks.md
+++ b/content/docker-hub/webhooks.md
@@ -54,36 +54,3 @@ Webhook payloads have the following JSON format:
   }
 }
 ```
-
-## Validate a webhook callback
-
-To validate a callback in a webhook chain, you need to:
-
-1. Retrieve the `callback_url` value in the request's JSON payload.
-2. Send a POST request to this URL containing a valid JSON body.
-
-> **Note**
->
-> A chain request is only considered complete once the last callback is validated.
-
-### Callback JSON data
-
-The following parameters are recognized in callback data:
-
-* `state` (required): Accepted values are `success`, `failure`, and `error`.
-  If the state isn't `success`, the webhook chain is interrupted.
-* `description`: A string containing miscellaneous information that is
-  available on Docker Hub. Maximum 255 characters.
-* `context`: A string containing the context of the operation. Can be retrieved
-  from the Docker Hub. Maximum 100 characters.
-* `target_url`: The URL where the results of the operation can be found. Can be
-  retrieved on the Docker Hub.
-
-The following is an example of a callback payload:
-
-    {
-      "state": "success",
-      "description": "387 tests PASSED",
-      "context": "Continuous integration by Acme CI",
-      "target_url": "https://ci.acme.com/results/afd339c1c3d27"
-    }


### PR DESCRIPTION
<!--Delete sections as needed -->

## Description

Removed section about using the callback_url as it does not work.

## Related issues or tickets

CSESC-179
ENGDOCS-2172

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Technical review
- [ ] Editorial review