### PR TITLE
build: add cloud driver documentation

### DIFF
--- a/content/manuals/build/builders/drivers/_index.md
+++ b/content/manuals/build/builders/drivers/_index.md
@@ -16,7 +16,8 @@ Buildx supports the following drivers:
 - `docker`: uses the BuildKit library bundled into the Docker daemon.
 - `docker-container`: creates a dedicated BuildKit container using Docker.
 - `kubernetes`: creates BuildKit pods in a Kubernetes cluster.
-- `remote`: connects directly to a manually managed BuildKit daemon.
+- `remote`: connects to a manually managed BuildKit daemon.
+- `cloud`: connects to a [Docker Build Cloud](/manuals/build-cloud/_index.md) builder.
 
 Different drivers support different use cases. The default `docker` driver
 prioritizes simplicity and ease of use. It has limited support for advanced
@@ -25,44 +26,44 @@ provide more flexibility and are better at handling advanced scenarios.
 
 The following table outlines some differences between drivers.
 
-| Feature                      |  `docker`   | `docker-container` | `kubernetes` |      `remote`      |
-| :--------------------------- | :---------: | :----------------: | :----------: | :----------------: |
-| **Automatically load image** |     ✅      |                    |              |                    |
-| **Cache export**             |     ✓\*     |         ✅         |      ✅      |         ✅         |
-| **Tarball output**           |             |         ✅         |      ✅      |         ✅         |
-| **Multi-arch images**        |             |         ✅         |      ✅      |         ✅         |
-| **BuildKit configuration**   |             |         ✅         |      ✅      | Managed externally |
+| Feature                      | `docker` | `docker-container` | `kubernetes` |      `remote`      | `cloud` |
+| :--------------------------- | :------: | :----------------: | :----------: | :----------------: | :-----: |
+| **Automatically load image** |    ✅    |                    |              |                    |   ✅    |
+| **Cache export**             |   ✓\*    |         ✅         |      ✅      |         ✅         |   ✅    |
+| **Tarball output**           |          |         ✅         |      ✅      |         ✅         |   ✅    |
+| **Multi-arch images**        |          |         ✅         |      ✅      |         ✅         |   ✅    |
+| **BuildKit configuration**   |          |         ✅         |      ✅      | Managed externally |   ❌    |
 
 \* _The `docker` driver doesn't support all cache export options.
 See [Cache storage backends](/manuals/build/cache/backends/_index.md) for more information._
 
 ## Loading to local image store
 
-Unlike when using the default `docker` driver, images built using other drivers
-aren't automatically loaded into the local image store. If you don't specify an
+When using a driver other than `docker` or `cloud`, built images aren't
+automatically loaded into the local image store. If you don't specify an
 output, the build result is exported to the build cache only.
 
 To build an image using a non-default driver and load it to the image store,
-   use the `--load` flag with the build command:
+use the `--load` flag with the build command:
 
-   ```console
-   $ docker buildx build --load -t <image> --builder=container .
-   ...
-   => exporting to oci image format                                                                                                      7.7s
-   => => exporting layers                                                                                                                4.9s
-   => => exporting manifest sha256:4e4ca161fa338be2c303445411900ebbc5fc086153a0b846ac12996960b479d3                                      0.0s
-   => => exporting config sha256:adf3eec768a14b6e183a1010cb96d91155a82fd722a1091440c88f3747f1f53f                                        0.0s
-   => => sending tarball                                                                                                                 2.8s
-   => importing to docker
-   ```
+```console
+$ docker buildx build --load -t <image> --builder=container .
+...
+=> exporting to oci image format                                                                                                      7.7s
+=> => exporting layers                                                                                                                4.9s
+=> => exporting manifest sha256:4e4ca161fa338be2c303445411900ebbc5fc086153a0b846ac12996960b479d3                                      0.0s
+=> => exporting config sha256:adf3eec768a14b6e183a1010cb96d91155a82fd722a1091440c88f3747f1f53f                                        0.0s
+=> => sending tarball                                                                                                                 2.8s
+=> importing to docker
+```
 
-   With this option, the image is available in the image store after the build finishes:
+With this option, the image is available in the image store after the build finishes:
 
-   ```console
-   $ docker image ls
-   REPOSITORY                       TAG               IMAGE ID       CREATED             SIZE
-   <image>                          latest            adf3eec768a1   2 minutes ago       197MB
-   ```
+```console
+$ docker image ls
+REPOSITORY                       TAG               IMAGE ID       CREATED             SIZE
+<image>                          latest            adf3eec768a1   2 minutes ago       197MB
+```
 
 ### Load by default
 
@@ -85,7 +86,8 @@ flag.
 
 Read about each driver:
 
-  - [Docker driver](./docker.md)
-  - [Docker container driver](./docker-container.md)
-  - [Kubernetes driver](./kubernetes.md)
+- [Docker driver](./docker.md)
+- [Docker container driver](./docker-container.md)
+- [Kubernetes driver](./kubernetes.md)
 - [Remote driver](./remote.md)
+- [Cloud driver](./cloud.md)

--- a/content/manuals/build/builders/drivers/cloud.md
+++ b/content/manuals/build/builders/drivers/cloud.md
@@ -1,0 +1,54 @@
+---
+title: Cloud driver
+description: |
+  The cloud driver lets you connect to a remote Docker Build Cloud builder.
+keywords: build, buildx, driver, builder, remote, cloud
+---
+
+The `cloud` driver establishes a connection to a cloud builder, a multi-node,
+high-performance remote builder managed through the Docker Build Cloud service.
+
+> [!NOTE]
+> - The `cloud` driver requires a Docker Build Cloud subscription. For more
+>   information on pricing and availability, visit the Docker Build Cloud
+>   [subscriptions and features page](/manuals/subscription/build-cloud/build-details.md).
+> - The `cloud` driver is not supported with the open source build of Buildx.
+>   You need to use a custom version of Buildx that supports this driver.
+>   See [Docker Build Cloud setup](/manuals/build-cloud/setup.md) for details.
+
+## Synopsis
+
+```console
+$ docker buildx create \
+  --driver cloud \
+  <org>/<builder_name>
+```
+
+The `cloud` builder does not support any driver options.
+
+## Build cache sharing
+
+Cloud builders are linked to a Docker organization, which means the build cache
+is shared among all members using the same builder. If two builds use identical
+resources or generate the same image layers, those layers will not be rebuilt.
+The cache is created once and automatically reused in all subsequent builds by
+any user connected to the builder.
+
+## Multi-player builds
+
+When using the cloud builder with Docker Desktop, build records from the entire
+team are automatically available in the [Docker Desktop Builds
+view](/manuals/desktop/use-desktop/builds.md). This lets team members directly
+inspect logs, cache usage, build errors, and more without needing to manually
+share logs.
+
+## Multi-node by default
+
+Cloud builders are provisioned with two high-performance nodes, supporting both
+`amd64` and `arm64` architectures. This lets you build multi-platform images at
+native speeds, regardless of your local architecture or CI environment.
+
+## Further reading
+
+For more information about Docker Build Cloud, refer to the
+[product manual](/manuals/build-cloud/_index.md).


### PR DESCRIPTION
adds a `cloud` driver section for build drivers

