### PR TITLE
ci: use official Hugo image

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -2,7 +2,7 @@ services:
   server:
     build:
       context: .
-      target: dev
+      target: build-base
     ports:
       - "1313:1313"
     entrypoint: ["hugo", "server", "--bind", "0.0.0.0"]
@@ -11,5 +11,3 @@ services:
         - action: sync
           path: .
           target: /src
-          ignore:
-            - node_modules/

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -1,9 +1,9 @@
 variable "HUGO_ENV" {
-  default = "development"
+  default = null
 }
 
 variable "DOCS_URL" {
-  default = "https://docs.docker.com"
+  default = null
 }
 
 variable "DOCS_SITE_DIR" {

--- a/netlify.toml
+++ b/netlify.toml
@@ -4,7 +4,7 @@ publish = "public"
 [context.deploy-preview.environment]
 NODE_VERSION = "20"
 NODE_ENV = "production"
-HUGO_VERSION = "0.134.3"
+HUGO_VERSION = "0.136.0"
 HUGO_ENABLEGITINFO = "true"
 HUGO_ENVIRONMENT = "preview"
 


### PR DESCRIPTION
Hugo now has an official Docker image containing the tools we need to build the site, including:

- Git
- Go
- Node.js / npm

This PR replaces the homegrown steps for installing Hugo and dependencies with the official image.
