### PR TITLE
buildx: image-manifest param for registry and local cache backends

### DIFF
--- a/content/build/cache/backends/_index.md
+++ b/content/build/cache/backends/_index.md
@@ -168,3 +168,16 @@ $ docker buildx build --push -t <registry>/<image> \
 
 This property is only meaningful with the `--cache-to` flag. When fetching
 cache, BuildKit will auto-detect the correct media types to use.
+
+By default, the OCI media type generates an image index for the cache image.
+Some OCI registries, such as Amazon ECR, don't support the image index media
+type: `application/vnd.oci.image.index.v1+json`. If you export cache images to
+ECR, or any other registry that doesn't support image indices, set the
+`image-manifest` parameter to `true` to generate a single image manifest
+instead of an image index for the cache image:
+
+```console
+$ docker buildx build --push -t <registry>/<image> \
+  --cache-to type=registry,ref=<registry>/<cache-image>,oci-mediatypes=true,image-manifest=true \
+  --cache-from type=registry,ref=<registry>/<cache-image> .
+```

--- a/content/build/cache/backends/local.md
+++ b/content/build/cache/backends/local.md
@@ -24,17 +24,18 @@ $ docker buildx build --push -t <registry>/<image> \
 The following table describes the available CSV parameters that you can pass to
 `--cache-to` and `--cache-from`.
 
-| Name                | Option       | Type                    | Default | Description                                                          |
-| ------------------- | ------------ | ----------------------- | ------- | -------------------------------------------------------------------- |
-| `src`               | `cache-from` | String                  |         | Path of the local directory where cache gets imported from.          |
-| `digest`            | `cache-from` | String                  |         | Digest of manifest to import, see [cache versioning][4].             |
-| `dest`              | `cache-to`   | String                  |         | Path of the local directory where cache gets exported to.            |
-| `mode`              | `cache-to`   | `min`,`max`             | `min`   | Cache layers to export, see [cache mode][1].                         |
-| `oci-mediatypes`    | `cache-to`   | `true`,`false`          | `true`  | Use OCI media types in exported manifests, see [OCI media types][2]. |
-| `compression`       | `cache-to`   | `gzip`,`estargz`,`zstd` | `gzip`  | Compression type, see [cache compression][3].                        |
-| `compression-level` | `cache-to`   | `0..22`                 |         | Compression level, see [cache compression][3].                       |
-| `force-compression` | `cache-to`   | `true`,`false`          | `false` | Forcibly apply compression, see [cache compression][3].              |
-| `ignore-error`      | `cache-to`   | Boolean                 | `false` | Ignore errors caused by failed cache exports.                        |
+| Name                | Option       | Type                    | Default | Description                                                                                                                     |
+| ------------------- | ------------ | ----------------------- | ------- | ------------------------------------------------------------------------------------------------------------------------------- |
+| `src`               | `cache-from` | String                  |         | Path of the local directory where cache gets imported from.                                                                     |
+| `digest`            | `cache-from` | String                  |         | Digest of manifest to import, see [cache versioning][4].                                                                        |
+| `dest`              | `cache-to`   | String                  |         | Path of the local directory where cache gets exported to.                                                                       |
+| `mode`              | `cache-to`   | `min`,`max`             | `min`   | Cache layers to export, see [cache mode][1].                                                                                    |
+| `oci-mediatypes`    | `cache-to`   | `true`,`false`          | `true`  | Use OCI media types in exported manifests, see [OCI media types][2].                                                            |
+| `image-manifest`    | `cache-to`   | `true`,`false`          | `false` | When using OCI media types, generate an image manifest instead of an image index for the cache image, see [OCI media types][2]. |
+| `compression`       | `cache-to`   | `gzip`,`estargz`,`zstd` | `gzip`  | Compression type, see [cache compression][3].                                                                                   |
+| `compression-level` | `cache-to`   | `0..22`                 |         | Compression level, see [cache compression][3].                                                                                  |
+| `force-compression` | `cache-to`   | `true`,`false`          | `false` | Forcibly apply compression, see [cache compression][3].                                                                         |
+| `ignore-error`      | `cache-to`   | Boolean                 | `false` | Ignore errors caused by failed cache exports.                                                                                   |
 
 [1]: _index.md#cache-mode
 [2]: _index.md#oci-media-types

--- a/content/build/cache/backends/registry.md
+++ b/content/build/cache/backends/registry.md
@@ -36,15 +36,16 @@ $ docker buildx build --push -t <registry>/<image> \
 The following table describes the available CSV parameters that you can pass to
 `--cache-to` and `--cache-from`.
 
-| Name                | Option                  | Type                    | Default | Description                                                          |
-| ------------------- | ----------------------- | ----------------------- | ------- | -------------------------------------------------------------------- |
-| `ref`               | `cache-to`,`cache-from` | String                  |         | Full name of the cache image to import.                              |
-| `mode`              | `cache-to`              | `min`,`max`             | `min`   | Cache layers to export, see [cache mode][1].                         |
-| `oci-mediatypes`    | `cache-to`              | `true`,`false`          | `true`  | Use OCI media types in exported manifests, see [OCI media types][2]. |
-| `compression`       | `cache-to`              | `gzip`,`estargz`,`zstd` | `gzip`  | Compression type, see [cache compression][3].                        |
-| `compression-level` | `cache-to`              | `0..22`                 |         | Compression level, see [cache compression][3].                       |
-| `force-compression` | `cache-to`              | `true`,`false`          | `false` | Forcibly apply compression, see [cache compression][3].              |
-| `ignore-error`      | `cache-to`              | Boolean                 | `false` | Ignore errors caused by failed cache exports.                        |
+| Name                | Option                  | Type                    | Default | Description                                                                                                                     |
+| ------------------- | ----------------------- | ----------------------- | ------- | ------------------------------------------------------------------------------------------------------------------------------- |
+| `ref`               | `cache-to`,`cache-from` | String                  |         | Full name of the cache image to import.                                                                                         |
+| `mode`              | `cache-to`              | `min`,`max`             | `min`   | Cache layers to export, see [cache mode][1].                                                                                    |
+| `oci-mediatypes`    | `cache-to`              | `true`,`false`          | `true`  | Use OCI media types in exported manifests, see [OCI media types][2].                                                            |
+| `image-manifest`    | `cache-to`              | `true`,`false`          | `false` | When using OCI media types, generate an image manifest instead of an image index for the cache image, see [OCI media types][2]. |
+| `compression`       | `cache-to`              | `gzip`,`estargz`,`zstd` | `gzip`  | Compression type, see [cache compression][3].                                                                                   |
+| `compression-level` | `cache-to`              | `0..22`                 |         | Compression level, see [cache compression][3].                                                                                  |
+| `force-compression` | `cache-to`              | `true`,`false`          | `false` | Forcibly apply compression, see [cache compression][3].                                                                         |
+| `ignore-error`      | `cache-to`              | Boolean                 | `false` | Ignore errors caused by failed cache exports.                                                                                   |
 
 [1]: _index.md#cache-mode
 [2]: _index.md#oci-media-types


### PR DESCRIPTION
## Description

Add `image-manifest` parameter to the `type=registry` and `type=local` cache
backend configurations. This parameter allows the user to specify the image
manifest to use when exporting an OCI cache image to a registry or to the local
filesystem.

## Related issues or tickets

- https://github.com/moby/buildkit/pull/3724
