### PR TITLE
scout: Save and enable policy is now the default action

### DIFF
--- a/content/manuals/scout/policy/configure.md
+++ b/content/manuals/scout/policy/configure.md
@@ -42,9 +42,9 @@ To add a policy:
 4. Update the policy parameters.
 5. Save the changes:
 
-   - Select **Save and enable** to commit the changes and enable the policy for
+   - Select **Save policy** to commit the changes and enable the policy for
      your current organization.
-   - Select **Save policy** to save the policy configuration without enabling
+   - Select **Save and disable** to save the policy configuration without enabling
      it.
 
 ## Disable a policy


### PR DESCRIPTION
<!--Delete sections as needed -->

## Description

We recently changed the default action when adding a policy to "Save policy" which enables it. We also changed the secondary action to be "Save and disable" to still let users create a disabled policy.

<img width="607" alt="image" src="https://github.com/user-attachments/assets/043afe21-42aa-4dd0-b186-6d575027e270">


## Related issues or tickets

https://github.com/docker/frontends/pull/10249
