### PR TITLE
hugo: show all guides when filters are unselected

### DIFF
--- a/layouts/guides/landing.html
+++ b/layouts/guides/landing.html
@@ -83,7 +83,10 @@
         updateVisible() {
           const hiddenSet = new Set();
           // show if no filters have been selected
-          if (this.noFilters()) return;
+          if (this.noFilters()) {
+            this.hidden = [];
+            return;
+          };
           const guideContainer = this.$refs['guide-container'];
           const guides = guideContainer.children
 


### PR DESCRIPTION
This fixes a bug where if you would first select some filters on the
/guides landing page, and then unselect them again, the "All guides"
section would still be filtered; not all guides were displayed when
filter selection was cleared.

Signed-off-by: David Karlsson <35727626+dvdksn@users.noreply.github.com>
