### PR TITLE
fix: update include.html for heading error

### DIFF
--- a/content/guides/swarm-deploy.md
+++ b/content/guides/swarm-deploy.md
@@ -13,7 +13,7 @@ params:
   time: 10 minutes
 ---
 
-{{< include "swarm-mode.md" >}}
+{{% include "swarm-mode.md" %}}
 
 ## Prerequisites
 
@@ -35,7 +35,7 @@ Swarm never creates individual containers like you did in the previous step of t
 
 Now you can write a simple stack file to run and manage your Todo app, the container `getting-started` image created in [Part 2](02_our_app.md) of the tutorial. Place the following in a file called `bb-stack.yaml`:
 
-{{< include "swarm-compose-compat.md" >}}
+{{% include "swarm-compose-compat.md" %}}
 
 ```yaml
 version: "3.7"

--- a/content/manuals/admin/company/_index.md
+++ b/content/manuals/admin/company/_index.md
@@ -44,7 +44,7 @@ aliases:
 
 {{< summary-bar feature_name="Company" >}}
 
-{{< include "admin-company-overview.md" >}}
+{{% include "admin-company-overview.md" %}}
 
 Learn how to administer a company in the following sections.
 

--- a/content/manuals/admin/company/new-company.md
+++ b/content/manuals/admin/company/new-company.md
@@ -12,7 +12,7 @@ You can create a new company in the Docker Admin Console. Before you begin, you 
 - Be the owner of the organization you want to add to your company
 - Have a Docker Business subscription
 
-{{< include "admin-early-access.md" >}}
+{{% include "admin-early-access.md" %}}
 
 ## Create a company
 

--- a/content/manuals/admin/company/organizations.md
+++ b/content/manuals/admin/company/organizations.md
@@ -8,7 +8,7 @@ title: Manage company organizations
 
 You can manage the organizations in a company in the Docker Admin Console.
 
-{{< include "admin-early-access.md" >}}
+{{% include "admin-early-access.md" %}}
 
 ## View all organizations
 

--- a/content/manuals/admin/company/owners.md
+++ b/content/manuals/admin/company/owners.md
@@ -15,7 +15,7 @@ owners for all associated organizations. Unlike organization owners, company
 owners don't need to be member of an organization. When company owners aren't a
 member in an organization, they don't occupy a seat.
 
-{{< include "admin-early-access.md" >}}
+{{% include "admin-early-access.md" %}}
 
 ## Add a company owner
 

--- a/content/manuals/admin/company/users.md
+++ b/content/manuals/admin/company/users.md
@@ -10,7 +10,7 @@ You can manage users at the company-level in the Docker Admin Console.
 
 {{% admin-users product="admin" layer="company" %}}
 
-{{< include "admin-early-access.md" >}}
+{{% include "admin-early-access.md" %}}
 
 ## Manage members on a team
 

--- a/content/manuals/admin/organization/_index.md
+++ b/content/manuals/admin/organization/_index.md
@@ -45,7 +45,7 @@ grid:
   icon: help
 ---
 
-{{< include "admin-org-overview.md" >}}
+{{% include "admin-org-overview.md" %}}
 
 To create an organization, see [Create your organization](../organization/orgs.md).
 

--- a/content/manuals/admin/organization/activity-logs.md
+++ b/content/manuals/admin/organization/activity-logs.md
@@ -30,7 +30,7 @@ Owners can also see the activity logs for their repository if the repository is 
 {{< /tab >}}
 {{< tab name="Admin Console" >}}
 
-{{< include "admin-early-access.md" >}}
+{{% include "admin-early-access.md" %}}
 
 {{% admin-org-audit-log product="admin" %}}
 

--- a/content/manuals/admin/organization/general-settings.md
+++ b/content/manuals/admin/organization/general-settings.md
@@ -5,7 +5,7 @@ description: Learn how to manage settings for organizations using Docker Admin C
 keywords: organization, settings, Admin Console
 ---
 
-{{< include "admin-early-access.md" >}}
+{{% include "admin-early-access.md" %}}
 
 This section describes how to manage organization settings in the Docker Admin Console.
 

--- a/content/manuals/admin/organization/insights.md
+++ b/content/manuals/admin/organization/insights.md
@@ -30,7 +30,7 @@ Key benefits include:
 
 ## View Insights for organization users
 
-{{< include "admin-early-access.md" >}}
+{{% include "admin-early-access.md" %}}
 
 To access Insights, you must contact your Customer Success Manager to have the
 feature enabled. Once the feature is enabled, access Insights using the following

--- a/content/manuals/admin/organization/manage-a-team.md
+++ b/content/manuals/admin/organization/manage-a-team.md
@@ -46,7 +46,7 @@ The organization owner can also add additional organization owners to help them 
 {{< /tab >}}
 {{< tab name="Admin Console" >}}
 
-{{< include "admin-early-access.md" >}}
+{{% include "admin-early-access.md" %}}
 
 1. In Admin Console, select your organization.
 2. In the **User management** section, select **Teams**.
@@ -133,7 +133,7 @@ Organization owners can delete a team in Docker Hub or Admin Console. When you r
 {{< /tab >}}
 {{< tab name="Admin Console" >}}
 
-{{< include "admin-early-access.md" >}}
+{{% include "admin-early-access.md" %}}
 
 1. In the [Admin Console](https://app.docker.com/admin), select your organization.
 2. In the **User management** section, select **Teams**.

--- a/content/manuals/admin/organization/members.md
+++ b/content/manuals/admin/organization/members.md
@@ -19,7 +19,7 @@ Learn how to manage members for your organization in Docker Hub and the Docker A
 {{< /tab >}}
 {{< tab name="Admin Console" >}}
 
-{{< include "admin-early-access.md" >}}
+{{% include "admin-early-access.md" %}}
 
 {{% admin-users product="admin" %}}
 
@@ -66,7 +66,7 @@ To resend an invitation from Docker Hub:
 {{< /tab >}}
 {{< tab name="Admin Console" >}}
 
-{{< include "admin-early-access.md" >}}
+{{% include "admin-early-access.md" %}}
 
 To resend an invitation from the Admin Console:
 
@@ -93,7 +93,7 @@ To remove a member's invitation from Docker Hub:
 {{< /tab >}}
 {{< tab name="Admin Console" >}}
 
-{{< include "admin-early-access.md" >}}
+{{% include "admin-early-access.md" %}}
 
 To remove an invitation from the Admin Console:
 
@@ -132,7 +132,7 @@ To add a member to a team with Docker Hub:
 {{< /tab >}}
 {{< tab name="Admin Console" >}}
 
-{{< include "admin-early-access.md" >}}
+{{% include "admin-early-access.md" %}}
 
 To add a member to a team with the Admin Console:
 
@@ -164,7 +164,7 @@ To remove a member from a specific team with Docker Hub:
 {{< /tab >}}
 {{< tab name="Admin Console" >}}
 
-{{< include "admin-early-access.md" >}}
+{{% include "admin-early-access.md" %}}
 
 To remove a member from a specific team with the Admin Console:
 
@@ -219,7 +219,7 @@ To export a CSV file of your members:
 {{< /tab >}}
 {{< tab name="Admin Console" >}}
 
-{{< include "admin-early-access.md" >}}
+{{% include "admin-early-access.md" %}}
 
 To export a CSV file of your members:
 

--- a/content/manuals/admin/organization/onboard.md
+++ b/content/manuals/admin/organization/onboard.md
@@ -13,7 +13,7 @@ aliases:
 
 {{< summary-bar feature_name="Admin orgs" >}}
 
-{{< include "admin-early-access.md" >}}
+{{% include "admin-early-access.md" %}}
 
 Learn how to onboard your organization using Docker Hub or the Docker Admin Console.
 

--- a/content/manuals/admin/organization/orgs.md
+++ b/content/manuals/admin/organization/orgs.md
@@ -53,7 +53,7 @@ You've now created an organization.
 {{< /tab >}}
 {{< tab name="Admin Console" >}}
 
-{{< include "admin-early-access.md" >}}
+{{% include "admin-early-access.md" %}}
 
 To create an organization:
 
@@ -138,7 +138,7 @@ configure your organization.
 {{< /tab >}}
 {{< tab name="Admin Console" >}}
 
-{{< include "admin-early-access.md" >}}
+{{% include "admin-early-access.md" %}}
 
 To view an organization in the Admin Console:
 

--- a/content/manuals/billing/cycle.md
+++ b/content/manuals/billing/cycle.md
@@ -23,7 +23,7 @@ When you change the billing cycle's duration:
 - The subscription's start date resets. For example, if the start date of the monthly subscription is March 1st and the end date is April 1st, then after switching the billing duration to March 15th, 2024 the new start date is March 15th, 2024, and the new end date is March 15th, 2025.
 - Any unused monthly subscription is prorated and applied as credit towards the new annual period. For example, if you switch from a $10 monthly subscription to a $100 annual plan, deducting the unused monthly value (in this case $5), the migration cost becomes $95 ($100 - $5). The renewal cost after March 15, 2025 is $100.
 
-{{< include "tax-compliance.md" >}}
+{{% include "tax-compliance.md" %}}
 
 ## Personal account
 

--- a/content/manuals/billing/details.md
+++ b/content/manuals/billing/details.md
@@ -9,7 +9,7 @@ You can update the billing information for your personal account or for an organ
 
 The billing information provided appears on all your billing invoices. The email address provided is where Docker sends all invoices and other [billing-related communication](#update-your-billing-invoice-email-address).
 
-{{< include "tax-compliance.md" >}}
+{{% include "tax-compliance.md" %}}
 
 ## Manage billing information
 

--- a/content/manuals/billing/history.md
+++ b/content/manuals/billing/history.md
@@ -7,7 +7,7 @@ keywords: payments, billing, subscription, invoices, renewals, invoice managemen
 
 In this section, learn how you can view your billing history, manage your invoices, and verify your renewal date. All monthly and annual subscriptions are automatically renewed at the end of the term using the original form of payment.
 
-{{< include "tax-compliance.md" >}}
+{{% include "tax-compliance.md" %}}
 
 ## Invoices
 

--- a/content/manuals/billing/payment-method.md
+++ b/content/manuals/billing/payment-method.md
@@ -27,7 +27,7 @@ The following payment methods are supported:
 
 All currency, for example the amount listed on your billing invoice, is in United States dollar (USD).
 
-{{< include "tax-compliance.md" >}}
+{{% include "tax-compliance.md" %}}
 
 ## Manage payment method
 

--- a/content/manuals/billing/tax-certificate.md
+++ b/content/manuals/billing/tax-certificate.md
@@ -7,7 +7,7 @@ weight: 50
 
 If you're a customer in the United States and you're exempt from sales tax, you can register a valid tax exemption certificate with Docker's Support team. If you're a global customer subject to VAT, make sure that you provide your [VAT number](/billing/history/#include-your-vat-number-on-your-invoice).
 
-{{< include "tax-compliance.md" >}}
+{{% include "tax-compliance.md" %}}
 
 ## Prerequisites
 

--- a/content/manuals/build/buildkit/dockerfile-release-notes.md
+++ b/content/manuals/build/buildkit/dockerfile-release-notes.md
@@ -277,7 +277,7 @@ The following features have graduated from the labs channel to stable:
 
 {{< release-date date="2023-01-10" >}}
 
-{{< include "dockerfile-labs-channel.md" >}}
+{{% include "dockerfile-labs-channel.md" %}}
 
 ### New
 
@@ -371,7 +371,7 @@ The following features have graduated from the labs channel to stable:
 
 {{< release-date date="2021-07-16" >}}
 
-{{< include "dockerfile-labs-channel.md" >}}
+{{% include "dockerfile-labs-channel.md" %}}
 
 ### New
 
@@ -402,7 +402,7 @@ The following features have graduated from the labs channel to stable:
 
 {{< release-date date="2020-12-12" >}}
 
-{{< include "dockerfile-labs-channel.md" >}}
+{{% include "dockerfile-labs-channel.md" %}}
 
 ### Bug fixes and enhancements
 
@@ -423,7 +423,7 @@ The following features have graduated from the labs channel to stable:
 
 {{< release-date date="2020-12-03" >}}
 
-{{< include "dockerfile-labs-channel.md" >}}
+{{% include "dockerfile-labs-channel.md" %}}
 
 ### Bug fixes and enhancements
 
@@ -460,7 +460,7 @@ The following features have graduated from the labs channel to stable:
 
 {{< release-date date="2019-07-31" >}}
 
-{{< include "dockerfile-labs-channel.md" >}}
+{{% include "dockerfile-labs-channel.md" %}}
 
 ### Bug fixes and enhancements
 

--- a/content/manuals/build/release-notes.md
+++ b/content/manuals/build/release-notes.md
@@ -648,7 +648,7 @@ The full release note for this release is available
 
 {{< release-date date="2023-03-06" >}}
 
-{{< include "buildx-v0.10-disclaimer.md" >}}
+{{% include "buildx-v0.10-disclaimer.md" %}}
 
 ### Bug fixes and enhancements
 
@@ -660,7 +660,7 @@ The full release note for this release is available
 
 {{< release-date date="2023-02-16" >}}
 
-{{< include "buildx-v0.10-disclaimer.md" >}}
+{{% include "buildx-v0.10-disclaimer.md" %}}
 
 ### Bug fixes and enhancements
 
@@ -674,7 +674,7 @@ The full release note for this release is available
 
 {{< release-date date="2023-01-30" >}}
 
-{{< include "buildx-v0.10-disclaimer.md" >}}
+{{% include "buildx-v0.10-disclaimer.md" %}}
 
 ### Bug fixes and enhancements
 
@@ -688,7 +688,7 @@ The full release note for this release is available
 
 {{< release-date date="2023-01-27" >}}
 
-{{< include "buildx-v0.10-disclaimer.md" >}}
+{{% include "buildx-v0.10-disclaimer.md" %}}
 
 ### Bug fixes and enhancements
 
@@ -705,7 +705,7 @@ The full release note for this release is available
 
 {{< release-date date="2023-01-10" >}}
 
-{{< include "buildx-v0.10-disclaimer.md" >}}
+{{% include "buildx-v0.10-disclaimer.md" %}}
 
 ### New
 

--- a/content/manuals/compose/how-tos/file-watch.md
+++ b/content/manuals/compose/how-tos/file-watch.md
@@ -9,7 +9,7 @@ aliases:
 
 {{< introduced compose 2.22.0 "/manuals/compose/releases/release-notes.md#2220" >}}
 
-{{< include "compose/watch.md" >}}
+{{% include "compose/watch.md" %}}
 
 `watch` adheres to the following file path rules:
 * All paths are relative to the project directory
@@ -187,7 +187,7 @@ This setup demonstrates how to use the `sync+restart` action in Docker Compose t
 
 ## Use `watch`
 
-{{< include "compose/configure-watch.md" >}}
+{{% include "compose/configure-watch.md" %}}
 
 > [!NOTE]
 >

--- a/content/manuals/compose/how-tos/multiple-compose-files/include.md
+++ b/content/manuals/compose/how-tos/multiple-compose-files/include.md
@@ -8,7 +8,7 @@ aliases:
 
 {{< introduced compose 2.20.3 "/manuals/compose/releases/release-notes.md#2203" >}}
 
-{{< include "compose/include.md" >}}
+{{% include "compose/include.md" %}}
 
 The [`include` top-level element](/reference/compose-file/include.md) helps to reflect the engineering team responsible for the code directly in the config file's organization. It also solves the relative path problem that [`extends`](extends.md) and [merge](merge.md) present. 
 

--- a/content/manuals/compose/how-tos/networking.md
+++ b/content/manuals/compose/how-tos/networking.md
@@ -8,7 +8,7 @@ aliases:
 - /compose/networking/
 ---
 
-{{< include "compose-eol.md" >}}
+{{% include "compose-eol.md" %}}
 
 By default Compose sets up a single
 [network](/reference/cli/docker/network/create.md) for your app. Each

--- a/content/manuals/compose/how-tos/profiles.md
+++ b/content/manuals/compose/how-tos/profiles.md
@@ -8,7 +8,7 @@ aliases:
 - /compose/profiles/
 ---
 
-{{< include "compose/profiles.md" >}}
+{{% include "compose/profiles.md" %}}
 
 ## Assigning profiles to services
 

--- a/content/manuals/compose/how-tos/use-secrets.md
+++ b/content/manuals/compose/how-tos/use-secrets.md
@@ -11,7 +11,7 @@ aliases:
 
 A secret is any piece of data, such as a password, certificate, or API key, that shouldn’t be transmitted over a network or stored unencrypted in a Dockerfile or in your application’s source code.
 
-{{< include "compose/secrets.md" >}}
+{{% include "compose/secrets.md" %}}
 
 Environment variables are often available to all processes, and it can be difficult to track access. They can also be printed in logs when debugging errors without your knowledge. Using secrets mitigates these risks.
 

--- a/content/manuals/desktop/features/dev-environments/_index.md
+++ b/content/manuals/desktop/features/dev-environments/_index.md
@@ -8,7 +8,7 @@ aliases:
 - /desktop/dev-environments/
 ---
 
-{{< include "dev-envs-changing.md" >}}
+{{% include "dev-envs-changing.md" %}}
 
 {{< summary-bar feature_name="Dev Environments" >}}
 

--- a/content/manuals/desktop/features/dev-environments/create-dev-env.md
+++ b/content/manuals/desktop/features/dev-environments/create-dev-env.md
@@ -8,7 +8,7 @@ aliases:
 weight: 10
 ---
 
-{{< include "dev-envs-changing.md" >}}
+{{% include "dev-envs-changing.md" %}}
 
 You can launch a dev environment from a:
 - Git repository

--- a/content/manuals/desktop/features/dev-environments/dev-cli.md
+++ b/content/manuals/desktop/features/dev-environments/dev-cli.md
@@ -6,7 +6,7 @@ aliases:
 - /desktop/dev-environments/dev-cli/
 ---
 
-{{< include "dev-envs-changing.md" >}}
+{{% include "dev-envs-changing.md" %}}
 
 Use the new `docker dev` CLI plugin to get the full Dev Environments experience from the terminal in addition to the Dashboard.
 

--- a/content/manuals/desktop/features/dev-environments/set-up.md
+++ b/content/manuals/desktop/features/dev-environments/set-up.md
@@ -7,7 +7,7 @@ aliases:
 - /desktop/dev-environments/set-up/
 ---
 
-{{< include "dev-envs-changing.md" >}}
+{{% include "dev-envs-changing.md" %}}
 
 >**Changes to Dev Environments with Docker Desktop 4.13**
 >

--- a/content/manuals/desktop/features/dev-environments/share.md
+++ b/content/manuals/desktop/features/dev-environments/share.md
@@ -7,7 +7,7 @@ aliases:
 - /desktop/dev-environments/share/
 ---
 
-{{< include "dev-envs-changing.md" >}}
+{{% include "dev-envs-changing.md" %}}
 
 The `compose-dev.yaml` config file makes distributing your dev environment easy so everyone can access the same code and any dependencies.
 

--- a/content/manuals/desktop/setup/install/linux/archlinux.md
+++ b/content/manuals/desktop/setup/install/linux/archlinux.md
@@ -46,7 +46,7 @@ To install Docker Desktop successfully, you must meet the [general system requir
 
 ## Launch Docker Desktop
 
-{{< include "desktop-linux-launch.md" >}}
+{{% include "desktop-linux-launch.md" %}}
 
 ## Next steps
 

--- a/content/manuals/desktop/setup/install/linux/debian.md
+++ b/content/manuals/desktop/setup/install/linux/debian.md
@@ -72,7 +72,7 @@ The post-install script:
 
 ## Launch Docker Desktop
 
-{{< include "desktop-linux-launch.md" >}}
+{{% include "desktop-linux-launch.md" %}}
 
 ## Upgrade Docker Desktop
 

--- a/content/manuals/desktop/setup/install/linux/fedora.md
+++ b/content/manuals/desktop/setup/install/linux/fedora.md
@@ -62,7 +62,7 @@ The post-install script:
 
 ## Launch Docker Desktop
 
-{{< include "desktop-linux-launch.md" >}}
+{{% include "desktop-linux-launch.md" %}}
 
 ## Upgrade Docker Desktop
 

--- a/content/manuals/desktop/setup/install/linux/rhel.md
+++ b/content/manuals/desktop/setup/install/linux/rhel.md
@@ -113,7 +113,7 @@ The post-install script:
 
 ## Launch Docker Desktop
 
-{{< include "desktop-linux-launch.md" >}}
+{{% include "desktop-linux-launch.md" %}}
 
 > [!IMPORTANT]
 >

--- a/content/manuals/desktop/setup/install/linux/ubuntu.md
+++ b/content/manuals/desktop/setup/install/linux/ubuntu.md
@@ -72,7 +72,7 @@ The post-install script:
 
 ## Launch Docker Desktop
 
-{{< include "desktop-linux-launch.md" >}}
+{{% include "desktop-linux-launch.md" %}}
 
 ## Upgrade Docker Desktop
 

--- a/content/manuals/desktop/setup/install/windows-install.md
+++ b/content/manuals/desktop/setup/install/windows-install.md
@@ -250,7 +250,7 @@ Docker Desktop does not start automatically after installation. To start Docker 
 
 2. The Docker menu ({{< inline-image src="images/whale-x.svg" alt="whale menu" >}}) displays the Docker Subscription Service Agreement.
 
-   {{< include "desktop-license-update.md" >}}
+   {{% include "desktop-license-update.md" %}}
 
 3. Select **Accept** to continue. Docker Desktop starts after you accept the terms.
 

--- a/content/manuals/docker-hub/image-library/search.md
+++ b/content/manuals/docker-hub/image-library/search.md
@@ -104,7 +104,7 @@ Categories group images based on their primary use case, helping you quickly
 locate the tools and resources you need to build, deploy, and run your
 applications.
 
-{{< include "hub-categories.md" >}}
+{{% include "hub-categories.md" %}}
 
 ### Operating systems
 

--- a/content/manuals/docker-hub/repos/manage/information.md
+++ b/content/manuals/docker-hub/repos/manage/information.md
@@ -114,7 +114,7 @@ explore content for the problem domain that they're interested in.
 
 The Docker Hub content team maintains a curated list of categories.
 
-{{< include "hub-categories.md" >}}
+{{% include "hub-categories.md" %}}
 
 ### Auto-generated categories
 

--- a/content/manuals/docker-hub/service-accounts.md
+++ b/content/manuals/docker-hub/service-accounts.md
@@ -5,7 +5,7 @@ title: Service accounts
 weight: 50
 ---
 
-{{< include "new-plans.md" >}}
+{{% include "new-plans.md" %}}
 
 > [!IMPORTANT]
 >

--- a/content/manuals/docker-hub/usage/_index.md
+++ b/content/manuals/docker-hub/usage/_index.md
@@ -8,7 +8,7 @@ aliases:
   /docker-hub/download-rate-limit/
 ---
 
-{{< include "hub-limits.md" >}}
+{{% include "hub-limits.md" %}}
 
 When using Docker Hub, unauthenticated and Docker Personal users are subject to
 strict limits. In contrast, Docker Pro, Team, and Business users benefit from a

--- a/content/manuals/docker-hub/usage/pulls.md
+++ b/content/manuals/docker-hub/usage/pulls.md
@@ -6,7 +6,7 @@ linkTitle: Pulls
 weight: 10
 ---
 
-{{< include "hub-limits.md" >}}
+{{% include "hub-limits.md" %}}
 
 Unauthenticated and Docker Personal users are subject to hourly pull rate limits
 on Docker Hub. In contrast, Docker Pro, Team, and Business users benefit from a

--- a/content/manuals/docker-hub/usage/storage.md
+++ b/content/manuals/docker-hub/usage/storage.md
@@ -6,7 +6,7 @@ linkTitle: Storage
 weight: 20
 ---
 
-{{< include "hub-limits.md" >}}
+{{% include "hub-limits.md" %}}
 
 The following storage and repository limits apply based on your subscription, subject to fair use:
 

--- a/content/manuals/engine/install/binaries.md
+++ b/content/manuals/engine/install/binaries.md
@@ -138,7 +138,7 @@ instructions for enabling and configuring AppArmor or SELinux.
 
 You have now successfully installed and started Docker Engine.
 
-{{< include "root-errors.md" >}}
+{{% include "root-errors.md" %}}
 
 ## Install client binaries on macOS
 

--- a/content/manuals/engine/install/centos.md
+++ b/content/manuals/engine/install/centos.md
@@ -165,7 +165,7 @@ $ sudo dnf config-manager --add-repo {{% param "download-url-base" %}}/docker-ce
 
 You have now successfully installed and started Docker Engine.
 
-{{< include "root-errors.md" >}}
+{{% include "root-errors.md" %}}
 
 #### Upgrade Docker Engine
 
@@ -214,7 +214,7 @@ download a new file each time you want to upgrade Docker Engine.
 
 You have now successfully installed and started Docker Engine.
 
-{{< include "root-errors.md" >}}
+{{% include "root-errors.md" %}}
 
 #### Upgrade Docker Engine
 
@@ -222,7 +222,7 @@ To upgrade Docker Engine, download the newer package files and repeat the
 [installation procedure](#install-from-a-package), using `dnf upgrade`
 instead of `dnf install`, and point to the new files.
 
-{{< include "install-script.md" >}}
+{{% include "install-script.md" %}}
 
 ## Uninstall Docker Engine
 

--- a/content/manuals/engine/install/debian.md
+++ b/content/manuals/engine/install/debian.md
@@ -181,7 +181,7 @@ Docker from the repository.
 
 You have now successfully installed and started Docker Engine.
 
-{{< include "root-errors.md" >}}
+{{% include "root-errors.md" %}}
 
 #### Upgrade Docker Engine
 
@@ -237,14 +237,14 @@ download a new file each time you want to upgrade Docker Engine.
 
 You have now successfully installed and started Docker Engine.
 
-{{< include "root-errors.md" >}}
+{{% include "root-errors.md" %}}
 
 #### Upgrade Docker Engine
 
 To upgrade Docker Engine, download the newer package files and repeat the
 [installation procedure](#install-from-a-package), pointing to the new files.
 
-{{< include "install-script.md" >}}
+{{% include "install-script.md" %}}
 
 ## Uninstall Docker Engine
 

--- a/content/manuals/engine/install/fedora.md
+++ b/content/manuals/engine/install/fedora.md
@@ -162,7 +162,7 @@ $ sudo dnf-3 config-manager --add-repo {{% param "download-url-base" %}}/docker-
 
 You have now successfully installed and started Docker Engine.
 
-{{< include "root-errors.md" >}}
+{{% include "root-errors.md" %}}
 
 #### Upgrade Docker Engine
 
@@ -211,7 +211,7 @@ download a new file each time you want to upgrade Docker Engine.
 
 You have now successfully installed and started Docker Engine.
 
-{{< include "root-errors.md" >}}
+{{% include "root-errors.md" %}}
 
 #### Upgrade Docker Engine
 
@@ -219,7 +219,7 @@ To upgrade Docker Engine, download the newer package files and repeat the
 [installation procedure](#install-from-a-package), using `dnf upgrade`
 instead of `dnf install`, and point to the new files.
 
-{{< include "install-script.md" >}}
+{{% include "install-script.md" %}}
 
 ## Uninstall Docker Engine
 

--- a/content/manuals/engine/install/raspberry-pi-os.md
+++ b/content/manuals/engine/install/raspberry-pi-os.md
@@ -169,7 +169,7 @@ Docker from the repository.
 
 You have now successfully installed and started Docker Engine.
 
-{{< include "root-errors.md" >}}
+{{% include "root-errors.md" %}}
 
 #### Upgrade Docker Engine
 
@@ -225,14 +225,14 @@ download a new file each time you want to upgrade Docker Engine.
 
 You have now successfully installed and started Docker Engine.
 
-{{< include "root-errors.md" >}}
+{{% include "root-errors.md" %}}
 
 #### Upgrade Docker Engine
 
 To upgrade Docker Engine, download the newer package files and repeat the
 [installation procedure](#install-from-a-package), pointing to the new files.
 
-{{< include "install-script.md" >}}
+{{% include "install-script.md" %}}
 
 ## Uninstall Docker Engine
 

--- a/content/manuals/engine/install/rhel.md
+++ b/content/manuals/engine/install/rhel.md
@@ -165,7 +165,7 @@ $ sudo dnf config-manager --add-repo {{% param "download-url-base" %}}/docker-ce
 
 You have now successfully installed and started Docker Engine.
 
-{{< include "root-errors.md" >}}
+{{% include "root-errors.md" %}}
 
 #### Upgrade Docker Engine
 
@@ -230,7 +230,7 @@ download a new file each time you want to upgrade Docker Engine.
 
 You have now successfully installed and started Docker Engine.
 
-{{< include "root-errors.md" >}}
+{{% include "root-errors.md" %}}
 
 #### Upgrade Docker Engine
 
@@ -238,7 +238,7 @@ To upgrade Docker Engine, download the newer package files and repeat the
 [installation procedure](#install-from-a-package), using `dnf upgrade`
 instead of `dnf install`, and point to the new files.
 
-{{< include "install-script.md" >}}
+{{% include "install-script.md" %}}
 
 ## Uninstall Docker Engine
 

--- a/content/manuals/engine/install/sles.md
+++ b/content/manuals/engine/install/sles.md
@@ -185,7 +185,7 @@ $ sudo zypper addrepo {{% param "download-url-base" %}}/docker-ce.repo
 
 You have now successfully installed and started Docker Engine.
 
-{{< include "root-errors.md" >}}
+{{% include "root-errors.md" %}}
 
 #### Upgrade Docker Engine
 
@@ -234,7 +234,7 @@ download a new file each time you want to upgrade Docker Engine.
 
 You have now successfully installed and started Docker Engine.
 
-{{< include "root-errors.md" >}}
+{{% include "root-errors.md" %}}
 
 #### Upgrade Docker Engine
 
@@ -242,7 +242,7 @@ To upgrade Docker Engine, download the newer package files and repeat the
 [installation procedure](#install-from-a-package), using `zypper -y upgrade`
 instead of `zypper -y install`, and point to the new files.
 
-{{< include "install-script.md" >}}
+{{% include "install-script.md" %}}
 
 ## Uninstall Docker Engine
 

--- a/content/manuals/engine/install/ubuntu.md
+++ b/content/manuals/engine/install/ubuntu.md
@@ -184,7 +184,7 @@ Docker from the repository.
 
 You have now successfully installed and started Docker Engine.
 
-{{< include "root-errors.md" >}}
+{{% include "root-errors.md" %}}
 
 #### Upgrade Docker Engine
 
@@ -240,14 +240,14 @@ download a new file each time you want to upgrade Docker Engine.
 
 You have now successfully installed and started Docker Engine.
 
-{{< include "root-errors.md" >}}
+{{% include "root-errors.md" %}}
 
 #### Upgrade Docker Engine
 
 To upgrade Docker Engine, download the newer package files and repeat the
 [installation procedure](#install-from-a-package), pointing to the new files.
 
-{{< include "install-script.md" >}}
+{{% include "install-script.md" %}}
 
 ## Uninstall Docker Engine
 

--- a/content/manuals/engine/swarm/_index.md
+++ b/content/manuals/engine/swarm/_index.md
@@ -46,7 +46,7 @@ aliases:
 - /swarm/swarm_at_scale/troubleshoot/
 ---
 
-{{< include "swarm-mode.md" >}}
+{{% include "swarm-mode.md" %}}
 
 Current versions of Docker include Swarm mode for natively managing a cluster
 of Docker Engines called a swarm. Use the Docker CLI to create a swarm, deploy

--- a/content/manuals/engine/swarm/stack-deploy.md
+++ b/content/manuals/engine/swarm/stack-deploy.md
@@ -8,7 +8,7 @@ When running Docker Engine in swarm mode, you can use `docker stack deploy` to
 deploy a complete application stack to the swarm. The `deploy` command accepts
 a stack description in the form of a [Compose file](/reference/compose-file/legacy-versions.md).
 
-{{< include "swarm-compose-compat.md" >}}
+{{% include "swarm-compose-compat.md" %}}
 
 To run through this tutorial, you need:
 

--- a/content/manuals/extensions/extensions-sdk/_index.md
+++ b/content/manuals/extensions/extensions-sdk/_index.md
@@ -47,6 +47,6 @@ For further information, see [Architecture](architecture/_index.md).
 You distribute extensions through Docker Hub. However, you can develop them locally without the need to push 
 the extension to Docker Hub. See [Extensions distribution](extensions/DISTRIBUTION.md) for further details.
 
-{{< include "extensions-form.md" >}}
+{{% include "extensions-form.md" %}}
 
 {{< grid >}}

--- a/content/manuals/extensions/extensions-sdk/extensions/_index.md
+++ b/content/manuals/extensions/extensions-sdk/extensions/_index.md
@@ -44,4 +44,4 @@ Extensions published in the Marketplace benefit from update notifications to all
 
 In addition to providing a description of your extension's features and screenshots, you should also specify additional URLs using [extension labels](labels.md). This direct users to your website for reporting bugs and feedback, and accessing documentation and support.
 
-{{< include "extensions-form.md" >}}
+{{% include "extensions-form.md" %}}

--- a/content/manuals/extensions/extensions-sdk/process.md
+++ b/content/manuals/extensions/extensions-sdk/process.md
@@ -42,7 +42,7 @@ Docker Desktop displays published extensions in the Extensions Marketplace. The 
 
 If you want your extension published in the Marketplace, read the [publish documentation](extensions/publish.md).
 
-{{< include "extensions-form.md" >}}
+{{% include "extensions-form.md" %}}
 
 ## What’s next?
 

--- a/content/manuals/scout/integrations/environment/cli.md
+++ b/content/manuals/scout/integrations/environment/cli.md
@@ -5,7 +5,7 @@ title: Generic environment integration with CLI
 linkTitle: Generic (CLI)
 ---
 
-{{< include "scout-early-access.md" >}}
+{{% include "scout-early-access.md" %}}
 
 You can create a generic environment integration by running the Docker Scout
 CLI client in your CI workflows. The CLI client is available as a binary on

--- a/content/manuals/scout/integrations/environment/sysdig.md
+++ b/content/manuals/scout/integrations/environment/sysdig.md
@@ -5,7 +5,7 @@ description: Integrate your runtime environments with Docker Scout using Sysdig
 keywords: scout, sysdig, integration, image analysis, environments, supply chain
 ---
 
-{{< include "scout-early-access.md" >}}
+{{% include "scout-early-access.md" %}}
 
 The Sysdig integration enables Docker Scout to automatically detect the images
 you're using for your running workloads. Activating this integration gives you

--- a/content/manuals/security/for-admins/domain-audit.md
+++ b/content/manuals/security/for-admins/domain-audit.md
@@ -52,7 +52,7 @@ Before you audit your domains, review the following required prerequisites:
 {{< /tab >}}
 {{< tab name="Admin Console" >}}
 
-{{< include "admin-early-access.md" >}}
+{{% include "admin-early-access.md" %}}
 
 {{% admin-domain-audit product="admin" %}}
 

--- a/content/manuals/security/for-admins/hardened-desktop/image-access-management.md
+++ b/content/manuals/security/for-admins/hardened-desktop/image-access-management.md
@@ -31,7 +31,7 @@ You first need to [enforce sign-in](/manuals/security/for-admins/enforce-sign-in
 {{< /tab >}}
 {{< tab name="Admin Console" >}}
 
-{{< include "admin-early-access.md" >}}
+{{% include "admin-early-access.md" %}}
 
 {{% admin-image-access product="admin" %}}
 

--- a/content/manuals/security/for-admins/hardened-desktop/registry-access-management.md
+++ b/content/manuals/security/for-admins/hardened-desktop/registry-access-management.md
@@ -46,7 +46,7 @@ feature always takes effect.
 {{< /tab >}}
 {{< tab name="Admin Console" >}}
 
-{{< include "admin-early-access.md" >}}
+{{% include "admin-early-access.md" %}}
 
 {{% admin-registry-access product="admin" %}}
 

--- a/content/manuals/security/for-admins/provisioning/scim.md
+++ b/content/manuals/security/for-admins/provisioning/scim.md
@@ -53,7 +53,7 @@ You must [configure SSO](../single-sign-on/configure/_index.md) before you enabl
 {{< tabs >}}
 {{< tab name="Admin Console" >}}
 
-{{< include "admin-early-access.md" >}}
+{{% include "admin-early-access.md" %}}
 
 {{% admin-scim product="admin" %}}
 
@@ -245,7 +245,7 @@ If SCIM is disabled, any user provisioned through SCIM will remain in the organi
 {{< tabs >}}
 {{< tab name="Admin Console" >}}
 
-{{< include "admin-early-access.md" >}}
+{{% include "admin-early-access.md" %}}
 
 {{% admin-scim-disable product="admin" %}}
 

--- a/content/manuals/security/for-admins/single-sign-on/configure.md
+++ b/content/manuals/security/for-admins/single-sign-on/configure.md
@@ -21,7 +21,7 @@ Get started creating a single sign-on (SSO) connection for your organization or 
 {{< tabs >}}
 {{< tab name="Admin Console" >}}
 
-{{< include "admin-early-access.md" >}}
+{{% include "admin-early-access.md" %}}
 
 1. Sign in to the [Admin Console](https://admin.docker.com/).
 2. Select your organization or company from the **Choose profile** page. Note that when an organization is part of a company, you must select the company and configure the domain for the organization at the company level.
@@ -50,7 +50,7 @@ Verifying your domain ensures Docker knows you own it. Domain verification is do
 {{< tabs >}}
 {{< tab name="Admin Console" >}}
 
-{{< include "admin-early-access.md" >}}
+{{% include "admin-early-access.md" %}}
 
 1. Navigate to your domain host, create a new TXT record, and paste the **TXT Record Value** from Docker.
 2. TXT record verification can take 72 hours. Once you have waited for TXT record verification, return to the **Domain management** page of the Admin Console and select **Verify** next to your domain name.

--- a/content/manuals/security/for-admins/single-sign-on/connect.md
+++ b/content/manuals/security/for-admins/single-sign-on/connect.md
@@ -30,7 +30,7 @@ Make sure you have completed the following before you begin:
 {{< tabs >}}
 {{< tab name="Admin Console" >}}
 
-{{< include "admin-early-access.md" >}}
+{{% include "admin-early-access.md" %}}
 
 1. Sign in to the [Admin Console](https://admin.docker.com/).
 2. Select your organization or company from the **Choose profile** page. Note that when an organization is part of a company, you must select the company and configure the domain for the organization at the company level.

--- a/content/manuals/security/for-admins/single-sign-on/manage.md
+++ b/content/manuals/security/for-admins/single-sign-on/manage.md
@@ -16,7 +16,7 @@ aliases:
 >
 > You must have a [company](/admin/company/) to manage more than one organization.
 
-{{< include "admin-early-access.md" >}}
+{{% include "admin-early-access.md" %}}
 
 {{% admin-sso-management-orgs product="admin" %}}
 
@@ -25,7 +25,7 @@ aliases:
 {{< tabs >}}
 {{< tab name="Admin Console" >}}
 
-{{< include "admin-early-access.md" >}}
+{{% include "admin-early-access.md" %}}
 
 {{% admin-sso-management product="admin" %}}
 
@@ -42,7 +42,7 @@ aliases:
 {{< tabs >}}
 {{< tab name="Admin Console" >}}
 
-{{< include "admin-early-access.md" >}}
+{{% include "admin-early-access.md" %}}
 
 {{% admin-sso-management-connections product="admin" %}}
 

--- a/content/manuals/subscription/change.md
+++ b/content/manuals/subscription/change.md
@@ -15,7 +15,7 @@ aliases:
 weight: 30
 ---
 
-{{< include "tax-compliance.md" >}}
+{{% include "tax-compliance.md" %}}
 
 The following sections describe how to change plans when you have a Docker
 subscription plan or legacy Docker subscription plan.

--- a/content/manuals/subscription/manage-seats.md
+++ b/content/manuals/subscription/manage-seats.md
@@ -17,7 +17,7 @@ You can add seats at anytime to your existing subscription.
 
 When you add seats to your subscription in the middle of your billing cycle, you are charged a prorated amount for the additional seats.
 
-{{< include "tax-compliance.md" >}}
+{{% include "tax-compliance.md" %}}
 
 ## Add seats
 

--- a/content/manuals/subscription/scale.md
+++ b/content/manuals/subscription/scale.md
@@ -64,7 +64,7 @@ charges, pre-purchase additional minutes.
 
 ## Add Docker Hub storage or image pulls
 
-{{< include "hub-limits.md" >}}
+{{% include "hub-limits.md" %}}
 
 You can pre-purchase images pulls and storage by [contacting
 sales](https://www.docker.com/pricing/contact-sales/).

--- a/content/manuals/subscription/setup.md
+++ b/content/manuals/subscription/setup.md
@@ -9,7 +9,7 @@ Docker subscriptions offer features and benefits to support both new and profess
 
 In this section, learn how to get started with a Docker subscription for individuals or for organizations. Before you begin, make sure you have a [Docker ID](../accounts/create-account.md).
 
-{{< include "tax-compliance.md" >}}
+{{% include "tax-compliance.md" %}}
 
 ## Set up a Docker subscription for a personal account
 

--- a/content/reference/cli/docker/scout/integration/_index.md
+++ b/content/reference/cli/docker/scout/integration/_index.md
@@ -15,4 +15,4 @@ repository on GitHub:
 https://github.com/docker/scout-cli
 -->
 
-{{< include "scout-early-access.md" >}}
+{{% include "scout-early-access.md" %}}

--- a/content/reference/cli/docker/scout/integration/configure.md
+++ b/content/reference/cli/docker/scout/integration/configure.md
@@ -15,4 +15,4 @@ repository on GitHub:
 https://github.com/docker/scout-cli
 -->
 
-{{< include "scout-early-access.md" >}}
+{{% include "scout-early-access.md" %}}

--- a/content/reference/cli/docker/scout/integration/delete.md
+++ b/content/reference/cli/docker/scout/integration/delete.md
@@ -15,4 +15,4 @@ repository on GitHub:
 https://github.com/docker/scout-cli
 -->
 
-{{< include "scout-early-access.md" >}}
+{{% include "scout-early-access.md" %}}

--- a/content/reference/cli/docker/scout/integration/list.md
+++ b/content/reference/cli/docker/scout/integration/list.md
@@ -15,4 +15,4 @@ repository on GitHub:
 https://github.com/docker/scout-cli
 -->
 
-{{< include "scout-early-access.md" >}}
+{{% include "scout-early-access.md" %}}

--- a/content/reference/compose-file/build.md
+++ b/content/reference/compose-file/build.md
@@ -7,7 +7,7 @@ aliases:
 weight: 130
 ---
 
-{{< include "compose/build.md" >}}
+{{% include "compose/build.md" %}}
 
 In the former case, the whole path is used as a Docker context to execute a Docker build, looking for a canonical
 `Dockerfile` at the root of the directory. The path can be absolute or relative. If it is relative, it is resolved

--- a/content/reference/compose-file/configs.md
+++ b/content/reference/compose-file/configs.md
@@ -7,7 +7,7 @@ aliases:
 weight: 50
 ---
 
-{{< include "compose/configs.md" >}}
+{{% include "compose/configs.md" %}}
 
 Services can only access configs when explicitly granted by a [`configs`](services.md#configs) attribute within the `services` top-level element.
 

--- a/content/reference/compose-file/deploy.md
+++ b/content/reference/compose-file/deploy.md
@@ -7,7 +7,7 @@ aliases:
 weight: 140
 ---
 
-{{< include "compose/deploy.md" >}}
+{{% include "compose/deploy.md" %}}
 
 ## Attributes
 

--- a/content/reference/compose-file/develop.md
+++ b/content/reference/compose-file/develop.md
@@ -11,7 +11,7 @@ weight: 150
 >
 > Develop is an optional part of the Compose Specification. It is available with Docker Compose version 2.22.0 and later.
 
-{{< include "compose/develop.md" >}}
+{{% include "compose/develop.md" %}}
 
 This page defines how Compose behaves to efficiently assist you and defines the development constraints and workflows set by Compose. Only a subset of Compose file services may require a `develop` subsection.
 

--- a/content/reference/compose-file/extension.md
+++ b/content/reference/compose-file/extension.md
@@ -7,7 +7,7 @@ aliases:
 weight: 80
 ---
 
-{{< include "compose/extension.md" >}}
+{{% include "compose/extension.md" %}}
 
 Extensions can also be used with [anchors and aliases](fragments.md).
 

--- a/content/reference/compose-file/fragments.md
+++ b/content/reference/compose-file/fragments.md
@@ -7,7 +7,7 @@ aliases:
 weight: 70
 ---
 
-{{< include "compose/fragments.md" >}}
+{{% include "compose/fragments.md" %}}
 
 Anchors are created using the `&` sign. The sign is followed by an alias name. You can use this alias with the `*` sign later to reference the value following the anchor. Make sure there is no space between the `&` and the `*` characters and the following alias name. 
 

--- a/content/reference/compose-file/interpolation.md
+++ b/content/reference/compose-file/interpolation.md
@@ -7,7 +7,7 @@ aliases:
 weight: 90
 ---
 
-{{< include "compose/interpolation.md" >}}
+{{% include "compose/interpolation.md" %}}
 
 For braced expressions, the following formats are supported:
 - Direct substitution

--- a/content/reference/compose-file/merge.md
+++ b/content/reference/compose-file/merge.md
@@ -7,7 +7,7 @@ aliases:
 weight: 100
 ---
 
-{{< include "compose/merge.md" >}}
+{{% include "compose/merge.md" %}}
 
 These rules are outlined below. 
 

--- a/content/reference/compose-file/networks.md
+++ b/content/reference/compose-file/networks.md
@@ -7,7 +7,7 @@ aliases:
 weight: 30
 ---
 
-{{< include "compose/networks.md" >}}
+{{% include "compose/networks.md" %}}
 
 To use a network across multiple services, you must explicitly grant each service access by using the [networks](services.md) attribute within the `services` top-level element. The `networks` top-level element has additional syntax that provides more granular control.
 

--- a/content/reference/compose-file/services.md
+++ b/content/reference/compose-file/services.md
@@ -7,7 +7,7 @@ aliases:
 weight: 20
 ---
 
-{{< include "compose/services.md" >}}
+{{% include "compose/services.md" %}}
 
 A Compose file must declare a `services` top-level element as a map whose keys are string representations of service names,
 and whose values are service definitions. A service definition contains the configuration that is applied to each
@@ -405,7 +405,7 @@ configs:
 
 ### `depends_on`
 
-{{< include "compose/services-depends-on.md" >}}
+{{% include "compose/services-depends-on.md" %}}
 
 #### Short syntax
 
@@ -617,7 +617,7 @@ If the value is `[]` (empty list) or `''` (empty string), the default entrypoint
 
 ### `env_file`
 
-{{< include "compose/services-env-file.md" >}} 
+{{% include "compose/services-env-file.md" %}}
 
 ```yml
 env_file: .env
@@ -709,7 +709,7 @@ VAR="quoted"
 
 ### `environment`
 
-{{< include "compose/services-environment.md" >}}
+{{% include "compose/services-environment.md" %}}
 
 Environment variables can be declared by a single key (no value to equals sign). In this case Compose
 relies on you to resolve the value. If the value is not resolved, the variable
@@ -1026,7 +1026,7 @@ been the case if `group_add` were not declared.
 
 ### `healthcheck`
 
-{{< include "compose/services-healthcheck.md" >}} 
+{{% include "compose/services-healthcheck.md" %}}
 
 For more information on `HEALTHCHECK`, see the [Dockerfile reference](/reference/dockerfile.md#healthcheck).
 
@@ -1280,7 +1280,7 @@ Compose file containing both attributes.
 
 ### `networks`
 
-{{< include "compose/services-networks.md" >}}
+{{% include "compose/services-networks.md" %}}
 
 ```yml
 services:
@@ -1469,7 +1469,7 @@ platform: linux/arm64/v8
 
 ### `ports`
 
-{{< include "compose/services-ports.md" >}}
+{{% include "compose/services-ports.md" %}}
 
 > [!NOTE]
 >
@@ -1668,7 +1668,7 @@ When both are set, `scale` must be consistent with the `replicas` attribute in t
 
 ### `secrets`
 
-{{< include "compose/services-secrets.md" >}}
+{{% include "compose/services-secrets.md" %}}
 
 Two different syntax variants are supported; the short syntax and the long syntax. Long and short syntax for secrets may be used in the same Compose file.
 
@@ -1887,7 +1887,7 @@ it is the runtime's decision to assign a UTS namespace, if supported. Available 
 
 ### `volumes`
 
-{{< include "compose/services-volumes.md" >}}
+{{% include "compose/services-volumes.md" %}}
 
 The following example shows a named volume (`db-data`) being used by the `backend` service,
 and a bind mount defined for a single service.

--- a/content/reference/compose-file/volumes.md
+++ b/content/reference/compose-file/volumes.md
@@ -7,7 +7,7 @@ aliases:
 weight: 40
 ---
 
-{{< include "compose/volumes.md" >}}
+{{% include "compose/volumes.md" %}}
 
 To use a volume across multiple services, you must explicitly grant each service access by using the [volumes](services.md#volumes) attribute within the `services` top-level element. The `volumes` attribute has additional syntax that provides more granular control.
 

--- a/layouts/shortcodes/include.html
+++ b/layouts/shortcodes/include.html
@@ -1,4 +1,3 @@
 {{ $fileToInclude := .Get 0 }}
-{{ with (site.GetPage (printf "includes/%s" $fileToInclude)) }}
-  {{ page.RenderString (dict "display" "block") .RenderShortcodes }}
-{{ end }}
+{{ $filePath := printf "includes/%s" $fileToInclude }}
+{{ readFile $filePath | safeHTML }}


### PR DESCRIPTION
## Description
- Problem: Some include shortcodes produce missing H3 ToC headings (ex: https://docker.slack.com/archives/C039ZM6GH4Z/p1737545677728649)
- Fix: Update to include.html uses Hugo readFile function to fix parsing errors and updated all include shortcodes using Find and Replace to use correct syntax: `{{% "include-file" %}}`

## Related issues or tickets
- [ENGDOCS-2398](https://docker.atlassian.net/browse/ENGDOCS-2398?atlOrigin=eyJpIjoiZGE3OTBmY2ExOTliNDVjY2JlOTc4Y2ViY2MwNDI3NDEiLCJwIjoiaiJ9)

## Reviews
- [ ] Technical review

[ENGDOCS-2398]: https://docker.atlassian.net/browse/ENGDOCS-2398?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ