### PR TITLE
accounts: add instructions for adding avatar in Docker settings

### DIFF
--- a/content/manuals/accounts/manage-account.md
+++ b/content/manuals/accounts/manage-account.md
@@ -27,7 +27,7 @@ To update your account information, select the arrow icon. You can edit the foll
 - Company
 - Location
 - Website
-- Gravatar email
+- Gravatar email: To add an avatar to your Docker account, create a [Gravatar account](https://gravatar.com/) and create your avatar. Next, add your Gravatar email to your Docker account settings. It may take some time for your avatar to update in Docker.
 
 This information is visible on your account profile in Docker Hub.
 

--- a/content/manuals/admin/faqs/general-faqs.md
+++ b/content/manuals/admin/faqs/general-faqs.md
@@ -80,3 +80,9 @@ If the user is a member of your organization, you can remove the user from your 
 ### How do I manage settings for a user account?
 
 You can manage your account settings anytime when you sign in to your [Docker account](https://app.docker.com/login). In Docker Home, select your avatar in the top-right navigation, then select **My Account**. You can also access this menu from any Docker web applications when you're signed in to your account. See [Manage your Docker account](/accounts/manage-account). If your account is associated with an organization that uses SSO, you may have limited access to the settings that you can control.
+
+### How do I add an avatar to my Docker account?
+
+To add an avatar to your Docker account, create a [Gravatar account](https://gravatar.com/) and create your avatar. Next, add your Gravatar email to your Docker account settings.
+
+Note, that it may take some time for your avatar to update in Docker.

--- a/content/manuals/admin/organization/general-settings.md
+++ b/content/manuals/admin/organization/general-settings.md
@@ -18,7 +18,7 @@ This information includes:
  - Company
  - Location
  - Website
- - Avatar
+ - Gravatar email: To add an avatar to your Docker account, create a [Gravatar account](https://gravatar.com/) and create your avatar. Next, add your Gravatar email to your Docker account settings. It may take some time for your avatar to update in Docker.
 
 To edit this information:
 


### PR DESCRIPTION
## Description
- Add instructions/clarity for adding avatar in Docker settings using Gravatar email address
- Added FAQ to general FAQs

## Related issues or tickets
- Resolves: https://github.com/docker/docs/issues/19192
- [ENGDOCS-2250](https://docker.atlassian.net/browse/ENGDOCS-2250?atlOrigin=eyJpIjoiNjU0ZTQ4ZTk0ZjU5NDhlNzkzNjIyMjZhM2Y3NDE2NjEiLCJwIjoiaiJ9)
## Reviews
- [ ] Editorial review

[ENGDOCS-2250]: https://docker.atlassian.net/browse/ENGDOCS-2250?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ