### PR TITLE
vale: properly allow pluralized acronyms

### DIFF
--- a/_vale/config/vocabularies/Docker/accept.txt
+++ b/_vale/config/vocabularies/Docker/accept.txt
@@ -1,4 +1,4 @@
-(?-i)[A-Z]{2,}'?s
+(?i)[A-Z]{2,}'?s
 Amazon
 Anchore
 Apple


### PR DESCRIPTION
Something changed in a recent vale release where the old regex syntax
for enforcing case-sensitivity does not work anymore. This change
ensures that the allow-rule for ignoring pluralized acronyms only flag
terms that begin with two or more *uppercase* letters, followed by an s.

## Related issues

- Fixes incorrectly flagged words, as seen in #21712