### PR TITLE
site: remove target=_blank

### DIFF
--- a/content/manuals/desktop/previous-versions/edge-releases-windows.md
+++ b/content/manuals/desktop/previous-versions/edge-releases-windows.md
@@ -2279,7 +2279,7 @@ This Beta release includes some significant changes:
 
 **Upgrades**
 
-* docker-compose 1.7.1  (see <a href="https://github.com/docker/compose/releases/tag/1.7.1" target="_blank"> changelog</a>)
+* docker-compose 1.7.1 (see [changelog](https://github.com/docker/compose/releases/tag/1.7.1))
 * Kernel 4.4.9
 
 **Bug fixes and minor changes**

--- a/content/reference/api/hub/latest.yaml
+++ b/content/reference/api/hub/latest.yaml
@@ -23,7 +23,7 @@ tags:
     description: |
       The following resources are available to interact with the documented API:
 
-      - <a href="https://github.com/docker/hub-tool#readme" target="_blank">Docker Hub CLI tool</a> (currently experimental)
+      - <a href="https://github.com/docker/hub-tool#readme">Docker Hub CLI tool</a> (currently experimental)
   - name: rate-limiting
     x-displayName: Rate Limiting
     description: |

--- a/layouts/_default/_markup/render-link.html
+++ b/layouts/_default/_markup/render-link.html
@@ -4,7 +4,6 @@
   <a
     class="link"
     href="{{ $url | safeURL }}"
-    target="_blank"
     rel="noopener">
       {{- .Text | safeHTML -}}
       <span class="pl-1 icon-svg icon-sm">

--- a/layouts/partials/github-links.html
+++ b/layouts/partials/github-links.html
@@ -3,7 +3,7 @@
 {{ if not (in .Filename "/_vendor/") }}
 <p class="flex items-center gap-2">
   <span class="icon-svg">{{ partialCached "icon" "edit" "edit" }}</span>
-  <a class="link" target="_blank" rel="noopener"
+  <a class="link" rel="noopener"
     href="{{ site.Params.repo }}/edit/main/content/{{ .Path }}">{{- T "editPage" -}}
     <span class="icon-svg icon-sm">
       {{ partialCached "icon" "open_in_new" "open_in_new" }}
@@ -13,7 +13,7 @@
 {{ end }}
 <p class="flex items-center gap-2">
   <span class="icon-svg">{{ partialCached "icon" "check" "check" }}</span>
-  <a class="link" target="_blank" rel="noopener"
+  <a class="link" rel="noopener"
     href="{{ site.Params.repo }}/issues/new?template=doc_issue.yml&location={{ .Permalink }}&labels=status%2Ftriage">{{- T "requestChanges" -}}
     <span class="icon-svg icon-sm">
       {{ partialCached "icon" "open_in_new" "open_in_new" }}

--- a/layouts/shortcodes/desktop-install-v2.html
+++ b/layouts/shortcodes/desktop-install-v2.html
@@ -8,38 +8,38 @@
 <p>Download Docker Desktop</p>
 <p>
   {{- if or $all $win }}
-  <a target="_blank" rel="noopener"
+  <a rel="noopener"
      href="https://desktop.docker.com/win/main/amd64{{ $build_path }}Docker%20Desktop%20Installer.exe">Windows</a>
-  (<a target="_blank" rel="noopener"
+  (<a rel="noopener"
       href="https://desktop.docker.com/win/main/amd64{{ $build_path }}checksums.txt">checksum</a>) |
   {{ end }}
   {{- if or $beta_win_arm }}
-  <a target="_blank" rel="noopener"
+  <a rel="noopener"
      href="https://desktop.docker.com/win/main/arm64{{ $build_path }}Docker%20Desktop%20Installer.exe">Windows ARM Beta</a>
-  (<a target="_blank" rel="noopener"
+  (<a rel="noopener"
       href="https://desktop.docker.com/win/main/arm64{{ $build_path }}checksums.txt">checksum</a>) |
   {{ end }}
   {{- if or $all $mac }}
-  <a target="_blank" rel="noopener" href="https://desktop.docker.com/mac/main/arm64{{ $build_path }}Docker.dmg">Mac
+  <a rel="noopener" href="https://desktop.docker.com/mac/main/arm64{{ $build_path }}Docker.dmg">Mac
     with Apple chip</a>
-  (<a target="_blank" rel="noopener"
+  (<a rel="noopener"
       href="https://desktop.docker.com/mac/main/arm64{{ $build_path }}checksums.txt">checksum</a>) |
-  <a target="_blank" rel="noopener" href="https://desktop.docker.com/mac/main/amd64{{ $build_path }}Docker.dmg">Mac
+  <a rel="noopener" href="https://desktop.docker.com/mac/main/amd64{{ $build_path }}Docker.dmg">Mac
     with Intel chip</a>
-  (<a target="_blank" rel="noopener"
+  (<a rel="noopener"
       href="https://desktop.docker.com/mac/main/amd64{{ $build_path }}checksums.txt">checksum</a>)
   {{ end -}}
   {{- if or $all $linux }}
   |
-  <a target="_blank" rel="noopener"
+  <a rel="noopener"
      href="https://desktop.docker.com/linux/main/amd64{{ $build_path }}docker-desktop-amd64.deb">Debian</a>
   -
-  <a target="_blank" rel="noopener"
+  <a rel="noopener"
      href="https://desktop.docker.com/linux/main/amd64{{ $build_path }}docker-desktop-x86_64.rpm">RPM</a>
   -
-  <a target="_blank" rel="noopener"
+  <a rel="noopener"
      href="https://desktop.docker.com/linux/main/amd64{{ $build_path }}docker-desktop-x86_64.pkg.tar.zst">Arch</a>
-  (<a target="_blank" rel="noopener"
+  (<a rel="noopener"
       href="https://desktop.docker.com/linux/main/amd64{{ $build_path }}checksums.txt">checksum</a>)
   {{- end -}}
 </p>

--- a/layouts/shortcodes/desktop-install.html
+++ b/layouts/shortcodes/desktop-install.html
@@ -9,38 +9,38 @@
 <p>Download Docker Desktop</p>
 <p>
   {{- if or $all $win }}
-  <a target="_blank" rel="noopener"
+  <a rel="noopener"
      href="https://desktop.docker.com/win/main/amd64{{ $build_path }}Docker%20Desktop%20Installer.exe">Windows</a>
-  (<a target="_blank" rel="noopener"
+  (<a rel="noopener"
       href="https://desktop.docker.com/win/main/amd64{{ $build_path }}checksums.txt">checksum</a>) |
   {{ end }}
   {{- if or $beta_win_arm }}
-  <a target="_blank" rel="noopener"
+  <a rel="noopener"
      href="https://desktop.docker.com/win/main/arm64{{ $build_path }}Docker%20Desktop%20Installer.exe">Windows ARM Beta</a>
-  (<a target="_blank" rel="noopener"
+  (<a rel="noopener"
       href="https://desktop.docker.com/win/main/arm64{{ $build_path }}checksums.txt">checksum</a>) |
   {{ end }}
   {{- if or $all $mac }}
-  <a target="_blank" rel="noopener" href="https://desktop.docker.com/mac/main/arm64{{ $build_path }}Docker.dmg">Mac
+  <a rel="noopener" href="https://desktop.docker.com/mac/main/arm64{{ $build_path }}Docker.dmg">Mac
     with Apple chip</a>
-  (<a target="_blank" rel="noopener"
+  (<a rel="noopener"
       href="https://desktop.docker.com/mac/main/arm64{{ $build_path }}checksums.txt">checksum</a>) |
-  <a target="_blank" rel="noopener" href="https://desktop.docker.com/mac/main/amd64{{ $build_path }}Docker.dmg">Mac
+  <a rel="noopener" href="https://desktop.docker.com/mac/main/amd64{{ $build_path }}Docker.dmg">Mac
     with Intel chip</a>
-  (<a target="_blank" rel="noopener"
+  (<a rel="noopener"
       href="https://desktop.docker.com/mac/main/amd64{{ $build_path }}checksums.txt">checksum</a>)
   {{ end -}}
   {{- if or $all $linux }}
   |
-  <a target="_blank" rel="noopener"
+  <a rel="noopener"
      href="https://desktop.docker.com/linux/main/amd64{{ $build_path }}docker-desktop-{{ $version }}-amd64.deb">Debian</a>
   -
-  <a target="_blank" rel="noopener"
+  <a rel="noopener"
      href="https://desktop.docker.com/linux/main/amd64{{ $build_path }}docker-desktop-{{ $version }}-x86_64.rpm">RPM</a>
   -
-  <a target="_blank" rel="noopener"
+  <a rel="noopener"
      href="https://desktop.docker.com/linux/main/amd64{{ $build_path }}docker-desktop-{{ $version }}-x86_64.pkg.tar.zst">Arch</a>
-  (<a target="_blank" rel="noopener"
+  (<a rel="noopener"
       href="https://desktop.docker.com/linux/main/amd64{{ $build_path }}checksums.txt">checksum</a>)
   {{- end -}}
 </p>


### PR DESCRIPTION
- Closes #21291

The `target="_blank"` attribute is best avoided because it infringes on the default behavior of the web and introduces accessibility concerns.
