### PR TITLE
engine: update versions for v27.4.0

### DIFF
--- a/content/manuals/engine/install/centos.md
+++ b/content/manuals/engine/install/centos.md
@@ -119,8 +119,8 @@ $ sudo dnf config-manager --add-repo {{% param "download-url-base" %}}/docker-ce
    ```console
    $ dnf list docker-ce --showduplicates | sort -r
 
+   docker-ce.x86_64    3:27.4.0-1.el9    docker-ce-stable
    docker-ce.x86_64    3:27.3.1-1.el9    docker-ce-stable
-   docker-ce.x86_64    3:27.3.0-1.el9    docker-ce-stable
    <...>
    ```
 
@@ -129,7 +129,7 @@ $ sudo dnf config-manager --add-repo {{% param "download-url-base" %}}/docker-ce
 
    Install a specific version by its fully qualified package name, which is
    the package name (`docker-ce`) plus the version string (2nd column),
-   separated by a hyphen (`-`). For example, `docker-ce-3:27.3.1-1.el9`.
+   separated by a hyphen (`-`). For example, `docker-ce-3:27.4.0-1.el9`.
 
    Replace `<VERSION_STRING>` with the desired version and then run the following
    command to install:

--- a/content/manuals/engine/install/debian.md
+++ b/content/manuals/engine/install/debian.md
@@ -155,15 +155,15 @@ Docker from the repository.
    # List the available versions:
    $ apt-cache madison docker-ce | awk '{ print $3 }'
 
+   5:27.4.0-1~debian.12~bookworm
    5:27.3.1-1~debian.12~bookworm
-   5:27.3.0-1~debian.12~bookworm
    ...
    ```
 
    Select the desired version and install:
 
    ```console
-   $ VERSION_STRING=5:27.3.1-1~debian.12~bookworm
+   $ VERSION_STRING=5:27.4.0-1~debian.12~bookworm
    $ sudo apt-get install docker-ce=$VERSION_STRING docker-ce-cli=$VERSION_STRING containerd.io docker-buildx-plugin docker-compose-plugin
    ```
 

--- a/content/manuals/engine/install/fedora.md
+++ b/content/manuals/engine/install/fedora.md
@@ -116,8 +116,8 @@ $ sudo dnf-3 config-manager --add-repo {{% param "download-url-base" %}}/docker-
    ```console
    $ dnf list docker-ce --showduplicates | sort -r
 
+   docker-ce.x86_64    3:27.4.0-1.fc41    docker-ce-stable
    docker-ce.x86_64    3:27.3.1-1.fc41    docker-ce-stable
-   docker-ce.x86_64    3:27.3.0-1.fc41    docker-ce-stable
    <...>
    ```
 
@@ -126,7 +126,7 @@ $ sudo dnf-3 config-manager --add-repo {{% param "download-url-base" %}}/docker-
 
    Install a specific version by its fully qualified package name, which is
    the package name (`docker-ce`) plus the version string (2nd column),
-   separated by a hyphen (`-`). For example, `docker-ce-3:27.3.1-1.fc41`.
+   separated by a hyphen (`-`). For example, `docker-ce-3:27.4.0-1.fc41`.
 
    Replace `<VERSION_STRING>` with the desired version and then run the following
    command to install:

--- a/content/manuals/engine/install/raspberry-pi-os.md
+++ b/content/manuals/engine/install/raspberry-pi-os.md
@@ -143,15 +143,15 @@ Docker from the repository.
    # List the available versions:
    $ apt-cache madison docker-ce | awk '{ print $3 }'
 
+   5:27.4.0-1~raspbian.12~bookworm
    5:27.3.1-1~raspbian.12~bookworm
-   5:27.3.0-1~raspbian.12~bookworm
    ...
    ```
 
    Select the desired version and install:
 
    ```console
-   $ VERSION_STRING=5:27.3.1-1~raspbian.12~bookworm
+   $ VERSION_STRING=5:27.4.0-1~raspbian.12~bookworm
    $ sudo apt-get install docker-ce=$VERSION_STRING docker-ce-cli=$VERSION_STRING containerd.io docker-buildx-plugin docker-compose-plugin
    ```
 

--- a/content/manuals/engine/install/rhel.md
+++ b/content/manuals/engine/install/rhel.md
@@ -119,8 +119,8 @@ $ sudo dnf config-manager --add-repo {{% param "download-url-base" %}}/docker-ce
    ```console
    $ dnf list docker-ce --showduplicates | sort -r
 
+   docker-ce.x86_64    3:27.4.0-1.el9    docker-ce-stable
    docker-ce.x86_64    3:27.3.1-1.el9    docker-ce-stable
-   docker-ce.x86_64    3:27.3.0-1.el9    docker-ce-stable
    <...>
    ```
 
@@ -129,7 +129,7 @@ $ sudo dnf config-manager --add-repo {{% param "download-url-base" %}}/docker-ce
 
    Install a specific version by its fully qualified package name, which is
    the package name (`docker-ce`) plus the version string (2nd column),
-   separated by a hyphen (`-`). For example, `docker-ce-3:27.3.1-1.el9`.
+   separated by a hyphen (`-`). For example, `docker-ce-3:27.4.0-1.el9`.
 
    Replace `<VERSION_STRING>` with the desired version and then run the following
    command to install:

--- a/content/manuals/engine/install/sles.md
+++ b/content/manuals/engine/install/sles.md
@@ -140,8 +140,8 @@ $ sudo zypper addrepo {{% param "download-url-base" %}}/docker-ce.repo
    ```console
    $ sudo zypper search -s --match-exact docker-ce | sort -r
  
+     v  | docker-ce | package | 3:27.4.0-1 | s390x | Docker CE Stable - s390x
      v  | docker-ce | package | 3:27.3.1-1 | s390x | Docker CE Stable - s390x
-     v  | docker-ce | package | 3:27.3.0-1 | s390x | Docker CE Stable - s390x
    ```
 
    The list returned depends on which repositories are enabled, and is specific
@@ -149,7 +149,7 @@ $ sudo zypper addrepo {{% param "download-url-base" %}}/docker-ce.repo
 
    Install a specific version by its fully qualified package name, which is
    the package name (`docker-ce`) plus the version string (2nd column),
-   separated by a hyphen (`-`). For example, `docker-ce-3:27.3.1`.
+   separated by a hyphen (`-`). For example, `docker-ce-3:27.4.0`.
 
    Replace `<VERSION_STRING>` with the desired version and then run the following
    command to install:

--- a/content/manuals/engine/install/ubuntu.md
+++ b/content/manuals/engine/install/ubuntu.md
@@ -158,15 +158,15 @@ Docker from the repository.
    # List the available versions:
    $ apt-cache madison docker-ce | awk '{ print $3 }'
 
+   5:27.4.0-1~ubuntu.24.04~noble
    5:27.3.1-1~ubuntu.24.04~noble
-   5:27.3.0-1~ubuntu.24.04~noble
    ...
    ```
 
    Select the desired version and install:
 
    ```console
-   $ VERSION_STRING=5:27.3.1-1~ubuntu.24.04~noble
+   $ VERSION_STRING=5:27.4.0-1~ubuntu.24.04~noble
    $ sudo apt-get install docker-ce=$VERSION_STRING docker-ce-cli=$VERSION_STRING containerd.io docker-buildx-plugin docker-compose-plugin
    ```
 

--- a/content/reference/api/engine/_index.md
+++ b/content/reference/api/engine/_index.md
@@ -72,23 +72,23 @@ To see the highest version of the API your Docker daemon and client support, use
 
 ```console
 $ docker version
-Client:
- Version:           27.3.1
+Client: Docker Engine - Community
+ Version:           27.4.0
  API version:       1.47
- Go version:        go1.22.7
- Git commit:        ce12230
- Built:             Fri Sep 20 11:38:18 2024
- OS/Arch:           darwin/arm64
- Context:           desktop-linux
+ Go version:        go1.22.10
+ Git commit:        bde2b89
+ Built:             Sat Dec  7 10:38:33 2024
+ OS/Arch:           linux/amd64
+ Context:           default
 
-Server: Docker Desktop 4.36.0 (172961)
+Server: Docker Engine - Community
  Engine:
-  Version:          27.3.1
+  Version:          27.4.0
   API version:      1.47 (minimum version 1.24)
-  Go version:       go1.22.7
-  Git commit:       41ca978
-  Built:            Fri Sep 20 11:41:19 2024
-  OS/Arch:          linux/arm64
+  Go version:       go1.22.10
+  Git commit:       92a8393
+  Built:            Sat Dec  7 10:38:33 2024
+  OS/Arch:          linux/amd64
   Experimental:     false
   ...
 ```
@@ -133,6 +133,7 @@ You can specify the API version to use in any of the following ways:
 
 | Docker version | Maximum API version        | Change log                                                                   |
 |:---------------|:---------------------------|:-----------------------------------------------------------------------------|
+| 27.4           | [1.47](/reference/api/engine/version/v1.47/) | [changes](/reference/api/engine/version-history/#v147-api-changes) |
 | 27.3           | [1.47](/reference/api/engine/version/v1.47/) | [changes](/reference/api/engine/version-history/#v147-api-changes) |
 | 27.2           | [1.47](/reference/api/engine/version/v1.47/) | [changes](/reference/api/engine/version-history/#v147-api-changes) |
 | 27.1           | [1.46](/reference/api/engine/version/v1.46/) | [changes](/reference/api/engine/version-history/#v146-api-changes) |

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -107,7 +107,7 @@ params:
   docs_url: https://docs.docker.com
 
   latest_engine_api_version: "1.47"
-  docker_ce_version: "27.3.1"
+  docker_ce_version: "27.4.0"
   compose_version: "v2.30.3"
   compose_file_v3: "3.8"
   compose_file_v2: "2.4"


### PR DESCRIPTION
Update example/engine versions for v27.4.0

(Bit awkward to swap the `docker version` example back and forth between DD and
CE versions, but at the time of writing there's no DD version with 27.4.0
available.)
