### PR TITLE
Update overriding-container-defaults.md

### DIFF
--- a/content/get-started/docker-concepts/running-containers/overriding-container-defaults.md
+++ b/content/get-started/docker-concepts/running-containers/overriding-container-defaults.md
@@ -15,7 +15,7 @@ When a Docker container starts, it executes an application or command. The conta
 
 For example, if you have an existing database container that listens on the standard port and you want to run a new instance of the same database container, then you might want to change the port settings the new container listens on so that it doesn’t conflict with the existing container. Sometimes you might want to increase the memory available to the container if the program needs more resources to handle a heavy workload or set the environment variables to provide specific configuration details the program needs to function properly.
 
-The `docker run` command offers a powerful way to override these defaults and tailor the container's behavior to your liking. The command offers several flags that let you to customize container behavior on the fly.
+The `docker run` command offers a powerful way to override these defaults and tailor the container's behavior to your liking. The command offers several flags that let you customize container behavior on the fly.
 
 Here's a few ways you can achieve this.
 


### PR DESCRIPTION
Remove unnecessary 'to' from Overriding container defaults

## Description
The sentence
`The command offers several flags that let you to customize container behavior on the fly.`
didn't grammatically make sense, so I removed the 'to' from it.

I changed it to
`The command offers several flags that let you customize container behavior on the fly.`

- [ ] Technical review
- [x] Editorial review
- [ ] Product review