### PR TITLE
fix[engine]: add info to use bash -i for non posix shells

### DIFF
--- a/content/manuals/engine/install/debian.md
+++ b/content/manuals/engine/install/debian.md
@@ -74,6 +74,9 @@ Run the following command to uninstall all conflicting packages:
 $ for pkg in docker.io docker-doc docker-compose podman-docker containerd runc; do sudo apt-get remove $pkg; done
 ```
 
+> These commands require a POSIX compatible shell like bash.
+> For other shells like fish, temporarily run `bash -i`.
+
 `apt-get` might report that you have none of these packages installed.
 
 Images, containers, volumes, and networks stored in `/var/lib/docker/` aren't
@@ -121,6 +124,9 @@ Docker from the repository.
    sudo apt-get update
    ```
 
+   > These commands require a POSIX compatible shell like bash.
+   > For other shells like fish, temporarily run `bash -i`.
+
    > [!NOTE]
    >
    > If you use a derivative distribution, such as Kali Linux,
@@ -144,7 +150,7 @@ Docker from the repository.
    ```console
    $ sudo apt-get install docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
    ```
-  
+
    {{< /tab >}}
    {{< tab name="Specific version" >}}
 

--- a/content/manuals/engine/install/raspberry-pi-os.md
+++ b/content/manuals/engine/install/raspberry-pi-os.md
@@ -75,6 +75,9 @@ Run the following command to uninstall all conflicting packages:
 $ for pkg in docker.io docker-doc docker-compose podman-docker containerd runc; do sudo apt-get remove $pkg; done
 ```
 
+> These commands require a POSIX compatible shell like bash.
+> For other shells like fish, temporarily run `bash -i`.
+
 `apt-get` might report that you have none of these packages installed.
 
 Images, containers, volumes, and networks stored in `/var/lib/docker/` aren't
@@ -122,6 +125,9 @@ Docker from the repository.
    sudo apt-get update
    ```
 
+   > These commands require a POSIX compatible shell like bash.
+   > For other shells like fish, temporarily run `bash -i`.
+
 2. Install the Docker packages.
 
    {{< tabs >}}
@@ -132,7 +138,7 @@ Docker from the repository.
    ```console
    $ sudo apt-get install docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
    ```
-  
+
    {{< /tab >}}
    {{< tab name="Specific version" >}}
 

--- a/content/manuals/engine/install/ubuntu.md
+++ b/content/manuals/engine/install/ubuntu.md
@@ -85,6 +85,9 @@ Run the following command to uninstall all conflicting packages:
 $ for pkg in docker.io docker-doc docker-compose docker-compose-v2 podman-docker containerd runc; do sudo apt-get remove $pkg; done
 ```
 
+> These commands require a POSIX compatible shell like bash.
+> For other shells like fish, temporarily run `bash -i`.
+
 `apt-get` might report that you have none of these packages installed.
 
 Images, containers, volumes, and networks stored in `/var/lib/docker/` aren't
@@ -132,6 +135,9 @@ Docker from the repository.
    sudo apt-get update
    ```
 
+   > These commands require a POSIX compatible shell like bash.
+   > For other shells like fish, temporarily run `bash -i`.
+
    > [!NOTE]
    >
    > If you use an Ubuntu derivative distribution, such as Linux Mint,
@@ -147,7 +153,7 @@ Docker from the repository.
    ```console
    $ sudo apt-get install docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
    ```
-  
+
    {{< /tab >}}
    {{< tab name="Specific version" >}}
 


### PR DESCRIPTION
## Description

The docker engine install commands for debian and related distros depended on bash scripting which didn't work well with non-posix shells like fish. This PR aims to solve it.

I have added alerts to use `bash -i` before running those commands. `bash -i` starts an interactive bash shell

## Related issues or tickets

[#20285](https://github.com/docker/docs/issues/20285)

## Reviews

@thaJeztah 

- [ ] Technical review
- [ ] Editorial review
- [ ] Product review