### PR TITLE
bake: remove empty build network for compose files

### DIFF
--- a/content/guides/compose-bake/index.md
+++ b/content/guides/compose-bake/index.md
@@ -172,23 +172,19 @@ represents a single build.
     "result": {
       "context": "result",
       "dockerfile": "Dockerfile",
-      "network": ""
     },
     "seed": {
       "context": "seed-data",
       "dockerfile": "Dockerfile",
-      "network": ""
     },
     "vote": {
       "context": "vote",
       "dockerfile": "Dockerfile",
       "target": "dev",
-      "network": ""
     },
     "worker": {
       "context": "worker",
       "dockerfile": "Dockerfile",
-      "network": ""
     }
   }
 }


### PR DESCRIPTION
- This issue was fixed in https://github.com/docker/buildx/pull/2790

Signed-off-by: David Karlsson <35727626+dvdksn@users.noreply.github.com>
