### PR TITLE
Fix command and the result at linux installation

### DIFF
--- a/content/manuals/compose/install/linux.md
+++ b/content/manuals/compose/install/linux.md
@@ -118,5 +118,10 @@ To update the Compose plugin, run the following commands:
 
     ```console
     $ docker compose version
+    ```
+   
+   Expected output:
+
+    ```text
     Docker Compose version {{% param "compose_version" %}}
     ```


### PR DESCRIPTION

![Screenshot from 2024-10-02 20-59-18](https://github.com/user-attachments/assets/fb6e087f-bbc9-4f4d-a3d8-91cbedfb60cc)
The copy button in linux installation at the latest section will also copy the result.

The result should be separate with the command.
This PR will solve the problem.