### PR TITLE
build: profiling with pprof

### DIFF
--- a/content/manuals/build/building/variables.md
+++ b/content/manuals/build/building/variables.md
@@ -304,24 +304,26 @@ Note that these variables aren't used to configure the build container;
 they aren't available inside the build and they have no relation to the `ENV` instruction.
 They're used to configure the Buildx client, or the BuildKit daemon.
 
-| Variable                                                                    | Type              | Description                                          |
-| --------------------------------------------------------------------------- | ----------------- | ---------------------------------------------------- |
-| [BUILDKIT_COLORS](#buildkit_colors)                                         | String            | Configure text color for the terminal output.        |
-| [BUILDKIT_HOST](#buildkit_host)                                             | String            | Specify host to use for remote builders.             |
-| [BUILDKIT_PROGRESS](#buildkit_progress)                                     | String            | Configure type of progress output.                   |
-| [BUILDKIT_TTY_LOG_LINES](#buildkit_tty_log_lines)                           | String            | Number of log lines (for active steps in TTY mode).  |
-| [BUILDX_BAKE_GIT_AUTH_HEADER](#buildx_bake_git_auth_header)                 | String            | HTTP authentication scheme for remote Bake files.    |
-| [BUILDX_BAKE_GIT_AUTH_TOKEN](#buildx_bake_git_auth_token)                   | String            | HTTP authentication token for remote Bake files.     |
-| [BUILDX_BAKE_GIT_SSH](#buildx_bake_git_ssh)                                 | String            | SSH authentication for remote Bake files.            |
-| [BUILDX_BUILDER](#buildx_builder)                                           | String            | Specify the builder instance to use.                 |
-| [BUILDX_CONFIG](#buildx_config)                                             | String            | Specify location for configuration, state, and logs. |
-| [BUILDX_EXPERIMENTAL](#buildx_experimental)                                 | Boolean           | Turn on experimental features.                       |
-| [BUILDX_GIT_CHECK_DIRTY](#buildx_git_check_dirty)                           | Boolean           | Enable dirty Git checkout detection.                 |
-| [BUILDX_GIT_INFO](#buildx_git_info)                                         | Boolean           | Remove Git information in provenance attestations.   |
-| [BUILDX_GIT_LABELS](#buildx_git_labels)                                     | String \| Boolean | Add Git provenance labels to images.                 |
-| [BUILDX_NO_DEFAULT_ATTESTATIONS](#buildx_no_default_attestations)           | Boolean           | Turn off default provenance attestations.            |
-| [BUILDX_NO_DEFAULT_LOAD](#buildx_no_default_load)                           | Boolean           | Turn off loading images to image store by default.   |
-| [EXPERIMENTAL_BUILDKIT_SOURCE_POLICY](#experimental_buildkit_source_policy) | String            | Specify a BuildKit source policy file.               |
+| Variable                                                                    | Type              | Description                                                  |
+| --------------------------------------------------------------------------- | ----------------- | ------------------------------------------------------------ |
+| [BUILDKIT_COLORS](#buildkit_colors)                                         | String            | Configure text color for the terminal output.                |
+| [BUILDKIT_HOST](#buildkit_host)                                             | String            | Specify host to use for remote builders.                     |
+| [BUILDKIT_PROGRESS](#buildkit_progress)                                     | String            | Configure type of progress output.                           |
+| [BUILDKIT_TTY_LOG_LINES](#buildkit_tty_log_lines)                           | String            | Number of log lines (for active steps in TTY mode).          |
+| [BUILDX_BAKE_GIT_AUTH_HEADER](#buildx_bake_git_auth_header)                 | String            | HTTP authentication scheme for remote Bake files.            |
+| [BUILDX_BAKE_GIT_AUTH_TOKEN](#buildx_bake_git_auth_token)                   | String            | HTTP authentication token for remote Bake files.             |
+| [BUILDX_BAKE_GIT_SSH](#buildx_bake_git_ssh)                                 | String            | SSH authentication for remote Bake files.                    |
+| [BUILDX_BUILDER](#buildx_builder)                                           | String            | Specify the builder instance to use.                         |
+| [BUILDX_CONFIG](#buildx_config)                                             | String            | Specify location for configuration, state, and logs.         |
+| [BUILDX_CPU_PROFILE](#buildx_cpu_profile)                                   | String            | Generate a `pprof` CPU profile at the specified location.    |
+| [BUILDX_EXPERIMENTAL](#buildx_experimental)                                 | Boolean           | Turn on experimental features.                               |
+| [BUILDX_GIT_CHECK_DIRTY](#buildx_git_check_dirty)                           | Boolean           | Enable dirty Git checkout detection.                         |
+| [BUILDX_GIT_INFO](#buildx_git_info)                                         | Boolean           | Remove Git information in provenance attestations.           |
+| [BUILDX_GIT_LABELS](#buildx_git_labels)                                     | String \| Boolean | Add Git provenance labels to images.                         |
+| [BUILDX_MEM_PROFILE](#buildx_mem_profile)                                   | String            | Generate a `pprof` memory profile at the specified location. |
+| [BUILDX_NO_DEFAULT_ATTESTATIONS](#buildx_no_default_attestations)           | Boolean           | Turn off default provenance attestations.                    |
+| [BUILDX_NO_DEFAULT_LOAD](#buildx_no_default_load)                           | Boolean           | Turn off loading images to image store by default.           |
+| [EXPERIMENTAL_BUILDKIT_SOURCE_POLICY](#experimental_buildkit_source_policy) | String            | Specify a BuildKit source policy file.                       |
 
 BuildKit also supports a few additional configuration parameters. Refer to
 [BuildKit built-in build args](/reference/dockerfile.md#buildkit-built-in-build-args).
@@ -507,6 +509,22 @@ Usage:
 $ export BUILDX_CONFIG=/usr/local/etc
 ```
 
+### BUILDX_CPU_PROFILE
+
+{{< introduced buildx 0.18.0 >}}
+
+If specified, Buildx generates a `pprof` CPU profile at the specified location.
+
+> [!NOTE]
+> This property is only useful for when developing Buildx. The profiling data
+> is not relevant for analyzing a build's performance.
+
+Usage:
+
+```console
+$ export BUILDX_CPU_PROFILE=buildx_cpu.prof
+```
+
 ### BUILDX_EXPERIMENTAL
 
 Enables experimental build features.
@@ -571,6 +589,23 @@ Usage:
 - Set `BUILDX_GIT_LABELS=full` to include all labels.
 
 If the repository is in a dirty state, the `revision` gets a `-dirty` suffix.
+
+### BUILDX_MEM_PROFILE
+
+{{< introduced buildx 0.18.0 >}}
+
+If specified, Buildx generates a `pprof` memory profile at the specified
+location.
+
+> [!NOTE]
+> This property is only useful for when developing Buildx. The profiling data
+> is not relevant for analyzing a build's performance.
+
+Usage:
+
+```console
+$ export BUILDX_MEM_PROFILE=buildx_mem.prof
+```
 
 ### BUILDX_NO_DEFAULT_ATTESTATIONS
 


### PR DESCRIPTION
## Description

Adds documentation for new buildx environment variables to enable buildx to
generate profiling samples.

## Related issues

- docker/buildx#2757