### PR TITLE
build(s3-cache): new/updated cache opt descriptions

### DIFF
--- a/content/manuals/build/cache/backends/s3.md
+++ b/content/manuals/build/cache/backends/s3.md
@@ -37,6 +37,7 @@ The following table describes the available CSV parameters that you can pass to
 | `name`              | `cache-to`,`cache-from` | String      |         | Name of the cache image.                                   |
 | `endpoint_url`      | `cache-to`,`cache-from` | String      |         | Endpoint of the S3 bucket.                                 |
 | `blobs_prefix`      | `cache-to`,`cache-from` | String      |         | Prefix to prepend to blob filenames.                       |
+| `upload_parallelism`| `cache-to`              | Integer     | `4`     | Number of parallel layer uploads.                          |
 | `manifests_prefix`  | `cache-to`,`cache-from` | String      |         | Prefix to prepend on manifest filenames.                   |
 | `use_path_style`    | `cache-to`,`cache-from` | Boolean     | `false` | When `true`, uses `bucket` in the URL instead of hostname. |
 | `access_key_id`     | `cache-to`,`cache-from` | String      |         | See [authentication][1].                                   |

--- a/content/manuals/build/cache/backends/s3.md
+++ b/content/manuals/build/cache/backends/s3.md
@@ -30,21 +30,22 @@ $ docker buildx build --push -t <user>/<image> \
 The following table describes the available CSV parameters that you can pass to
 `--cache-to` and `--cache-from`.
 
-| Name                | Option                  | Type        | Default | Description                                                |
-| ------------------- | ----------------------- | ----------- | ------- | ---------------------------------------------------------- |
-| `region`            | `cache-to`,`cache-from` | String      |         | Required. Geographic location.                             |
-| `bucket`            | `cache-to`,`cache-from` | String      |         | Required. Name of the S3 bucket.                           |
-| `name`              | `cache-to`,`cache-from` | String      |         | Name of the cache image.                                   |
-| `endpoint_url`      | `cache-to`,`cache-from` | String      |         | Endpoint of the S3 bucket.                                 |
-| `blobs_prefix`      | `cache-to`,`cache-from` | String      |         | Prefix to prepend to blob filenames.                       |
-| `upload_parallelism`| `cache-to`              | Integer     | `4`     | Number of parallel layer uploads.                          |
-| `manifests_prefix`  | `cache-to`,`cache-from` | String      |         | Prefix to prepend on manifest filenames.                   |
-| `use_path_style`    | `cache-to`,`cache-from` | Boolean     | `false` | When `true`, uses `bucket` in the URL instead of hostname. |
-| `access_key_id`     | `cache-to`,`cache-from` | String      |         | See [authentication][1].                                   |
-| `secret_access_key` | `cache-to`,`cache-from` | String      |         | See [authentication][1].                                   |
-| `session_token`     | `cache-to`,`cache-from` | String      |         | See [authentication][1].                                   |
-| `mode`              | `cache-to`              | `min`,`max` | `min`   | Cache layers to export, see [cache mode][2].               |
-| `ignore-error`      | `cache-to`              | Boolean     | `false` | Ignore errors caused by failed cache exports.              |
+| Name                 | Option                  | Type        | Default | Description                                                    |
+| -------------------- | ----------------------- | ----------- | ------- | -------------------------------------------------------------- |
+| `region`             | `cache-to`,`cache-from` | String      |         | Required. Geographic location.                                 |
+| `bucket`             | `cache-to`,`cache-from` | String      |         | Required. Name of the S3 bucket.                               |
+| `name`               | `cache-to`,`cache-from` | String      |         | Name of the cache image.                                       |
+| `endpoint_url`       | `cache-to`,`cache-from` | String      |         | Endpoint of the S3 bucket.                                     |
+| `blobs_prefix`       | `cache-to`,`cache-from` | String      |         | Prefix to prepend to blob filenames.                           |
+| `upload_parallelism` | `cache-to`              | Integer     | `4`     | Number of parallel layer uploads.                              |
+| `touch_refresh`      | `cache-to`              | Time        | `24h`   | Interval for updating the timestamp of unchanged cache layers. |
+| `manifests_prefix`   | `cache-to`,`cache-from` | String      |         | Prefix to prepend on manifest filenames.                       |
+| `use_path_style`     | `cache-to`,`cache-from` | Boolean     | `false` | When `true`, uses `bucket` in the URL instead of hostname.     |
+| `access_key_id`      | `cache-to`,`cache-from` | String      |         | See [authentication][1].                                       |
+| `secret_access_key`  | `cache-to`,`cache-from` | String      |         | See [authentication][1].                                       |
+| `session_token`      | `cache-to`,`cache-from` | String      |         | See [authentication][1].                                       |
+| `mode`               | `cache-to`              | `min`,`max` | `min`   | Cache layers to export, see [cache mode][2].                   |
+| `ignore-error`       | `cache-to`              | Boolean     | `false` | Ignore errors caused by failed cache exports.                  |
 
 [1]: #authentication
 [2]: _index.md#cache-mode


### PR DESCRIPTION
- `upload_parallelism` for controlling the number of parallel layers uploaded to S3.
- `touch_refresh` for setting the refresh interval for unmodified files. (not a new attr, just undocumented)

## related issues

- https://github.com/moby/buildkit/pull/5266
- https://github.com/moby/buildkit/pull/5270
