### PR TITLE
remove newlines in command to install docker

### DIFF
--- a/content/engine/install/debian.md
+++ b/content/engine/install/debian.md
@@ -112,10 +112,7 @@ Docker from the repository.
    sudo chmod a+r /etc/apt/keyrings/docker.asc
 
    # Add the repository to Apt sources:
-   echo \
-     "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] {{% param "download-url-base" %}} \
-     $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | \
-     sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+   echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] {{% param "download-url-base" %}} $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
    sudo apt-get update
    ```
 


### PR DESCRIPTION
## Description

Removed the newlines for this command

![image](https://github.com/user-attachments/assets/819b77c0-2c5e-49ef-b09a-5cd751aef627)

As it caused errors

![image](https://github.com/user-attachments/assets/050e743d-fa5d-4c36-b341-6c4be7ac057d)

## Related issues or tickets

N/A

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Technical review
- [ ] Editorial review
- [ ] Product review