### PR TITLE
Removed duplicate section in dockerfile reference

### DIFF
--- a/_vendor/github.com/moby/buildkit/frontend/dockerfile/docs/reference.md
+++ b/_vendor/github.com/moby/buildkit/frontend/dockerfile/docs/reference.md
@@ -192,11 +192,6 @@ following lines are all treated identically:
 #	  dIrEcTiVe=value
 ```
 
-The following parser directives are supported:
-
-- `syntax`
-- `escape`
-
 ### syntax
 
 <a name="external-implementation-features"><!-- included for deep-links to old section --></a>


### PR DESCRIPTION
## Description
Community reported duplicate section in dockerfile reference, removed

## Related issues or tickets
- Issue: https://github.com/docker/docs/issues/21315
[ENGDOCS-2296](https://docker.atlassian.net/browse/ENGDOCS-2296)

## Reviews
- [ ] Editorial review

[ENGDOCS-2296]: https://docker.atlassian.net/browse/ENGDOCS-2296?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ