### PR TITLE
Update DH release notes to include OATs and PAT expiration

### DIFF
--- a/content/manuals/docker-hub/release-notes.md
+++ b/content/manuals/docker-hub/release-notes.md
@@ -15,6 +15,18 @@ known issues for each Docker Hub release.
 
 Take a look at the [Docker Public Roadmap](https://github.com/orgs/docker/projects/51/views/1?filterQuery=) to see what's coming next.
 
+## 2024-11-11
+
+### New
+
+- [Personal access tokens](/security/for-developers/access-tokens/) (PATs) now support expiration dates.
+
+## 2024-10-15
+
+### New
+
+- Beta: You can now create [organization access tokens](/security/for-admins/access-tokens/) (OATs) to enhance security for organizations and streamline access management for organizations.
+
 ## 2024-03-23
 
 ### New


### PR DESCRIPTION
## Description
- Update Docker Hub release notes for OATs beta release and PAT expiration feature

## Related issues or tickets
- [ENGDOCS-2307](https://docker.atlassian.net/browse/ENGDOCS-2307?atlOrigin=eyJpIjoiM2JjYzI4OTIwYjMzNDRmZWFmNzAyNzhhOTJmNTg0YTciLCJwIjoiaiJ9)
- Requested in [Slack thread](https://docker.slack.com/archives/C046HE6K4CC/p1730742870804099)

## Reviews
- [ ] Editorial review

[ENGDOCS-2307]: https://docker.atlassian.net/browse/ENGDOCS-2307?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ