### PR TITLE
Revert "site: add cookie settings button"

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -62,10 +62,5 @@
           >Legal</a>
       </div>
     </div>
-    <div>
-      <button type="button" id="ot-sdk-btn" className="ot-sdk-show-settings">
-        Cookies Settings
-      </button>
-    </div>
   </div>
 </div>


### PR DESCRIPTION
This reverts commit e845f4250abd52e8e6acb1eb73a5393165cf4e41.

To try and diagnose why onetrust doesn't seem to load properly after changing the ID and adding the settings button, I'm temporarily removing the settings button to see if it works with the ID.
