### PR TITLE
config: bump example versions

### DIFF
--- a/hugo.yaml
+++ b/hugo.yaml
@@ -99,7 +99,7 @@ params:
 
   latest_engine_api_version: "1.46"
   docker_ce_version: "27.1.2"
-  compose_version: "v2.29.1"
+  compose_version: "v2.29.2"
   compose_file_v3: "3.8"
   compose_file_v2: "2.4"
   buildkit_version: "0.15.1"

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -104,7 +104,7 @@ params:
   compose_file_v2: "2.4"
   buildkit_version: "0.15.1"
 
-  example_go_version: "1.21"
+  example_go_version: "1.23"
   example_golangci_lint_version: "v1.59"
   example_alpine_version: "3.20"
   example_node_version: "20"

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -105,7 +105,6 @@ params:
   buildkit_version: "0.15.1"
 
   example_go_version: "1.23"
-  example_golangci_lint_version: "v1.59"
   example_alpine_version: "3.20"
   example_node_version: "20"
 


### PR DESCRIPTION
update/tidy example versions in site config

- **config: bump example go version to 1.23**
- **config: remove example version for golangci lint (not used)**
- **config: bump latest compose version to v2.29.2**
