### PR TITLE
release: increase timeout for creating lambda from 3s to 10s

### DIFF
--- a/_releaser/aws.go
+++ b/_releaser/aws.go
@@ -129,6 +129,7 @@ func (s *AwsCloudfrontUpdateCmd) Run() error {
 		}
 		_, err = svc.CreateFunction(&lambda.CreateFunctionInput{
 			FunctionName: aws.String(s.Function),
+			Timeout:      aws.Int64(10),
 		})
 		if aerr, ok := err.(awserr.Error); ok && aerr.Code() != lambda.ErrCodeResourceConflictException {
 			return err


### PR DESCRIPTION
We've seen instances where the publishing workflow has recently started
failing when trying to update the CloudFront config (create lambda
function). Re-running the workflow usually fixes the problem.

https://github.com/docker/docs/actions/runs/10395290852/job/28786977469

The default timeout for creating a lambda function is 3 seconds. Bumping
the limit to 10s might help resolve this issue.

Signed-off-by: David Karlsson <35727626+dvdksn@users.noreply.github.com>
