### PR TITLE
Update _index.md about switching container mode

### DIFF
--- a/content/manuals/desktop/features/wsl/_index.md
+++ b/content/manuals/desktop/features/wsl/_index.md
@@ -90,6 +90,7 @@ Docker Desktop does not require any particular Linux distributions to be install
      ```console
     $ wsl --set-default <distribution name>
     ```
+   If **WSL Integrations** isn't available in the resources panel, Docker may be in Windows container mode. In the task bar, right click on the Docker icon and select "switch to Linux containers".
 
 3. Select **Apply & Restart**.
 


### PR DESCRIPTION
<!--Delete sections as needed -->

## Description

<!-- Tell us what you did and why -->
Docker desktop was installed by an automated system on my device and when I went to change the WSL Integration settings, the panel was not available.  The app had been configured to use "Windows containers mode" and I had to switch it to "Linux containers mode" to be able to see the panel. I have added text to help others who may face the same problem.

## Related issues or tickets

<!-- Related issues, pull requests, or Jira tickets -->

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Technical review
- [ ] Editorial review
- [ ] Product review