### PR TITLE
Updated pricing information

### DIFF
--- a/content/guides/docker-build-cloud/common-questions.md
+++ b/content/guides/docker-build-cloud/common-questions.md
@@ -30,13 +30,7 @@ Build Cloud-compatible client (buildx) and it works with both commands.
 
 ### How many minutes are included in Docker Build Cloud Team plans?
 
-You receive 200 minutes per month per purchased seat. If you are also a Docker
-subscriber (Personal, Pro, Team, Business), you will also receive your included
-build minutes from that plan.
-
-For example, if a Docker Team customer purchases 5 Build Cloud Team seats, they
-will have 400 minutes from their Docker Team plan plus 1000 minutes (200 min/mo * 5 seats) 
-for a total of 1400 minutes per month.
+Pricing details for Docker Build Cloud can be found on the [pricing page](https://www.docker.com/pricing/).
 
 ### I’m a Docker personal user. Can I try Docker Build Cloud?
 


### PR DESCRIPTION
## Description

As our Docker subscription plans are being updated, we need to remove subscription information from our guides. Instead of hardcoding pricing information, we need to point to the official pricing pages instead.

- [ ] Technical review
- [ ] Editorial review
- [ ] Product review