### PR TITLE
uninstall: vmnetd and socket can remain on disk before 4.37

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ resources
 public
 tmp
 static/pagefind
+.idea/

--- a/content/manuals/desktop/uninstall.md
+++ b/content/manuals/desktop/uninstall.md
@@ -80,6 +80,13 @@ $ rm -rf ~/Library/Group\ Containers/group.com.docker
 $ rm -rf ~/.docker
 ```
 
+Before Docker Desktop version `4.37` (excluded), the following files can also be left on the file system (which you can remove with administrative privileges):
+
+```console
+/Library/PrivilegedHelperTools/com.docker.vmnetd
+/Library/PrivilegedHelperTools/com.docker.socket
+```
+
 You can also move the Docker application to the trash. 
 
 {{< /tab >}}


### PR DESCRIPTION
ref: ART-68

<!--Delete sections as needed -->

## Description

Inform users that before `4.37` versions, the uninstaller could leave 2 files on MacOS: `vmnetd` and `socket` in the `/Library/PrivilegedHelperTools` folder.

## Related issues or tickets

ART-68

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [X] Technical review
- [ ] Editorial review
- [ ] Product review