### PR TITLE
scout: fix broken screenshot link

### DIFF
--- a/content/manuals/scout/explore/exceptions.md
+++ b/content/manuals/scout/explore/exceptions.md
@@ -75,7 +75,7 @@ Vulnerability exceptions are highlighted in the CLI when you run `docker scout
 cves <image>`. If a CVE is suppressed by an exception, a `SUPPRESSED` label
 appears next to the CVE ID. Details about the exception are also displayed.
 
-![SUPPRESSED label in the CLI output](../../images/suppressed-cve-cli.png)
+![SUPPRESSED label in the CLI output](/scout/images/suppressed-cve-cli.png)
 
 > [!IMPORTANT]
 > In order to view exceptions in the CLI, you must configure the CLI to use


### PR DESCRIPTION

<img width="838" alt="image" src="https://github.com/user-attachments/assets/4adc23af-6ec0-43a8-8de7-0a8d1007ef2e">
<img width="791" alt="image" src="https://github.com/user-attachments/assets/4ebf6df2-c682-4fee-b8c1-7729258ef9ff">
