### PR TITLE
Set linktitles for Kafka and LocalStack guides

### DIFF
--- a/content/guides/use-case/kafka.md
+++ b/content/guides/use-case/kafka.md
@@ -2,6 +2,7 @@
 description: Developing event-driven applications with Kafka and Docker
 keywords: kafka, container-supported development
 title: Developing event-driven applications with Kafka and Docker
+linktitle: Event-driven apps with Kafka
 toc_max: 2
 ---
 

--- a/content/guides/use-case/localstack.md
+++ b/content/guides/use-case/localstack.md
@@ -2,6 +2,7 @@
 description: How to develop and test AWS Cloud applications using LocalStack and Docker
 keywords: LocalStack, container-supported development
 title: Develop and test AWS Cloud applications using LocalStack and Docker
+linktitle: AWS development with LocalStack
 ---
 
 In modern application development, testing cloud applications locally before deploying them to a live environment helps you ship faster and with more confidence. This approach involves simulating services locally, identifying and fixing issues early, and iterating quickly without incurring costs or facing the complexities of a full cloud environment. Tools like [LocalStack](https://www.localstack.cloud/) have become invaluable in this process, enabling you to emulate AWS services and containerize applications for consistent, isolated testing environments. 


### PR DESCRIPTION
## Description

Adjusting the link titles for the Kafka and LocalStack guides so they fit in the left-hand nav menu

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Technical review
- [x] Editorial review
- [ ] Product review