### PR TITLE
Adjust Compose watch settings to sync to new working directory

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -10,4 +10,4 @@ services:
       watch:
         - action: sync
           path: .
-          target: /src
+          target: /project


### PR DESCRIPTION
## Description

Adjusts the path of the Compose watch to align with the working directory of the hugo image with the recent version bump.

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [x] Technical review
- [ ] Editorial review
- [ ] Product review