### PR TITLE
admin: update sso for companies

### DIFF
--- a/content/security/for-admins/single-sign-on/troubleshoot.md
+++ b/content/security/for-admins/single-sign-on/troubleshoot.md
@@ -16,6 +16,12 @@ their service.
 1. Sign in to the [Admin Console](https://app.docker.com/admin/).
 2. Select your organization or company in the left navigation drop-down menu,
    and then select **SSO and SCIM**.
+
+   > [!NOTE]
+   >
+   > When an organization is part of a company, you must select the company and
+   > view the SSO connection for that organization at the company level.
+
 3. In the SSO connections table, select the **Actions** icon and **View error
    logs**. The **Connection errors** page appears with a list of errors that
    have occurred in the past 7 days.

--- a/layouts/shortcodes/admin-domains.html
+++ b/layouts/shortcodes/admin-domains.html
@@ -12,6 +12,14 @@
 
 1. Sign in to {{ $product_link }}.
 2. {{ $domain_navigation }}
+
+   > [!NOTE]
+   >
+   > When an organization is part of a company, you must select the company and
+   > configure the domain for that organization at the company level. Each
+   > organization in a company can have its own domain, but it must be
+   > configured at the company level.
+
 3. Select **Add a domain**.
 4. Continue with the on-screen instructions to get a verification code for
    your domain as a **TXT Record Value**.

--- a/layouts/shortcodes/admin-sso-config.md
+++ b/layouts/shortcodes/admin-sso-config.md
@@ -21,6 +21,14 @@ After your domain is verified, create an SSO connection.
 
 1. Sign in to {{ $product_link }}.
 2. {{ $sso_navigation }}
+
+   > [!NOTE]
+   >
+   > When an organization is part of a company, you must select the company and
+   > configure SSO for that organization at the company level. Each organization
+   > can have its own SSO configuration and domain, but it must be configured at
+   > the company level.
+
 3. In the SSO connections table select **Create Connection**, and create a name for the connection.
 
    > [!NOTE]

--- a/layouts/shortcodes/admin-sso-connect.md
+++ b/layouts/shortcodes/admin-sso-connect.md
@@ -36,6 +36,14 @@ The SSO connection is now created. You can continue to set up SCIM without enfor
 
 1. Sign in to {{ $product_link }}.
 2. {{ $sso_navigation }}
+
+   > [!NOTE]
+   >
+   > When an organization is part of a company, you must select the company and
+   > configure SSO enforcement for that organization at the company level. Each
+   > organization in a company can have its own configuration, but it must be
+   > configured at the company level.
+
 3. In the SSO connections table, select the **Action** icon and then **Enable enforcement**.
 
    When SSO is enforced, your users are unable to modify their email address and password, convert a user account to an organization, or set up 2FA through Docker Hub. You must enable 2FA through your IdP.

--- a/layouts/shortcodes/admin-sso-management-connections.md
+++ b/layouts/shortcodes/admin-sso-management-connections.md
@@ -12,6 +12,14 @@
 
 1. Sign in to {{ $product_link }}.
 2. {{ $sso_navigation }}
+
+   > [!NOTE]
+   >
+   > When an organization is part of a company, you must select the company and
+   > manage the SSO settings for that organization at the company level. Each
+   > organization can have its own domain and SSO configuration, but it must be
+   > managed at the company level.
+
 3. In the SSO connections table, select the **Action** icon.
 4. Select **Edit connection** to edit your connection.
 5. Follow the on-screen instructions to edit the connection.
@@ -20,6 +28,15 @@
 
 1. Sign in to {{ $product_link }}.
 2. {{ $sso_navigation }}
+
+   > [!NOTE]
+   >
+   > When an organization is part of a company, you must select the company and
+   > delete the SSO connection for that organization at the company level. If a
+   > connection is used by mulitple organizations and you only want to delete
+   > the connection for specific organizations, you can [remove those
+   > organizations](/security/for-admins/single-sign-on/manage/#remove-an-organization).
+
 3. In the SSO connections table, select the **Action** icon.
 4. Select **Delete connection**.
 5. Follow the on-screen instructions to delete a connection.


### PR DESCRIPTION
<!--Delete sections as needed -->

## Description

When organizations are part of a company, admins must manage the SSO settings for those organizations at the company level. If admins go to the SSO settings at the org level, the settings are locked and there is a UI message that says the settings are managed by the company. Users misunderstood that company level settings only apply to the whole company and can't be applied to individual orgs.  

Added a note to notify users to select the company even if they're trying to change the SSO settings for a specific org within a company.

## Related issues or tickets

ENGDOCS-2192

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Editorial review
