### PR TITLE
freshness: add Beta badge to OATs doc

### DIFF
--- a/content/manuals/security/for-admins/access-tokens.md
+++ b/content/manuals/security/for-admins/access-tokens.md
@@ -3,7 +3,12 @@ title: Organization access tokens
 description: Learn how to create and manage organization access tokens
   to securely push and pull images programmatically.
 keywords: docker hub, security, OAT, organization access token
-linkTitle: Organization access tokens (Beta)
+linkTitle: Organization access tokens
+params:
+  sidebar:
+    badge:
+      color: blue
+      text: Beta
 ---
 
 {{< summary-bar feature_name="OATs" >}}


### PR DESCRIPTION
## Description
Little nit. Noticed OATs was using (Beta) and not the blue Beta badge. Removed (Beta) and added badge to be in line with style guide standards

## Related issues or tickets
[ENGDOCS-2386](https://docker.atlassian.net/browse/ENGDOCS-2386)

## Reviews
- [ ] Technical review
- [ ] Editorial review

[ENGDOCS-2386]: https://docker.atlassian.net/browse/ENGDOCS-2386?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ