### PR TITLE
Clarify that `run -e DEBUG` might read values from `.env` file

### DIFF
--- a/content/compose/environment-variables/set-environment-variables.md
+++ b/content/compose/environment-variables/set-environment-variables.md
@@ -103,13 +103,13 @@ $ docker compose run -e DEBUG=1 web python console.py
 
 ### Additional information 
 
-- You can also pass a variable from the shell by not giving it a value:
+- You can also pass a variable from the shell or your environment files by not giving it a value:
 
   ```console
   $ docker compose run -e DEBUG web python console.py
   ```
 
-The value of the `DEBUG` variable in the container is taken from the value for the same variable in the shell in which Compose is run.
+The value of the `DEBUG` variable in the container is taken from the value for the same variable in the shell in which Compose is run or from the environment files.
 
 ## Further resources
 


### PR DESCRIPTION
<!--Delete sections as needed -->

## Description

Running `docker compose run -e DEBUG web python console.py` might read `DEBUG` from an `.env` file if the variable is not defined in the shell. 

<!-- Tell us what you did and why -->

## Related issues or tickets

<!-- Related issues, pull requests, or Jira tickets -->

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Technical review
- [ ] Editorial review
- [ ] Product review