### PR TITLE
hugo: minimize width of lineno column for code blocks

### DIFF
--- a/assets/css/code.css
+++ b/assets/css/code.css
@@ -51,6 +51,9 @@
         margin: 0;
         font-weight: 400;
         padding: 0 4px;
+        &:first-child {
+          width: 0;
+        }
       }
 
       /* LineTableTD */


### PR DESCRIPTION
First column was growing super wide for some reason

<img width="564" alt="image" src="https://github.com/user-attachments/assets/7e4f7c55-f8cc-413a-8ad7-472a190c22c4">
