### PR TITLE
Specify that there might be multiple files in the DVP namespace data retrieval endpoint

### DIFF
--- a/content/reference/api/hub/dvp.yaml
+++ b/content/reference/api/hub/dvp.yaml
@@ -561,6 +561,8 @@ components:
       properties:
         data:
           type: array
+          description: |
+            List of urls to download the data. When the data is large, the data will be split into multiple files.
           items: 
             $ref: '#/components/schemas/ResponseDataFile'
     ResponseDataFile:


### PR DESCRIPTION
<!--Delete sections as needed -->

## Description

Publishers reported that they got partial data from a DVP API endpoint. They actually never noticed that the endpoint was returning an array of URL to download files. This PR tries to make it clearer that there is probably multiple files.

<!-- Tell us what you did and why -->

## Related issues or tickets

<!-- Related issues, pull requests, or Jira tickets -->

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Technical review
- [ ] Editorial review
- [ ] Product review