### PR TITLE
Fix the error describes of `COPY` chapter in reference.md

### DIFF
--- a/_vendor/github.com/moby/buildkit/frontend/dockerfile/docs/reference.md
+++ b/_vendor/github.com/moby/buildkit/frontend/dockerfile/docs/reference.md
@@ -1547,11 +1547,11 @@ relative to the root of the current build stage.
 
 ```dockerfile
 # create /abs/test.txt
-ADD test.txt /abs/
+COPY test.txt /abs/
 ```
 
-Trailing slashes are significant. For example, `ADD test.txt /abs` creates a
-file at `/abs`, whereas `ADD test.txt /abs/` creates `/abs/test.txt`.
+Trailing slashes are significant. For example, `COPY test.txt /abs` creates a
+file at `/abs`, whereas `COPY test.txt /abs/` creates `/abs/test.txt`.
 
 If the destination path doesn't begin with a leading slash, it's interpreted as
 relative to the working directory of the build container.
@@ -1559,7 +1559,7 @@ relative to the working directory of the build container.
 ```dockerfile
 WORKDIR /usr/src/app
 # create /usr/src/app/rel/test.txt
-ADD test.txt rel/
+COPY test.txt rel/
 ```
 
 If destination doesn't exist, it's created, along with all missing directories


### PR DESCRIPTION
<!--Delete sections as needed -->

## Description

This chapter is describing the usage of `COPY`. While these places is using `ADD` instead，Which could make users confused。

## Related issues or tickets

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [  ] Technical review
- [ x ] Editorial review
- [  ] Product review