### PR TITLE
[docs] update Register a tax certificate 

### DIFF
--- a/content/billing/tax-certificate.md
+++ b/content/billing/tax-certificate.md
@@ -36,7 +36,7 @@ Palo Alto, CA 94306
    >
    > You can list multiple namespaces that share the same tax exemption certificate, if applicable.
    { .tip }
-4. Select **Browse Files** to upload the tax certificate from your system or simply drag and drop the certificate in the given space.
+4. Add the tax certificate from your system by dragging and dropping them onto the file area, or select the **Browse Files** button to open a file dialog.
 5. Select **Submit**.
 
-Docker's Support team will reach out to you once a ticket is open and if Support team needs any additional information. You'll receive a confirmation from Docker once your tax exemption status has processed and is applied to your account.
+Docker's support team will reach out to you if any additional information is required. You'll receive an e-mail confirmation from Docker once your tax exemption status is applied to your account.

--- a/content/billing/tax-certificate.md
+++ b/content/billing/tax-certificate.md
@@ -29,13 +29,16 @@ Palo Alto, CA 94306
 ## Register a tax certificate
 
 1. [Submit a Docker Support ticket](https://hub.docker.com/support/contact) to initiate the process to register a tax certificate.
-2. Enter the required information. Select **Billing** from the **Topic** drop-down.
-3. In the **Additional Information** field, list the Docker ID/namespace(s) of the accounts that you want to apply the tax exemption certificate to.  
+2. Enter the required information.
+3. Select **Billing** from the **Topic** drop-down.
+4. Select **Tax Information** from the **Subtopic** drop-down.
+5. In the **Additional Information** field, list the Docker ID/namespace(s) of the accounts that you want to apply the tax exemption certificate to.  
 
    > **Tip**
    >
    > You can list multiple namespaces that share the same tax exemption certificate, if applicable.
    { .tip }
-4. Select **Submit**.
+6. Click on **Browse Files** to upload the tax certificate from your system or simply drag and drop the certificate in the given space.
+7. Select **Submit**.
 
-Docker's Support team will reach out for you to submit your certificate once a ticket is open. You'll receive a confirmation from Docker once your tax exemption status has processed and is applied to your account.
+Docker's Support team will reach out to you once a ticket is open and if we need any additional information. You'll receive a confirmation from Docker once your tax exemption status has processed and is applied to your account.

--- a/content/billing/tax-certificate.md
+++ b/content/billing/tax-certificate.md
@@ -28,17 +28,15 @@ Palo Alto, CA 94306
 
 ## Register a tax certificate
 
-1. [Submit a Docker Support ticket](https://hub.docker.com/support/contact) to initiate the process to register a tax certificate.
+1. [Submit a Docker Support ticket](https://hub.docker.com/support/contact?topic=Billing&subtopic=Tax%20information) to initiate the process to register a tax certificate.
 2. Enter the required information.
-3. Select **Billing** from the **Topic** drop-down.
-4. Select **Tax Information** from the **Subtopic** drop-down.
-5. In the **Additional Information** field, list the Docker ID/namespace(s) of the accounts that you want to apply the tax exemption certificate to.  
+3. In the **Additional Information** field, list the Docker ID/namespace(s) of the accounts that you want to apply the tax exemption certificate to.  
 
    > **Tip**
    >
    > You can list multiple namespaces that share the same tax exemption certificate, if applicable.
    { .tip }
-6. Click on **Browse Files** to upload the tax certificate from your system or simply drag and drop the certificate in the given space.
-7. Select **Submit**.
+4. Click on **Browse Files** to upload the tax certificate from your system or simply drag and drop the certificate in the given space.
+5. Select **Submit**.
 
 Docker's Support team will reach out to you once a ticket is open and if we need any additional information. You'll receive a confirmation from Docker once your tax exemption status has processed and is applied to your account.

--- a/content/billing/tax-certificate.md
+++ b/content/billing/tax-certificate.md
@@ -36,7 +36,7 @@ Palo Alto, CA 94306
    >
    > You can list multiple namespaces that share the same tax exemption certificate, if applicable.
    { .tip }
-4. Click on **Browse Files** to upload the tax certificate from your system or simply drag and drop the certificate in the given space.
+4. Select **Browse Files** to upload the tax certificate from your system or simply drag and drop the certificate in the given space.
 5. Select **Submit**.
 
-Docker's Support team will reach out to you once a ticket is open and if we need any additional information. You'll receive a confirmation from Docker once your tax exemption status has processed and is applied to your account.
+Docker's Support team will reach out to you once a ticket is open and if Support team needs any additional information. You'll receive a confirmation from Docker once your tax exemption status has processed and is applied to your account.


### PR DESCRIPTION
<!--Delete sections as needed -->

## Description

I updated tax certificate upload instructions because the support form now has the ability for a customer to be able to upload the certificate directly into the ticket as opposed to the support team asking for the certificate after the ticket is open. 

## Related issues or tickets

<!-- Related issues, pull requests, or Jira tickets -->

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Technical review
- [ ] Editorial review
- [ ] Product review