### PR TITLE
engine: 27.3.1 release notes

### DIFF
--- a/_vendor/modules.txt
+++ b/_vendor/modules.txt
@@ -1,4 +1,4 @@
-# github.com/moby/moby v27.3.0+incompatible
+# github.com/moby/moby v27.3.1+incompatible
 # github.com/moby/buildkit v0.16.0
 # github.com/docker/buildx v0.17.0
 # github.com/docker/cli v27.3.1+incompatible

--- a/_vendor/modules.txt
+++ b/_vendor/modules.txt
@@ -1,6 +1,6 @@
 # github.com/moby/moby v27.3.0+incompatible
 # github.com/moby/buildkit v0.16.0
 # github.com/docker/buildx v0.17.0
-# github.com/docker/cli v27.3.0+incompatible
+# github.com/docker/cli v27.3.1+incompatible
 # github.com/docker/compose/v2 v2.29.6
 # github.com/docker/scout-cli v1.13.0

--- a/content/manuals/engine/release-notes/27.md
+++ b/content/manuals/engine/release-notes/27.md
@@ -27,6 +27,23 @@ For more information about:
 
 Release notes for Docker Engine version 27.3 releases.
 
+### 27.3.1
+
+{{< release-date date="2024-09-20" >}}
+
+For a full list of pull requests and changes in this release, refer to the relevant GitHub milestones:
+
+- [docker/cli, 27.3.1 milestone](https://github.com/docker/cli/issues?q=sort%3Aupdated-desc+is%3Aclosed+milestone%3A27.3.1)
+- [moby/moby, 27.3.1 milestone](https://github.com/moby/moby/issues?q=sort%3Aupdated-desc+is%3Aclosed+milestone%3A27.3.1)
+
+#### Bug fixes and enhancements
+
+- CLI: Fix issue with command execution metrics not being exported correctly. [docker/cli#5457](https://github.com/docker/cli/pull/5457)
+
+#### Packaging updates
+
+- Update Compose to [v2.29.7](https://github.com/docker/compose/releases/tag/v2.29.7)
+
 ### 27.3.0
 
 {{< release-date date="2024-09-19" >}}

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ toolchain go1.22.5
 
 require (
 	github.com/docker/buildx v0.17.0 // indirect
-	github.com/docker/cli v27.3.0+incompatible // indirect
+	github.com/docker/cli v27.3.1+incompatible // indirect
 	github.com/docker/compose/v2 v2.29.6 // indirect
 	github.com/docker/scout-cli v1.13.0 // indirect
 	github.com/moby/buildkit v0.16.0 // indirect
@@ -15,7 +15,7 @@ require (
 
 replace (
 	github.com/docker/buildx => github.com/docker/buildx v0.17.0
-	github.com/docker/cli => github.com/docker/cli v27.3.0+incompatible
+	github.com/docker/cli => github.com/docker/cli v27.3.1+incompatible
 	github.com/docker/compose/v2 => github.com/docker/compose/v2 v2.29.2
 	github.com/docker/scout-cli => github.com/docker/scout-cli v1.13.0
 	github.com/moby/buildkit => github.com/moby/buildkit v0.16.0

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/docker/compose/v2 v2.29.6 // indirect
 	github.com/docker/scout-cli v1.13.0 // indirect
 	github.com/moby/buildkit v0.16.0 // indirect
-	github.com/moby/moby v27.3.0+incompatible // indirect
+	github.com/moby/moby v27.3.1+incompatible // indirect
 )
 
 replace (
@@ -19,5 +19,5 @@ replace (
 	github.com/docker/compose/v2 => github.com/docker/compose/v2 v2.29.2
 	github.com/docker/scout-cli => github.com/docker/scout-cli v1.13.0
 	github.com/moby/buildkit => github.com/moby/buildkit v0.16.0
-	github.com/moby/moby => github.com/moby/moby v27.3.0+incompatible
+	github.com/moby/moby => github.com/moby/moby v27.3.1+incompatible
 )

--- a/go.sum
+++ b/go.sum
@@ -325,6 +325,8 @@ github.com/moby/moby v27.2.1+incompatible h1:mIRBoOsLr+Q6s+h65ZFyi6cXBEVy2RXCWS5
 github.com/moby/moby v27.2.1+incompatible/go.mod h1:fDXVQ6+S340veQPv35CzDahGBmHsiclFwfEygB/TWMc=
 github.com/moby/moby v27.3.0+incompatible h1:AhSu/R7C5uiyd+JCts3kxrKyTzXa3FilBJ0KCLUHXqA=
 github.com/moby/moby v27.3.0+incompatible/go.mod h1:fDXVQ6+S340veQPv35CzDahGBmHsiclFwfEygB/TWMc=
+github.com/moby/moby v27.3.1+incompatible h1:KQbXBjo7PavKpzIl7UkHT31y9lw/e71Uvrqhr4X+zMA=
+github.com/moby/moby v27.3.1+incompatible/go.mod h1:fDXVQ6+S340veQPv35CzDahGBmHsiclFwfEygB/TWMc=
 github.com/moby/sys/symlink v0.1.0/go.mod h1:GGDODQmbFOjFsXvfLVn3+ZRxkch54RkSiGqsZeMYowQ=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/morikuni/aec v1.0.0/go.mod h1:BbKIizmSmc5MMPqRYbxO4ZU0S0+P200+tUnFx7PXmsc=

--- a/go.sum
+++ b/go.sum
@@ -124,6 +124,8 @@ github.com/docker/cli v27.2.2-0.20240909090509-65decb573126+incompatible h1:if+X
 github.com/docker/cli v27.2.2-0.20240909090509-65decb573126+incompatible/go.mod h1:JLrzqnKDaYBop7H2jaqPtU4hHvMKP+vjCwu2uszcLI8=
 github.com/docker/cli v27.3.0+incompatible h1:h7J5eiGdUbH2Q4EcGr1mFb20qzS7Nrot3EI9hwycpK0=
 github.com/docker/cli v27.3.0+incompatible/go.mod h1:JLrzqnKDaYBop7H2jaqPtU4hHvMKP+vjCwu2uszcLI8=
+github.com/docker/cli v27.3.1+incompatible h1:qEGdFBF3Xu6SCvCYhc7CzaQTlBmqDuzxPDpigSyeKQQ=
+github.com/docker/cli v27.3.1+incompatible/go.mod h1:JLrzqnKDaYBop7H2jaqPtU4hHvMKP+vjCwu2uszcLI8=
 github.com/docker/compose-cli v1.0.35 h1:uZyEHLalfqBS2PiTpA1LAULyJmuQ+YtZg7nG4Xl3/Cc=
 github.com/docker/compose-cli v1.0.35/go.mod h1:mSXI4hFLpRU3EtI8NTo32bNwI0UXSr8jnq+/rYjGAUU=
 github.com/docker/compose/v2 v2.22.0 h1:3rRz4L7tPU75wRsV8JZh2/aTgerQvPa1cpzZN+tHqUY=


### PR DESCRIPTION
## Description

Add engine 27.3.1 release notes.

## Related issues or tickets

https://github.com/moby/moby/releases/tag/v27.3.1