### PR TITLE
Update 05_persisting_data.md

### DIFF
--- a/content/get-started/workshop/05_persisting_data.md
+++ b/content/get-started/workshop/05_persisting_data.md
@@ -102,7 +102,7 @@ You can create the volume and start the container using the CLI or Docker Deskto
    container, which captures all files created at the path.
 
    ```console
-   $ docker run -dp 127.0.0.1:3000:3000 --mount type=volume,src=todo-db,target=/etc/todos getting-started
+   $ docker run -dp 127.0.0.1:3000:3000 --mount type=volume,src=todo-db,target=/etc/todos docker/getting-started
    ```
 
    > [!NOTE]
@@ -110,7 +110,7 @@ You can create the volume and start the container using the CLI or Docker Deskto
    > If you're using Git Bash, you must use different syntax for this command.
    >
    > ```console
-   > $ docker run -dp 127.0.0.1:3000:3000 --mount type=volume,src=todo-db,target=//etc/todos getting-started
+   > $ docker run -dp 127.0.0.1:3000:3000 --mount type=volume,src=todo-db,target=//etc/todos docker/getting-started
    > ```
    >
    > For more details about Git Bash's syntax differences, see


### PR DESCRIPTION
Solution for: Unable to find image 'getting-started:latest' locally

<!--Delete sections as needed -->

## Description
The issue arises because the documentation mistakenly refers to the image as getting-started:latest, which implies it is a locally available image or one in your Docker Hub namespace. However, the correct image name is docker/getting-started:latest, as it is hosted in the Docker Hub namespace "docker".
<!-- Tell us what you did and why -->

## Related issues or tickets

<!-- Related issues, pull requests, or Jira tickets -->

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Technical review
- [ ] Editorial review
- [ ] Product review