### PR TITLE
fix: multi-platform build command for Neovim example

### DIFF
--- a/content/manuals/build/building/multi-platform.md
+++ b/content/manuals/build/building/multi-platform.md
@@ -342,7 +342,7 @@ Steps:
    $ docker build \
       --builder <cloud-builder> \
       --platform linux/amd64,linux/arm64 \
-      --output ./bin
+      --output ./bin .
    ```
 
    This command builds the image using the cloud builder and exports the


### PR DESCRIPTION
## Description

Resolves the following error:

```
ERROR: "docker buildx build" requires exactly 1 argument.
```

<img width="1496" alt="Screenshot 2024-11-17 at 23 26 10" src="https://github.com/user-attachments/assets/c857cebc-7e53-45d1-bb5d-ffa9dcd88c3e">

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Technical review
- [ ] Editorial review
- [ ] Product review