### PR TITLE
UBUNTU_CODENAME

### DIFF
--- a/content/engine/install/debian.md
+++ b/content/engine/install/debian.md
@@ -114,11 +114,11 @@ Docker from the repository.
    # Add the repository to Apt sources:
    echo \
      "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] {{% param "download-url-base" %}} \
-     $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | \
+     $(. /etc/os-release && echo "$UBUNTU_CODENAME") stable" | \
      sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
    sudo apt-get update
    ```
-
+[//]: <> (If possible, include links to find the relevant links for finding $VERSION_CODENAME)
    > [!NOTE]
    >
    > If you use a derivative distro, such as Kali Linux,
@@ -126,7 +126,7 @@ Docker from the repository.
    > print the version codename:
    >
    > ```console
-   > $(. /etc/os-release && echo "$VERSION_CODENAME")
+   > $(. /etc/os-release && echo "$UBUNTU_CODENAME")
    > ```
    >
    > Replace this part with the codename of the corresponding Debian release,


### PR DESCRIPTION


<!--Delete sections as needed -->

## Description
As a Linux Mint user, it is a little confusing.
In my opinions $UBUNTU_CODENAME instead of $VERSION_CODENAME is much better.

I thought I was the only one facing this issue. But as it seems others have faced it in 2024 as well. https://forums.linuxmint.com/viewtopic.php?t=414617

If possible we could include link that tells about the UBUNTU_CODENAME https://www.linuxmint.com/download_all.php

<!-- Tell us what you did and why -->

## Related issues or tickets

<!-- Related issues, pull requests, or Jira tickets -->

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Technical review
- [X] Editorial review
- [ ] Product review