### PR TITLE
build: replace absolute /tmp with runner context temp dir

### DIFF
--- a/content/manuals/build/ci/github-actions/cache.md
+++ b/content/manuals/build/ci/github-actions/cache.md
@@ -248,7 +248,7 @@ jobs:
       - name: Cache Docker layers
         uses: actions/cache@v4
         with:
-          path: /tmp/.buildx-cache
+          path: ${{ runner.temp }}/.buildx-cache
           key: ${{ runner.os }}-buildx-${{ github.sha }}
           restore-keys: |
             ${{ runner.os }}-buildx-
@@ -258,14 +258,14 @@ jobs:
         with:
           push: true
           tags: user/app:latest
-          cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
+          cache-from: type=local,src=${{ runner.temp }}/.buildx-cache
+          cache-to: type=local,dest=${{ runner.temp }}/.buildx-cache-new,mode=max
 
       - # Temp fix
         # https://github.com/docker/build-push-action/issues/252
         # https://github.com/moby/buildkit/issues/1896
         name: Move cache
         run: |
-          rm -rf /tmp/.buildx-cache
-          mv /tmp/.buildx-cache-new /tmp/.buildx-cache
+          rm -rf ${{ runner.temp }}/.buildx-cache
+          mv ${{ runner.temp }}/.buildx-cache-new ${{ runner.temp }}/.buildx-cache
 ```

--- a/content/manuals/build/ci/github-actions/multi-platform.md
+++ b/content/manuals/build/ci/github-actions/multi-platform.md
@@ -179,15 +179,15 @@ jobs:
 
       - name: Export digest
         run: |
-          mkdir -p /tmp/digests
+          mkdir -p ${{ runner.temp }}/digests
           digest="${{ steps.build.outputs.digest }}"
-          touch "/tmp/digests/${digest#sha256:}"
+          touch "${{ runner.temp }}/digests/${digest#sha256:}"
 
       - name: Upload digest
         uses: actions/upload-artifact@v4
         with:
           name: digests-${{ env.PLATFORM_PAIR }}
-          path: /tmp/digests/*
+          path: ${{ runner.temp }}/digests/*
           if-no-files-found: error
           retention-days: 1
 
@@ -199,7 +199,7 @@ jobs:
       - name: Download digests
         uses: actions/download-artifact@v4
         with:
-          path: /tmp/digests
+          path: ${{ runner.temp }}/digests
           pattern: digests-*
           merge-multiple: true
 
@@ -233,7 +233,7 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}
 
       - name: Create manifest list and push
-        working-directory: /tmp/digests
+        working-directory: ${{ runner.temp }}/digests
         run: |
           docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
             $(printf '${{ env.DOCKERHUB_REPO }}@sha256:%s ' *)
@@ -326,13 +326,13 @@ jobs:
 
       - name: Rename meta bake definition file
         run: |
-          mv "${{ steps.meta.outputs.bake-file }}" "/tmp/bake-meta.json"
+          mv "${{ steps.meta.outputs.bake-file }}" "${{ runner.temp }}/bake-meta.json"
 
       - name: Upload meta bake definition
         uses: actions/upload-artifact@v4
         with:
           name: bake-meta
-          path: /tmp/bake-meta.json
+          path: ${{ runner.temp }}/bake-meta.json
           if-no-files-found: error
           retention-days: 1
 
@@ -354,7 +354,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: bake-meta
-          path: /tmp
+          path: ${{ runner.temp }}
       
       - name: Login to Docker Hub
         uses: docker/login-action@v3
@@ -374,7 +374,7 @@ jobs:
         with:
           files: |
             ./docker-bake.hcl
-            cwd:///tmp/bake-meta.json
+            cwd://${{ runner.temp }}/bake-meta.json
           targets: image
           set: |
             *.tags=
@@ -383,15 +383,15 @@ jobs:
 
       - name: Export digest
         run: |
-          mkdir -p /tmp/digests
+          mkdir -p ${{ runner.temp }}/digests
           digest="${{ fromJSON(steps.bake.outputs.metadata).image['containerimage.digest'] }}"
-          touch "/tmp/digests/${digest#sha256:}"
+          touch "${{ runner.temp }}/digests/${digest#sha256:}"
 
       - name: Upload digest
         uses: actions/upload-artifact@v4
         with:
           name: digests-${{ env.PLATFORM_PAIR }}
-          path: /tmp/digests/*
+          path: ${{ runner.temp }}/digests/*
           if-no-files-found: error
           retention-days: 1
 
@@ -404,12 +404,12 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: bake-meta
-          path: /tmp
+          path: ${{ runner.temp }}
 
       - name: Download digests
         uses: actions/download-artifact@v4
         with:
-          path: /tmp/digests
+          path: ${{ runner.temp }}/digests
           pattern: digests-*
           merge-multiple: true
 
@@ -423,12 +423,12 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Create manifest list and push
-        working-directory: /tmp/digests
+        working-directory: ${{ runner.temp }}/digests
         run: |
-          docker buildx imagetools create $(jq -cr '.target."docker-metadata-action".tags | map(select(startswith("${{ env.REGISTRY_IMAGE }}")) | "-t " + .) | join(" ")' /tmp/bake-meta.json) \
+          docker buildx imagetools create $(jq -cr '.target."docker-metadata-action".tags | map(select(startswith("${{ env.REGISTRY_IMAGE }}")) | "-t " + .) | join(" ")' ${{ runner.temp }}/bake-meta.json) \
             $(printf '${{ env.REGISTRY_IMAGE }}@sha256:%s ' *)
 
       - name: Inspect image
         run: |
-          docker buildx imagetools inspect ${{ env.REGISTRY_IMAGE }}:$(jq -r '.target."docker-metadata-action".args.DOCKER_META_VERSION' /tmp/bake-meta.json)
+          docker buildx imagetools inspect ${{ env.REGISTRY_IMAGE }}:$(jq -r '.target."docker-metadata-action".args.DOCKER_META_VERSION' ${{ runner.temp }}/bake-meta.json)
 ```

--- a/content/manuals/build/ci/github-actions/share-image-jobs.md
+++ b/content/manuals/build/ci/github-actions/share-image-jobs.md
@@ -29,13 +29,13 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           tags: myimage:latest
-          outputs: type=docker,dest=/tmp/myimage.tar
+          outputs: type=docker,dest=${{ runner.temp }}/myimage.tar
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
           name: myimage
-          path: /tmp/myimage.tar
+          path: ${{ runner.temp }}/myimage.tar
 
   use:
     runs-on: ubuntu-latest
@@ -45,10 +45,10 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: myimage
-          path: /tmp
+          path: ${{ runner.temp }}
 
       - name: Load image
         run: |
-          docker load --input /tmp/myimage.tar
+          docker load --input ${{ runner.temp }}/myimage.tar
           docker image ls -a
 ```


### PR DESCRIPTION
Replaces the use of an absolute path for `/tmp` in github actions examples with
a temporary directory defined by the `runner` context. Using the `runner.temp`
directory ensures that the temp directory is properly cleaned up after the job
ends, avoiding situations where an absolute path like `/tmp` would accumulate
data, eventually resulting in build errors (on self-hosted runners).

- Closes #21779
