### PR TITLE
update bake-action to v6

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,9 +24,6 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       -
-        name: Checkout
-        uses: actions/checkout@v4
-      -
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
         with:
@@ -34,7 +31,7 @@ jobs:
           driver-opts: image=${{ env.SETUP_BUILDKIT_IMAGE }}
       -
         name: Build
-        uses: docker/bake-action@v5
+        uses: docker/bake-action@v6
         with:
           files: |
             docker-bake.hcl
@@ -56,8 +53,9 @@ jobs:
         uses: docker/setup-buildx-action@v3
       -
         name: Build
-        uses: docker/bake-action@v5
+        uses: docker/bake-action@v6
         with:
+          source: .
           files: |
             docker-bake.hcl
           targets: release
@@ -66,8 +64,9 @@ jobs:
             *.cache-to=type=gha,scope=build,mode=max
       -
         name: Check Cloudfront config
-        uses: docker/bake-action@v5
+        uses: docker/bake-action@v6
         with:
+          source: .
           targets: aws-cloudfront-update
         env:
           DRY_RUN: true
@@ -100,19 +99,17 @@ jobs:
           - path-warnings
     steps:
       -
-        name: Checkout
-        uses: actions/checkout@v4
-      -
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       -
         name: Validate
-        uses: docker/bake-action@v5
+        uses: docker/bake-action@v6
         with:
           files: |
             docker-bake.hcl
           targets: ${{ matrix.target }}
           set: |
+            *.args.BUILDKIT_CONTEXT_KEEP_GIT_DIR=1
             *.cache-to=type=gha,scope=validate-${{ matrix.target }},mode=max
             *.cache-from=type=gha,scope=validate-${{ matrix.target }}
             *.cache-from=type=gha,scope=build

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -90,8 +90,9 @@ jobs:
           driver-opts: image=${{ env.SETUP_BUILDKIT_IMAGE }}
       -
         name: Build website
-        uses: docker/bake-action@v5
+        uses: docker/bake-action@v6
         with:
+          source: .
           files: |
             docker-bake.hcl
           targets: release
@@ -127,8 +128,9 @@ jobs:
       -
         name: Update S3 config
         if: ${{ env.DOCS_S3_BUCKET != '' && env.DOCS_S3_CONFIG != '' }}
-        uses: docker/bake-action@v5
+        uses: docker/bake-action@v6
         with:
+          source: .
           files: |
             docker-bake.hcl
           targets: aws-s3-update-config
@@ -141,8 +143,9 @@ jobs:
       -
         name: Update Cloudfront config
         if: ${{ env.DOCS_CLOUDFRONT_ID != '' }}
-        uses: docker/bake-action@v5
+        uses: docker/bake-action@v6
         with:
+          source: .
           files: |
             docker-bake.hcl
           targets: aws-cloudfront-update

--- a/.github/workflows/validate-upstream.yml
+++ b/.github/workflows/validate-upstream.yml
@@ -90,8 +90,9 @@ jobs:
           driver-opts: image=${{ env.SETUP_BUILDKIT_IMAGE }}
       -
         name: Validate
-        uses: docker/bake-action@v5
+        uses: docker/bake-action@v6
         with:
+          source: .
           files: |
             docker-bake.hcl
           targets: validate-upstream

--- a/content/manuals/build/bake/remote-definition.md
+++ b/content/manuals/build/bake/remote-definition.md
@@ -174,9 +174,8 @@ and use the `cwd://` prefix for the metadata Bake file:
 
 ```yml
       - name: Build
-        uses: docker/bake-action@v4
+        uses: docker/bake-action@v6
         with:
-          source: "${{ github.server_url }}/${{ github.repository }}.git#${{ github.ref }}"
           files: |
             ./docker-bake.hcl
             cwd://${{ steps.meta.outputs.bake-file }}

--- a/content/manuals/build/ci/github-actions/annotations.md
+++ b/content/manuals/build/ci/github-actions/annotations.md
@@ -72,9 +72,6 @@ jobs:
   docker:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
@@ -91,12 +88,12 @@ jobs:
           images: ${{ env.IMAGE_NAME }}
 
       - name: Build
-        uses: docker/bake-action@v5
+        uses: docker/bake-action@v6
         with:
           files: |
             ./docker-bake.hcl
-            ${{ steps.meta.outputs.bake-file-tags }}
-            ${{ steps.meta.outputs.bake-file-annotations }}
+            cwd://${{ steps.meta.outputs.bake-file-tags }}
+            cwd://${{ steps.meta.outputs.bake-file-annotations }}
           push: true
 ```
 

--- a/content/manuals/build/ci/github-actions/build-summary.md
+++ b/content/manuals/build/ci/github-actions/build-summary.md
@@ -20,7 +20,7 @@ or [Docker Buildx Bake](https://github.com/marketplace/actions/docker-buildx-bak
 GitHub Actions:
 
 - `docker/build-push-action@v6`
-- `docker/bake-action@v5`
+- `docker/bake-action@v6`
 
 To view the job summary, open the details page for the job in GitHub after the
 job has finished. The summary is available for both failed and successful

--- a/content/manuals/build/ci/github-actions/checks.md
+++ b/content/manuals/build/ci/github-actions/checks.md
@@ -78,9 +78,6 @@ jobs:
   docker:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
@@ -91,12 +88,12 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Validate build configuration
-        uses: docker/bake-action@v5
+        uses: docker/bake-action@v6
         with:
           targets: validate-build
 
       - name: Build
-        uses: docker/bake-action@v5
+        uses: docker/bake-action@v6
         with:
           targets: build
           push: true

--- a/content/manuals/build/ci/github-actions/multi-platform.md
+++ b/content/manuals/build/ci/github-actions/multi-platform.md
@@ -350,9 +350,6 @@ jobs:
           platform=${{ matrix.platform }}
           echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV
 
-      - name: Checkout
-        uses: actions/checkout@v4
-
       - name: Download meta bake definition
         uses: actions/download-artifact@v4
         with:
@@ -373,11 +370,11 @@ jobs:
 
       - name: Build
         id: bake
-        uses: docker/bake-action@v5
+        uses: docker/bake-action@v6
         with:
           files: |
             ./docker-bake.hcl
-            /tmp/bake-meta.json
+            cwd:///tmp/bake-meta.json
           targets: image
           set: |
             *.tags=

--- a/content/manuals/build/ci/github-actions/reproducible-builds.md
+++ b/content/manuals/build/ci/github-actions/reproducible-builds.md
@@ -56,14 +56,11 @@ jobs:
   docker:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
       - name: Build
-        uses: docker/bake-action@v5
+        uses: docker/bake-action@v6
         env:
           SOURCE_DATE_EPOCH: 0
 ```
@@ -115,9 +112,6 @@ jobs:
   docker:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -125,7 +119,7 @@ jobs:
         run: echo "TIMESTAMP=$(git log -1 --pretty=%ct)" >> $GITHUB_ENV
 
       - name: Build
-        uses: docker/bake-action@v5
+        uses: docker/bake-action@v6
         env:
           SOURCE_DATE_EPOCH: ${{ env.TIMESTAMP }}
 ```

--- a/content/manuals/build/ci/github-actions/secrets.md
+++ b/content/manuals/build/ci/github-actions/secrets.md
@@ -198,9 +198,6 @@ jobs:
   docker:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
       - name: Set up SSH
         uses: MrSquaare/ssh-setup-action@2d028b70b5e397cf8314c6eaea229a6c3e34977a # v3.1.0
         with:
@@ -209,7 +206,7 @@ jobs:
           private-key-name: github-ppk
 
       - name: Build
-        uses: docker/bake-action@v5
+        uses: docker/bake-action@v6
         with:
           set: |
             *.ssh=default


### PR DESCRIPTION
<!--Delete sections as needed -->

## Description

Update bake-action to v6: https://github.com/docker/bake-action/releases/tag/v6.0.0

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [x] Technical review
- [ ] Editorial review
- [ ] Product review