### PR TITLE
add port requirement to registry-mirrors in mirror.md

### DIFF
--- a/content/docker-hub/mirror.md
+++ b/content/docker-hub/mirror.md
@@ -115,7 +115,7 @@ and add the `registry-mirrors` key and value, to make the change persistent.
 
 ```json
 {
-  "registry-mirrors": ["https://<my-docker-mirror-host>"]
+  "registry-mirrors": ["https://<my-docker-mirror-host-and-port>"]
 }
 ```
 


### PR DESCRIPTION
## Description

This section is about running the registry as a pull-through cache. And by default the running registry listens on port 5000. The placeholder sample for `/etc/docker/daemon.json` shows that one can configure the mirrors as an array of `<https://<my-docker-mirror-host>` values. But it's not just the host name that's required, the port is too. I tripped up on this just now. So this change makes things clearer. Thanks. 