### PR TITLE
accounts: align topics with toc

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -66,7 +66,7 @@ grid:
       - text: "Overview"
         url: "/docker-hub/"
       - text: "Create an account"
-        url: "/docker-id/"
+        url: "/accounts/create-account/"
       - text: "Create a repository"
         url: "/docker-hub/repos/create/"
   - title: Docker Scout

--- a/content/accounts/_index.md
+++ b/content/accounts/_index.md
@@ -6,7 +6,7 @@ grid:
 - title: Create a Docker ID
   description: Get started with Docker and create an account.
   icon: fingerprint
-  link: /docker-id/
+  link: /accounts/create-account/
 - title: Manage account
   description: Learn how to manage the settings for your account.
   icon: manage_accounts

--- a/content/accounts/create-account.md
+++ b/content/accounts/create-account.md
@@ -5,6 +5,7 @@ keywords: accounts, docker ID, billing, paid plans, support, Hub, Store, Forums,
 title: Create an account
 aliases:
 - /docker-hub/accounts/
+- /docker-id/
 ---
 
 You can create a free Docker account with your email address or by signing up with your Google or GitHub account. Once you've created your account with a unique Docker ID, you can access all Docker products, including Docker Hub. With Docker Hub, you can access repositories and explore images that are available from the community and verified publishers.

--- a/content/admin/faqs/general-faqs.md
+++ b/content/admin/faqs/general-faqs.md
@@ -14,7 +14,7 @@ aliases:
 A Docker ID is a username for your Docker account that lets you access Docker products. All you need is an email address to create a Docker ID, or you can sign up with your Google or GitHub account. Your Docker ID must be between 4 and 30 characters long, and can only contain
 numbers and lowercase letters. You can't use any special characters or spaces.
 
-For more information, see [Docker ID](../../docker-id/index.md). If your administrator enforces [single sign-on (SSO)](../../security/for-admins/single-sign-on/index.md), this provisions a Docker ID for new users.
+For more information, see [Docker ID](/accounts/create-account/). If your administrator enforces [single sign-on (SSO)](../../security/for-admins/single-sign-on/index.md), this provisions a Docker ID for new users.
 
 Developers may have multiple Docker IDs in order to separate their Docker IDs associated with an organization with a Docker Business or Team subscription, and their personal use Docker IDs.
 

--- a/content/admin/organization/orgs.md
+++ b/content/admin/organization/orgs.md
@@ -9,7 +9,7 @@ aliases:
 
 This section describes how to create an organization. Before you begin:
 
-- You need a [Docker ID](../../docker-id/_index.md).
+- You need a [Docker ID](/accounts/create-account/).
 - Review the [Docker subscriptions and features](../../subscription/core-subscription/details.md) to determine what plan to choose for your organization.
 
 ## Create an organization
@@ -23,7 +23,7 @@ detailed instructions on converting an existing user account to an organization,
 
 To create an organization:
 
-1. Sign in to [Docker Hub](https://hub.docker.com/) using your [Docker ID](../../docker-id/_index.md), your email address, or your social provider.
+1. Sign in to [Docker Hub](https://hub.docker.com/) using your Docker ID, your email address, or your social provider.
 2. Select **Organizations** and then **Create Organization** to create a new
    organization.
 3. Choose a plan for your organization and select **Buy Now**. See

--- a/content/billing/core-billing/get-started-core.md
+++ b/content/billing/core-billing/get-started-core.md
@@ -8,7 +8,7 @@ keywords: payments, billing, subscription, invoices, docker core, subscribe
 
 Docker Core subscriptions offer features and benefits to support both new and professional developers, as well as plans for individuals, teams, and enterprise businesses. To learn more about what's included with each tier, see [Docker Core subscriptions and features](../../subscription/core-subscription/details.md) and [Docker Pricing](https://www.docker.com/pricing/).
 
-In this section, learn how to get started with a Docker Core subscription for individuals or for organizations. Before you begin, make sure you have a [Docker ID](../../docker-id/_index.md).
+In this section, learn how to get started with a Docker Core subscription for individuals or for organizations. Before you begin, make sure you have a [Docker ID](/accounts/create-account/).
 
 ## Set up Docker Core subscription for personal account
 

--- a/content/build-cloud/_index.md
+++ b/content/build-cloud/_index.md
@@ -51,7 +51,7 @@ data between cloud builders.
 ## Get Docker Build Cloud
 
 To get started with Docker Build Cloud,
-[create a Docker account](/docker-id/_index.md)
+[create a Docker account](/accounts/create-account/)
 and sign up for the starter plan on the
 [Docker Build Cloud Dashboard](https://build.docker.com/).
 

--- a/content/desktop/get-started.md
+++ b/content/desktop/get-started.md
@@ -50,7 +50,7 @@ In large enterprises where admin access is restricted, administrators can [enfor
 ## Signing in with Docker Desktop for Linux
 
 Docker Desktop for Linux relies on [`pass`](https://www.passwordstore.org/) to store credentials in gpg2-encrypted files.
-Before signing in to Docker Desktop with your [Docker ID](../docker-id/_index.md), you must initialize `pass`.
+Before signing in to Docker Desktop with your [Docker ID](/accounts/create-account/), you must initialize `pass`.
 Docker Desktop displays a warning if you've not initialized `pass`.
 
 You can initialize pass by using a gpg key. To generate a gpg key, run:

--- a/content/docker-hub/_index.md
+++ b/content/docker-hub/_index.md
@@ -3,10 +3,6 @@ description: Find a comprehensive overview of Docker Hub, including its features
 keywords: Docker, docker, docker hub, hub, repositories, docker account
 title: Overview of Docker Hub
 grid:
-- title: Create a Docker ID
-  description: Register and create a new Docker ID.
-  icon: fingerprint
-  link: /docker-id
 - title: Quickstart
   description: Step-by-step instructions on getting started on Docker Hub.
   icon: explore

--- a/content/docker-hub/quickstart.md
+++ b/content/docker-hub/quickstart.md
@@ -11,7 +11,7 @@ The following section contains step-by-step instructions on how to get started w
 
 Start by creating a [Docker ID](https://hub.docker.com/signup).
 
-A [Docker ID](../docker-id/_index.md) grants you access to Docker Hub repositories and lets you explore available images from the community and verified publishers. You also need a Docker ID to share images on Docker Hub.
+A [Docker ID](/accounts/create-account/) grants you access to Docker Hub repositories and lets you explore available images from the community and verified publishers. You also need a Docker ID to share images on Docker Hub.
 
 > **Tip**
 >

--- a/content/scout/guides/vex.md
+++ b/content/scout/guides/vex.md
@@ -26,7 +26,7 @@ If you want to follow along the steps of this guide, you'll need the following:
 - The latest version of Docker Desktop
 - The [containerd image store](../../desktop/containerd.md) must be enabled
 - Git
-- A [Docker account](../../docker-id/_index.md)
+- A [Docker account](/accounts/create-account/)
 - A GitHub account
 
 ## Introduction to VEX

--- a/content/subscription/core-subscription/downgrade.md
+++ b/content/subscription/core-subscription/downgrade.md
@@ -27,7 +27,7 @@ You may need to reduce the number of team members and convert any private reposi
 
 ### SSO and SCIM
 
-If you want to downgrade a Docker Business subscription and your organization uses single sign-on (SSO) for user authentication, you need to remove your SSO connection and verified domains before downgrading. After removing the SSO connection, any organization members that were auto-provisioned (for example, with SCIM) need to set up a password to sign in without SSO. To do this, users can [reset their password at sign in](/docker-id/#reset-your-password-at-sign-in).
+If you want to downgrade a Docker Business subscription and your organization uses single sign-on (SSO) for user authentication, you need to remove your SSO connection and verified domains before downgrading. After removing the SSO connection, any organization members that were auto-provisioned (for example, with SCIM) need to set up a password to sign in without SSO. To do this, users can [reset their password at sign in](/accounts/create-account/#reset-your-password-at-sign-in).
 
 ## Downgrade your Docker subscription
 

--- a/data/toc.yaml
+++ b/data/toc.yaml
@@ -2235,7 +2235,7 @@ Manuals:
   section:
   - path: /accounts/
     title: Overview
-  - path: /docker-id/
+  - path: /accounts/create-account/
     title: Create an account
   - path: /accounts/manage-account/
     title: Manage an account


### PR DESCRIPTION
<!--Delete sections as needed -->

## Description

Moved docker-id topic to accounts/ to align with toc.
Updated links for the moved topic.
Removed docker-id topic from Hub overview topic as it no longer lives in that section.

## Related issues or tickets

ENGDOCS-2169

## Reviews

- [ ] Editorial review
