### PR TITLE
fix: badge markup showing up in preview titles

### DIFF
--- a/content/contribute/file-conventions.md
+++ b/content/contribute/file-conventions.md
@@ -31,6 +31,7 @@ following keys are supported. The title, description, and keywords are required.
 | sitemap         | no       | Exclude the page from indexing by search engines. When set to `false`, the page is excluded from `sitemap.xml`, and a `<meta name="robots" content="noindex"/>` header is added to the page.                   |
 | sidebar.reverse | no       | This parameter for section pages changes the sort order of the pages in that section. Pages that would normally appear at the top, by weight or by title, will instead appear near the bottom, and vice versa. |
 | sidebar.goto    | no       | Set this to change the URL that the sidebar should point to for this entry. See [pageless sidebar entries](#pageless-sidebar-entries).                                                                         |
+| sidebar.badge   | no       | Set this to add a badge to the sidebar entry for this page. This param option consists of two fields: `badge.text` and `badge.color`.                                                                          |
 
 Here's an example of a valid (but contrived) page metadata. The order of
 the metadata elements in the front matter isn't important.

--- a/content/manuals/build/checks.md
+++ b/content/manuals/build/checks.md
@@ -1,6 +1,11 @@
 ---
 title: Checking your build configuration
-linkTitle: Build checks {{< badge color="green" text="New" >}}
+linkTitle: Build checks
+params:
+  sidebar:
+    badge:
+      color: green
+      text: New
 weight: 30
 description: Learn how to use build checks to validate your build configuration.
 keywords: build, buildx, buildkit, checks, validate, configuration, lint

--- a/content/manuals/copilot/index.md
+++ b/content/manuals/copilot/index.md
@@ -1,6 +1,11 @@
 ---
 title: Docker for GitHub Copilot
-linkTitle: Docker for GitHub Copilot {{< badge color="violet" text="Early Access" >}}
+linkTitle: Docker for GitHub Copilot
+params:
+  sidebar:
+    badge:
+      color: violet
+      text: Early Access
 weight: 100
 description: Learn how to use the Docker Extension for GitHub Copilot to streamline Docker-related tasks.
 keywords: Docker, GitHub Copilot, extension, Visual Studio Code, chat, ai, containerization

--- a/layouts/partials/sidebar.html
+++ b/layouts/partials/sidebar.html
@@ -46,12 +46,14 @@
         {{- if .Permalink }}
           {{/* If the link is not empty, use it */}}
           <a class="select-none hover:text-blue-light hover:dark:text-blue-dark"
-            href="{{ .Permalink }}">{{ markdownify .LinkTitle }}</a>
+            href="{{ .Permalink }}">
+            {{ template "renderTitle" . }}
+          </a>
         {{- else }}
           {{/* Otherwise, just expand the section */}}
           <button @click="expanded = !expanded"
             class="select-none hover:text-blue-light hover:dark:text-blue-dark">
-            {{ markdownify .LinkTitle }}
+            {{ template "renderTitle" . }}
           </button>
           {{- end }}
       </span>
@@ -76,7 +78,9 @@
       <a class="py-2 w-full truncate block"
          href="{{ markdownify .Params.goto }}"
          title="{{ markdownify .Title }}">
-        <span class="flex items-center gap-2">{{ markdownify .LinkTitle }}</span>
+        <span class="flex items-center gap-2">
+          {{ template "renderTitle" . }}
+        </span>
       </a>
     </li>
   {{- else }}
@@ -85,8 +89,17 @@
       {{ if $isCurrent }} bg-gray-light-200 dark:bg-gray-dark-200{{ end }}">
       <a {{ if $isCurrent }}aria-current="page" {{ end }} class="py-2 w-full truncate block"
           href="{{ .Permalink }}" title="{{ markdownify .Title }}"
-          ><span class="flex items-center gap-2">{{ markdownify .LinkTitle }}</span>
+          ><span class="flex items-center gap-2">
+            {{ template "renderTitle" . }}
+      </span>
       </a>
     </li>
+  {{- end }}
+{{ end }}
+
+{{ define "renderTitle" }}
+  {{ .LinkTitle }}
+  {{- with .Params.sidebar.badge }}
+    {{- partial "components/badge.html" (dict "color" .color "content" .text) }}
   {{- end }}
 {{ end }}


### PR DESCRIPTION
## Description

This PR removes the "markdownify" call to handle rendering of titles with shortcodes and other markup (used to generate badges in the sidebar). Instead, it adds a `params.sidebar.badge` front matter config option for setting a sidebar badge.
