### PR TITLE
chore: cleanup instructions for unsupported version

### DIFF
--- a/content/manuals/engine/security/rootless.md
+++ b/content/manuals/engine/security/rootless.md
@@ -98,9 +98,6 @@ testuser:231072:65536
 {{< tab name="Debian GNU/Linux" >}}
 - Install `dbus-user-session` package if not installed. Run `sudo apt-get install -y dbus-user-session` and relogin.
 
-- For Debian 10, add `kernel.unprivileged_userns_clone=1` to `/etc/sysctl.conf` (or
-  `/etc/sysctl.d`) and run `sudo sysctl --system`. This step is not required on Debian 11.
-
 - For Debian 11, installing `fuse-overlayfs` is recommended. Run `sudo apt-get install -y fuse-overlayfs`.
   This step is not required on Debian 12.
 


### PR DESCRIPTION
## Description

Debian 10 is no longer a supported version
https://github.com/docker/docs/blob/73d74add2bb1825d562770362da8247e925e8801/content/manuals/engine/install/debian.md?plain=1#L40-L49