### PR TITLE
Update compose networking for container-container communication

### DIFF
--- a/content/manuals/compose/how-tos/networking.md
+++ b/content/manuals/compose/how-tos/networking.md
@@ -59,6 +59,14 @@ Within the `web` container, your connection string to `db` would look like
 `postgres://db:5432`, and from the host machine, the connection string would
 look like `postgres://{DOCKER_IP}:8001` for example `postgres://localhost:8001` if your container is running locally.
 
+## Container to container communication
+
+Those familiar with using `http://localhost:3000` to reference a local development URL, use `http://servicename:3000` instead when using docker compose.
+
+Example: In local development you have a frontend node app running at `http://localhost:3000` which references a backend api running at `http://localhost:8080/api`.  In Docker networking, you would replace the node app api reference to the backend api with `http://apiservice:8080/api`. Similarly, the frontend app would be referenced by service name `http://myapp:3000`
+
+This DNS resolution only works between compose services. For example, if you would like to view your node frontend app in your browser running at container port 80 and host port 3000, you would still need to publish the port from the container to the host then you can view the node app at `http://localhost:3000`.
+
 ## Update containers on the network
 
 If you make a configuration change to a service and run `docker compose up` to update it, the old container is removed and the new one joins the network under a different IP address but the same name. Running containers can look up that name and connect to the new address, but the old address stops working.
@@ -178,7 +186,7 @@ networks:
 
 Instead of attempting to create a network called `[projectname]_default`, Compose looks for a network called `my-pre-existing-network` and connects your app's containers to it.
 
-## Further reference information 
+## Further reference information
 
 For full details of the network configuration options available, see the following references:
 

--- a/content/manuals/engine/network/drivers/bridge.md
+++ b/content/manuals/engine/network/drivers/bridge.md
@@ -37,6 +37,8 @@ network.**
 
 - **User-defined bridges provide automatic DNS resolution between containers**.
 
+  > **See also**: Learn how to communicate between containers by name (containername:port instead of localhost:port) in: [Container to container communication in Docker Compose](/manuals/compose/how-tos/networking.md#container-to-container-communication).
+
   Containers on the default bridge network can only access each other by IP
   addresses, unless you use the [`--link` option](../links.md), which is
   considered legacy. On a user-defined bridge network, containers can resolve


### PR DESCRIPTION
## Description

This PR updates the documentation for 
https://docs.docker.com/compose/how-tos/networking/
https://docs.docker.com/engine/network/drivers/bridge/

This would be helpful for developers familiar with local web development e.g. `http://localhost:3000` for learning how to communicate between two containers in docker compose.

**/compose/how-tos/networking**

- Mention that `http://localhost:3000` in local development needs to be changed to `http://servicename:3000` when communicating between two services/containers

**/engine/network/drivers/bridge/**

- Created a link to the section about Container to container communication in the bridge networking docs.  I was hesitant about this addition, but I thought it would be helpful in case someone reading the docs is not in the correct place

**How I got here**

For fun, I was learning react and got the Tic tac toe example working.  Next, I wanted to see if I could deploy the app using Kamal 2.  Problem was, Kamal 2 requires a healthcheck at the `/up` route returning 200.  React doesn't do this out of the box, and you would need a NextJS routing to accomplish this, which **SpBills** managed to do: see the issue comment on the [Kamal 2 repository](https://github.com/basecamp/kamal/issues/1041#issuecomment-2439188679).  I didnt want to bloat the simple tic tac toe project, so I found how to proxy a request in a React app, using `setupProxy` middleware.  I set up a go app on port 8081 for the healthcheck route, and had the react app running on port 8080 with this setupProxy code:

```
const { createProxyMiddleware } = require('http-proxy-middleware');

module.exports = function(app) {
  app.use(
    '/up',
    createProxyMiddleware({
      target: 'http://localhost:8081',
      changeOrigin: true,
    })
  );
};
```                                                            
I managed to achieve this locally (going to `http://localhost:8080/up` showed the static page from the go app with a 200.  However, when using docker compose running two services, `tictactoe` and `healthcheck` the same test resulted in 504s.  

**networking documentation**

Guessing that docker does something differently for inter-container communication, I began reading about networking in docker, I was scanning https://docs.docker.com/engine/network/drivers/bridge/ for something that would give me a hint how to achieve container to container communication.
I finally figured out that I needed to replace `http://localhost:8081` with `http://healthcheck:8081`

This PR adds documentation about the familiar `http://localhost:3000` URL needing to be `http://servicename:3000` in docker compose for container to container communication.

Hopefully this familiarity can help out a developer to bridge the gap about URL naming so they can communicate between containers successfully.

## Related issues or tickets

none

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Technical review
- [ ] Editorial review
- [ ] Product review