### PR TITLE
Merge Compose files: fix merge example

### DIFF
--- a/content/manuals/compose/how-tos/multiple-compose-files/merge.md
+++ b/content/manuals/compose/how-tos/multiple-compose-files/merge.md
@@ -67,7 +67,6 @@ webapp:
     - "/data"
   environment:
     - DEBUG=1
-    - ANOTHER_VARIABLE=value
 ```
 
 > [!IMPORTANT]


### PR DESCRIPTION
## Description
Neither `compose.yml` nor `compose.admin.yml` contain `ANOTHER_VARIABLE=value` but the merge did.

## Reviews
- [ ] Technical review
- [ ] Editorial review
- [ ] Product review