### PR TITLE
redirect: removes an incorrect alias

### DIFF
--- a/content/guides/docker-concepts/building-images/multi-stage-builds.md
+++ b/content/guides/docker-concepts/building-images/multi-stage-builds.md
@@ -2,8 +2,6 @@
 title: Multi-stage builds
 keywords: concepts, build, images, container, docker desktop
 description: This concept page will teach you about the purpose of the multi-stage build and its benefits
-aliases:
-  - /build/guides/multi-stage/
 ---
 
 {{< youtube-embed vR185cjwxZ8 >}}


### PR DESCRIPTION
that page doesn't exist, and the actual page that it was meant to replace (`/build/guide/multi-stage`) has not yet been removed.