### PR TITLE
security: enforce sign in vs enforce sso

### DIFF
--- a/content/admin/organization/onboard.md
+++ b/content/admin/organization/onboard.md
@@ -67,7 +67,13 @@ Configuring SSO and SCIM is optional and only available to Docker Business subsc
 
 You can manage your members in your identity provider and automatically provision them to your Docker organization with SSO and SCIM. See the following for more details.
    - [Configure SSO](/security/for-admins/single-sign-on/) to authenticate and add members when they sign in to Docker through your identity provider.
-   - Optional: [Enforce SSO](/security/for-admins/single-sign-on/connect/#optional-enforce-sso) to ensure that users must sign in to Docker with SSO.
+   - Optional: [Enforce SSO](/security/for-admins/single-sign-on/connect/#optional-enforce-sso) to ensure that when users sign in to Docker, they must use SSO.
+     > [!NOTE]
+     >
+     > Enforcing single sign-on (SSO) and [Step 5: Enforce sign-in for Docker
+     > Desktop](#step-5-enforce-sign-in-for-docker-desktop) are different
+     > features. For more details, see
+     > [Enforcing sign-in versus enforcing single sign-on (SSO)](/security/for-admins/enforce-sign-in/#enforcing-sign-in-versus-enforcing-single-sign-on-sso).
    - [Configure SCIM](/security/for-admins/provisioning/scim/) to automatically provision, add, and de-provision members to Docker through your identity provider.
 
 ## Step 5: Enforce sign-in for Docker Desktop

--- a/content/security/for-admins/enforce-sign-in/_index.md
+++ b/content/security/for-admins/enforce-sign-in/_index.md
@@ -35,10 +35,16 @@ following occurs:
 - When a user signs out, the **Sign in required!** prompt appears and they can
   no longer use Docker Desktop.
 
-> **Enforce sign-in versus enforce SSO**
->
-> Enforcing sign-in ensures that users are required to sign in to use Docker Desktop.
-> If your organization is also using single sign-on (SSO), you can optionally enforce SSO.
-> This means that your users must use SSO to sign in, instead of a username and password.
-> When you enforce sign-in and enforce SSO, your users must sign in and must use SSO to do so.
-> See [Enforce SSO](/security/for-admins/single-sign-on/connect#optional-enforce-sso) for details on how to enable this for your SSO connection.
+## Enforcing sign-in versus enforcing single sign-on (SSO)
+
+[Enforcing
+SSO](/security/for-admins/single-sign-on/connect#optional-enforce-sso) and
+enforcing sign-in are different features. The following table provides a
+description and benefits when using each feature.
+
+| Enforcement                       | Description                                                     | Benefits                                                                                                                                                                                                                                                   |
+|:----------------------------------|:----------------------------------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| Enforce sign-in only              | Users must sign in before using Docker Desktop.                 | Ensures users receive the benefits of your subscription and ensures security features are applied. In addition, you gain insights into users’ activity.                                                                                                    |
+| Enforce single sign-on (SSO) only | If users sign in, they must sign in using SSO.                  | Centralizes authentication and enforces unified policies set by the identity provider.                                                                                                                                                                     |
+| Enforce both                      | Users must sign in using SSO before using Docker Desktop.       | Ensures users receive the benefits of your subscription and ensures security features are applied. In addition, you gain insights into users’ activity. Finally, it centralizes authentication and enforces unified policies set by the identity provider. |
+| Enforce neither                   | If users sign in, they can use SSO or their Docker credentials. | Allows users to access Docker Desktop without barriers, but at the cost of reduced security and insights.                                                                                                                                                  |


### PR DESCRIPTION
<!--Delete sections as needed -->

## Description

Users often confuse these very similar terms.
- Added a callout in org onboarding where they both appear.
  https://deploy-preview-20794--docsdocker.netlify.app/admin/organization/onboard/#step-4-manage-members-with-sso-and-scim
- Updated the comparison callout to a table.
  https://deploy-preview-20794--docsdocker.netlify.app/security/for-admins/enforce-sign-in/#enforcing-sign-in-versus-enforcing-single-sign-on-sso

## Related issues or tickets

Insights-1123
ENGDOCS-2205

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Editorial review
