### PR TITLE
Fixes broken language guides link

### DIFF
--- a/_vendor/github.com/moby/buildkit/frontend/dockerfile/docs/reference.md
+++ b/_vendor/github.com/moby/buildkit/frontend/dockerfile/docs/reference.md
@@ -3017,7 +3017,7 @@ For examples of Dockerfiles, refer to:
 
 - The [building best practices page](https://docs.docker.com/build/building/best-practices/)
 - The ["get started" tutorials](https://docs.docker.com/get-started/)
-- The [language-specific getting started guides](https://docs.docker.com/guides/language/)
+- The [language-specific getting started guides](https://docs.docker.com/guides/?languages=c-sharp%7Ecpp%7Ego%7Ejava%7Ejs%7Ephp%7Epython%7Erust%7Er%7Eruby)
 
 [^1]: Value required
 [^2]: For Docker-integrated [BuildKit](https://docs.docker.com/build/buildkit/#getting-started) and `docker buildx build`


### PR DESCRIPTION
## Description

Edited the link so that the languages are included in the parameters, since a standalone language guides page does not exist to my knowledge.

## Related issues or tickets

Fixes #21677 , #21547 


## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Technical review
- [ ] Editorial review
- [ ] Product review