### PR TITLE
revert 98987a6

### DIFF
--- a/_releaser/aws.go
+++ b/_releaser/aws.go
@@ -129,7 +129,6 @@ func (s *AwsCloudfrontUpdateCmd) Run() error {
 		}
 		_, err = svc.CreateFunction(&lambda.CreateFunctionInput{
 			FunctionName: aws.String(s.Function),
-			Timeout:      aws.Int64(10),
 		})
 		if aerr, ok := err.(awserr.Error); ok && aerr.Code() != lambda.ErrCodeResourceConflictException {
 			return err

--- a/_releaser/aws.go
+++ b/_releaser/aws.go
@@ -153,8 +153,8 @@ func (s *AwsCloudfrontUpdateCmd) Run() error {
 
 	log.Printf("INFO: waiting for lambda function to be processed\n")
 	// the lambda function code image is never ready right away, AWS has to
-	// process it, so we wait 3 seconds before trying to publish the version.
-	time.Sleep(3 * time.Second)
+	// process it, so we wait 8 seconds before trying to publish the version.
+	time.Sleep(8 * time.Second)
 
 	publishConfig, err := svc.PublishVersion(&lambda.PublishVersionInput{
 		FunctionName: aws.String(s.Function),


### PR DESCRIPTION
- **Revert "release: increase timeout for creating lambda from 3s to 10s"**
- **releaser: increase sleep before publishing lambda**

<!--Delete sections as needed -->

## Description

<!-- Tell us what you did and why -->

## Related issues or tickets

<!-- Related issues, pull requests, or Jira tickets -->

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Technical review
- [ ] Editorial review
- [ ] Product review