### PR TITLE
layouts: cli.html: fix incorrect closing tag

### DIFF
--- a/layouts/_default/cli.html
+++ b/layouts/_default/cli.html
@@ -17,7 +17,7 @@
           {{ with $data.short }}
           <tr>
             <th class="text-left w-32">Description</th>
-            <td>{{ . }}</th>
+            <td>{{ . }}</td>
           </tr>
           {{ end }}
           {{ with $data.usage }}


### PR DESCRIPTION
- relates to https://github.com/docker/docs/pull/19489

The opening tag was a "td", but the closing tag a "th". Looks like browsers fix this up, but let's change it to be correct.

updates 56679aec9870a57dc306a781e3e445be70aba1a6

<!--Delete sections as needed -->

## Description

<!-- Tell us what you did and why -->

## Related issues or tickets

<!-- Related issues, pull requests, or Jira tickets -->

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Technical review
- [ ] Editorial review
- [ ] Product review