### PR TITLE
engine(swarm): update example redis tags

### DIFF
--- a/content/manuals/engine/swarm/services.md
+++ b/content/manuals/engine/swarm/services.md
@@ -762,7 +762,7 @@ $ docker service create \
   --replicas 9 \
   --name redis_2 \
   --placement-pref 'spread=node.labels.datacenter' \
-  redis:3.0.6
+  redis:7.4.0
 ```
 
 > [!NOTE]
@@ -786,7 +786,7 @@ $ docker service create \
   --name redis_2 \
   --placement-pref 'spread=node.labels.datacenter' \
   --placement-pref 'spread=node.labels.rack' \
-  redis:3.0.6
+  redis:7.4.0
 ```
 
 You can also use placement preferences in conjunction with placement constraints

--- a/content/manuals/engine/swarm/swarm-tutorial/drain-node.md
+++ b/content/manuals/engine/swarm/swarm-tutorial/drain-node.md
@@ -41,7 +41,7 @@ node and launches replica tasks on a node with `Active` availability.
     [rolling update](rolling-update.md) tutorial, start it now:
 
     ```console
-    $ docker service create --replicas 3 --name redis --update-delay 10s redis:3.0.6
+    $ docker service create --replicas 3 --name redis --update-delay 10s redis:7.4.0
 
     c5uo6kdmzpon37mgj9mwglcfw
     ```
@@ -53,9 +53,9 @@ tasks to different nodes:
     $ docker service ps redis
 
     NAME                               IMAGE        NODE     DESIRED STATE  CURRENT STATE
-    redis.1.7q92v0nr1hcgts2amcjyqg3pq  redis:3.0.6  manager1 Running        Running 26 seconds
-    redis.2.7h2l8h3q3wqy5f66hlv9ddmi6  redis:3.0.6  worker1  Running        Running 26 seconds
-    redis.3.9bg7cezvedmkgg6c8yzvbhwsd  redis:3.0.6  worker2  Running        Running 26 seconds
+    redis.1.7q92v0nr1hcgts2amcjyqg3pq  redis:7.4.0  manager1 Running        Running 26 seconds
+    redis.2.7h2l8h3q3wqy5f66hlv9ddmi6  redis:7.4.0  worker1  Running        Running 26 seconds
+    redis.3.9bg7cezvedmkgg6c8yzvbhwsd  redis:7.4.0  worker2  Running        Running 26 seconds
     ```
 
     In this case the swarm manager distributed one task to each node. You may
@@ -92,10 +92,10 @@ task assignments for the `redis` service:
     $ docker service ps redis
 
     NAME                                    IMAGE        NODE      DESIRED STATE  CURRENT STATE           ERROR
-    redis.1.7q92v0nr1hcgts2amcjyqg3pq       redis:3.0.6  manager1  Running        Running 4 minutes
-    redis.2.b4hovzed7id8irg1to42egue8       redis:3.0.6  worker2   Running        Running About a minute
-     \_ redis.2.7h2l8h3q3wqy5f66hlv9ddmi6   redis:3.0.6  worker1   Shutdown       Shutdown 2 minutes ago
-    redis.3.9bg7cezvedmkgg6c8yzvbhwsd       redis:3.0.6  worker2   Running        Running 4 minutes
+    redis.1.7q92v0nr1hcgts2amcjyqg3pq       redis:7.4.0  manager1  Running        Running 4 minutes
+    redis.2.b4hovzed7id8irg1to42egue8       redis:7.4.0  worker2   Running        Running About a minute
+     \_ redis.2.7h2l8h3q3wqy5f66hlv9ddmi6   redis:7.4.0  worker1   Shutdown       Shutdown 2 minutes ago
+    redis.3.9bg7cezvedmkgg6c8yzvbhwsd       redis:7.4.0  worker2   Running        Running 4 minutes
     ```
 
     The swarm manager maintains the desired state by ending the task on a node

--- a/content/manuals/engine/swarm/swarm-tutorial/rolling-update.md
+++ b/content/manuals/engine/swarm/swarm-tutorial/rolling-update.md
@@ -8,8 +8,8 @@ notoc: true
 
 In a previous step of the tutorial, you [scaled](scale-service.md) the number of
 instances of a service. In this part of the tutorial, you deploy a service based
-on the Redis 3.0.6 container tag. Then you upgrade the service to use the
-Redis 3.0.7 container image using rolling updates.
+on the Redis 7.4.0 container tag. Then you upgrade the service to use the
+Redis 7.4.1 container image using rolling updates.
 
 1.  If you haven't already, open a terminal and ssh into the machine where you
     run your manager node. For example, the tutorial uses a machine named
@@ -23,7 +23,7 @@ Redis 3.0.7 container image using rolling updates.
       --replicas 3 \
       --name redis \
       --update-delay 10s \
-      redis:3.0.6
+      redis:7.4.0
 
     0u6a4s31ybk7yw2wyvtikmu50
     ```
@@ -61,7 +61,7 @@ Redis 3.0.7 container image using rolling updates.
      Parallelism:   1
      Delay:         10s
     ContainerSpec:
-     Image:         redis:3.0.6
+     Image:         redis:7.4.0
     Resources:
     Endpoint Mode:  vip
     ```
@@ -70,7 +70,7 @@ Redis 3.0.7 container image using rolling updates.
     applies the update to nodes according to the `UpdateConfig` policy:
 
     ```console
-    $ docker service update --image redis:3.0.7 redis
+    $ docker service update --image redis:7.4.1 redis
     redis
     ```
 
@@ -100,7 +100,7 @@ Redis 3.0.7 container image using rolling updates.
      Parallelism:   1
      Delay:         10s
     ContainerSpec:
-     Image:         redis:3.0.7
+     Image:         redis:7.4.1
     Resources:
     Endpoint Mode:  vip
     ```
@@ -135,16 +135,16 @@ Redis 3.0.7 container image using rolling updates.
     $ docker service ps redis
 
     NAME                                   IMAGE        NODE       DESIRED STATE  CURRENT STATE            ERROR
-    redis.1.dos1zffgeofhagnve8w864fco      redis:3.0.7  worker1    Running        Running 37 seconds
-     \_ redis.1.88rdo6pa52ki8oqx6dogf04fh  redis:3.0.6  worker2    Shutdown       Shutdown 56 seconds ago
-    redis.2.9l3i4j85517skba5o7tn5m8g0      redis:3.0.7  worker2    Running        Running About a minute
-     \_ redis.2.66k185wilg8ele7ntu8f6nj6i  redis:3.0.6  worker1    Shutdown       Shutdown 2 minutes ago
-    redis.3.egiuiqpzrdbxks3wxgn8qib1g      redis:3.0.7  worker1    Running        Running 48 seconds
-     \_ redis.3.ctzktfddb2tepkr45qcmqln04  redis:3.0.6  mmanager1  Shutdown       Shutdown 2 minutes ago
+    redis.1.dos1zffgeofhagnve8w864fco      redis:7.4.1  worker1    Running        Running 37 seconds
+     \_ redis.1.88rdo6pa52ki8oqx6dogf04fh  redis:7.4.0  worker2    Shutdown       Shutdown 56 seconds ago
+    redis.2.9l3i4j85517skba5o7tn5m8g0      redis:7.4.1  worker2    Running        Running About a minute
+     \_ redis.2.66k185wilg8ele7ntu8f6nj6i  redis:7.4.0  worker1    Shutdown       Shutdown 2 minutes ago
+    redis.3.egiuiqpzrdbxks3wxgn8qib1g      redis:7.4.1  worker1    Running        Running 48 seconds
+     \_ redis.3.ctzktfddb2tepkr45qcmqln04  redis:7.4.0  mmanager1  Shutdown       Shutdown 2 minutes ago
     ```
 
     Before Swarm updates all of the tasks, you can see that some are running
-    `redis:3.0.6` while others are running `redis:3.0.7`. The output above shows
+    `redis:7.4.0` while others are running `redis:7.4.1`. The output above shows
     the state once the rolling updates are done.
 
 ## Next steps


### PR DESCRIPTION
The previous tag examples were too old.
Updated to latest n and n-1 patch versions.

## Related issues or tickets

- Closes #21330
