### PR TITLE
guides: fix typo in python guide

### DIFF
--- a/content/guides/python/develop.md
+++ b/content/guides/python/develop.md
@@ -427,7 +427,7 @@ Let's create an object with a post method
 
 ```console
 $ curl -X 'POST' \
-  'http://0.0.0.0:8001/heroes/' \
+  'http://localhost:8001/heroes/' \
   -H 'accept: application/json' \
   -H 'Content-Type: application/json' \
   -d '{
@@ -453,7 +453,7 @@ Let's make a get request with the next curl command:
 
 ```console
 curl -X 'GET' \
-  'http://0.0.0.0:8001/heroes/' \
+  'http://localhost:8001/heroes/' \
   -H 'accept: application/json'
 ```
 


### PR DESCRIPTION
<!--Delete sections as needed -->

## Description

Fixed address typo in the curl command.

## Related issues or tickets

Fixes #21200 

## Reviews

- [ ] Editorial review
