### PR TITLE
Update callouts for pull rate limits in Docker Hub

### DIFF
--- a/content/manuals/docker-hub/download-rate-limit.md
+++ b/content/manuals/docker-hub/download-rate-limit.md
@@ -168,18 +168,19 @@ URLs (`/v2/*/manifests/*`).
 >   different architecture.
 > - Pulls are accounted to the user doing the pull, not to the owner of the
 >   image.
->
-> There will be no image pull rate limit for users or automated systems with a
-> paid subscription. Anonymous and Docker Personal users using Docker Hub will
-> experience rate limits on image pull requests. For authenticated users, there
-> will be a 40 pull/hour rate limit per user; for unauthenticated usage, there
-> will be a 10 pull/hour rate limit per IP address.
 
 ### What's the download rate limit on Docker Hub?
 
+> [!IMPORTANT]
+>
+> After March 3rd, 2025, with Docker's enhanced subscription plans, there will be no image pull rate limit for users or automated systems with a
+> paid subscription.
+>
+> Anonymous and Docker Personal users using Docker Hub will experience rate limits on image pull requests. For authenticated users, there will be a 40 pull/hour rate limit per user; for unauthenticated usage, there will be a 10 pull/hour rate limit per IP address.
+
 Docker Hub limits the number of Docker image downloads, or pulls, based on the
 account type of the user pulling the image. Pull rate limits are based on
-individual IP address.
+individual IP address. The following table reflects Docker's current rate limits:
 
 | User type                                                               | Rate limit                           |
 |-------------------------------------------------------------------------|--------------------------------------|


### PR DESCRIPTION
## Description
- Callouts in https://docs.docker.com/docker-hub/download-rate-limit/#rate-limit were confusing, the callout for DCP stated the *new* rate limits, while the rate limit section explains the existing rate limits
- Updated callout to reflect the rate limits are for DCP changes
- Clarified the existing table is for existing Docker plans
- See: https://docker.atlassian.net/browse/IN-5058 for context

## Related issues or tickets
[ENGDOCS-2326](https://docker.atlassian.net/browse/ENGDOCS-2326?atlOrigin=eyJpIjoiZTBjNjBjZmE2ZGYxNDk5MWIzYzNmN2YxOTllZDdiNDYiLCJwIjoiaiJ9)

## Reviews
- [ ] Technical review
- [ ] Editorial review

[ENGDOCS-2326]: https://docker.atlassian.net/browse/ENGDOCS-2326?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ