### PR TITLE
get-started: small updates to workshop contents

### DIFF
--- a/content/get-started/workshop/02_our_app.md
+++ b/content/get-started/workshop/02_our_app.md
@@ -2,15 +2,17 @@
 title: Containerize an application
 weight: 20
 linkTitle: "Part 1: Containerize an application"
-keywords: dockerfile example, Containerize an application, run docker file, running
+keywords: |
+  dockerfile example, Containerize an application, run docker file, running
   docker file, how to run dockerfile, example dockerfile, how to create a docker container,
   create dockerfile, simple dockerfile, creating containers
-description: Follow this step-by-step guide to learn how to create and run a containerized
+description: |
+  Follow this step-by-step guide to learn how to create and run a containerized
   application using Docker
 aliases:
- - /get-started/part2/
- - /get-started/02_our_app/
- - /guides/workshop/02_our_app/
+  - /get-started/part2/
+  - /get-started/02_our_app/
+  - /guides/workshop/02_our_app/
 ---
 
 For the rest of this guide, you'll be working with a simple todo
@@ -49,68 +51,13 @@ Before you can run the application, you need to get the application source code 
 
 To build the image, you'll need to use a Dockerfile. A Dockerfile is simply a text-based file with no file extension that contains a script of instructions. Docker uses this script to build a container image.
 
-1. In the `getting-started-app` directory, the same location as the `package.json` file, create a file named `Dockerfile`. You can use the following commands to create a Dockerfile based on your operating system.
-
-   {{< tabs >}}
-   {{< tab name="Mac / Linux / Windows (Git Bash)" >}}
-
-   In the terminal, run the following commands.
-
-   Make sure you're in the `getting-started-app` directory. Replace `/path/to/getting-started-app` with the path to your `getting-started-app` directory.
-
-   ```console
-   $ cd /path/to/getting-started-app
-   ```
-
-   Create an empty file named `Dockerfile`.
-
-   ```console
-   $ touch Dockerfile
-   ```
-
-   {{< /tab >}}
-   {{< tab name="Windows (Command Prompt)" >}}
-
-   In the Windows Command Prompt, run the following commands.
-
-   Make sure you're in the `getting-started-app` directory. Replace `\path\to\getting-started-app` with the path to your `getting-started-app` directory.
-
-   ```console
-   $ cd \path\to\getting-started-app
-   ```
-
-   Create an empty file named `Dockerfile`.
-
-   ```console
-   $ type nul > Dockerfile
-   ```
-
-   {{< /tab >}}
-   {{< tab name="Windows (PowerShell)" >}}
-
-   In PowerShell, run the following commands.
-
-   Make sure you're in the `getting-started-app` directory. Replace `\path\to\getting-started-app` with the path to your `getting-started-app` directory.
-
-   ```console
-   $ cd \path\to\getting-started-app
-   ```
-
-   Create an empty file named `Dockerfile`.
-
-   ```powershell
-   $ New-Item -Path . -Name Dockerfile -ItemType File
-   ```
-
-   {{< /tab >}}
-   {{< /tabs >}}
-
-2. Using a text editor or code editor, add the following contents to the Dockerfile:
+1. In the `getting-started-app` directory, the same location as the
+   `package.json` file, create a file named `Dockerfile` with the following contents:
 
    ```dockerfile
    # syntax=docker/dockerfile:1
-   
-   FROM node:18-alpine
+
+   FROM node:lts-alpine
    WORKDIR /app
    COPY . .
    RUN yarn install --production
@@ -118,7 +65,12 @@ To build the image, you'll need to use a Dockerfile. A Dockerfile is simply a te
    EXPOSE 3000
    ```
 
-3. Build the image using the following commands:
+   This Dockerfile starts off with a `node:lts-alpine` base image, a
+   light-weight Linux image that comes with Node.js and the Yarn package
+   manager pre-installed. It copies all of the source code into the image,
+   installs the necessary dependencies, and starts the application.
+
+2. Build the image using the following commands:
 
    In the terminal, make sure you're in the `getting-started-app` directory. Replace `/path/to/getting-started-app` with the path to your `getting-started-app` directory.
 
@@ -127,11 +79,12 @@ To build the image, you'll need to use a Dockerfile. A Dockerfile is simply a te
    ```
 
    Build the image.
+
    ```console
    $ docker build -t getting-started .
    ```
 
-   The `docker build` command uses the Dockerfile to build a new image. You might have noticed that Docker downloaded a lot of "layers". This is because you instructed the builder that you wanted to start from the `node:18-alpine` image. But, since you didn't have that on your machine, Docker needed to download the image.
+   The `docker build` command uses the Dockerfile to build a new image. You might have noticed that Docker downloaded a lot of "layers". This is because you instructed the builder that you wanted to start from the `node:lts-alpine` image. But, since you didn't have that on your machine, Docker needed to download the image.
 
    After Docker downloaded the image, the instructions from the Dockerfile copied in your application and used `yarn` to install your application's dependencies. The `CMD` directive specifies the default command to run when starting a container from this image.
 
@@ -146,29 +99,26 @@ Now that you have an image, you can run the application in a container using the
 1. Run your container using the `docker run` command and specify the name of the image you just created:
 
    ```console
-   $ docker run -dp 127.0.0.1:3000:3000 getting-started
+   $ docker run -d -p 127.0.0.1:3000:3000 getting-started
    ```
 
    The `-d` flag (short for `--detach`) runs the container in the background.
    This means that Docker starts your container and returns you to the terminal
-   prompt. You can verify that a container is running by viewing it in Docker
-   Dashboard under **Containers**, or by running `docker ps` in the terminal.
+   prompt.
 
-   The `-p` flag (short for `--publish`) creates a port mapping between the host
-   and the container. The `-p` flag takes a string value in the format of
-   `HOST:CONTAINER`, where `HOST` is the address on the host, and `CONTAINER` is
-   the port on the container. The command publishes the container's port 3000 to
-   `127.0.0.1:3000` (`localhost:3000`) on the host. Without the port mapping,
-   you wouldn't be able to access the application from the host.
+   The `-p` flag (short for `--publish`) creates a port mapping between the
+   host and the container. The `-p` flag takes a string value in the format of
+   `HOST:CONTAINER`, where `HOST` is the address on the host, and `CONTAINER`
+   is the port on the container. The command publishes the container's port
+   3000 to `127.0.0.1:3000` (`localhost:3000`) on the host. Without the port
+   mapping, you wouldn't be able to access the application from the host.
 
 2. After a few seconds, open your web browser to [http://localhost:3000](http://localhost:3000).
    You should see your app.
 
    ![Empty todo list](images/todo-list-empty.webp)
-   
 
 3. Add an item or two and see that it works as you expect. You can mark items as complete and remove them. Your frontend is successfully storing items in the backend.
-
 
 At this point, you have a running todo list manager with a few items.
 
@@ -177,12 +127,14 @@ If you take a quick look at your containers, you should see at least one contain
 {{< tabs >}}
 {{< tab name="CLI" >}}
 
-Run the following `docker ps` command in a terminal to list your containers.
+Run the `docker ps` command in a terminal to list your containers.
 
 ```console
 $ docker ps
 ```
+
 Output similar to the following should appear.
+
 ```console
 CONTAINER ID        IMAGE               COMMAND                  CREATED             STATUS              PORTS                      NAMES
 df784548666d        getting-started     "docker-entrypoint.s…"   2 minutes ago       Up 2 minutes        127.0.0.1:3000->3000/tcp   priceless_mcclintock
@@ -204,8 +156,8 @@ In this section, you learned the basics about creating a Dockerfile to build an 
 
 Related information:
 
- - [Dockerfile reference](/reference/dockerfile/)
- - [docker CLI reference](/reference/cli/docker/)
+- [Dockerfile reference](/reference/dockerfile/)
+- [docker CLI reference](/reference/cli/docker/)
 
 ## Next steps
 

--- a/content/get-started/workshop/05_persisting_data.md
+++ b/content/get-started/workshop/05_persisting_data.md
@@ -21,43 +21,37 @@ changes won't be seen in another container, even if they're using the same image
 
 ### See this in practice
 
-To see this in action, you're going to start two containers. In one container, you'll create a file. In the other container, you'll verify the file exists.
-What you'll see is that the file created in one container isn't available in another.
+To see this in action, you're going to start two containers. In one container,
+you'll create a file. In the other container, you'll check whether that same
+file exists.
 
-1. Start an Alpine container and access its shell.
-
-    ```console
-    $ docker run -ti --name=mytest alpine
-    ```
-
-2. In the container, create a `greeting.txt` file with `hello` inside.
+1. Start an Alpine container and create a new file in it.
 
     ```console
-    / # echo "hello" > greeting.txt
+    $ docker run --rm alpine touch greeting.txt
     ```
 
-3. Exit the container.
+    > [!TIP]
+    > Any commands you specify after the image name (in this case, `alpine`)
+    > are executed inside the container. In this case, the command `touch
+    > greeting.txt` puts a file named `greeting.txt` on the container's filesystem.
 
-   ```console
-   / # exit
-   ```
-
-4. Run a new Alpine container and use the `cat` command to verify that the
-   file does not exist.
+2. Run a new Alpine container and use the `stat` command to check whether the file exists.
    
    ```console
-   $ docker run alpine cat greeting.txt
+   $ docker run --rm alpine stat greeting.txt
    ```
 
    You should see output similar to the following that indicates the file does not exist in the new container.
 
    ```console
-   cat: can't open 'greeting.txt': No such file or directory
+   stat: can't stat 'greeting.txt': No such file or directory
    ```
 
-5. Go ahead and remove the containers using `docker ps --all` to get the IDs,
-   and then `docker rm -f <container-id>` to remove the containers.
-
+The `greeting.txt` file created by the first container did not exist in the
+second container. That is because the writeable "top layer" of each container
+is isolated. Even though both containers shared the same underlying layers that
+make up the base image, the writable layer is unique to each container.
 
 ## Container volumes
 


### PR DESCRIPTION
- **get-started: simplify workshop intro, update node version**

I removed the `cd /path/to/dir` (implied) and `touch Dockerfile`, and reduced it down to "create a file named Dockerfile". Also updated node-18 to lts to make it evergreen... ish.

- **get-started: fix/simplify the persisting data experiment**

There was a small issue with the writing here that I wanted to fix, but then I went ahead and simplified this bit too. Less is more.