### PR TITLE
desktop: proxy config not supported through daemon.json/config.json

### DIFF
--- a/content/manuals/desktop/settings.md
+++ b/content/manuals/desktop/settings.md
@@ -258,8 +258,10 @@ The HTTPS proxy settings used for scanning images are set using the `HTTPS_PROXY
 > If you are using a PAC file hosted on a web server, make sure to add the MIME type `application/x-ns-proxy-autoconfig` for the `.pac` file extension on the server or website. Without this configuration, the PAC file may not be parsed correctly.
 
 > [!IMPORTANT]
->
-> You do not need to separately configure proxy settings for the Docker CLI or Docker daemon.
+> You cannot separately configure proxy settings for Docker Desktop using the
+> Docker CLI or Docker daemon configuration files. Proxy configurations for
+> Docker Desktop are controlled through settings in the Docker Desktop app or
+> through Settings Management.
 
 #### Proxy authentication
 

--- a/content/manuals/engine/daemon/proxy.md
+++ b/content/manuals/engine/daemon/proxy.md
@@ -23,6 +23,11 @@ This page describes how to configure a proxy for the Docker daemon. For
 instructions on configuring proxy settings for the Docker CLI, see [Configure
 Docker CLI to use a proxy server](/manuals/engine/cli/proxy.md).
 
+> [!IMPORTANT]
+> Proxy configurations specified in the `daemon.json` are ignored by Docker
+> Desktop. If you use Docker Desktop, you can configure proxies using the
+> [Docker Desktop settings](/manuals/desktop/settings.md#proxies).
+
 There are two ways you can configure these settings:
 
 - [Configuring the daemon](#daemon-configuration) through a configuration file or CLI flags


### PR DESCRIPTION
## Description

Docker Desktop does not respect proxy configuration through config.json (cli) or daemon.json (dameon). Proxy config for DD is only supported through the settings menu or via settings management.

## Related issues or tickets

docker/pinata#30436
