### PR TITLE
engine/install: enable engine as system service on rpm installs

### DIFF
--- a/content/manuals/engine/install/centos.md
+++ b/content/manuals/engine/install/centos.md
@@ -142,11 +142,17 @@ $ sudo yum-config-manager --add-repo {{% param "download-url-base" %}}/docker-ce
    {{< /tab >}}
    {{< /tabs >}}
 
-2. Start Docker.
+2. Start Docker Engine.
+
+   Start the Docker Engine and containerd as a systemd service that will launch
+   on boot:
 
    ```console
-   $ sudo systemctl start docker
+   $ sudo systemctl enable --now containerd docker
    ```
+
+   If you prefer Docker to only start manually, use `sudo systemctl start docker`
+   instead, which runs it only for the current session.
 
 3. Verify that the Docker Engine installation is successful by running the
    `hello-world` image.
@@ -188,11 +194,17 @@ download a new file each time you want to upgrade Docker Engine.
    Docker is installed but not started. The `docker` group is created, but no
    users are added to the group.
 
-3. Start Docker.
+3. Start Docker Engine.
+ 
+   Start the Docker Engine and containerd as a systemd service that will launch
+   on boot:
 
    ```console
-   $ sudo systemctl start docker
+   $ sudo systemctl enable --now containerd docker
    ```
+
+   If you prefer Docker to only start manually, use `sudo systemctl start docker`
+   instead, which runs it only for the current session.
 
 4. Verify that the Docker Engine installation is successful by running the
    `hello-world` image.

--- a/content/manuals/engine/install/fedora.md
+++ b/content/manuals/engine/install/fedora.md
@@ -139,11 +139,17 @@ $ sudo dnf-3 config-manager --add-repo {{% param "download-url-base" %}}/docker-
    {{< /tab >}}
    {{< /tabs >}}
 
-2. Start Docker.
+2. Start Docker Engine.
+
+   Start the Docker Engine and containerd as a systemd service that will launch
+   on boot:
 
    ```console
-   $ sudo systemctl start docker
+   $ sudo systemctl enable --now containerd docker
    ```
+
+   If you prefer Docker to only start manually, use `sudo systemctl start docker`
+   instead, which runs it only for the current session.
 
 3. Verify that the Docker Engine installation is successful by running the
    `hello-world` image.
@@ -185,19 +191,19 @@ download a new file each time you want to upgrade Docker Engine.
    Docker is installed but not started. The `docker` group is created, but no
    users are added to the group.
 
-3. Start Docker.
+3. Start Docker Engine.
+
+   Start the Docker Engine and containerd as a systemd service that will launch
+   on boot:
 
    ```console
-   $ sudo systemctl start docker
+   $ sudo systemctl enable --now containerd docker
    ```
 
-4. Make Docker start automatically after reboot.
+   If you prefer Docker to only start manually, use `sudo systemctl start docker`
+   instead, which runs it only for the current session.
 
-   ```console
-   $ sudo systemctl enable docker
-   ```
-
-5. Verify that the Docker Engine installation is successful by running the
+4. Verify that the Docker Engine installation is successful by running the
    `hello-world` image.
 
    ```console

--- a/content/manuals/engine/install/rhel.md
+++ b/content/manuals/engine/install/rhel.md
@@ -143,11 +143,17 @@ $ sudo yum-config-manager --add-repo {{% param "download-url-base" %}}/docker-ce
    {{< /tab >}}
    {{< /tabs >}}
 
-2. Start Docker.
+2. Start Docker Engine.
+
+   Start the Docker Engine and containerd as a systemd service that will launch
+   on boot:
 
    ```console
-   $ sudo systemctl start docker
+   $ sudo systemctl enable --now containerd docker
    ```
+
+   If you prefer Docker to only start manually, use `sudo systemctl start docker`
+   instead, which runs it only for the current session.
 
 3. Verify that the Docker Engine installation is successful by running the
    `hello-world` image.
@@ -205,11 +211,17 @@ download a new file each time you want to upgrade Docker Engine.
    Docker is installed but not started. The `docker` group is created, but no
    users are added to the group.
 
-6. Start Docker.
+6. Start Docker Engine.
+
+   Start the Docker Engine and containerd as a systemd service that will launch
+   on boot:
 
    ```console
-   $ sudo systemctl start docker
+   $ sudo systemctl enable --now containerd docker
    ```
+
+   If you prefer Docker to only start manually, use `sudo systemctl start docker`
+   instead, which runs it only for the current session.
 
 7. Verify that the Docker Engine installation is successful by running the
    `hello-world` image.

--- a/content/manuals/engine/install/sles.md
+++ b/content/manuals/engine/install/sles.md
@@ -162,11 +162,17 @@ $ sudo zypper addrepo {{% param "download-url-base" %}}/docker-ce.repo
    {{< /tab >}}
    {{< /tabs >}}
 
-2. Start Docker.
+2. Start Docker Engine.
+
+   Start the Docker Engine and containerd as a systemd service that will launch
+   on boot:
 
    ```console
-   $ sudo systemctl start docker
+   $ sudo systemctl enable --now containerd docker
    ```
+
+   If you prefer Docker to only start manually, use `sudo systemctl start docker`
+   instead, which runs it only for the current session.
 
 3. Verify that the Docker Engine installation is successful by running the
    `hello-world` image.
@@ -208,11 +214,17 @@ download a new file each time you want to upgrade Docker Engine.
    Docker is installed but not started. The `docker` group is created, but no
    users are added to the group.
 
-3. Start Docker.
+3. Start Docker Engine.
+
+   Start the Docker Engine and containerd as a systemd service that will launch
+   on boot:
 
    ```console
-   $ sudo systemctl start docker
+   $ sudo systemctl enable --now containerd docker
    ```
+
+   If you prefer Docker to only start manually, use `sudo systemctl start docker`
+   instead, which runs it only for the current session.
 
 4. Verify that the Docker Engine installation is successful by running the
    `hello-world` image.


### PR DESCRIPTION
- related / alternative to https://github.com/docker/docs/pull/21380
- ℹ️ more follow-ups coming; getting this one in first 😄 

Unlike deb-based systems, installing an rpm doesn't automatically start the Docker service, and starting the service doesn't make it automatically start on (re)boot.

Update the instructions so that Docker is automatically started on boot.

<!--Delete sections as needed -->

## Description

<!-- Tell us what you did and why -->

## Related issues or tickets

<!-- Related issues, pull requests, or Jira tickets -->

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Technical review
- [ ] Editorial review
- [ ] Product review