### PR TITLE
corrected the max events returned

### DIFF
--- a/data/engine-cli/docker_system_events.yaml
+++ b/data/engine-cli/docker_system_events.yaml
@@ -7,7 +7,7 @@ long: |-
     scoped events are only seen on the node they take place on, and Swarm scoped
     events are seen on all managers.
 
-    Only the last 1000 log events are returned. You can use filters to further limit
+    Only the last 256 log events are returned. You can use filters to further limit
     the number of events returned.
 
     ### Object types
@@ -137,7 +137,7 @@ long: |-
     seconds (aka Unix epoch or Unix time), and the optional .nanoseconds field is a
     fraction of a second no more than nine digits long.
 
-    Only the last 1000 log events are returned. You can use filters to further limit
+    Only the last 256 log events are returned. You can use filters to further limit
     the number of events returned.
 
     #### Filtering (--filter) {#filter}


### PR DESCRIPTION
<!--Delete sections as needed -->

## Description

From the discussion here: https://docker.slack.com/archives/C01UJM51MGT/p1729066868896059?thread_ts=1729016089.514749&cid=C01UJM51MGT
and testing, 256 is the max events 'docker events' can return.

## Related issues or tickets

<!-- Related issues, pull requests, or Jira tickets -->

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Technical review
- [ ] Editorial review
- [ ] Product review