### PR TITLE
Docs: Update compose-application-model.md: Added period

### DIFF
--- a/content/manuals/compose/intro/compose-application-model.md
+++ b/content/manuals/compose/intro/compose-application-model.md
@@ -49,7 +49,7 @@ Multiple Compose files can be [merged](/reference/compose-file/merge.md) togethe
 Simple attributes and maps get overridden by the highest order Compose file, lists get merged by appending. Relative
 paths are resolved based on the first Compose file's parent folder, whenever complimentary files being
 merged are hosted in other folders. As some Compose file elements can both be expressed as single strings or complex objects, merges apply to
-the expanded form. For more information, see [Working with multiple Compose files](/manuals/compose/how-tos/multiple-compose-files/_index.md)
+the expanded form. For more information, see [Working with multiple Compose files](/manuals/compose/how-tos/multiple-compose-files/_index.md).
 
 If you want to reuse other Compose files, or factor out parts of your application model into separate Compose files, you can also use [`include`](/reference/compose-file/include.md). This is useful if your Compose application is dependent on another application which is managed by a different team, or needs to be shared with others.
 


### PR DESCRIPTION
## Description

Added missing period to end of sentence in [HowCompose works](https://docs.docker.com/compose/intro/compose-application-model/).

## Related issues or tickets

none

## Reviews

- [ ] Technical review
- [ ] Editorial review
- [ ] Product review