### PR TITLE
hub: add alias for moved content

### DIFF
--- a/content/manuals/docker-hub/repos/manage/hub-images/oci-artifacts.md
+++ b/content/manuals/docker-hub/repos/manage/hub-images/oci-artifacts.md
@@ -4,6 +4,8 @@ linkTitle: Software artifacts
 weight: 20
 keywords: oci, artifacts, docker hub
 description: You can use Docker Hub to store software artifacts packaged as OCI artifacts.
+aliases:
+- /docker-hub/oci-artifacts/
 ---
 
 You can use Docker Hub to store any kind of software artifact, not just


### PR DESCRIPTION
<!--Delete sections as needed -->

## Description

- Added alias for oci-artifacts topic

Started seeing some 404's for this topic.
In https://github.com/docker/docs/pull/21435, moved from `/docker-hub/oci-artifacts/` to `/docker-hub/repos/manage/hub-images/oci-artifacts/`.

## Related issues or tickets

<!-- Related issues, pull requests, or Jira tickets -->

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->


- [ ] Editorial review
