### PR TITLE
samples: fix postgres alias

### DIFF
--- a/content/reference/samples/postgres.md
+++ b/content/reference/samples/postgres.md
@@ -5,5 +5,5 @@ service: postgresql
 aliases:
 - /engine/examples/postgresql_service/
 - /samples/postgresql_service/
-- /samples/postgresql/
+- /samples/postgres/
 ---


### PR DESCRIPTION
<!--Delete sections as needed -->

## Description
- Updated alias for postgres samples page

Originally added in https://github.com/docker/docs/pull/21441, but mistyped `postgresql` instead of `postgres`.

<!-- Tell us what you did and why -->

## Related issues or tickets

Fixes #21513
## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->


- [ ] Editorial review
