### PR TITLE
dnf5 have no config-manager

### DIFF
--- a/content/manuals/engine/install/fedora.md
+++ b/content/manuals/engine/install/fedora.md
@@ -83,7 +83,7 @@ your DNF repositories) and set up the repository.
 
 ```console
 $ sudo dnf -y install dnf-plugins-core
-$ sudo dnf config-manager --add-repo {{% param "download-url-base" %}}/docker-ce.repo
+$ sudo dnf-3 config-manager --add-repo {{% param "download-url-base" %}}/docker-ce.repo
 ```
 
 #### Install Docker Engine


### PR DESCRIPTION
in the fedora 40 and above dnf5 is implemented and hence the dnf command listed in the docker will not work. I have updated the dnf command to dnf-3 as then you will be able to use the same.

<!--Delete sections as needed -->

## Description

<!-- Tell us what you did and why -->

## Related issues or tickets

<!-- Related issues, pull requests, or Jira tickets -->

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Technical review
- [ ] Editorial review
- [ ] Product review