### PR TITLE
site: remove the floating cookie widget, use button in footer

### DIFF
--- a/hugo.yaml
+++ b/hugo.yaml
@@ -93,7 +93,7 @@ params:
       prod: 3169877
       stage: 3218181
     google: GTM-WL2QLG5
-    onetrust: 8e0ebfd9-035d-4ec2-9b2f-a2de9c09f906
+    onetrust: 65425fb0-7b36-4317-9f10-7b3e08039af0
     vwo: 723167
   algolia:
     appid: 3XRLW0LZH9

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -62,5 +62,10 @@
           >Legal</a>
       </div>
     </div>
+    <div>
+      <button type="button" id="ot-sdk-btn" className="ot-sdk-show-settings">
+        Cookies Settings
+      </button>
+    </div>
   </div>
 </div>


### PR DESCRIPTION
- **site: use the correct OneTrust ID**
- **site: add cookie settings button**

We were using an incorrect OneTrust ID. The ID should be the same as on Docker Hub and WWW. This might have been an outdated ID, not sure what the root cause is. But this changes the ID to the correct one, and adds the cookie button HTML in the footer, which should get rid of the floating widget.