### PR TITLE
Fix typo in Java guide for running tests

### DIFF
--- a/content/guides/java/run-tests.md
+++ b/content/guides/java/run-tests.md
@@ -95,7 +95,7 @@ fail if the tests fail.
 Finally, you updated the deps stage to be based on the base stage and removed
 the instructions that are now in the base stage.
 
-Run the following command to build a new image using the test stage as the target and view the test results. Include `--progress=plain` to view the build output, `--no-cache` to ensure the tests always run, and `--target-test` to target the test stage.
+Run the following command to build a new image using the test stage as the target and view the test results. Include `--progress=plain` to view the build output, `--no-cache` to ensure the tests always run, and `--target test` to target the test stage.
 
 Now, build your image and run your tests. You'll run the `docker build` command and add the `--target test` flag so that you specifically run the test build stage.
 


### PR DESCRIPTION
## Description

Fix typo when targeting the `test` stage - it was mentioning a non-exisiting `--target-test` parameter which could confuse new users: `unknown flag: --target-test`.
It should be `--target test` or `--target=test`. I went with `--target test` since that's what is used in the rest of the guide.


## Related issues or tickets

Introduced in https://github.com/docker/docs/pull/19390

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Technical review
- [ ] Editorial review
- [ ] Product review