### PR TITLE
gha: move docker login step up

### DIFF
--- a/content/guides/bun/configure-ci-cd.md
+++ b/content/guides/bun/configure-ci-cd.md
@@ -79,17 +79,16 @@ to Docker Hub.
      build:
        runs-on: ubuntu-latest
        steps:
-         -
-           name: Login to Docker Hub
+         - name: Login to Docker Hub
            uses: docker/login-action@v3
            with:
              username: ${{ vars.DOCKER_USERNAME }}
              password: ${{ secrets.DOCKERHUB_TOKEN }}
-         -
-           name: Set up Docker Buildx
+
+         - name: Set up Docker Buildx
            uses: docker/setup-buildx-action@v3
-         -
-           name: Build and push
+
+         - name: Build and push
            uses: docker/build-push-action@v6
            with:
              platforms: linux/amd64,linux/arm64

--- a/content/guides/cpp/configure-ci-cd.md
+++ b/content/guides/cpp/configure-ci-cd.md
@@ -85,8 +85,10 @@ to Docker Hub.
            with:
              username: ${{ vars.DOCKER_USERNAME }}
              password: ${{ secrets.DOCKERHUB_TOKEN }}
+
          - name: Set up Docker Buildx
            uses: docker/setup-buildx-action@v3
+
          - name: Build and push
            uses: docker/build-push-action@v6
            with:

--- a/content/guides/dotnet/configure-ci-cd.md
+++ b/content/guides/dotnet/configure-ci-cd.md
@@ -93,13 +93,16 @@ to Docker Hub.
            with:
              username: ${{ vars.DOCKER_USERNAME }}
              password: ${{ secrets.DOCKERHUB_TOKEN }}
+
          - name: Set up Docker Buildx
            uses: docker/setup-buildx-action@v3
+
          - name: Build and test
            uses: docker/build-push-action@v6
            with:
              target: build
              load: true
+
          - name: Build and push
            uses: docker/build-push-action@v6
            with:

--- a/content/guides/golang/configure-ci-cd.md
+++ b/content/guides/golang/configure-ci-cd.md
@@ -85,8 +85,10 @@ to Docker Hub.
            with:
              username: ${{ vars.DOCKER_USERNAME }}
              password: ${{ secrets.DOCKERHUB_TOKEN }}
+
          - name: Set up Docker Buildx
            uses: docker/setup-buildx-action@v3
+
          - name: Build and push
            uses: docker/build-push-action@v6
            with:

--- a/content/guides/java/configure-ci-cd.md
+++ b/content/guides/java/configure-ci-cd.md
@@ -88,13 +88,16 @@ to Docker Hub.
            with:
              username: ${{ vars.DOCKER_USERNAME }}
              password: ${{ secrets.DOCKERHUB_TOKEN }}
+
          - name: Set up Docker Buildx
            uses: docker/setup-buildx-action@v3
+
          - name: Build and test
            uses: docker/build-push-action@v6
            with:
              target: test
              load: true
+
          - name: Build and push
            uses: docker/build-push-action@v6
            with:

--- a/content/guides/nodejs/configure-ci-cd.md
+++ b/content/guides/nodejs/configure-ci-cd.md
@@ -85,17 +85,20 @@ to Docker Hub.
            with:
              username: ${{ vars.DOCKER_USERNAME }}
              password: ${{ secrets.DOCKERHUB_TOKEN }}
+
          - name: Set up Docker Buildx
            uses: docker/setup-buildx-action@v3
+
          - name: Build and test
            uses: docker/build-push-action@v6
            with:
              target: test
              load: true
+
          - name: Build and push
            uses: docker/build-push-action@v6
            with:
-             platforms: linux/amd64,linux/arm64/v8
+             platforms: linux/amd64,linux/arm64
              push: true
              target: prod
              tags: ${{ vars.DOCKER_USERNAME }}/${{ github.event.repository.name }}:latest

--- a/content/guides/php/configure-ci-cd.md
+++ b/content/guides/php/configure-ci-cd.md
@@ -93,13 +93,16 @@ to Docker Hub.
            with:
              username: ${{ vars.DOCKER_USERNAME }}
              password: ${{ secrets.DOCKERHUB_TOKEN }}
+
          - name: Set up Docker Buildx
            uses: docker/setup-buildx-action@v3
+
          - name: Build and test
            uses: docker/build-push-action@v6
            with:
              target: test
              load: true
+
          - name: Build and push
            uses: docker/build-push-action@v6
            with:

--- a/content/guides/python/configure-ci-cd.md
+++ b/content/guides/python/configure-ci-cd.md
@@ -85,8 +85,10 @@ to Docker Hub.
            with:
              username: ${{ vars.DOCKER_USERNAME }}
              password: ${{ secrets.DOCKERHUB_TOKEN }}
+
          - name: Set up Docker Buildx
            uses: docker/setup-buildx-action@v3
+
          - name: Build and push
            uses: docker/build-push-action@v6
            with:

--- a/content/guides/r/configure-ci-cd.md
+++ b/content/guides/r/configure-ci-cd.md
@@ -85,8 +85,10 @@ to Docker Hub.
            with:
              username: ${{ vars.DOCKER_USERNAME }}
              password: ${{ secrets.DOCKERHUB_TOKEN }}
+
          - name: Set up Docker Buildx
            uses: docker/setup-buildx-action@v3
+
          - name: Build and push
            uses: docker/build-push-action@v6
            with:

--- a/content/guides/ruby/configure-ci-cd.md
+++ b/content/guides/ruby/configure-ci-cd.md
@@ -85,12 +85,13 @@ to Docker Hub.
            with:
              username: ${{ vars.DOCKER_USERNAME }}
              password: ${{ secrets.DOCKERHUB_TOKEN }}
+
          - name: Set up Docker Buildx
            uses: docker/setup-buildx-action@v3
+
          - name: Build and push
            uses: docker/build-push-action@v6
            with:
-             platforms: linux/amd64
              push: true
              tags: ${{ vars.DOCKER_USERNAME }}/${{ github.event.repository.name }}:latest
    ```

--- a/content/guides/rust/configure-ci-cd.md
+++ b/content/guides/rust/configure-ci-cd.md
@@ -85,8 +85,10 @@ to Docker Hub.
            with:
              username: ${{ vars.DOCKER_USERNAME }}
              password: ${{ secrets.DOCKERHUB_TOKEN }}
+
          - name: Set up Docker Buildx
            uses: docker/setup-buildx-action@v3
+
          - name: Build and push
            uses: docker/build-push-action@v6
            with:

--- a/content/manuals/build-cloud/ci.md
+++ b/content/manuals/build-cloud/ci.md
@@ -65,11 +65,12 @@ jobs:
   docker:
     runs-on: ubuntu-latest
     steps:
-      - name: Log in to Docker Hub
+      - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
           username: ${{ vars.DOCKER_USER }}
           password: ${{ secrets.DOCKER_PAT }}
+      
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
         with:
@@ -77,6 +78,7 @@ jobs:
           driver: cloud
           endpoint: "<ORG>/default"
           install: true
+      
       - name: Build and push
         uses: docker/build-push-action@v6
         with:

--- a/content/manuals/build/bake/remote-definition.md
+++ b/content/manuals/build/bake/remote-definition.md
@@ -173,8 +173,7 @@ remote definition and the local "metadata-only" Bake file, specify both files
 and use the `cwd://` prefix for the metadata Bake file:
 
 ```yml
-      -
-        name: Build
+      - name: Build
         uses: docker/bake-action@v4
         with:
           source: "${{ github.server_url }}/${{ github.repository }}.git#${{ github.ref }}"

--- a/content/manuals/build/cache/optimize.md
+++ b/content/manuals/build/cache/optimize.md
@@ -323,15 +323,15 @@ jobs:
   docker:
     runs-on: ubuntu-latest
     steps:
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-      
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
           username: ${{ vars.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-      
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Build and push
         uses: docker/build-push-action@v6
         with:

--- a/content/manuals/build/ci/github-actions/_index.md
+++ b/content/manuals/build/ci/github-actions/_index.md
@@ -122,17 +122,16 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      -
-        name: Login to Docker Hub
+      - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
           username: ${{ vars.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-      -
-        name: Set up Docker Buildx
+
+      - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-      -
-        name: Build and push
+
+      - name: Build and push
         uses: docker/build-push-action@v6
         with:
           push: true
@@ -170,17 +169,16 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      -
-        name: Login to Docker Hub
+      - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
           username: ${{ vars.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-      -
-        name: Set up Docker Buildx
+
+      - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-      -
-        name: Build and push
+
+      - name: Build and push
         uses: docker/build-push-action@v6
         with:
           push: true

--- a/content/manuals/build/ci/github-actions/annotations.md
+++ b/content/manuals/build/ci/github-actions/annotations.md
@@ -33,14 +33,14 @@ jobs:
   docker:
     runs-on: ubuntu-latest
     steps:
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
           username: ${{ vars.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
 
       - name: Extract metadata
         id: meta
@@ -75,14 +75,14 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
           username: ${{ vars.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
+      
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
 
       - name: Extract metadata
         id: meta
@@ -128,14 +128,14 @@ jobs:
   docker:
     runs-on: ubuntu-latest
     steps:
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
           username: ${{ vars.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
+      
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
 
       - name: Extract metadata
         id: meta

--- a/content/manuals/build/ci/github-actions/attestations.md
+++ b/content/manuals/build/ci/github-actions/attestations.md
@@ -62,14 +62,14 @@ jobs:
   docker:
     runs-on: ubuntu-latest
     steps:
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
           username: ${{ vars.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
+      
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
 
       - name: Extract metadata
         id: meta
@@ -108,14 +108,14 @@ jobs:
   docker:
     runs-on: ubuntu-latest
     steps:
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
           username: ${{ vars.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
 
       - name: Extract metadata
         id: meta

--- a/content/manuals/build/ci/github-actions/build-summary.md
+++ b/content/manuals/build/ci/github-actions/build-summary.md
@@ -69,9 +69,8 @@ select the item in the list.
 To disable job summaries, set the `DOCKER_BUILD_SUMMARY` environment variable
 in the YAML configuration for your build step:
 
-```yaml {hl_lines=5}
-      -
-        name: Build
+```yaml {hl_lines=4}
+      - name: Build
         uses: docker/docker-build-push-action@v6
         env:
           DOCKER_BUILD_SUMMARY: false
@@ -86,9 +85,8 @@ To disable the upload of the build record archive to GitHub, set the
 `DOCKER_BUILD_RECORD_UPLOAD` environment variable in the YAML configuration for
 your build step:
 
-```yaml {hl_lines=5}
-      -
-        name: Build
+```yaml {hl_lines=4}
+      - name: Build
         uses: docker/docker-build-push-action@v6
         env:
           DOCKER_BUILD_RECORD_UPLOAD: false

--- a/content/manuals/build/ci/github-actions/cache.md
+++ b/content/manuals/build/ci/github-actions/cache.md
@@ -29,14 +29,14 @@ jobs:
   docker:
     runs-on: ubuntu-latest
     steps:
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-      
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
           username: ${{ vars.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
       
       - name: Build and push
         uses: docker/build-push-action@v6
@@ -62,14 +62,14 @@ jobs:
   docker:
     runs-on: ubuntu-latest
     steps:
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-      
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
           username: ${{ vars.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
+      
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
       
       - name: Build and push
         uses: docker/build-push-action@v6
@@ -107,14 +107,14 @@ jobs:
   docker:
     runs-on: ubuntu-latest
     steps:
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-      
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
           username: ${{ vars.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
+      
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
       
       - name: Build and push
         uses: docker/build-push-action@v6
@@ -165,6 +165,12 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ vars.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
 
@@ -175,7 +181,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: YOUR_IMAGE
+          images: user/app
           tags: |
             type=ref,event=branch
             type=ref,event=pr
@@ -188,7 +194,7 @@ jobs:
           path: go-build-cache
           key: ${{ runner.os }}-go-build-cache-${{ hashFiles('**/go.sum') }}
 
-      - name: inject go-build-cache into docker
+      - name: Inject go-build-cache
         uses: reproducible-containers/buildkit-cache-dance@4b2444fec0c0fb9dbf175a96c094720a692ef810 # v2.1.4
         with:
           cache-source: go-build-cache
@@ -230,9 +236,15 @@ jobs:
   docker:
     runs-on: ubuntu-latest
     steps:
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ vars.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-      
+
       - name: Cache Docker layers
         uses: actions/cache@v4
         with:
@@ -240,13 +252,7 @@ jobs:
           key: ${{ runner.os }}-buildx-${{ github.sha }}
           restore-keys: |
             ${{ runner.os }}-buildx-
-      
-      - name: Login to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ vars.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-      
+
       - name: Build and push
         uses: docker/build-push-action@v6
         with:
@@ -254,7 +260,7 @@ jobs:
           tags: user/app:latest
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
-      
+
       - # Temp fix
         # https://github.com/docker/build-push-action/issues/252
         # https://github.com/moby/buildkit/issues/1896

--- a/content/manuals/build/ci/github-actions/checks.md
+++ b/content/manuals/build/ci/github-actions/checks.md
@@ -24,14 +24,14 @@ jobs:
   docker:
     runs-on: ubuntu-latest
     steps:
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
+      
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
 
       - name: Validate build configuration
         uses: docker/build-push-action@v6
@@ -81,14 +81,14 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
           username: ${{ vars.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
 
       - name: Validate build configuration
         uses: docker/bake-action@v5

--- a/content/manuals/build/ci/github-actions/copy-image-registries.md
+++ b/content/manuals/build/ci/github-actions/copy-image-registries.md
@@ -18,25 +18,25 @@ jobs:
   docker:
     runs-on: ubuntu-latest
     steps:
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-      
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-      
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
           username: ${{ vars.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-      
+
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
       
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Build and push
         uses: docker/build-push-action@v6
         with:
@@ -45,7 +45,7 @@ jobs:
           tags: |
             user/app:latest
             user/app:1.0.0
-      
+
       - name: Push image to GHCR
         run: |
           docker buildx imagetools create \

--- a/content/manuals/build/ci/github-actions/manage-tags-labels.md
+++ b/content/manuals/build/ci/github-actions/manage-tags-labels.md
@@ -44,20 +44,14 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
             type=sha
-      
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-      
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-      
+
       - name: Login to Docker Hub
         if: github.event_name != 'pull_request'
         uses: docker/login-action@v3
         with:
           username: ${{ vars.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-      
+
       - name: Login to GHCR
         if: github.event_name != 'pull_request'
         uses: docker/login-action@v3
@@ -65,7 +59,13 @@ jobs:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Build and push
         uses: docker/build-push-action@v6
         with:

--- a/content/manuals/build/ci/github-actions/multi-platform.md
+++ b/content/manuals/build/ci/github-actions/multi-platform.md
@@ -25,18 +25,18 @@ jobs:
   docker:
     runs-on: ubuntu-latest
     steps:
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-      
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-      
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
           username: ${{ vars.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-      
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Build and push
         uses: docker/build-push-action@v6
         with:
@@ -81,14 +81,14 @@ jobs:
               }
             }
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
           username: ${{ vars.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
 
       - name: Build and push
         uses: docker/build-push-action@v6
@@ -139,25 +139,25 @@ jobs:
         run: |
           platform=${{ matrix.platform }}
           echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV
-      
+
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@v5
         with:
           images: ${{ env.REGISTRY_IMAGE }}
-      
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-      
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-      
+
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
           username: ${{ vars.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-      
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Build and push by digest
         id: build
         uses: docker/build-push-action@v6
@@ -165,13 +165,13 @@ jobs:
           platforms: ${{ matrix.platform }}
           labels: ${{ steps.meta.outputs.labels }}
           outputs: type=image,name=${{ env.REGISTRY_IMAGE }},push-by-digest=true,name-canonical=true,push=true
-      
+
       - name: Export digest
         run: |
           mkdir -p /tmp/digests
           digest="${{ steps.build.outputs.digest }}"
           touch "/tmp/digests/${digest#sha256:}"
-      
+
       - name: Upload digest
         uses: actions/upload-artifact@v4
         with:
@@ -191,28 +191,28 @@ jobs:
           path: /tmp/digests
           pattern: digests-*
           merge-multiple: true
-      
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-      
-      - name: Docker meta
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: ${{ env.REGISTRY_IMAGE }}
-      
+
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
           username: ${{ vars.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-      
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY_IMAGE }}
+
       - name: Create manifest list and push
         working-directory: /tmp/digests
         run: |
           docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
             $(printf '${{ env.REGISTRY_IMAGE }}@sha256:%s ' *)
-      
+
       - name: Inspect image
         run: |
           docker buildx imagetools inspect ${{ env.REGISTRY_IMAGE }}:${{ steps.meta.outputs.version }}
@@ -280,26 +280,26 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      
+
       - name: Create matrix
         id: platforms
         run: |
           echo "matrix=$(docker buildx bake image-all --print | jq -cr '.target."image-all".platforms')" >>${GITHUB_OUTPUT}
-      
+
       - name: Show matrix
         run: |
           echo ${{ steps.platforms.outputs.matrix }}
-      
+
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@v5
         with:
           images: ${{ env.REGISTRY_IMAGE }}
-      
+
       - name: Rename meta bake definition file
         run: |
           mv "${{ steps.meta.outputs.bake-file }}" "/tmp/bake-meta.json"
-      
+
       - name: Upload meta bake definition
         uses: actions/upload-artifact@v4
         with:
@@ -321,28 +321,28 @@ jobs:
         run: |
           platform=${{ matrix.platform }}
           echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV
-      
+
       - name: Checkout
         uses: actions/checkout@v4
-      
+
       - name: Download meta bake definition
         uses: actions/download-artifact@v4
         with:
           name: bake-meta
           path: /tmp
       
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-      
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-      
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
           username: ${{ vars.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-      
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Build
         id: bake
         uses: docker/bake-action@v5
@@ -355,13 +355,13 @@ jobs:
             *.tags=
             *.platform=${{ matrix.platform }}
             *.output=type=image,"name=${{ env.REGISTRY_IMAGE }}",push-by-digest=true,name-canonical=true,push=true
-      
+
       - name: Export digest
         run: |
           mkdir -p /tmp/digests
           digest="${{ fromJSON(steps.bake.outputs.metadata).image['containerimage.digest'] }}"
           touch "/tmp/digests/${digest#sha256:}"
-      
+
       - name: Upload digest
         uses: actions/upload-artifact@v4
         with:
@@ -380,29 +380,29 @@ jobs:
         with:
           name: bake-meta
           path: /tmp
-      
+
       - name: Download digests
         uses: actions/download-artifact@v4
         with:
           path: /tmp/digests
           pattern: digests-*
           merge-multiple: true
-      
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-      
+
       - name: Login to DockerHub
         uses: docker/login-action@v3
         with:
           username: ${{ vars.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-      
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Create manifest list and push
         working-directory: /tmp/digests
         run: |
           docker buildx imagetools create $(jq -cr '.target."docker-metadata-action".tags | map(select(startswith("${{ env.REGISTRY_IMAGE }}")) | "-t " + .) | join(" ")' /tmp/bake-meta.json) \
             $(printf '${{ env.REGISTRY_IMAGE }}@sha256:%s ' *)
-      
+
       - name: Inspect image
         run: |
           docker buildx imagetools inspect ${{ env.REGISTRY_IMAGE }}:$(jq -r '.target."docker-metadata-action".args.DOCKER_META_VERSION' /tmp/bake-meta.json)

--- a/content/manuals/build/ci/github-actions/named-contexts.md
+++ b/content/manuals/build/ci/github-actions/named-contexts.md
@@ -34,7 +34,7 @@ jobs:
     steps:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-      
+
       - name: Build
         uses: docker/build-push-action@v6
         with:
@@ -71,14 +71,14 @@ jobs:
         uses: docker/setup-buildx-action@v3
         with:
           driver: docker
-      
+
       - name: Build base image
         uses: docker/build-push-action@v6
         with:
           context: "{{defaultContext}}:base"
           load: true
           tags: my-base-image:latest
-      
+
       - name: Build
         uses: docker/build-push-action@v6
         with:
@@ -118,20 +118,20 @@ jobs:
     steps:
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
-      
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
         with:
           # network=host driver-opt needed to push to local registry
           driver-opts: network=host
-      
+
       - name: Build base image
         uses: docker/build-push-action@v6
         with:
           context: "{{defaultContext}}:base"
           tags: localhost:5000/my-base-image:latest
           push: true
-      
+
       - name: Build
         uses: docker/build-push-action@v6
         with:

--- a/content/manuals/build/ci/github-actions/push-multi-registries.md
+++ b/content/manuals/build/ci/github-actions/push-multi-registries.md
@@ -18,25 +18,25 @@ jobs:
   docker:
     runs-on: ubuntu-latest
     steps:
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-      
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-      
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
           username: ${{ vars.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-      
+
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Build and push
         uses: docker/build-push-action@v6
         with:

--- a/content/manuals/build/ci/github-actions/reproducible-builds.md
+++ b/content/manuals/build/ci/github-actions/reproducible-builds.md
@@ -34,7 +34,7 @@ jobs:
     steps:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-      
+
       - name: Build
         uses: docker/build-push-action@v6
         with:
@@ -58,10 +58,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-      
+
       - name: Build
         uses: docker/bake-action@v5
         env:
@@ -90,10 +90,10 @@ jobs:
     steps:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-      
+
       - name: Get Git commit timestamps
         run: echo "TIMESTAMP=$(git log -1 --pretty=%ct)" >> $GITHUB_ENV
-      
+
       - name: Build
         uses: docker/build-push-action@v6
         with:
@@ -117,13 +117,13 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-      
+
       - name: Get Git commit timestamps
         run: echo "TIMESTAMP=$(git log -1 --pretty=%ct)" >> $GITHUB_ENV
-      
+
       - name: Build
         uses: docker/bake-action@v5
         env:

--- a/content/manuals/build/ci/github-actions/secrets.md
+++ b/content/manuals/build/ci/github-actions/secrets.md
@@ -44,10 +44,10 @@ jobs:
     steps:
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
-      
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-      
+
       - name: Build
         uses: docker/build-push-action@v6
         with:
@@ -176,7 +176,7 @@ jobs:
           host: github.com
           private-key: ${{ secrets.SSH_GITHUB_PPK }}
           private-key-name: github-ppk
-      
+
       - name: Build and push
         uses: docker/build-push-action@v6
         with:
@@ -200,14 +200,14 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      
+
       - name: Set up SSH
         uses: MrSquaare/ssh-setup-action@2d028b70b5e397cf8314c6eaea229a6c3e34977a # v3.1.0
         with:
           host: github.com
           private-key: ${{ secrets.SSH_GITHUB_PPK }}
           private-key-name: github-ppk
-      
+
       - name: Build
         uses: docker/bake-action@v5
         with:

--- a/content/manuals/build/ci/github-actions/share-image-jobs.md
+++ b/content/manuals/build/ci/github-actions/share-image-jobs.md
@@ -24,13 +24,13 @@ jobs:
     steps:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-      
+
       - name: Build and export
         uses: docker/build-push-action@v6
         with:
           tags: myimage:latest
           outputs: type=docker,dest=/tmp/myimage.tar
-      
+
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
@@ -46,7 +46,7 @@ jobs:
         with:
           name: myimage
           path: /tmp
-      
+
       - name: Load image
         run: |
           docker load --input /tmp/myimage.tar

--- a/content/manuals/build/ci/github-actions/test-before-push.md
+++ b/content/manuals/build/ci/github-actions/test-before-push.md
@@ -27,28 +27,28 @@ jobs:
   docker:
     runs-on: ubuntu-latest
     steps:
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-      
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-      
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
           username: ${{ vars.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-      
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Build and export to Docker
         uses: docker/build-push-action@v6
         with:
           load: true
           tags: ${{ env.TEST_TAG }}
-      
+
       - name: Test
         run: |
           docker run --rm ${{ env.TEST_TAG }}
-      
+
       - name: Build and push
         uses: docker/build-push-action@v6
         with:

--- a/content/manuals/build/ci/github-actions/update-dockerhub-desc.md
+++ b/content/manuals/build/ci/github-actions/update-dockerhub-desc.md
@@ -19,24 +19,24 @@ jobs:
   docker:
     runs-on: ubuntu-latest
     steps:
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-      
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-      
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
           username: ${{ vars.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-      
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Build and push
         uses: docker/build-push-action@v6
         with:
           push: true
           tags: user/app:latest
-      
+
       - name: Update repo description
         uses: peter-evans/dockerhub-description@e98e4d1628a5f3be2be7c231e50981aee98723ae # v4.0.0
         with:

--- a/content/manuals/scout/integrations/ci/gha.md
+++ b/content/manuals/scout/integrations/ci/gha.md
@@ -56,9 +56,6 @@ jobs:
       pull-requests: write
 
     steps:
-      - name: Setup Docker buildx
-        uses: docker/setup-buildx-action@v3
-
       # Authenticate to the container registry
       - name: Authenticate to registry ${{ env.REGISTRY }}
         uses: docker/login-action@v3
@@ -66,6 +63,9 @@ jobs:
           registry: ${{ env.REGISTRY }}
           username: ${{ secrets.REGISTRY_USER }}
           password: ${{ secrets.REGISTRY_TOKEN }}
+      
+      - name: Setup Docker buildx
+        uses: docker/setup-buildx-action@v3
 
       # Extract metadata (tags, labels) for Docker
       - name: Extract Docker metadata

--- a/content/manuals/scout/policy/ci.md
+++ b/content/manuals/scout/policy/ci.md
@@ -94,15 +94,15 @@ jobs:
 
     runs-on: ubuntu-latest
     steps:
-      - name: Setup Docker buildx
-        uses: docker/setup-buildx-action@v3
-
       - name: Log into registry ${{ env.REGISTRY }}
         uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ secrets.REGISTRY_USER }}
           password: ${{ secrets.REGISTRY_TOKEN }}
+      
+      - name: Setup Docker buildx
+        uses: docker/setup-buildx-action@v3
 
       - name: Extract metadata
         id: meta


### PR DESCRIPTION
## Description

Move docker login step before setup-buildx / setup-qemu actions to avoid rate limit for self-hosted runners. Also some fixes with yaml syntax to be consistent.

## Related issues or tickets

* https://github.com/docker/setup-qemu-action/issues/166

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Technical review
- [ ] Editorial review
- [ ] Product review