### PR TITLE
Update documentation regarding `target` value in compose file sample

### DIFF
--- a/content/manuals/compose/how-tos/file-watch.md
+++ b/content/manuals/compose/how-tos/file-watch.md
@@ -136,7 +136,7 @@ services:
       watch:
         - action: sync
           path: ./web
-          target: /src/web
+          target: /app/web
           ignore:
             - node_modules/
         - action: rebuild


### PR DESCRIPTION
## Description
The `WORKDIR` in the Dockerfile was set to `/app`, but the `target` in the `compose.yaml` file was incorrectly set to `/src/web` instead of `/app/web`.

## Reviews
- [x] Technical review
- [ ] Editorial review
- [ ] Product review