### PR TITLE
fix: clarified rprivate by adding spell out recursive private in volumes.md

### DIFF
--- a/content/manuals/engine/storage/volumes.md
+++ b/content/manuals/engine/storage/volumes.md
@@ -56,7 +56,7 @@ If your container generates non-persistent state data, consider using a
 increase the container's performance by avoiding writing into the container's
 writable layer.
 
-Volumes use `rprivate` bind propagation, and bind propagation isn't
+Volumes use `rprivate (recursive private)` bind propagation, and bind propagation isn't
 configurable for volumes.
 
 ## A volume's lifecycle


### PR DESCRIPTION
## Description

<!-- Tell us what you did and why -->
To avoid confusion of rprivate provided fix: clarified rprivate by adding spell out recursive private in volumes.md

## Related issues or tickets
#21688

<!-- Related issues, pull requests, or Jira tickets --> 
#21688

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Technical review
- [ ] Editorial review
- [ ] Product review