### PR TITLE
rhel: the rpm has -rhel in the URL

### DIFF
--- a/content/manuals/desktop/setup/install/linux/rhel.md
+++ b/content/manuals/desktop/setup/install/linux/rhel.md
@@ -93,7 +93,7 @@ To install Docker Desktop on RHEL:
    $ sudo dnf config-manager --add-repo {{% param "download-url-base" %}}/docker-ce.repo
    ```
 
-2. Download the latest [RPM package](https://desktop.docker.com/linux/main/amd64/docker-desktop-x86_64.rpm?utm_source=docker&utm_medium=webreferral&utm_campaign=docs-driven-download-linux-amd64).
+2. Download the latest [RPM package](https://desktop.docker.com/linux/main/amd64/docker-desktop-x86_64-rhel.rpm?utm_source=docker&utm_medium=webreferral&utm_campaign=docs-driven-download-linux-amd64).
 
 3. Install the package with dnf as follows:
 


### PR DESCRIPTION


<!--Delete sections as needed -->

## Description

<!-- Tell us what you did and why -->
The download link for Docker Desktop on RHEL links to the wrong RPM, resulting in errors like https://forums.docker.com/t/cant-download-docker-desktop-for-rhel/142639/4
```
# dnf install ./docker-desktop-x86_64.rpm 
Error: 
 Problem: conflicting requests
  - nothing provides qemu-system-x86 >= 5.2.0 needed by docker-desktop-4.32.0-157355.x86_64 from @commandline
```

Upstream RHEL renamed `qemu-system-x86` to `qemu-kvm`

Tested on `docker run -it rockylinux:9` with

```
dnf install https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm
dnf install pass
dnf config-manager --add-repo https://download.docker.com/linux/rhel/docker-ce.repo
curl
https://desktop.docker.com/linux/main/amd64/docker-desktop-x86_64-rhel.rpm
-o docker-desktop-x86_64-rhel.rpm
dnf install ./docker-desktop-x86_64-rhel.rpm
```

## Related issues or tickets

<!-- Related issues, pull requests, or Jira tickets -->

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Technical review
- [ ] Editorial review
- [ ] Product review