### PR TITLE
cli: remove shorthand linktitle for legacy build reference

### DIFF
--- a/content/reference/cli/docker/build-legacy.md
+++ b/content/reference/cli/docker/build-legacy.md
@@ -1,7 +1,6 @@
 ---
 datafolder: engine-cli
 datafile: docker_image_build
-linkTitle: docker build
 title: docker build (legacy builder)
 layout: cli
 ---


### PR DESCRIPTION
quick fix for the sidebar showing "docker build" as an entry, which really refers to the legacy `docker build` command for the non-buildkit builder.
this is a quick fix for clarifying the title. in a follow-up we should probably make sure to reintroduce command shorthands in the toc, using something like stub files that don't render a page to disk but only act as link items.
