### PR TITLE
remove typo in reference guide

### DIFF
--- a/content/engine/swarm/key-concepts.md
+++ b/content/engine/swarm/key-concepts.md
@@ -49,7 +49,7 @@ including nodes, services, tasks, and load balancing.
 A node is an instance of the Docker engine participating in the swarm. You can also think of this as a Docker node. You can run one or more nodes on a single physical computer or cloud server, but production swarm deployments typically include Docker nodes distributed across multiple physical and cloud machines.
 
 To deploy your application to a swarm, you submit a service definition to a
-manager node*. The manager node dispatches units of work called
+manager node. The manager node dispatches units of work called
 [tasks](#services-and-tasks) to worker nodes.
 
 Manager nodes also perform the orchestration and cluster management functions


### PR DESCRIPTION
<!--Delete sections as needed -->

## Description

<!-- Tell us what you did and why -->
I found typo in [reference guide](https://docs.docker.com/engine/swarm/key-concepts/#nodes) that should be removed in [here](https://github.com/docker/docs/commit/9970f81c0d2f258ce2f1b8043ebfa0eeec1fc8c1).
## Related issues or tickets

<!-- Related issues, pull requests, or Jira tickets -->

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Technical review
- [ ] Editorial review
- [ ] Product review