### PR TITLE
build(cloud): setup-buildx-action automatically fetches the buildx-private binary if driver == cloud

### DIFF
--- a/content/manuals/build-cloud/ci.md
+++ b/content/manuals/build-cloud/ci.md
@@ -74,7 +74,6 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
         with:
-          version: "lab:latest"
           driver: cloud
           endpoint: "<ORG>/default"
           install: true


### PR DESCRIPTION
- needs docker/actions-toolkit#532
- needs docker/setup-buildx-action#390