### PR TITLE
cli: fix cli completion setup for zsh

### DIFF
--- a/content/manuals/engine/cli/completion.md
+++ b/content/manuals/engine/cli/completion.md
@@ -89,8 +89,8 @@ $ docker completion zsh > ~/.docker/completions/_docker
 ```
 
 ```console
-$ cat <<EOT >> ~/.zshrc
-fpath=(~/.docker/completions \\$fpath)
+$ cat <<"EOT" >> ~/.zshrc
+FPATH="$HOME/.docker/completions:$FPATH"
 autoload -Uz compinit
 compinit
 EOT


### PR DESCRIPTION
Autocomplete was not set up correctly when tilde was used in FPATH.

Changed the `.zshrc` config to use `$HOME` instead (and quoting the heredoc delimiter to escape env vars)

- Closes #21060
