### PR TITLE
redirect: alias /language/ to /guides/

### DIFF
--- a/content/guides/_index.md
+++ b/content/guides/_index.md
@@ -7,6 +7,7 @@ params:
 layout: landing
 aliases:
   - /learning-paths/
+  - /language/
 ---
 
 Explore our collection of guides to learn how Docker can optimize your


### PR DESCRIPTION
- Closes #21249
- Closes #21213

(and a few other similar issues in the past)
