### PR TITLE
Update new-plans.md callouts for Dec. 10th date

### DIFF
--- a/content/includes/new-plans.md
+++ b/content/includes/new-plans.md
@@ -6,8 +6,8 @@
 > Docker is introducing enhanced subscription plans. Our new plans are packed
 > with more features, higher usage limits, and simplified pricing. The new
 > subscription plans take effect at your next renewal date that occurs on or
-> after November 15, 2024. No charges on Docker Hub image pulls or storage will
-> be incurred between November 15, 2024, and January 31, 2025. See [Announcing
+> after December 10, 2024. No charges on Docker Hub image pulls or storage will
+> be incurred before February 28, 2025. See [Announcing
 > Upgraded Docker
 > Plans](https://www.docker.com/blog/november-2024-updated-plans-announcement/)
 > for more details and learn how your usage fits into these updates.

--- a/content/manuals/docker-hub/download-rate-limit.md
+++ b/content/manuals/docker-hub/download-rate-limit.md
@@ -149,8 +149,8 @@ URLs (`/v2/*/manifests/*`).
 > Docker is introducing enhanced subscription plans. Our new plans are packed
 > with more features, higher usage limits, and simplified pricing. The new
 > subscription plans take effect at your next renewal date that occurs on or
-> after November 1, 2024. No charges on Docker Hub image pulls or storage will
-> be incurred between November 15, 2024, and January 31, 2025. See [Announcing
+> after December 10, 2024. No charges on Docker Hub image pulls or storage will
+> be incurred before February 28, 2025. See [Announcing
 > Upgraded Docker
 > Plans](https://www.docker.com/blog/november-2024-updated-plans-announcement/)
 > for more details and learn how your usage fits into these updates.


### PR DESCRIPTION
## Description
- Marketing team will be updating the website and pricing pages to reflect the Nov. 15th to Dec. 10th date change for self service consolidated plans, so we need to update the callouts in our current docs to reflect this
- Updated the `new-plans.md` include to reflect the date changes for self-serve new plans, as well as the Feb. 28 consumption dates

## Related issues or tickets
[ENGDOCS-2288](https://docker.atlassian.net/browse/ENGDOCS-2303?atlOrigin=eyJpIjoiYzQ4ZWM4ZjkyOTNlNDE1MmIxYzRkN2FhMmViNWFmODgiLCJwIjoiaiJ9)

## Reviews
@docker/billing

- [ ] Technical review
- [ ] Editorial review
- [ ] Product review

[ENGDOCS-2288]: https://docker.atlassian.net/browse/ENGDOCS-2288?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ