### PR TITLE
build: run mount secrets as env

### DIFF
--- a/content/manuals/build/cache/invalidation.md
+++ b/content/manuals/build/cache/invalidation.md
@@ -82,12 +82,12 @@ Build arguments do result in cache invalidation.
 ```dockerfile
 FROM alpine
 ARG CACHEBUST
-RUN --mount=type=secret,id=foo \
-    TOKEN=$(cat /run/secrets/foo) ...
+RUN --mount=type=secret,id=TOKEN,env=TOKEN \
+    some-command ...
 ```
 
 ```console
-$ TOKEN=verysecret docker build --secret id=foo,env=TOKEN --build-arg CACHEBUST=1 .
+$ TOKEN="tkn_pat123456" docker build --secret id=TOKEN --build-arg CACHEBUST=1 .
 ```
 
 Properties of secrets such as IDs and mount paths do participate in the cache

--- a/content/manuals/build/ci/github-actions/secrets.md
+++ b/content/manuals/build/ci/github-actions/secrets.md
@@ -26,8 +26,7 @@ First, create a `Dockerfile` that uses the secret:
 ```dockerfile
 # syntax=docker/dockerfile:1
 FROM alpine
-RUN --mount=type=secret,id=github_token \
-  cat /run/secrets/github_token
+RUN --mount=type=secret,id=github_token,env=GITHUB_TOKEN ...
 ```
 
 In this example, the secret name is `github_token`. The following workflow


### PR DESCRIPTION

## Description

`RUN --mount=type=secret,id=foo,env=FOO`

## Related issues or tickets

- https://github.com/docker/buildx/pull/2675
- https://github.com/moby/buildkit/pull/5296
- https://github.com/moby/buildkit/pull/5215
