### PR TITLE
engine: v27.5.1 follow-ups

### DIFF
--- a/_vendor/modules.txt
+++ b/_vendor/modules.txt
@@ -1,4 +1,4 @@
-# github.com/moby/moby v27.5.0+incompatible
+# github.com/moby/moby v27.5.1+incompatible
 # github.com/moby/buildkit v0.19.0
 # github.com/docker/buildx v0.20.1
 # github.com/docker/cli v27.5.0+incompatible

--- a/_vendor/modules.txt
+++ b/_vendor/modules.txt
@@ -1,6 +1,6 @@
 # github.com/moby/moby v27.5.1+incompatible
 # github.com/moby/buildkit v0.19.0
 # github.com/docker/buildx v0.20.1
-# github.com/docker/cli v27.5.0+incompatible
+# github.com/docker/cli v27.5.1+incompatible
 # github.com/docker/compose/v2 v2.32.4
 # github.com/docker/scout-cli v1.15.0

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/docker/compose/v2 v2.32.4 // indirect
 	github.com/docker/scout-cli v1.15.0 // indirect
 	github.com/moby/buildkit v0.19.0 // indirect
-	github.com/moby/moby v27.5.0+incompatible // indirect
+	github.com/moby/moby v27.5.1+incompatible // indirect
 )
 
 replace (
@@ -17,5 +17,5 @@ replace (
 	github.com/docker/compose/v2 => github.com/docker/compose/v2 v2.32.4
 	github.com/docker/scout-cli => github.com/docker/scout-cli v1.15.0
 	github.com/moby/buildkit => github.com/moby/buildkit v0.19.0
-	github.com/moby/moby => github.com/moby/moby v27.5.0+incompatible
+	github.com/moby/moby => github.com/moby/moby v27.5.1+incompatible
 )

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.23.1
 
 require (
 	github.com/docker/buildx v0.20.1 // indirect
-	github.com/docker/cli v27.5.0+incompatible // indirect
+	github.com/docker/cli v27.5.1+incompatible // indirect
 	github.com/docker/compose/v2 v2.32.4 // indirect
 	github.com/docker/scout-cli v1.15.0 // indirect
 	github.com/moby/buildkit v0.19.0 // indirect
@@ -13,7 +13,7 @@ require (
 
 replace (
 	github.com/docker/buildx => github.com/docker/buildx v0.20.1
-	github.com/docker/cli => github.com/docker/cli v27.5.0+incompatible
+	github.com/docker/cli => github.com/docker/cli v27.5.1+incompatible
 	github.com/docker/compose/v2 => github.com/docker/compose/v2 v2.32.4
 	github.com/docker/scout-cli => github.com/docker/scout-cli v1.15.0
 	github.com/moby/buildkit => github.com/moby/buildkit v0.19.0

--- a/go.sum
+++ b/go.sum
@@ -374,6 +374,8 @@ github.com/moby/moby v27.4.0+incompatible h1:jGXXZCMAmFZS9pKsQqUt9yAPHOC450PM9lb
 github.com/moby/moby v27.4.0+incompatible/go.mod h1:fDXVQ6+S340veQPv35CzDahGBmHsiclFwfEygB/TWMc=
 github.com/moby/moby v27.5.0+incompatible h1:RuYLppjLxMzWmPUQAy/hkJ6pGcXsuVdcmIVFqVPegO8=
 github.com/moby/moby v27.5.0+incompatible/go.mod h1:fDXVQ6+S340veQPv35CzDahGBmHsiclFwfEygB/TWMc=
+github.com/moby/moby v27.5.1+incompatible h1:/pN59F/t3U7Q4FPzV88nzqf7Fp0qqCSL2KzhZaiKcKw=
+github.com/moby/moby v27.5.1+incompatible/go.mod h1:fDXVQ6+S340veQPv35CzDahGBmHsiclFwfEygB/TWMc=
 github.com/moby/sys/symlink v0.1.0/go.mod h1:GGDODQmbFOjFsXvfLVn3+ZRxkch54RkSiGqsZeMYowQ=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/morikuni/aec v1.0.0/go.mod h1:BbKIizmSmc5MMPqRYbxO4ZU0S0+P200+tUnFx7PXmsc=

--- a/go.sum
+++ b/go.sum
@@ -144,6 +144,8 @@ github.com/docker/cli v27.4.0+incompatible h1:/nJzWkcI1MDMN+U+px/YXnQWJqnu4J+QKG
 github.com/docker/cli v27.4.0+incompatible/go.mod h1:JLrzqnKDaYBop7H2jaqPtU4hHvMKP+vjCwu2uszcLI8=
 github.com/docker/cli v27.5.0+incompatible h1:aMphQkcGtpHixwwhAXJT1rrK/detk2JIvDaFkLctbGM=
 github.com/docker/cli v27.5.0+incompatible/go.mod h1:JLrzqnKDaYBop7H2jaqPtU4hHvMKP+vjCwu2uszcLI8=
+github.com/docker/cli v27.5.1+incompatible h1:JB9cieUT9YNiMITtIsguaN55PLOHhBSz3LKVc6cqWaY=
+github.com/docker/cli v27.5.1+incompatible/go.mod h1:JLrzqnKDaYBop7H2jaqPtU4hHvMKP+vjCwu2uszcLI8=
 github.com/docker/compose-cli v1.0.35 h1:uZyEHLalfqBS2PiTpA1LAULyJmuQ+YtZg7nG4Xl3/Cc=
 github.com/docker/compose-cli v1.0.35/go.mod h1:mSXI4hFLpRU3EtI8NTo32bNwI0UXSr8jnq+/rYjGAUU=
 github.com/docker/compose/v2 v2.22.0 h1:3rRz4L7tPU75wRsV8JZh2/aTgerQvPa1cpzZN+tHqUY=

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -113,10 +113,10 @@ params:
   # Latest version of the Docker Engine API
   latest_engine_api_version: "1.47"
   # Latest version of Docker Engine
-  docker_ce_version: "27.5.0"
+  docker_ce_version: "27.5.1"
   # Previous version of the Docker Engine
   # (Used to show e.g., "latest" and "latest"-1 in engine install examples
-  docker_ce_version_prev: "27.4.1"
+  docker_ce_version_prev: "27.5.0"
   # Latest Docker Compose version
   compose_version: "v2.32.4"
   # Latest BuildKit version


### PR DESCRIPTION
- **vendor: github.com/moby/moby v27.5.1**
- **vendor: github.com/docker/cli v27.5.1**
- **engine: bump latest engine version**
