### PR TITLE
iam: remove group mapping with sso using azure id

### DIFF
--- a/content/security/faqs/single-sign-on/faqs.md
+++ b/content/security/faqs/single-sign-on/faqs.md
@@ -46,3 +46,13 @@ You must provide an email address as an attribute to authenticate through SAML. 
 ### Does the application recognize the NameID/Unique Identifier in the `SAMLResponse` subject?
 
 The preferred format is your email address, which should also be your Name ID.
+
+### Can I use group mapping with SSO and the Azure AD (OIDC) authentication method?
+
+No. Group mapping with SSO isn't supported with the Azure AD (OIDC)
+authentication method because it requires granting the OIDC app the
+Directory.Read.All permission, which provides access to all users, groups, and
+other sensitive data in the directory. Due to potential security risks, Docker
+doesn't support this configuration. Instead, Docker recommends [configuring SCIM
+to enable group sync
+securely](/security/for-admins/provisioning/group-mapping/#use-group-mapping-with-scim).

--- a/content/security/for-admins/provisioning/group-mapping.md
+++ b/content/security/for-admins/provisioning/group-mapping.md
@@ -54,7 +54,10 @@ The exact configuration may vary depending on your IdP. You can use [group mappi
 
 ### Use group mapping with SSO
 
-The following steps describe how to set up and use group mapping with your SSO connection only. For these configurations, enabling SCIM isn't required.
+The following steps describe how to set up and use group mapping with SSO
+connections that use the SAML authentication method. Note that group mapping
+with SSO isn't supported with the Azure AD (OIDC) authentication method.
+Additionally, SCIM isn't required for these configurations.
 
 {{< tabs >}}
 {{< tab name="Okta" >}}

--- a/content/security/for-admins/single-sign-on/configure/configure-idp.md
+++ b/content/security/for-admins/single-sign-on/configure/configure-idp.md
@@ -144,9 +144,8 @@ See [More resources](#more-resources) for a video overview on how to set up SSO 
 3. Select **Grant admin consent for YOUR TENANT NAME > Yes**.
 4. Next, you need to add additional permissions. Select **Add a permission**.
 5. Select **Delegated permissions**.
-6. Search for `Directory.Read.All`, and select this option.
-7. Then, search for `User.Read`, and select this option.
-8. Select **Add permissions**.
+6. Then, search for `User.Read`, and select this option.
+7. Select **Add permissions**.
 
 You can verify admin consent was granted for each permission correctly by checking the **Status** column.
 


### PR DESCRIPTION
<!--Delete sections as needed -->

## Description

Support for group mapping with SSO using the Azure ID auth method was removed. Only SAML auth method supported.

- Updated **Use group mapping with SSO** to note SAML is supported and Azure ID is not.
- Removed the `Search for Directory.Read.All, and select this option.` step from Azure ID config as it was used for group mapping which is no longer supported.
- Added FAQ in case users ask why it's not supported.


## Related issues or tickets

ENGDOCS-2194

## Reviews

- [ ] Technical review
- [ ] Editorial review
