### PR TITLE
hub/samples: add some aliases

### DIFF
--- a/content/get-started/docker-concepts/the-basics/what-is-an-image.md
+++ b/content/get-started/docker-concepts/the-basics/what-is-an-image.md
@@ -5,6 +5,7 @@ keywords: concepts, build, images, container, docker desktop
 description: What is an image
 aliases:
   - /guides/docker-concepts/the-basics/what-is-an-image/
+  - /get-started/run-docker-hub-images/
 ---
 
 {{< youtube-embed NyvT9REqLe4 >}}

--- a/content/manuals/security/for-admins/provisioning/scim.md
+++ b/content/manuals/security/for-admins/provisioning/scim.md
@@ -5,6 +5,7 @@ linkTitle: SCIM
 description: Learn how System for Cross-domain Identity Management works and how to set it up.
 aliases:
   - /security/for-admins/scim/
+  - /docker-hub/scim/
 weight: 30
 ---
 

--- a/content/reference/samples/_index.md
+++ b/content/reference/samples/_index.md
@@ -12,6 +12,7 @@ aliases:
 - /examples/
 - /samples/runnning_riak_service/
 - /samples/apt-cacher-ng/
+- /samples/
 ---
 
 Learn how to containerize different types of services by walking through Official Docker samples.

--- a/content/reference/samples/ai-ml.md
+++ b/content/reference/samples/ai-ml.md
@@ -2,4 +2,6 @@
 title: AI/ML samples
 description: Docker samples for AI/ML.
 service: aiml
+aliases:
+- /samples/ai-ml/
 ---

--- a/content/reference/samples/angular.md
+++ b/content/reference/samples/angular.md
@@ -2,4 +2,6 @@
 title: Angular samples
 description: Docker samples for Angular.
 service: angular
+aliases:
+- /samples/angular/
 ---

--- a/content/reference/samples/cloudflared.md
+++ b/content/reference/samples/cloudflared.md
@@ -2,4 +2,6 @@
 title: Cloudflared samples
 description: Docker samples for cloudflared.
 service: cloudflared
+aliases:
+- /samples/cloudflared/
 ---

--- a/content/reference/samples/django.md
+++ b/content/reference/samples/django.md
@@ -4,4 +4,5 @@ description: Docker samples for Django.
 service: django
 aliases:
 - /compose/django/
+- /samples/django/
 ---

--- a/content/reference/samples/dotnet.md
+++ b/content/reference/samples/dotnet.md
@@ -6,4 +6,5 @@ aliases:
 - /samples/dotnetcore/
 - /compose/aspnet-mssql-compose/
 - /samples/aspnet-mssql-compose/
+- /samples/dotnet/
 ---

--- a/content/reference/samples/elasticsearch.md
+++ b/content/reference/samples/elasticsearch.md
@@ -2,4 +2,6 @@
 title: Elasticsearch / Logstash / Kibana samples
 description: Docker samples for Elasticsearch, Logstash, and Kibana.
 service: elk
+aliases:
+- /samples/elasticsearch/
 ---

--- a/content/reference/samples/express.md
+++ b/content/reference/samples/express.md
@@ -2,4 +2,6 @@
 title: Express samples
 description: Docker samples for Express.
 service: express
+aliases:
+- /samples/express/
 ---

--- a/content/reference/samples/fastapi.md
+++ b/content/reference/samples/fastapi.md
@@ -2,4 +2,6 @@
 title: FastAPI samples
 description: Docker samples for .NET.
 service: fastapi
+aliases:
+- /samples/fastapi/
 ---

--- a/content/reference/samples/flask.md
+++ b/content/reference/samples/flask.md
@@ -2,4 +2,6 @@
 title: Flask samples
 description: Docker samples for Flask.
 service: flask
+aliases:
+- /samples/flask/
 ---

--- a/content/reference/samples/gitea.md
+++ b/content/reference/samples/gitea.md
@@ -2,4 +2,6 @@
 title: Gitea samples
 description: Docker samples for Gitea.
 service: gitea
+aliases:
+- /samples/gitea/
 ---

--- a/content/reference/samples/go.md
+++ b/content/reference/samples/go.md
@@ -2,4 +2,6 @@
 title: Go samples
 description: Docker samples for Go.
 service: go
+aliases:
+- /samples/go/
 ---

--- a/content/reference/samples/java.md
+++ b/content/reference/samples/java.md
@@ -2,4 +2,6 @@
 title: Java samples
 description: Docker samples for Java.
 service: java
+aliases:
+- /samples/java/
 ---

--- a/content/reference/samples/javascript.md
+++ b/content/reference/samples/javascript.md
@@ -2,4 +2,6 @@
 title: JavaScript samples
 description: Docker samples for JavaScript.
 service: javascript
+aliases:
+- /samples/javascript/
 ---

--- a/content/reference/samples/mariadb.md
+++ b/content/reference/samples/mariadb.md
@@ -2,4 +2,6 @@
 title: MariaDB samples
 description: Docker samples for MariaDB.
 service: mariadb
+aliases:
+- /samples/mariadb/
 ---

--- a/content/reference/samples/minecraft.md
+++ b/content/reference/samples/minecraft.md
@@ -2,4 +2,6 @@
 title: Minecraft samples
 description: Docker samples for Minecraft.
 service: minecraft
+aliases:
+- /samples/minecraft/
 ---

--- a/content/reference/samples/mongodb.md
+++ b/content/reference/samples/mongodb.md
@@ -2,4 +2,6 @@
 title: MongoDB samples
 description: Docker samples for MongoDB.
 service: mongodb
+aliases:
+- /samples/mongodb/
 ---

--- a/content/reference/samples/ms-sql.md
+++ b/content/reference/samples/ms-sql.md
@@ -2,4 +2,6 @@
 title: MS-SQL samples
 description: Docker samples for MS-SQL.
 service: ms-sql
+aliases:
+- /samples/ms-sql/
 ---

--- a/content/reference/samples/mysql.md
+++ b/content/reference/samples/mysql.md
@@ -2,4 +2,6 @@
 title: MySQL samples
 description: Docker samples for MySQL.
 service: mysql
+aliases:
+- /samples/mysql/
 ---

--- a/content/reference/samples/nextcloud.md
+++ b/content/reference/samples/nextcloud.md
@@ -2,4 +2,6 @@
 title: Nextcloud samples
 description: Docker samples for Nextcloud.
 service: nextcloud
+aliases:
+- /samples/nexcloud/
 ---

--- a/content/reference/samples/nginx.md
+++ b/content/reference/samples/nginx.md
@@ -2,4 +2,6 @@
 title: NGINX samples
 description: Docker samples for NGINX.
 service: nginx
+aliases:
+- /samples/nginx/
 ---

--- a/content/reference/samples/nodejs.md
+++ b/content/reference/samples/nodejs.md
@@ -2,4 +2,6 @@
 title: Node.js samples
 description: Docker samples for Node.js.
 service: nodejs
+aliases:
+- /samples/nodejs/
 ---

--- a/content/reference/samples/php.md
+++ b/content/reference/samples/php.md
@@ -2,4 +2,6 @@
 title: PHP samples
 description: Docker samples for PHP.
 service: php
+aliases:
+- /samples/php/
 ---

--- a/content/reference/samples/pi-hole.md
+++ b/content/reference/samples/pi-hole.md
@@ -2,4 +2,6 @@
 title: Pi-hole samples
 description: Docker samples for Pi-hole.
 service: pi-hole
+aliases:
+- /samples/pi-hole/
 ---

--- a/content/reference/samples/plex.md
+++ b/content/reference/samples/plex.md
@@ -2,4 +2,6 @@
 title: Plex samples
 description: Docker samples for Plex.
 service: plex
+aliases:
+- /samples/plex/
 ---

--- a/content/reference/samples/portainer.md
+++ b/content/reference/samples/portainer.md
@@ -2,4 +2,6 @@
 title: Portainer samples
 description: Docker samples for Portainer.
 service: portainer
+aliases:
+- /samples/portainer/
 ---

--- a/content/reference/samples/postgres.md
+++ b/content/reference/samples/postgres.md
@@ -5,4 +5,5 @@ service: postgresql
 aliases:
 - /engine/examples/postgresql_service/
 - /samples/postgresql_service/
+- /samples/postgresql/
 ---

--- a/content/reference/samples/prometheus.md
+++ b/content/reference/samples/prometheus.md
@@ -2,4 +2,6 @@
 title: Prometheus samples
 description: Docker samples for Prometheus.
 service: prometheus
+aliases:
+- /samples/prometheus/
 ---

--- a/content/reference/samples/python.md
+++ b/content/reference/samples/python.md
@@ -2,4 +2,6 @@
 title: Python samples
 description: Docker samples for Python.
 service: python
+aliases:
+- /samples/python/
 ---

--- a/content/reference/samples/rails.md
+++ b/content/reference/samples/rails.md
@@ -2,4 +2,6 @@
 title: Rails samples
 description: Docker samples for Rails.
 service: rails
+aliases:
+- /samples/rails/
 ---

--- a/content/reference/samples/react.md
+++ b/content/reference/samples/react.md
@@ -2,4 +2,6 @@
 title: React samples
 description: Docker samples for React.
 service: react
+aliases:
+- /samples/react/
 ---

--- a/content/reference/samples/redis.md
+++ b/content/reference/samples/redis.md
@@ -2,4 +2,6 @@
 title: Redis samples
 description: Docker samples for Redis.
 service: redis
+aliases:
+- /samples/redis/
 ---

--- a/content/reference/samples/ruby.md
+++ b/content/reference/samples/ruby.md
@@ -2,4 +2,6 @@
 title: Ruby samples
 description: Docker samples for Ruby.
 service: ruby
+aliases:
+- /samples/ruby/
 ---

--- a/content/reference/samples/rust.md
+++ b/content/reference/samples/rust.md
@@ -2,4 +2,6 @@
 title: Rust samples
 description: Docker samples for Rust.
 service: rust
+aliases:
+- /samples/rust/
 ---

--- a/content/reference/samples/spark.md
+++ b/content/reference/samples/spark.md
@@ -2,4 +2,6 @@
 title: Spark samples
 description: Docker samples for Spark.
 service: spark
+aliases:
+- /samples/spark/
 ---

--- a/content/reference/samples/spring.md
+++ b/content/reference/samples/spring.md
@@ -2,4 +2,6 @@
 title: Spring Boot samples
 description: Docker samples for Spring Boot.
 service: spring
+aliases:
+- /samples/spring/
 ---

--- a/content/reference/samples/traefik.md
+++ b/content/reference/samples/traefik.md
@@ -2,4 +2,6 @@
 title: Traefik samples
 description: Docker samples for Traefik.
 service: traefik
+aliases:
+- /samples/traefik/
 ---

--- a/content/reference/samples/typescript.md
+++ b/content/reference/samples/typescript.md
@@ -2,4 +2,6 @@
 title: TypeScript samples
 description: Docker samples for TypeScript.
 service: typescript
+aliases:
+- /samples/typescript/
 ---

--- a/content/reference/samples/vuejs.md
+++ b/content/reference/samples/vuejs.md
@@ -2,4 +2,6 @@
 title: Vue.js samples
 description: Docker samples for Vue.js.
 service: vuejs
+aliases:
+- /samples/vuejs/
 ---

--- a/content/reference/samples/wireguard.md
+++ b/content/reference/samples/wireguard.md
@@ -2,4 +2,6 @@
 title: WireGuard samples
 description: Docker samples for WireGuard.
 service: wireguard
+aliases:
+- /samples/wireguard/
 ---

--- a/content/reference/samples/wordpress.md
+++ b/content/reference/samples/wordpress.md
@@ -4,4 +4,5 @@ description: Docker samples for WordPress.
 service: wordpress
 aliases:
 - /compose/wordpress/
+- /samples/wordpress/
 ---


### PR DESCRIPTION
<!--Delete sections as needed -->

## Description

Added some redirects for moved/removed Hub/Samples content in an effort to reduce indexing issues for not found (404) URLs identified by Google Search Console. 

## Related issues or tickets

ENGDCOS-2311

## Reviews

- [ ] Editorial review
