### PR TITLE
Update engine versions for 27.3.1

### DIFF
--- a/content/manuals/engine/install/centos.md
+++ b/content/manuals/engine/install/centos.md
@@ -117,8 +117,8 @@ $ sudo yum-config-manager --add-repo {{% param "download-url-base" %}}/docker-ce
    ```console
    $ yum list docker-ce --showduplicates | sort -r
 
-   docker-ce.x86_64    3:27.1.1-1.el9    docker-ce-stable
-   docker-ce.x86_64    3:27.1.0-1.el9    docker-ce-stable
+   docker-ce.x86_64    3:27.3.1-1.el9    docker-ce-stable
+   docker-ce.x86_64    3:27.3.0-1.el9    docker-ce-stable
    <...>
    ```
 
@@ -127,7 +127,7 @@ $ sudo yum-config-manager --add-repo {{% param "download-url-base" %}}/docker-ce
 
    Install a specific version by its fully qualified package name, which is
    the package name (`docker-ce`) plus the version string (2nd column),
-   separated by a hyphen (`-`). For example, `docker-ce-3:27.1.1-1.el9`.
+   separated by a hyphen (`-`). For example, `docker-ce-3:27.3.1-1.el9`.
 
    Replace `<VERSION_STRING>` with the desired version and then run the following
    command to install:

--- a/content/manuals/engine/install/debian.md
+++ b/content/manuals/engine/install/debian.md
@@ -155,15 +155,15 @@ Docker from the repository.
    # List the available versions:
    $ apt-cache madison docker-ce | awk '{ print $3 }'
 
-   5:27.1.1-1~debian.12~bookworm
-   5:27.1.0-1~debian.12~bookworm
+   5:27.3.1-1~debian.12~bookworm
+   5:27.3.0-1~debian.12~bookworm
    ...
    ```
 
    Select the desired version and install:
 
    ```console
-   $ VERSION_STRING=5:27.1.1-1~debian.12~bookworm
+   $ VERSION_STRING=5:27.3.1-1~debian.12~bookworm
    $ sudo apt-get install docker-ce=$VERSION_STRING docker-ce-cli=$VERSION_STRING containerd.io docker-buildx-plugin docker-compose-plugin
    ```
 

--- a/content/manuals/engine/install/fedora.md
+++ b/content/manuals/engine/install/fedora.md
@@ -26,8 +26,8 @@ To get started with Docker Engine on Fedora, make sure you
 To install Docker Engine, you need a maintained version of one of the following
 Fedora versions:
 
-- Fedora 39
 - Fedora 40
+- Fedora 41
 
 ### Uninstall old versions
 

--- a/content/manuals/engine/install/fedora.md
+++ b/content/manuals/engine/install/fedora.md
@@ -114,8 +114,8 @@ $ sudo dnf-3 config-manager --add-repo {{% param "download-url-base" %}}/docker-
    ```console
    $ dnf list docker-ce --showduplicates | sort -r
 
-   docker-ce.x86_64    3:27.1.1-1.fc40    docker-ce-stable
-   docker-ce.x86_64    3:27.1.0-1.fc40    docker-ce-stable
+   docker-ce.x86_64    3:27.3.1-1.fc41    docker-ce-stable
+   docker-ce.x86_64    3:27.3.0-1.fc41    docker-ce-stable
    <...>
    ```
 
@@ -124,7 +124,7 @@ $ sudo dnf-3 config-manager --add-repo {{% param "download-url-base" %}}/docker-
 
    Install a specific version by its fully qualified package name, which is
    the package name (`docker-ce`) plus the version string (2nd column),
-   separated by a hyphen (`-`). For example, `docker-ce-3:27.1.1-1.fc40`.
+   separated by a hyphen (`-`). For example, `docker-ce-3:27.3.1-1.fc41`.
 
    Replace `<VERSION_STRING>` with the desired version and then run the following
    command to install:

--- a/content/manuals/engine/install/raspberry-pi-os.md
+++ b/content/manuals/engine/install/raspberry-pi-os.md
@@ -143,15 +143,15 @@ Docker from the repository.
    # List the available versions:
    $ apt-cache madison docker-ce | awk '{ print $3 }'
 
-   5:27.1.1-1~raspbian.12~bookworm
-   5:27.1.0-1~raspbian.12~bookworm
+   5:27.3.1-1~raspbian.12~bookworm
+   5:27.3.0-1~raspbian.12~bookworm
    ...
    ```
 
    Select the desired version and install:
 
    ```console
-   $ VERSION_STRING=5:27.1.1-1~raspbian.12~bookworm
+   $ VERSION_STRING=5:27.3.1-1~raspbian.12~bookworm
    $ sudo apt-get install docker-ce=$VERSION_STRING docker-ce-cli=$VERSION_STRING containerd.io docker-buildx-plugin docker-compose-plugin
    ```
 

--- a/content/manuals/engine/install/rhel.md
+++ b/content/manuals/engine/install/rhel.md
@@ -118,8 +118,8 @@ $ sudo yum-config-manager --add-repo {{% param "download-url-base" %}}/docker-ce
    ```console
    $ yum list docker-ce --showduplicates | sort -r
 
-   docker-ce.x86_64    3:27.1.1-1.el9    docker-ce-stable
-   docker-ce.x86_64    3:27.1.0-1.el9    docker-ce-stable
+   docker-ce.x86_64    3:27.3.1-1.el9    docker-ce-stable
+   docker-ce.x86_64    3:27.3.0-1.el9    docker-ce-stable
    <...>
    ```
 
@@ -128,7 +128,7 @@ $ sudo yum-config-manager --add-repo {{% param "download-url-base" %}}/docker-ce
 
    Install a specific version by its fully qualified package name, which is
    the package name (`docker-ce`) plus the version string (2nd column),
-   separated by a hyphen (`-`). For example, `docker-ce-3:27.1.1-1.el9`.
+   separated by a hyphen (`-`). For example, `docker-ce-3:27.3.1-1.el9`.
 
    Replace `<VERSION_STRING>` with the desired version and then run the following
    command to install:

--- a/content/manuals/engine/install/sles.md
+++ b/content/manuals/engine/install/sles.md
@@ -138,8 +138,8 @@ $ sudo zypper addrepo {{% param "download-url-base" %}}/docker-ce.repo
    ```console
    $ sudo zypper search -s --match-exact docker-ce | sort -r
  
-     v  | docker-ce | package | 3:27.0.3-1 | s390x | Docker CE Stable - s390x
-     v  | docker-ce | package | 3:27.0.2-1 | s390x | Docker CE Stable - s390x
+     v  | docker-ce | package | 3:27.3.1-1 | s390x | Docker CE Stable - s390x
+     v  | docker-ce | package | 3:27.3.0-1 | s390x | Docker CE Stable - s390x
    ```
 
    The list returned depends on which repositories are enabled, and is specific
@@ -147,7 +147,7 @@ $ sudo zypper addrepo {{% param "download-url-base" %}}/docker-ce.repo
 
    Install a specific version by its fully qualified package name, which is
    the package name (`docker-ce`) plus the version string (2nd column),
-   separated by a hyphen (`-`). For example, `docker-ce-3:27.0.3`.
+   separated by a hyphen (`-`). For example, `docker-ce-3:27.3.1`.
 
    Replace `<VERSION_STRING>` with the desired version and then run the following
    command to install:

--- a/content/manuals/engine/install/ubuntu.md
+++ b/content/manuals/engine/install/ubuntu.md
@@ -50,6 +50,7 @@ To get started with Docker Engine on Ubuntu, make sure you
 To install Docker Engine, you need the 64-bit version of one of these Ubuntu
 versions:
 
+- Ubuntu Oracular 24.10
 - Ubuntu Noble 24.04 (LTS)
 - Ubuntu Jammy 22.04 (LTS)
 - Ubuntu Focal 20.04 (LTS)

--- a/content/manuals/engine/install/ubuntu.md
+++ b/content/manuals/engine/install/ubuntu.md
@@ -157,8 +157,8 @@ Docker from the repository.
    # List the available versions:
    $ apt-cache madison docker-ce | awk '{ print $3 }'
 
-   5:27.1.1-1~ubuntu.24.04~noble
-   5:27.1.0-1~ubuntu.24.04~noble
+   5:27.3.1-1~ubuntu.24.04~noble
+   5:27.3.0-1~ubuntu.24.04~noble
    ...
    ```
 

--- a/content/reference/api/engine/_index.md
+++ b/content/reference/api/engine/_index.md
@@ -72,23 +72,23 @@ To see the highest version of the API your Docker daemon and client support, use
 
 ```console
 $ docker version
-Client: Docker Engine - Community
- Version:           27.1.2
- API version:       1.46
- Go version:        go1.21.13
- Git commit:        d01f264
- Built:             Mon Aug 12 11:51:13 2024
- OS/Arch:           linux/amd64
- Context:           default
+Client:
+ Version:           27.3.1
+ API version:       1.47
+ Go version:        go1.22.7
+ Git commit:        ce12230
+ Built:             Fri Sep 20 11:38:18 2024
+ OS/Arch:           darwin/arm64
+ Context:           desktop-linux
 
-Server: Docker Engine - Community
+Server: Docker Desktop 4.36.0 (172961)
  Engine:
-  Version:          27.1.2
-  API version:      1.46 (minimum version 1.24)
-  Go version:       go1.21.13
-  Git commit:       f9522e5
-  Built:            Mon Aug 12 11:51:13 2024
-  OS/Arch:          linux/amd64
+  Version:          27.3.1
+  API version:      1.47 (minimum version 1.24)
+  Go version:       go1.22.7
+  Git commit:       41ca978
+  Built:            Fri Sep 20 11:41:19 2024
+  OS/Arch:          linux/arm64
   Experimental:     false
   ...
 ```
@@ -99,14 +99,14 @@ You can specify the API version to use in any of the following ways:
   that incorporates the API version with the features you need.
 - When using `curl` directly, specify the version as the first part of the URL.
   For instance, if the endpoint is `/containers/` you can use
-  `/v1.46/containers/`.
+  `/v1.47/containers/`.
 - To force the Docker CLI or the Docker Engine SDKs to use an older version
   of the API than the version reported by `docker version`, set the
   environment variable `DOCKER_API_VERSION` to the correct version. This works
   on Linux, Windows, or macOS clients.
 
   ```console
-  $ DOCKER_API_VERSION='1.44'
+  $ DOCKER_API_VERSION=1.46
   ```
 
   While the environment variable is set, that version of the API is used, even
@@ -127,6 +127,7 @@ You can specify the API version to use in any of the following ways:
 
 | Docker version | Maximum API version        | Change log                                                                   |
 |:---------------|:---------------------------|:-----------------------------------------------------------------------------|
+| 27.3           | [1.47](/reference/api/engine/version/v1.47/) | [changes](/reference/api/engine/version-history/#v147-api-changes) |
 | 27.2           | [1.47](/reference/api/engine/version/v1.47/) | [changes](/reference/api/engine/version-history/#v147-api-changes) |
 | 27.1           | [1.46](/reference/api/engine/version/v1.46/) | [changes](/reference/api/engine/version-history/#v146-api-changes) |
 | 27.0           | [1.46](/reference/api/engine/version/v1.46/) | [changes](/reference/api/engine/version-history/#v146-api-changes) |

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -107,7 +107,7 @@ params:
   docs_url: https://docs.docker.com
 
   latest_engine_api_version: "1.47"
-  docker_ce_version: "27.2.1"
+  docker_ce_version: "27.3.1"
   compose_version: "v2.30.3"
   compose_file_v3: "3.8"
   compose_file_v2: "2.4"


### PR DESCRIPTION
<!--Delete sections as needed -->

## Description

<!-- Tell us what you did and why -->

- engine: update versions for 27.3.1
- engine/install: add Fedora 41, remove Fedora 39
  Fedora 39 is EOL next week, so slightly ahead of time, but new users should not be recommended to use it.
- engine/install: add Ubuntu Oracular 24.10


## Related issues or tickets

<!-- Related issues, pull requests, or Jira tickets -->

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Technical review
- [ ] Editorial review
- [ ] Product review