### PR TITLE
Remove an duplicate list of parser directives

### DIFF
--- a/_vendor/github.com/moby/buildkit/frontend/dockerfile/docs/reference.md
+++ b/_vendor/github.com/moby/buildkit/frontend/dockerfile/docs/reference.md
@@ -192,11 +192,6 @@ following lines are all treated identically:
 #	  dIrEcTiVe=value
 ```
 
-The following parser directives are supported:
-
-- `syntax`
-- `escape`
-
 ### syntax
 
 <a name="external-implementation-features"><!-- included for deep-links to old section --></a>


### PR DESCRIPTION
<!--Delete sections as needed -->

## Description

The [Dockerfile reference](https://docs.docker.com/reference/dockerfile/) has an extra -- incomplete and unlinked -- set of parser directives included in it.  I'm assuming it was just accidentally left over from a previous revision

![image](https://github.com/user-attachments/assets/66d9b086-1407-4f6c-9d99-22abef10401e)

*Further up the page is the "real" section:*

![image](https://github.com/user-attachments/assets/a181049f-57fb-409b-ba82-9bbb42d62283)