### PR TITLE
hugo: replace deprecated resources.PostCSS method

### DIFF
--- a/layouts/partials/utils/css.html
+++ b/layouts/partials/utils/css.html
@@ -1,5 +1,5 @@
 {{ $styles := resources.Get "css/styles.css" }}
-{{ $styles = $styles | resources.PostCSS }}
+{{ $styles = $styles | css.PostCSS }}
 {{ if hugo.IsProduction }}
   {{ $styles = $styles | minify | fingerprint | resources.PostProcess }}
 <style>


### PR DESCRIPTION
hugo --logLevel info
...
INFO  deprecated: resources.PostCSS was deprecated in Hugo v0.128.0 and will be removed in a future release. Use css.PostCSS.

Signed-off-by: David Karlsson <35727626+dvdksn@users.noreply.github.com>
