### PR TITLE
Update or remove links in installation documentation

### DIFF
--- a/content/get-started/get-docker.md
+++ b/content/get-started/get-docker.md
@@ -50,7 +50,7 @@ section and choose the best installation path for you.
 {{< card
   title="Docker Desktop for Linux"
   description="A native Linux application that delivers all Docker tools to your Linux computer."
-  link="/desktop/install/linux/"
+  link="/desktop/setup/install/linux/"
   icon="/assets/images/linux_48.svg" >}}
 
 > [!NOTE]

--- a/content/get-started/introduction/get-docker-desktop.md
+++ b/content/get-started/introduction/get-docker-desktop.md
@@ -42,7 +42,7 @@ This guide will walk you through the installation process, enabling you to exper
 
 {{< card
   title="Docker Desktop for Linux"
-  description="[Install instructions](/desktop/install/linux/)"
+  description="[Install instructions](/desktop/setup/install/linux/)"
   icon="/assets/images/linux_48.svg" >}}
 
 Once it's installed, complete the setup process and you're all set to run a Docker container.

--- a/content/manuals/desktop/_index.md
+++ b/content/manuals/desktop/_index.md
@@ -11,7 +11,7 @@ grid:
     Install Docker Desktop on
     [Mac](/desktop/setup/install/mac-install/),
     [Windows](/desktop/setup/install/windows-install/), or
-    [Linux](/desktop/install/linux/).
+    [Linux](/desktop/setup/install/linux/).
   icon: download
 - title: Explore Docker Desktop
   description: Navigate Docker Desktop and learn about its key features.

--- a/content/manuals/engine/install/_index.md
+++ b/content/manuals/engine/install/_index.md
@@ -35,11 +35,8 @@ aliases:
 
 This section describes how to install Docker Engine on Linux, also known as
 Docker CE. Docker Engine is also available for Windows, macOS, and Linux,
-through Docker Desktop. For instructions on how to install Docker Desktop, see:
-
-- [Docker Desktop for Linux](/manuals/desktop/setup/install/linux/_index.md)
-- [Docker Desktop for Mac (macOS)](/manuals/desktop/setup/install/mac-install.md)
-- [Docker Desktop for Windows](/manuals/desktop/setup/install/windows-install.md)
+through Docker Desktop. For instructions on how to install Docker Desktop,
+see: [Overview of Docker Desktop](/manuals/desktop/_index.md).
 
 ## Supported platforms
 


### PR DESCRIPTION
## Description

- [update links about docker desktop for linux](https://github.com/docker/docs/commit/3a01ae99390f8ad7570a80beda022dc21b19f0e5)  
Update outdated links to make them the same as Windows and macOS.
- [remove interference option in docker engine install doc](https://github.com/docker/docs/commit/9ccaf6f0aef64f25f46b3ef4e3474b57bdc31962)  
Seriously, it's not easy to find this place, don't add any more interference information.

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Technical review
- [x] Editorial review
- [ ] Product review