### PR TITLE
admin: seats and company owners

### DIFF
--- a/content/manuals/admin/company/owners.md
+++ b/content/manuals/admin/company/owners.md
@@ -13,8 +13,6 @@ owners for all associated organizations. Unlike organization owners, company
 owners don't need to be member of an organization. When company owners aren't a
 member in an organization, they don't occupy a seat.
 
-As a company owner, you can configure [Single Sign-on (SSO)](../../security/for-admins/single-sign-on/_index.md) and [System for Cross-domain Identity Management (SCIM)](../../security/for-admins/provisioning/scim.md) for all organizations under the company.
-
 {{< tabs >}}
 {{< tab name="Docker Hub" >}}
 

--- a/content/manuals/admin/company/owners.md
+++ b/content/manuals/admin/company/owners.md
@@ -6,6 +6,13 @@ aliases:
 - /docker-hub/company-owner/
 ---
 
+A company can have multiple owners. Company owners have company-wide
+observability and can manage company-wide settings that apply to all associated
+organizations. In addition, company owners have the same access as organization
+owners for all associated organizations. Unlike organization owners, company
+owners don't need to be member of an organization. When company owners aren't a
+member in an organization, they don't occupy a seat.
+
 As a company owner, you can configure [Single Sign-on (SSO)](../../security/for-admins/single-sign-on/_index.md) and [System for Cross-domain Identity Management (SCIM)](../../security/for-admins/provisioning/scim.md) for all organizations under the company.
 
 {{< tabs >}}

--- a/content/manuals/admin/faqs/company-faqs.md
+++ b/content/manuals/admin/faqs/company-faqs.md
@@ -30,6 +30,17 @@ No, you can continue with business as usual.
 
 You can add a maximum of 10 company owners to a single company account.
 
+### Do company owners occupy a subscription seat?
+
+Company owners don't occupy a seat in any organization unless they are added as
+member of the organization. Since company owners have the same access as
+organization owners for all organizations associated with the company, it is not
+necessary to add company owners to an organization.
+
+Note that when you first create a company, your account will be both a company
+owner and an organization owner. Your account will occupy a seat as long as
+you're an organization owner.
+
 ### What permissions does the company owner have in the associated/nested organizations?
 
 Company owners can navigate to the **Organizations** page to view all their nested organizations in a single location. They can also view or edit organization members and change single sign-on (SSO) and System for Cross-domain Identity Management (SCIM) settings. Changes to company settings impact all users in each organization under the company. See [Roles and permissions](../../security/for-admins/roles-and-permissions.md).


### PR DESCRIPTION
<!--Delete sections as needed -->

## Description

Received feedback that it was unclear if company owners need to be added to the organization and if they occupy a seat.

Updated manage company owners topic and faq to emphasize:
 - company owners don't need to be a member of a child organization
 - when company owners are not a member of a child organization, they do not occupy a seat
 - when initially creating a company, that user account will be both a company owner and org owner, and therefore occupy a seat

## Related issues or tickets

ENGDOCS-2206

## Reviews


- [ ] Editorial review
