### PR TITLE
Fix typo in local exporter example

### DIFF
--- a/content/manuals/build/exporters/_index.md
+++ b/content/manuals/build/exporters/_index.md
@@ -148,7 +148,7 @@ The `local` exporter unpacks the filesystem into a directory structure in the
 specified location. The `tar` exporter creates a tarball archive file.
 
 ```console
-$ docker buildx build --output type=tar,dest=<path/to/output> .
+$ docker buildx build --output type=local,dest=<path/to/output> .
 ```
 
 The `local` exporter is useful in [multi-stage builds](../building/multi-stage.md)


### PR DESCRIPTION
## Description

Fixes a small typo in a sample command
