### PR TITLE
Added libyaml-dev to the Rails Dockerfile example

### DIFF
--- a/content/guides/ruby/containerize.md
+++ b/content/guides/ruby/containerize.md
@@ -67,7 +67,7 @@ FROM base AS build
 
 # Install packages needed to build gems
 RUN apt-get update -qq && \
-    apt-get install --no-install-recommends -y build-essential curl git pkg-config && \
+    apt-get install --no-install-recommends -y build-essential curl git pkg-config libyaml-dev && \
     rm -rf /var/lib/apt/lists /var/cache/apt/archives
 
 # Install JavaScript dependencies and Node.js for asset compilation


### PR DESCRIPTION
## Description

Updated `Dockerfile` example to Install `libyaml-dev` in build stage because it was removed from slim and alpine Ruby images.

More info in the PRs below:
* [https://github.com/rails/rails/pull/54237](https://github.com/rails/rails/pull/54237)
* [https://github.com/docker-library/ruby/pull/493](https://github.com/docker-library/ruby/pull/493)
 
- [x] Technical review
- [ ] Editorial review
- [ ] Product review