### PR TITLE
ci: use edge releases of buildx

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,6 +11,11 @@ on:
       - main
   pull_request:
 
+env:
+  # Use edge release of buildx (latest RC, fallback to latest stable)
+  SETUP_BUILDX_VERSION: edge
+  SETUP_BUILDKIT_IMAGE: "moby/buildkit:latest"
+
 permissions:
   contents: read # to fetch code (actions/checkout)
 
@@ -24,6 +29,9 @@ jobs:
       -
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+        with:
+          version: ${{ env.SETUP_BUILDX_VERSION }}
+          driver-opts: image=${{ env.SETUP_BUILDKIT_IMAGE }}
       -
         name: Build
         uses: docker/bake-action@v5

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,6 +12,11 @@ on:
       - main
       - published
 
+env:
+  # Use edge release of buildx (latest RC, fallback to latest stable)
+  SETUP_BUILDX_VERSION: edge
+  SETUP_BUILDKIT_IMAGE: "moby/buildkit:latest"
+
 # these permissions are needed to interact with GitHub's OIDC Token endpoint.
 permissions:
   id-token: write
@@ -80,6 +85,9 @@ jobs:
       -
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+        with:
+          version: ${{ env.SETUP_BUILDX_VERSION }}
+          driver-opts: image=${{ env.SETUP_BUILDKIT_IMAGE }}
       -
         name: Build website
         uses: docker/bake-action@v5

--- a/.github/workflows/validate-upstream.yml
+++ b/.github/workflows/validate-upstream.yml
@@ -23,6 +23,11 @@ on:
         type: boolean
         required: false
 
+env:
+  # Use edge release of buildx (latest RC, fallback to latest stable)
+  SETUP_BUILDX_VERSION: edge
+  SETUP_BUILDKIT_IMAGE: "moby/buildkit:latest"
+
 jobs:
   run:
     runs-on: ubuntu-24.04
@@ -80,6 +85,9 @@ jobs:
       -
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+        with:
+          version: ${{ env.SETUP_BUILDX_VERSION }}
+          driver-opts: image=${{ env.SETUP_BUILDKIT_IMAGE }}
       -
         name: Validate
         uses: docker/bake-action@v5


### PR DESCRIPTION
Relates to:

- https://github.com/docker/actions-toolkit/pull/510
