### PR TITLE
scout: Add edit policy section

### DIFF
--- a/content/manuals/scout/policy/configure.md
+++ b/content/manuals/scout/policy/configure.md
@@ -47,6 +47,20 @@ To add a policy:
    - Select **Save policy** to save the policy configuration without enabling
      it.
 
+## Edit a policy
+
+Editing a policy allows you to modify its configuration without creating 
+a new one from scratch. This can be useful when policy parameters need adjustments 
+due to evolving requirements or changes in your organization's compliance goals.
+
+To edit a policy:
+
+1. Go to the [Policies page](https://scout.docker.com/reports/policy) in the Docker Scout Dashboard.
+2. Select the policy you want to edit.
+3. Select the **Edit** button.
+4. Update the policy parameters.
+5. Save the changes.
+
 ## Disable a policy
 
 When you disable a policy, evaluation results for that policy are hidden, and

--- a/content/manuals/scout/policy/configure.md
+++ b/content/manuals/scout/policy/configure.md
@@ -49,7 +49,7 @@ To add a policy:
 
 ## Edit a policy
 
-Editing a policy allows you to modify its configuration without creating 
+Editing a policy lets you to modify its configuration without creating 
 a new one from scratch. This can be useful when policy parameters need adjustments 
 due to evolving requirements or changes in your organization's compliance goals.
 


### PR DESCRIPTION
<!--Delete sections as needed -->

## Description

Noticed we were missing an edit policy section so I am proposing we add one. ChatGPT helped with the generic editing a policy description and I liked it. Feel free to change it yourself or just rewrite it from scratch.

I haven't specified the different actions when saving because it gets too verbose for my liking. You have "Save policy" which just saves your changes. You have a secondary action which could change depending on the status of the policy - Save and enable or Save and disable.
