### PR TITLE
Add callout to clarify 'Access token' in activity logs

### DIFF
--- a/content/manuals/admin/organization/activity-logs.md
+++ b/content/manuals/admin/organization/activity-logs.md
@@ -74,7 +74,7 @@ Refer to the following section for a list of events and their descriptions:
 
 > [!NOTE]
 >
-> Event descriptions that include a user action can refer to a Docker username, personal access token (PAT) or organization access token (OAT). For example, if a user pushes a tag to a repository, the event would include the description: `<user-access-token> pushed the tag <tag-name> to the <repository-name> repository".
+> Event descriptions that include a user action can refer to a Docker username, personal access token (PAT) or organization access token (OAT). For example, if a user pushes a tag to a repository, the event would include the description: <user-access-token> pushed the tag <tag-name> to the <repository-name> repository.
 
 | Event                                                          | Description                                   |
 |:------------------------------------------------------------------|:------------------------------------------------|

--- a/content/manuals/admin/organization/activity-logs.md
+++ b/content/manuals/admin/organization/activity-logs.md
@@ -45,6 +45,10 @@ Refer to the following section for a list of events and their descriptions:
 
 ### Organization events
 
+> [!NOTE]
+>
+> Access token activity logs include both personal acess tokens (PATs) and organization access tokens (OATs).
+
 | Event                                                          | Description                                   |
 |:------------------------------------------------------------------|:------------------------------------------------|
 | Team Created | Activities related to the creation of a team |

--- a/content/manuals/admin/organization/activity-logs.md
+++ b/content/manuals/admin/organization/activity-logs.md
@@ -45,10 +45,6 @@ Refer to the following section for a list of events and their descriptions:
 
 ### Organization events
 
-> [!NOTE]
->
-> Access token activity logs include both personal acess tokens (PATs) and organization access tokens (OATs).
-
 | Event                                                          | Description                                   |
 |:------------------------------------------------------------------|:------------------------------------------------|
 | Team Created | Activities related to the creation of a team |
@@ -75,6 +71,10 @@ Refer to the following section for a list of events and their descriptions:
 | Access token deleted | Access token deleted in organization |
 
 ### Repository events
+
+> [!NOTE]
+>
+> Event descriptions that include a user action can refer to a Docker username, personal access token (PAT) or organization access token (OAT). For example, if a user pushes a tag to a repository, the event would include the description: `<user-access-token> pushed the tag <tag-name> to the <repository-name> repository".
 
 | Event                                                          | Description                                   |
 |:------------------------------------------------------------------|:------------------------------------------------|

--- a/content/manuals/admin/organization/activity-logs.md
+++ b/content/manuals/admin/organization/activity-logs.md
@@ -74,7 +74,7 @@ Refer to the following section for a list of events and their descriptions:
 
 > [!NOTE]
 >
-> Event descriptions that include a user action can refer to a Docker username, personal access token (PAT) or organization access token (OAT). For example, if a user pushes a tag to a repository, the event would include the description: <user-access-token> pushed the tag <tag-name> to the <repository-name> repository.
+> Event descriptions that include a user action can refer to a Docker username, personal access token (PAT) or organization access token (OAT). For example, if a user pushes a tag to a repository, the event would include the description: `<user-access-token>` pushed the tag to the repository.
 
 | Event                                                          | Description                                   |
 |:------------------------------------------------------------------|:------------------------------------------------|


### PR DESCRIPTION
## Description
- The Activity log uses "Access token" to represent PATs and OATs
- I have added a callout to clarify that "Access token" refers to PATs and OATs

## Related issues or tickets
- [IAM-870](https://docker.atlassian.net/browse/IAM-870)

## Reviews
- [ ] Technical review
- [ ] Editorial review
- [ ] Product review

[IAM-870]: https://docker.atlassian.net/browse/IAM-870?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ