### PR TITLE
docs: typo in rootless docs

### DIFF
--- a/content/manuals/engine/security/rootless.md
+++ b/content/manuals/engine/security/rootless.md
@@ -592,7 +592,7 @@ For information about troubleshooting specific networking issues, see:
 - [Ping doesn't work](#ping-doesnt-work)
 - [`IPAddress` shown in `docker inspect` is unreachable](#ipaddress-shown-in-docker-inspect-is-unreachable)
 - [`--net=host` doesn't listen ports on the host network namespace](#--nethost-doesnt-listen-ports-on-the-host-network-namespace)
-- [Newtork is slow](#network-is-slow)
+- [Network is slow](#network-is-slow)
 - [`docker run -p` does not propagate source IP addresses](#docker-run--p-does-not-propagate-source-ip-addresses)
 
 #### `docker run -p` fails with `cannot expose privileged port`


### PR DESCRIPTION
## Description

Fixes a minor typo in the Networking Errors section: 
- `Newtork` --> `Network`

## Reviews

- [ ] Technical review
- [ ] Editorial review
- [ ] Product review