### PR TITLE
hub: update fair use link

### DIFF
--- a/content/manuals/docker-hub/mirror.md
+++ b/content/manuals/docker-hub/mirror.md
@@ -37,7 +37,7 @@ Hub can be mirrored.
 
 > [!NOTE]
 >
-> Mirrors of Docker Hub are still subject to Docker's [fair usage policy](https://www.docker.com/pricing/resource-consumption-updates).
+> Mirrors of Docker Hub are still subject to Docker's [fair use policy](./download-rate-limit.md#fair-use).
 
 ### Solution
 


### PR DESCRIPTION
<!--Delete sections as needed -->

## Description

Current link redirects to Docker homepage.
Updated link to point to new fair use section.

https://deploy-preview-20891--docsdocker.netlify.app/docker-hub/mirror/#gotcha
 
## Related issues or tickets

Closes #20884 

## Reviews

- [ ] Editorial review
