### PR TITLE
Fix ENV name typo

### DIFF
--- a/content/manuals/build/building/variables.md
+++ b/content/manuals/build/building/variables.md
@@ -158,7 +158,7 @@ COPY . .
 CMD ["node", "app.js"]
 ```
 
-With this Dockerfile, you can use `--build-arg` to override the default value of `ENV`:
+With this Dockerfile, you can use `--build-arg` to override the default value of `NODE_ENV`:
 
 ```console
 $ docker build --build-arg NODE_ENV=development .


### PR DESCRIPTION
## Description

This PR addresses a very minor typo that tripped me up when reading the docs. The ARG changes the value of the `ENV`, but the `ENV`'s name is `NODE_ENV`, not `ENV` as was previously written.

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Technical review
- [ ] Editorial review
- [ ] Product review