### PR TITLE
bake: shared session for local context

### DIFF
--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -14,21 +14,7 @@ group "default" {
   targets = ["release"]
 }
 
-target "ctx" {
-  target = "ctx"
-  context = "."
-  output = ["type=cacheonly"]
-  provenance = false
-}
-
-target "_common" {
-  contexts = {
-    ctx = "target:ctx"
-  }
-}
-
 target "index" {
-  inherits = ["_common"]
   # generate a new local search index
   target = "index"
   output = ["type=local,dest=static/pagefind"]
@@ -36,7 +22,6 @@ target "index" {
 }
 
 target "release" {
-  inherits = ["_common"]
   args = {
     HUGO_ENV = HUGO_ENV
     DOCS_URL = DOCS_URL
@@ -52,28 +37,24 @@ group "validate" {
 
 target "test" {
   target = "test"
-  inherits = ["_common"]
   output = ["type=cacheonly"]
   provenance = false
 }
 
 target "lint" {
   target = "lint"
-  inherits = ["_common"]
   output = ["type=cacheonly"]
   provenance = false
 }
 
 target "unused-media" {
   target = "unused-media"
-  inherits = ["_common"]
   output = ["type=cacheonly"]
   provenance = false
 }
 
 target "test-go-redirects" {
   target = "test-go-redirects"
-  inherits = ["_common"]
   output = ["type=cacheonly"]
   provenance = false
 }


### PR DESCRIPTION
## Description

With the latest Buildx, BuildKit, and Dockerfile, bake can detect when
multiple targets use the same local context, and deduplicate context
transfer.

## Related issues

- https://github.com/docker/buildx/pull/2615
