### PR TITLE
Update keep context small bullet point in optimize.md

### DIFF
--- a/content/manuals/build/cache/optimize.md
+++ b/content/manuals/build/cache/optimize.md
@@ -19,7 +19,7 @@ the build process:
   invalidation.
 - [Keep the context small](#keep-the-context-small): The context is the set of
   files and directories that are sent to the builder to process a build
-  instruction. Keeping the context as small reduces the amount of data that
+  instruction. Keeping the context as small as possible reduces the amount of data that
   needs to be sent to the builder, and reduces the likelihood of cache
   invalidation.
 - [Use bind mounts](#use-bind-mounts): Bind mounts let you mount a file or


### PR DESCRIPTION
Clarify the 'Keep context small' bullet point

## Description

The "Keep context small" bullet point didn't read clearly, proposed one change but it could also be modified to read.
"Keeping the context small reduces the amount of data that needs to be sent to..."