### PR TITLE
Update registry.md

### DIFF
--- a/content/manuals/registry.md
+++ b/content/manuals/registry.md
@@ -39,6 +39,11 @@ aliases:
   - /registry/storage-drivers/swift/
 ---
 
+> [!IMPORTANT]
+>
+> The ability to push [deprecated Docker image manifest version 2, schema 1](https://distribution.github.io/distribution/spec/deprecated-schema-v1/) images to Hub will be deprecated on November 4th, 2024.
+>
+
 Registry, the open source implementation for storing and distributing container
 images and other content, has been donated to the CNCF. Registry now goes under
 the name of Distribution, and the documentation has moved to


### PR DESCRIPTION
We will be deprecating the ability to push the deprecated format of v1 schema images on November 4th. We would like this message to show on this docs page on Oct 1st.

<!--Delete sections as needed -->

## Description

We will be deprecating the ability to push the deprecated format of v1 schema images on November 4th. We would like this message to show on this docs page on Oct 1st.

## Related issues or tickets

<!-- Related issues, pull requests, or Jira tickets -->

## Reviews

Release for this would be **October 1st**
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Technical review
- [ ] Editorial review
- [ ] Product review