### PR TITLE
Update order of images in docker image tag command

### DIFF
--- a/content/get-started/docker-concepts/building-images/build-tag-and-publish-an-image.md
+++ b/content/get-started/docker-concepts/building-images/build-tag-and-publish-an-image.md
@@ -94,7 +94,7 @@ docker build -t my-username/my-image .
 If you've already built an image, you can add another tag to the image by using the [`docker image tag`](https://docs.docker.com/engine/reference/commandline/image_tag/) command:
 
 ```console
-docker image tag my-username/my-image another-username/another-image:v1
+docker image tag already-present-image:tag my-username/my-image:tag
 ```
 
 ### Publishing images


### PR DESCRIPTION
There was a mistake in the command for tagging an image that you have present in your list of images, order should be like this:  `docker image tag ALREADY_PRESENT_IMAGE  IMAGE_THAT_YOU_WANT_TO_PUSH` not the other way around
