### PR TITLE
vendor: github.com/moby/buildkit v0.16.0

### DIFF
--- a/_vendor/github.com/moby/buildkit/docs/buildkitd.toml.md
+++ b/_vendor/github.com/moby/buildkit/docs/buildkitd.toml.md
@@ -1,4 +1,6 @@
-# buildkitd.toml
+---
+title: buildkitd.toml
+---
 
 The TOML file used to configure the buildkitd daemon settings has a short
 list of global settings followed by a series of sections for specific areas

--- a/_vendor/github.com/moby/buildkit/frontend/dockerfile/docs/rules/_index.md
+++ b/_vendor/github.com/moby/buildkit/frontend/dockerfile/docs/rules/_index.md
@@ -20,6 +20,9 @@ the rules. To run a check, use the `--check` flag:
 $ docker build --check .
 ```
 
+To learn more about how to use build checks, see
+[Checking your build configuration](https://docs.docker.com/build/checks/).
+
 <table>
   <thead>
     <tr>
@@ -97,7 +100,7 @@ $ docker build --check .
       <td>FROM --platform flag should not use a constant value</td>
     </tr>
     <tr>
-      <td><a href="./copy-ignored-file/">CopyIgnoredFile</a></td>
+      <td><a href="./copy-ignored-file/">CopyIgnoredFile (experimental)</a></td>
       <td>Attempting to Copy file that is excluded by .dockerignore</td>
     </tr>
   </tbody>

--- a/_vendor/github.com/moby/buildkit/frontend/dockerfile/docs/rules/copy-ignored-file.md
+++ b/_vendor/github.com/moby/buildkit/frontend/dockerfile/docs/rules/copy-ignored-file.md
@@ -5,6 +5,10 @@ aliases:
   - /go/dockerfile/rule/copy-ignored-file/
 ---
 
+> [!NOTE]
+> This check is experimental and is not enabled by default. To enable it, see
+> [Experimental checks](https://docs.docker.com/go/build-checks-experimental/).
+
 ## Output
 
 ```text

--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,6 @@ replace (
 	github.com/docker/cli => github.com/docker/cli v27.2.2-0.20240909090509-65decb573126+incompatible
 	github.com/docker/compose/v2 => github.com/docker/compose/v2 v2.29.2
 	github.com/docker/scout-cli => github.com/docker/scout-cli v1.13.0
-	github.com/moby/buildkit => github.com/moby/buildkit v0.15.1
+	github.com/moby/buildkit => github.com/moby/buildkit v0.16.0
 	github.com/moby/moby => github.com/moby/moby v27.2.1+incompatible
 )

--- a/go.sum
+++ b/go.sum
@@ -288,6 +288,8 @@ github.com/moby/buildkit v0.14.0-rc2.0.20240611065153-eed17a45c62b h1:n06ACmuRYP
 github.com/moby/buildkit v0.14.0-rc2.0.20240611065153-eed17a45c62b/go.mod h1:1XssG7cAqv5Bz1xcGMxJL123iCv5TYN4Z/qf647gfuk=
 github.com/moby/buildkit v0.15.1 h1:J6wrew7hphKqlq1wuu6yaUb/1Ra7gEzDAovylGztAKM=
 github.com/moby/buildkit v0.15.1/go.mod h1:Yis8ZMUJTHX9XhH9zVyK2igqSHV3sxi3UN0uztZocZk=
+github.com/moby/buildkit v0.16.0 h1:wOVBj1o5YNVad/txPQNXUXdelm7Hs/i0PUFjzbK0VKE=
+github.com/moby/buildkit v0.16.0/go.mod h1:Xqx/5GlrqE1yIRORk0NSCVDFpQAU1WjlT6KHYZdisIQ=
 github.com/moby/locker v1.0.1/go.mod h1:S7SDdo5zpBK84bzzVlKr2V0hz+7x9hWbYC/kq7oQppc=
 github.com/moby/moby v24.0.2+incompatible h1:yH+5dRHH1x3XRKzl1THA2aGTy6CHYnkt5N924ADMax8=
 github.com/moby/moby v24.0.2+incompatible/go.mod h1:fDXVQ6+S340veQPv35CzDahGBmHsiclFwfEygB/TWMc=


### PR DESCRIPTION
Something's off with the vendoring target.

e5fd2235880992714bc21ddf744613f1748e2b55

For some reason, it started quietly downgrading peer dependencies.

This PR manually bumps buildkit to v0.16.0. I need to look into the other issue separately.
