### PR TITLE
docs: typo in journald docs

### DIFF
--- a/content/config/containers/logging/journald.md
+++ b/content/config/containers/logging/journald.md
@@ -107,7 +107,7 @@ flag only retrieves messages generated since the last system boot:
 $ sudo journalctl -b CONTAINER_NAME=webserver
 ```
 
-The `-o` flag specifies the format for the retried log messages. Use `-o json`
+The `-o` flag specifies the format for the retrieved log messages. Use `-o json`
 to return the log messages in JSON format.
 
 ```console


### PR DESCRIPTION
## Description

Fixed small typo in journald docs:  `retried` ➡️ `retrieved`

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Technical review
- [ ] Editorial review
- [ ] Product review