### PR TITLE
admin: access to insights

### DIFF
--- a/content/manuals/admin/organization/insights.md
+++ b/content/manuals/admin/organization/insights.md
@@ -28,6 +28,10 @@ Key benefits include:
 
 {{< include "admin-early-access.md" >}}
 
+To access Insights, you must contact your Customer Success Manager to have the
+feature enabled. Once the feature is enabled, access Insights using the following
+steps:
+
 1. Go to the [Admin Console](https://app.docker.com/admin/) and sign in to an
    account that is an organization owner.
 2. Select your company on the **Choose profile** page.


### PR DESCRIPTION
## Description
- The support team requested that we add clarifying information to the Insights guide that customers need to request access to Insights from their CSM. Insights is not auto-enabled by default when a customer meets the criteria (business subscription + require sign-in). Support receives a lot of tickets where customers assume this is the case.

## Related issues or tickets
[ENGDOCS-2373](https://docker.atlassian.net/browse/ENGDOCS-2373)

## Reviews
- [ ] Technical review
- [ ] Editorial review
- [ ] Product review

[ENGDOCS-2373]: https://docker.atlassian.net/browse/ENGDOCS-2373?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ