### PR TITLE
redirects: add alias for /guides/language/

### DIFF
--- a/content/guides/_index.md
+++ b/content/guides/_index.md
@@ -6,8 +6,9 @@ params:
   icon: developer_guide
 layout: landing
 aliases:
-  - /learning-paths/
+  - /guides/language/
   - /language/
+  - /learning-paths/
 ---
 
 Explore our collection of guides to learn how Docker can optimize your


### PR DESCRIPTION
- Fixes #21677
- Fixes #21547

(Quick fix, might need to review/edit some of our internal links too (the dockerfile reference one, might be others), but we should have a redirect nonetheless.
