### PR TITLE
engine: unset api layout for engine v1.24 reference

### DIFF
--- a/content/reference/api/engine/version/_index.md
+++ b/content/reference/api/engine/version/_index.md
@@ -5,8 +5,11 @@ build:
 sidebar:
   reverse: true
 cascade:
-  _target:
-    path: /reference/api/engine/version/**
-  description: Reference documentation and Swagger (OpenAPI) specification for the Docker Engine API.
-  layout: api
+  - _target:
+      path: /reference/api/engine/version/v1.24
+    layout: default
+  - _target:
+      path: /reference/api/engine/version/**
+    description: Reference documentation and Swagger (OpenAPI) specification for the Docker Engine API.
+    layout: api
 ---

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -4,6 +4,8 @@ refLinksErrorLevel: ERROR
 enableGitInfo: true
 disablePathToLower: true
 enableInlineShortcodes: true
+ignoreLogs:
+  - cascade-pattern-with-extension
 
 taxonomies:
   tag: tags


### PR DESCRIPTION
- follow-up to #21014

The api layout should not be set for this route since it's backed by a markdown document.

Weird side note: it seems like the order of these cascades matter. I first tried to put the v1.24-specific target after the `**` target, but then it didn't do anything. I only got it to work by putting the route-specific cascade first, or else it seemed to be overruled by the later target.
