### PR TITLE
Add `rewrite-timestamp` buildx output parameter

### DIFF
--- a/content/manuals/build/exporters/image-registry.md
+++ b/content/manuals/build/exporters/image-registry.md
@@ -35,6 +35,7 @@ The following table describes the available parameters that you can pass to
 | `compression`          | `uncompressed`,`gzip`,`estargz`,`zstd` | `gzip`  | Compression type, see [compression][1]                                                                                                                                                                                              |
 | `compression-level`    | `0..22`                                |         | Compression level, see [compression][1]                                                                                                                                                                                             |
 | `force-compression`    | `true`,`false`                         | `false` | Forcefully apply compression, see [compression][1]                                                                                                                                                                                  |
+| `rewrite-timestamp`    | `true`,`false`                         | `false` | Rewrite the file timestamps to the `SOURCE_DATE_EPOCH` value. See [build reproducibility][4] for how to specify the `SOURCE_DATE_EPOCH` value.                                                                                      |
 | `oci-mediatypes`       | `true`,`false`                         | `false` | Use OCI media types in exporter manifests, see [OCI Media types][2]                                                                                                                                                                 |
 | `unpack`               | `true`,`false`                         | `false` | Unpack image after creation (for use with containerd)                                                                                                                                                                               |
 | `store`                | `true`,`false`                         | `true`  | Store the result images to the worker's (for example, containerd) image store, and ensures that the image has all blobs in the content store. Ignored if the worker doesn't have image store (when using OCI workers, for example). |
@@ -43,6 +44,7 @@ The following table describes the available parameters that you can pass to
 [1]: _index.md#compression
 [2]: _index.md#oci-media-types
 [3]: #annotations
+[4]: https://github.com/moby/buildkit/blob/master/docs/build-repro.md
 
 ## Annotations
 


### PR DESCRIPTION
<!--Delete sections as needed -->

## Description

Add `rewrite-timestamp` buildx output parameter (see https://github.com/moby/buildkit/commit/2f8292cf791b5effdf16d2bd88d23e9abf01d81b and [buildkit documentation](https://github.com/moby/buildkit/blob/master/README.md#imageregistry)), available since buildkit 0.13.

## Related issues or tickets

<!-- Related issues, pull requests, or Jira tickets -->

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Technical review
- [ ] Editorial review
- [ ] Product review