### PR TITLE
nav: add groupings for manuals

### DIFF
--- a/assets/css/toc.css
+++ b/assets/css/toc.css
@@ -11,4 +11,7 @@
       }
     }
   }
+  .group-header {
+    @apply text-gray-light-500 dark:text-gray-dark-700;
+  }
 }

--- a/content/manuals/_index.md
+++ b/content/manuals/_index.md
@@ -8,11 +8,28 @@ layout: wide
 params:
   icon: description
   notoc: true
-  development:
+  products:
   - title: Docker Desktop
     description: Your command center for container development.
     icon: /assets/icons/Whale.svg
     link: /desktop/
+  - title: Docker Hub
+    description: Discover, share, and integrate container images.
+    icon: hub
+    link: /docker-hub/
+  - title: Docker Scout
+    description: Image analysis and policy evaluation.
+    icon: /assets/icons/Scout.svg
+    link: /scout/
+  - title: Build Cloud
+    description: Build your images faster in the cloud.
+    icon: /assets/images/logo-build-cloud.svg
+    link: /build-cloud/
+  - title: Testcontainers Cloud
+    description: Automate container-based testing with enhanced performance and scalability.
+    icon: rule
+    link: https://testcontainers.com/cloud/docs/
+  tools:
   - title: Docker Compose
     description: Define and run multi-container applications.
     icon: /assets/icons/Compose.svg
@@ -25,27 +42,10 @@ params:
     description: The industry-leading container runtime.
     icon: developer_board
     link: /engine/
-  - title: Docker Extensions
-    description: Customize your Docker Desktop workflow.
-    icon: extension
-    link: /extensions/
-  services:
-  - title: Docker Hub
-    description: Discover, share, and integrate container images.
-    icon: hub
-    link: /docker-hub/
-  - title: Docker Scout
-    description: Image analysis and policy evaluation.
-    icon: /assets/icons/Scout.svg
-    link: /scout/
-  - title: Trusted content
-    description: Curated, high-quality content from trusted sources.
-    icon: verified
-    link: /trusted-content/
-  - title: Build Cloud
-    description: Build your images faster in the cloud.
-    icon: /assets/images/logo-build-cloud.svg
-    link: /build-cloud/
+  - title: Registry
+    description: Store and distribute container images.
+    icon: storage
+    link: /registry/
   admin:
   - title: Administration
     description: Centralized observability for companies and organizations.
@@ -68,20 +68,24 @@ params:
 This section contains user guides on how to install, set up, configure, and use
 Docker products.
 
-## Developer tools
+## Products
 
-Software development and containerization technologies.
+Explore Docker's flagship products, including tools for container development,
+image sharing, security analysis, and accelerated builds.
 
-{{< grid items=development >}}
+{{< grid items=products >}}
 
-## Services
+## Open source tools
 
-Artifact management and supply chain security.
+Discover how to leverage Docker’s open-source tools for orchestrating
+multi-container applications, building images, running containers, and managing
+container registries.
 
-{{< grid items=services >}}
+{{< grid items=tools >}}
 
-## Administration and accounts
+## Platform
 
-Administration and subscription management for organizations.
+Find resources for managing Docker organizations, accounts, subscriptions,
+billing, and security.
 
 {{< grid items=admin >}}

--- a/content/manuals/accounts/_index.md
+++ b/content/manuals/accounts/_index.md
@@ -24,6 +24,7 @@ grid:
   description: Add an extra layer of authentication to your Docker account.
   link: /security/for-developers/2fa/
   icon: phonelink_lock
+group: "Platform"
 ---
 
 You can create a Docker account to secure a Docker ID, which is a username for your account that lets you access Docker products. You can use your Docker account to sign in to Docker products like Docker Hub, Docker Desktop, or Docker Scout. You can centrally manage your [Docker account settings](https://app.docker.com/settings), as well as account security features, in [Docker Home](https://app.docker.com).

--- a/content/manuals/admin/_index.md
+++ b/content/manuals/admin/_index.md
@@ -30,6 +30,7 @@ grid:
   link: /security/
 aliases:
 - /docker-hub/admin-overview
+group: "Platform"
 ---
 
 Administrators can manage companies and organizations using the Docker Admin Console, or manage organizations in Docker Hub.

--- a/content/manuals/billing/_index.md
+++ b/content/manuals/billing/_index.md
@@ -43,6 +43,7 @@ grid_resources:
   description: Discover how Docker billing supports 3DS and how to troubleshoot potential issues.
   link: /billing/3d-secure/
   icon: wallet
+group: "Platform"
 ---
 
 Use the resources in this section to manage your billing and payment settings for your Docker subscriptions.

--- a/content/manuals/build-cloud/_index.md
+++ b/content/manuals/build-cloud/_index.md
@@ -1,11 +1,12 @@
 ---
 title: Docker Build Cloud
-weight: 100
+weight: 10
 description: Find documentation on Docker Build Cloud to help you build your container images faster, both locally and in CI
 keywords: build, cloud, cloud build, remote builder
 aliases:
   - /build/cloud/faq/
   - /build/cloud/
+group: "Products"
 ---
 
 Docker Build Cloud is a service that lets you build your container images

--- a/content/manuals/build/_index.md
+++ b/content/manuals/build/_index.md
@@ -42,6 +42,7 @@ grid:
 aliases:
 - /buildx/working-with-buildx/
 - /develop/develop-images/build_enhancements/
+group: "Open source tools"
 ---
 
 Docker Build is one of Docker Engine's most used features. Whenever you are

--- a/content/manuals/cloud/index.md
+++ b/content/manuals/cloud/index.md
@@ -12,6 +12,7 @@ aliases:
 - /cloud/aci-compose-features/
 - /cloud/aci-container-features/
 - /engine/context/ecs-integration/
+group: "Move?"
 ---
 
 Docker Compose's integration for Amazon's Elastic Container Service and Azure Container Instances has retired. The integration documentation is no longer available through the Docker Docs site. 

--- a/content/manuals/compose/_index.md
+++ b/content/manuals/compose/_index.md
@@ -47,6 +47,7 @@ aliases:
 - /compose/overview/
 - /compose/swarm/
 - /compose/completion/
+group: "Open source tools"
 ---
 
 Docker Compose is a tool for defining and running multi-container applications. 

--- a/content/manuals/copilot/_index.md
+++ b/content/manuals/copilot/_index.md
@@ -12,6 +12,7 @@ description: |
   vulnerabilities, and automate containerization through GitHub Copilot Chat in
   various development environments.
 keywords: Docker, GitHub Copilot, extension, Visual Studio Code, chat, ai, containerization
+group: "Products"
 ---
 
 {{% restricted title="Early Access" %}}

--- a/content/manuals/desktop/_index.md
+++ b/content/manuals/desktop/_index.md
@@ -39,6 +39,7 @@ aliases:
 - /docker-for-mac/opensource/
 - /docker-for-windows/dashboard/
 - /docker-for-windows/opensource/
+group: "Products"
 ---
 
 Docker Desktop is a one-click-install application for your Mac, Linux, or Windows environment

--- a/content/manuals/docker-hub/_index.md
+++ b/content/manuals/docker-hub/_index.md
@@ -25,6 +25,7 @@ grid:
   description: Find out about new features, improvements, and bug fixes.
   icon: note_add
   link: /docker-hub/release-notes
+group: "Products"
 ---
 
 Docker Hub simplifies development with the world's largest container registry

--- a/content/manuals/engine/_index.md
+++ b/content/manuals/engine/_index.md
@@ -46,6 +46,7 @@ aliases:
 - /engine/migration/
 - /engine/misc/
 - /linux/
+group: "Open source tools"
 ---
 
 Docker Engine is an open source containerization technology for building and

--- a/content/manuals/extensions/_index.md
+++ b/content/manuals/extensions/_index.md
@@ -1,10 +1,11 @@
 ---
 title: Docker Extensions
-weight: 100
+weight: 999
 description: Extensions
 keywords: Docker Extensions, Docker Desktop, Linux, Mac, Windows
 aliases:
  - /desktop/extensions/
+group: "Move?"
 ---
 
 Docker Extensions let you use third-party tools within Docker Desktop to extend its functionality.

--- a/content/manuals/registry.md
+++ b/content/manuals/registry.md
@@ -37,6 +37,7 @@ aliases:
   - /registry/storage-drivers/oss/
   - /registry/storage-drivers/s3/
   - /registry/storage-drivers/swift/
+group: "Open source tools"
 ---
 
 > [!IMPORTANT]

--- a/content/manuals/release-lifecycle.md
+++ b/content/manuals/release-lifecycle.md
@@ -4,6 +4,7 @@ linkTitle: Release lifecycle
 description: Describes the various stages of feature lifecycle from beta
   to GA.
 keywords: beta, GA, Early Access,
+group: "Products"
 ---
 
 This page details Docker's product release lifecycle and how Docker defines each stage. It also provides information on the product retirement process. Features and products may progress through some or all of these phases. 

--- a/content/manuals/scout/_index.md
+++ b/content/manuals/scout/_index.md
@@ -39,6 +39,7 @@ grid:
     description: |
       The free plan includes up to 3 repositories. Upgrade for more.
     icon: upgrade
+group: "Products"
 ---
 
 Container images consist of layers and software packages, which are susceptible to vulnerabilities.

--- a/content/manuals/security/_index.md
+++ b/content/manuals/security/_index.md
@@ -86,6 +86,7 @@ grid_resources:
   description: Learn how to suppress non-applicable or fixed vulnerabilities found in your images.
   icon: query_stats
   link: /scout/guides/vex/
+group: "Platform"
 ---
 
 Docker provides security guardrails for both administrators and developers.

--- a/content/manuals/subscription/_index.md
+++ b/content/manuals/subscription/_index.md
@@ -37,6 +37,7 @@ grid_resources:
 aliases:
 - /docker-hub/billing/
 - /docker-hub/billing/faq/
+group: "Platform"
 ---
 
 A Docker Core subscription includes licensing for commercial use of Docker components including Docker Desktop and Docker Hub.

--- a/content/manuals/tcc.md
+++ b/content/manuals/tcc.md
@@ -4,4 +4,5 @@ weight: 200
 params:
   sidebar:
     goto: "https://testcontainers.com/cloud/docs/"
+group: "Products"
 ---

--- a/content/manuals/trusted-content/_index.md
+++ b/content/manuals/trusted-content/_index.md
@@ -16,6 +16,7 @@ grid:
   description: High-quality images from non-commercial open source projects.
   icon: /trusted-content/images/dsos-icon.svg
   link: /trusted-content/dsos-program/
+group: "Move?"
 ---
 
 Trusted content is a selection of high-quality, secure images, curated by

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -40,7 +40,7 @@
         <!-- Actual Sidebar Content -->
         {{ block "left" . }}
           {{ partial "sidebar/mainnav.html" . }}
-          {{ partial "sidebar/sections.html" . }}
+          {{ partial "sidebar/sections.html" (dict "Page" . "Site" .Site) }}
         {{ end }}
       </div>
     </div>

--- a/layouts/partials/sidebar/sections.html
+++ b/layouts/partials/sidebar/sections.html
@@ -1,13 +1,55 @@
 <!-- section tree -->
 <nav class="md:text-sm flex flex-col">
-  <div
-    class="block py-4 md:hidden text-gray-light dark:text-gray-dark">This section</div>
-  {{/* The current page is in the table of contents */}}
+  <div class="block py-4 md:hidden text-gray-light dark:text-gray-dark">This section</div>
+
   <ul>
-    {{ template "renderChildren" .FirstSection }}
+    {{ $page := .Page }}
+
+    <!-- Check if the page belongs to `/manuals/` -->
+    {{ if and $page.File (strings.HasPrefix $page.File.Path "manuals/") }}
+      <!-- Set $parent explicitly to /manuals/ -->
+      {{ $parent := .Site.GetPage "section" "manuals" }}
+
+      <!-- Initialize groups and matched items -->
+      {{ $groups := slice }}
+      {{ $matched := slice }}
+
+      <!-- Collect Groups -->
+      {{ range (union $parent.Sections $parent.RegularPages).ByParam "weight" }}
+        {{ if and (not (eq .Params.sitemap false)) .Params.group }}
+          {{ if not (in $groups .Params.group) }}
+            {{ $groups = $groups | append .Params.group }}
+          {{ end }}
+        {{ end }}
+      {{ end }}
+
+
+      <!-- Render Grouped Items -->
+      {{ range $groups }}
+      {{ $group := . }}
+      <li>
+        <div class="group-header font-semibold uppercase py-2">{{ $group }}</div>
+        <ul>
+          {{ range (union $parent.Sections $parent.RegularPages).ByParam "weight" }}
+            {{ if eq (trim .Params.group " ") (trim $group " ") }}
+              {{ $matched = $matched | append . }}
+              {{ if .IsSection }}
+                {{ template "renderList" . }}
+              {{ else }}
+                {{ template "renderSingle" . }}
+              {{ end }}
+            {{ end }}
+          {{ end }}
+        </ul>
+      </li>
+    {{ end }}
+    
+    {{ else }}
+      <!-- Default Navigation for Other Sections -->
+      {{ template "renderChildren" $page.FirstSection }}
+    {{ end }}
   </ul>
 </nav>
-
 {{ define "renderChildren" }}
   {{- $pages := .Pages }}
   {{- if .Params.sidebar.reverse }}


### PR DESCRIPTION
<!--Delete sections as needed -->

## Description

Adds nav groups, specifically for manuals.
Allows for another layer of structure without hiding the children.

https://deploy-preview-21471--docsdocker.netlify.app/manuals/

Add 'group: "something"' to the top-level topic (_index.md for sections) in manuals to create a group.
Groups are dynamic and not defined.
It should use weight to sort for both group and within a group. 


Currently have the groups as:
- Products
- Open source tools
- Platform
- Move? (Temp group. Content that doesn't fit the above groups and should be handled)
  - I'm planning to move trusted content back into Hub very soon.
  - Maybe move extensions into Desktop and SDK into references?
  - Maybe move Cloud integrations into some deprecated/retired topic with other old products or into Compose?

Not sure about release lifecycle under products, because it applies to everything. Maybe a reference topic?

Aligned the manuals' landing page with the groups.

## Related issues or tickets

<!-- Related issues, pull requests, or Jira tickets -->

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->


- [ ] Editorial review
