### PR TITLE
guides: update powershell cmd in get started workshop

### DIFF
--- a/content/get-started/workshop/06_bind_mounts.md
+++ b/content/get-started/workshop/06_bind_mounts.md
@@ -59,7 +59,7 @@ filesystem you can share with containers. For details about accessing the settin
    bind mount.
 
    {{< tabs >}}
-   {{< tab name="Mac / Linux / PowerShell" >}}
+   {{< tab name="Mac / Linux" >}}
 
    ```console
    $ docker run -it --mount type=bind,src="$(pwd)",target=/src ubuntu bash
@@ -77,6 +77,13 @@ filesystem you can share with containers. For details about accessing the settin
 
    ```console
    $ docker run -it --mount type=bind,src="/$(pwd)",target=/src ubuntu bash
+   ```
+   
+   {{< /tab >}}
+   {{< tab name="PowerShell" >}}
+
+   ```console
+   $ docker run -it --mount "type=bind,src=$($pwd),target=/src" ubuntu bash
    ```
    
    {{< /tab >}}


### PR DESCRIPTION
<!--Delete sections as needed -->

## Description

Created new tab and added powershell-specific command.

The original command works for me using the default Windows 10/11 version of powershell.
It did fail once, but I wasn't able to reliably reproduce.

https://deploy-preview-21139--docsdocker.netlify.app/get-started/workshop/06_bind_mounts/#trying-out-bind-mounts

## Related issues or tickets

Hotjar-9181
https://forums.docker.com/t/error-in-poweshell-on-docker-run-it-mount-mount-type-bind-src-pwd/136051

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Editorial review
