### PR TITLE
Update admin doc for converting/personal access token

### DIFF
--- a/content/manuals/admin/convert-account.md
+++ b/content/manuals/admin/convert-account.md
@@ -45,6 +45,8 @@ Consider the following effects of converting your account:
 
 - The user account that you add as the first owner will have full administrative access to configure and manage the organization.
 
+- Converting a user account to an organization will delete all of the user's personal access tokens. See [Create an access token](https://docs.docker.com/security/for-developers/access-tokens/#create-an-access-token) for steps on creating personal access tokens after converting the user account.
+
 ## Convert an account into an organization
 
 1. Ensure you have removed your user account from any company or teams or organizations. Also make sure that you have a new Docker ID before you convert an account. See the [Prerequisites](#prerequisites) section for details.


### PR DESCRIPTION
## Description

Update administration doc to include note on personal access tokens. When a user is converted to an organization, all personal access tokens are deleted. I added a link to the doc on creating an access token for next steps if the reader needs it.

## Related issues or tickets

[ENGDOCS-2239](https://docker.atlassian.net/browse/ENGDOCS-2239?atlOrigin=eyJpIjoiNWI2MjE5YTI1ZTU0NDhjY2E0MWE2MGZiZjkyZjZiNDciLCJwIjoiaiJ9)

## Reviews
- [ ] Editorial review

[ENGDOCS-2239]: https://docker.atlassian.net/browse/ENGDOCS-2239?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ