### PR TITLE
Upgraded Docker plans changes for Docker Build Cloud

### DIFF
--- a/content/manuals/build-cloud/_index.md
+++ b/content/manuals/build-cloud/_index.md
@@ -61,6 +61,13 @@ need to provide a payment method to sign up for Docker Build Cloud. If you
 select the starter plan, there will be no charges on the provided payment
 method, it's only required for verification purposes.
 
+> [!NOTE]
+>
+> After November 15, 2024 ... if your organization isn't already on a paid Docker subscription, you can
+> activate a free-trial for 7 days. You need to provide a payment method in order
+> to claim 200 free minutes. There will be no charges on the provided payment
+> method, it's only required for verification purposes.
+
 Once you've signed up and created a builder, continue by
 [setting up the builder in your local environment](./setup.md).
 


### PR DESCRIPTION
<!--Delete sections as needed -->

## Description

Docker [recently announced](https://www.docker.com/blog/november-2024-updated-plans-announcement/) that there will be a free trial for Docker Build Cloud for users on a Personal plan. 

> Docker Personal users who want to start or continue using Docker Build Cloud may trial the service for seven days, or upgrade to a Docker Pro plan.

## Related issues or tickets

https://docker.atlassian.net/browse/HD-1831

## Reviews

<!-- Notes for reviewers here -->

At first I was thinking of just updating the section between ln.59-62 and merging on the 15th of November. Then I thought it might be better if we have a note/important alert similarly to [the new plans](https://github.com/docker/docs/blob/b1256d572f75131b9feb85c30fb1c25f9813dcb5/content/includes/new-plans.md?plain=1#L2) one. I've just noted the changes but unsure how to word it and mention the time period. Please, edit as you see fit.

<!-- List applicable reviews (optionally @tag reviewers) -->

@dvdksn 

- [ ] Technical review
- [ ] Editorial review
- [x] Product review