### PR TITLE
Update admin docs for note on personal access tokens

### DIFF
--- a/content/manuals/admin/convert-account.md
+++ b/content/manuals/admin/convert-account.md
@@ -45,6 +45,8 @@ Consider the following effects of converting your account:
 
 - The user account that you add as the first owner will have full administrative access to configure and manage the organization.
 
+- Converting a user account to an organization will delete all personal access tokens. See [Create an access token](https://docs.docker.com/security/for-developers/access-tokens/#create-an-access-token) for steps on creating personal access tokens after converting the user account. 
+
 ## Convert an account into an organization
 
 1. Ensure you have removed your user account from any company or teams or organizations. Also make sure that you have a new Docker ID before you convert an account. See the [Prerequisites](#prerequisites) section for details.

--- a/content/manuals/subscription/core-subscription/add-seats.md
+++ b/content/manuals/subscription/core-subscription/add-seats.md
@@ -19,9 +19,9 @@ When you add seats to your subscription in the middle of your billing cycle, you
 >
 > If you have a [sales-assisted Docker Business subscription](details.md#sales-assisted), contact your account manager to add seats to your subscription. 
 
-1. Sign in to your [Docker Hub](https://hub.docker.com) account.
+1. Sign in to [Docker Home](https://app.docker.com).
 
-2. Select **Organizations** and then choose your organization.
+2. Select your **avatar** to open the drop-down menu.
 
 3. Select the **Billing** tab and then **Add seats**.
 

--- a/content/manuals/subscription/core-subscription/downgrade.md
+++ b/content/manuals/subscription/core-subscription/downgrade.md
@@ -16,7 +16,7 @@ When you downgrade your subscription, access to paid features is available until
 
 > [!IMPORTANT]
 >
-> If you downgrade your personal account from a Pro subscription to a Personal subscription, note that [Personal subscriptions](details.md#docker-personal) don't include collaborators for private repositories, and only 1 private repository is included. When you downgrade, all collaborators will be removed and additional private repositories are locked.
+> If you downgrade your personal account from a Pro subscription to a Personal subscription, note that [Personal subscriptions](details.md#docker-personal) don't include collaborators for private repositories, and only one private repository is included. When you downgrade, all collaborators will be removed and additional private repositories are locked.
 
 ## Before you downgrade
 
@@ -36,9 +36,9 @@ If you want to downgrade a Docker Business subscription and your organization us
 >
 >If you have a [sales-assisted Docker Business subscription](details.md#sales-assisted), contact your account manager to downgrade your subscription. 
 
-1. Sign in to your [Docker Hub](https://hub.docker.com) account.
+1. Sign in to [Docker Home](https://app.docker.com).
 
-2. Select your avatar in the top-right corner and from the drop-down menu select **Billing**.
+2. Select your **avatar** and from the drop-down menu select **Billing**.
 
 3. Choose either your personal account or an organization to downgrade. 
 
@@ -48,7 +48,7 @@ If you want to downgrade a Docker Business subscription and your organization us
 
 6. Review the downgrade warning and select **Continue**.
 
-7. Optional: Select a reason for your downgrade from the list and select **Send**.
+7. Optional. Select a reason for your downgrade from the list and select **Send**.
     The **Billing** page displays a confirmation of the downgrade with details on when the downgrade changes take effect.
 
 If you want to cancel the downgrade, select **Cancel the downgrade** on the **Plan** tab.

--- a/content/manuals/subscription/core-subscription/remove-seats.md
+++ b/content/manuals/subscription/core-subscription/remove-seats.md
@@ -21,11 +21,11 @@ For example, if you receive your billing on the 8th of every month for 10 seats 
 >
 >If you have a [sales-assisted Docker Business subscription](details.md#sales-assisted), contact your account manager to remove seats from your subscription. 
 
-1. Sign in to your [Docker Hub](https://hub.docker.com) account.
+1. Sign in to [Docker Home](https://app.docker.com).
 
-2. Select **Organizations** and then choose your organization.
+2. Select your **avatar** to expand the drop-down menu.
 
-3. Select the **Billing** tab and then **Remove seats**.
+3. Select **Billing** and then **Remove seats**.
 
 4. Specify how many seats you’d like to remove and then select **Remove** to confirm.
 

--- a/content/manuals/subscription/core-subscription/upgrade.md
+++ b/content/manuals/subscription/core-subscription/upgrade.md
@@ -16,15 +16,15 @@ When you upgrade to a paid subscription, you immediately have access to all the 
 
 ## Upgrade your subscription 
 
-1. Sign in to your [Docker Hub](https://hub.docker.com) account.
+1. Sign in to [Docker Home](https://app.docker.com).
 
-2. Optional: If you're upgrading from a free user account to a Team subscription and want to keep your account name, [convert your user account into an organization](../../admin/convert-account.md).
+2. Optional. If you're upgrading from a free user account to a Team subscription and want to keep your account name, [convert your user account into an organization](../../admin/convert-account.md).
 
-3. Select your avatar in the top-right corner of Docker Hub.
+3. Select your **avatar** to expand the drop-down menu.
 
-4. From the drop-down menu select **Billing**, then the account you want to upgrade.
+4. Select **Billing**, then the account you want to upgrade.
 
-5. Go to your current plan, then select **Change plan** and then choose the plan you'd like to upgrade to.
+5. On the **Billing Details** tab, select **Change plan** and then choose the plan you'd like to upgrade to.
 
    > [!TIP]
    >


### PR DESCRIPTION
## Description
Update administration doc to include note on personal access tokens. When a user is converted to an organization, all personal access tokens are deleted. I added a link to the doc on creating an access token for next steps if the reader needs it. 

## Related issues or tickets
[ENGDOCS-2239](https://docker.atlassian.net/browse/ENGDOCS-2239)

## Reviews
@craig-osterhout @dvdksn @aevesdocker @usha-mandya @serjkarneichyk @ajthilakan 

- [ ] Technical review
- [ ] Editorial review
- [ ] Product review

[ENGDOCS-2239]: https://docker.atlassian.net/browse/ENGDOCS-2239?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ