### PR TITLE
hugo: use i18n strings in callouts

### DIFF
--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -17,6 +17,7 @@ important: Important
 note: Note
 tip: Tip
 warning: Warning
+caution: Caution
 
 ## openapi strings:
 

--- a/layouts/_default/_markup/render-blockquote.html
+++ b/layouts/_default/_markup/render-blockquote.html
@@ -28,7 +28,7 @@
       <span class="icon-svg pb-1">{{ $i := index $icons .AlertType }}
         {{ partialCached "icon.html" $i $i }}
       </span>
-      <strong>{{ or (i18n .AlertType) (title .AlertType) }}</strong>
+      <strong>{{ i18n .AlertType }}</strong>
     </p>
     {{ .Text | safeHTML }}
   </blockquote>

--- a/layouts/shortcodes/experimental.html
+++ b/layouts/shortcodes/experimental.html
@@ -3,7 +3,7 @@
     <span class="icon-svg pb-1">
       {{ partialCached "icon.html" "science" "science" }}
     </span>
-    <strong>{{ .Get "title" | default "Experimental" }}</strong>
+    <strong>{{ .Get "title" | default (i18n "experimental") }}</strong>
   </p>
   {{ .InnerDeindent | safe.HTML }}
 </div>

--- a/layouts/shortcodes/restricted.html
+++ b/layouts/shortcodes/restricted.html
@@ -3,7 +3,7 @@
     <span class="icon-svg pb-1">
       {{ partialCached "icon.html" "rocket_launch" "rocket_launch" }}
     </span>
-    <strong>{{ .Get "title" | default "Restricted" }}</strong>
+    <strong>{{ .Get "title" | default (i18n "restricted") }}</strong>
   </p>
   {{ .InnerDeindent | safe.HTML }}
 </div>


### PR DESCRIPTION
- **hugo: use i18n string for 'caution' alerts**
- **hugo: use i18n strings in 'experimental' and 'restricted' shortcodes**
