### PR TITLE
Add "rootless mode" to exceptions of "Privileged user requirement" in `docker login`

### DIFF
--- a/data/engine-cli/docker_login.yaml
+++ b/data/engine-cli/docker_login.yaml
@@ -77,6 +77,7 @@ examples: |-
 
     - Connecting to a remote daemon, such as a `docker-machine` provisioned `docker engine`.
     - The user is added to the `docker` group. This will impact the security of your system; the `docker` group is `root` equivalent.  See [Docker Daemon Attack Surface](/engine/security/#docker-daemon-attack-surface) for details.
+    - The Docker daemon is running as a non-root user, i.e. [rootless mode](https://docs.docker.com/engine/security/rootless/).
 
     You can log in to any public or private repository for which you have
     credentials.  When you log in, the command stores credentials in


### PR DESCRIPTION
Fixes #20415 