### PR TITLE
permission mode of secrets in services must be quoted

### DIFF
--- a/content/reference/compose-file/services.md
+++ b/content/reference/compose-file/services.md
@@ -1648,7 +1648,7 @@ services:
         target: server.cert
         uid: "103"
         gid: "103"
-        mode: 0440
+        mode: "0440"
 secrets:
   server-certificate:
     file: ./server.cert


### PR DESCRIPTION
## Description

Inside the documentation of services, I put the (permission) mode of secrets inside quotes. If not, yaml changes it into an integer, which is not what I wanted.

For example, I had put my secrets with a mode of 0400 (user-readable, aka r--------) and `docker compose config` interpreted it as mode 256 (-w-r-xrw-)

```
name: myproject
services:
  myservice:
    image: busybox
    secrets:
      - source: mysecret
        mode: 0400

secrets:
  mysecret:
    environment: "ENV_VAR"
```

Output of `docker compose config`:
```
services:
  myservice:
    image: busybox:latest
    secrets:
      - source: mysecret
        mode: 256
secrets:
  mysecret:
    name: myproject_mysecret
    environment: ENV_VAR
```


## Related issues or tickets

<!-- Related issues, pull requests, or Jira tickets -->

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Technical review
- [ ] Editorial review
- [ ] Product review