### PR TITLE
Fix slight error in profiles how-to documentation (profiles.md)

### DIFF
--- a/content/manuals/compose/how-tos/profiles.md
+++ b/content/manuals/compose/how-tos/profiles.md
@@ -153,7 +153,7 @@ $ docker compose up -d
 # by implicitly enabling profiles `dev`
 $ docker compose up -d mock-backend
 
-# This fails because profiles "dev" is not enabled
+# This fails because profiles "debug" is not enabled
 $ docker compose up phpmyadmin
 ```
 


### PR DESCRIPTION
## Description

This fixes an issue in the profiles how-to where the text uses the incorrect profile in one spot.
The `phpmyadmin` service in the example is associated with the "debug" profile, but the text implies that it is associated with the "dev" profile.

## Reviews

- [ ] Technical review
- [ ] Editorial review
- [ ] Product review