### PR TITLE
releaser: get redirects from files instead of env vars

### DIFF
--- a/_releaser/Dockerfile
+++ b/_releaser/Dockerfile
@@ -5,7 +5,7 @@ ARG GO_VERSION=1.19
 FROM scratch AS sitedir
 
 FROM golang:${GO_VERSION}-alpine AS base
-RUN apk add --no-cache jq openssl
+RUN apk add --no-cache openssl
 ENV CGO_ENABLED=0
 WORKDIR /src
 COPY go.mod go.sum ./
@@ -49,6 +49,6 @@ RUN --mount=type=bind,target=. \
   --mount=type=secret,id=AWS_SECRET_ACCESS_KEY \
   --mount=type=secret,id=AWS_SESSION_TOKEN \
   AWS_LAMBDA_FUNCTION_FILE=cloudfront-lambda-redirects.js \
-  REDIRECTS_JSON=$(jq -c '.' /site/redirects.json) \
-  REDIRECTS_PREFIXES_JSON=$(jq -c '.' redirects-prefixes.json) \
+  REDIRECTS_FILE="/site/redirects.json" \
+  REDIRECTS_PREFIXES_FILE="redirects-prefixes.json" \
   releaser aws cloudfront-update

--- a/layouts/index.redirects.json
+++ b/layouts/index.redirects.json
@@ -12,4 +12,5 @@
 {{- $redirects.SetInMap "paths" . $target -}}
 {{- end -}}
 {{- end -}}
-{{ $redirects.Get "paths" | jsonify }}
+{{- $opts := dict "noHTMLEscape" true }}
+{{- $redirects.Get "paths" | jsonify $opts }}


### PR DESCRIPTION
The deploy workflow is currently broken because we're passing too many arguments to `jq`. This changes the releaser tool to get the redirects from a file instead of reading them from an environment variable, avoiding `jq` altogether.
