### PR TITLE
scout: update ootb policy to match health score rules

### DIFF
--- a/.github/vale/config/vocabularies/Docker/accept.txt
+++ b/.github/vale/config/vocabularies/Docker/accept.txt
@@ -14,6 +14,7 @@ Autotest
 Azure
 BuildKit
 BusyBox
+CISA
 CNCF
 CVEs?
 CentOS

--- a/content/scout/policy/scores.md
+++ b/content/scout/policy/scores.md
@@ -108,20 +108,10 @@ The policies that influence the score, and their respective weights, are as foll
 | [No fixable critical or high vulnerabilities](/scout/policy#no-fixable-critical-or-high-vulnerabilities)   | 20     |
 | [No high-profile vulnerabilities](/scout/policy#no-high-profile-vulnerabilities)                           | 20     |
 | [Supply chain attestations](/scout/policy#supply-chain-attestations)                                       | 15     |
-| [No unapproved base images](/scout/policy/#no-unapproved-base-images) \*                                   | 15     |
+| [No unapproved base images](/scout/policy/#no-unapproved-base-images)                                      | 15     |
 | [No outdated base images](/scout/policy#no-outdated-base-images)                                           | 10     |
 | [Default non-root user](/scout/policy#default-non-root-user)                                               | 5      |
-| No AGPL v3 licenses \*\*                                                                                   | 5      |
-
-\* _The **No unapproved base images** policy used for health score evaluation also
-checks that the tags of Docker Official Images use supported tags and, where
-applicable, that the Linux distro that the image uses is a supported distro
-version. This is a policy configuration option that's enabled by default for
-health score evaluation. For more information, refer to the
-[Unapproved base images](/scout/policy/#no-unapproved-base-images) policy._
-
-\*\* _The **No AGPL v3 licenses** policy is a subset of the
-[Copyleft licenses](./_index.md#no-copyleft-licenses) policy._
+| [No AGPL v3 licenses](/scout/policy/_index.md#no-agpl-v3-licenses)                                         | 5      |
 
 ### Evaluation
 

--- a/content/scout/release-notes/platform.md
+++ b/content/scout/release-notes/platform.md
@@ -15,6 +15,29 @@ Docker Scout platform, including the Dashboard. For CLI release notes, refer to
 Take a look at the [Docker Public Roadmap](https://github.com/docker/roadmap/projects/1)
 for what's coming next.
 
+## Q3 2024
+
+New features and enhancements released in the third quarter of 2024.
+
+### 2024-08-13
+
+This release changes the out-of-the-box policies to align with the policy
+configurations used to evaluate Docker Scout [health scores](/scout/policy/scores.md).
+
+The default out-of-the-box policies are now:
+
+- **No high-profile vulnerabilities**
+- **No fixable critical or high vulnerabilities**
+- **No unapproved base images**
+- **Default non-root user**
+- **Supply chain attestations**
+- **No outdated base images**
+- **No AGPL v3 licenses**
+
+The configurations for these policies are now the same as the configurations
+used to calculate health scores. Previously, the out-of-the-box policies had
+different configurations than the health score policies.
+
 ## Q2 2024
 
 New features and enhancements released in the second quarter of 2024.

--- a/data/redirects.yml
+++ b/data/redirects.yml
@@ -615,7 +615,7 @@
   - /go/scout-policy/
 "/scout/policy/#no-fixable-critical-or-high-vulnerabilities":
   - /go/scout-policy-dsp001/
-"/scout/policy/#no-copyleft-licenses":
+"/scout/policy/#no-agpl-v3-licenses":
   - /go/scout-policy-dsp002/
 "/scout/policy/#no-outdated-base-images":
   - /go/scout-policy-dsp003/


### PR DESCRIPTION
## Description

Updates the ootb policy descriptions, defaults to align them with health score evaluation logic.
