### PR TITLE
Update callout in OATs docs

### DIFF
--- a/content/manuals/security/for-admins/access-tokens.md
+++ b/content/manuals/security/for-admins/access-tokens.md
@@ -12,13 +12,15 @@ The organization access tokens feature is currently in [Beta](../../release-life
 
 > [!WARNING]
 >
-> Organization access tokens aren't currently compatible with the following services:
+> Organization access tokens (OATs) are not intended to be used with Docker Desktop, and are incompatible.
+>
+> OATs are also currently incompatible with the following services:
 >
 > - Docker Build Cloud
 > - Docker Scout
 > - Docker REST APIs
 >
-> If you use these services, you must use personal access tokens instead.
+> If you use Docker Desktop or one of these services, you must use personal access tokens instead.
 
 An organization access token (OAT) is like a [personal access token
 (PAT)](/security/for-developers/access-tokens/), but an OAT is associated with


### PR DESCRIPTION
## Description
- OATs is incompatible with DD (and intended to be)
- Needed to add this to the existing callout, and clarify that it is intended to be incompatible
- Context: https://docker.slack.com/archives/C046HE6K4CC/p1733859712930509

## Related issues or tickets
[ENGDOCS-2355](https://docker.atlassian.net/browse/ENGDOCS-2355)

## Reviews
@technicallyjosh 
- [ ] Technical review
- [ ] Editorial review

[ENGDOCS-2355]: https://docker.atlassian.net/browse/ENGDOCS-2355?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ