### PR TITLE
guides: Fix cert extension to be auto-added by update-ca-certificates

### DIFF
--- a/content/guides/zscaler/index.md
+++ b/content/guides/zscaler/index.md
@@ -84,13 +84,13 @@ like this:
 
 ```dockerfile
 FROM debian:bookworm
-COPY zscaler-cert.pem /usr/local/share/ca-certificates/zscaler-cert.pem
+COPY zscaler-root-ca.crt /usr/local/share/ca-certificates/zscaler-root-ca.crt
 RUN apt-get update && \
     apt-get install -y ca-certificates && \
     update-ca-certificates
 ```
 
-Here, `zscaler-cert.pem` is the root certificate, located at the root of the
+Here, `zscaler-root-ca.crt` is the root certificate, located at the root of the
 build context (often within the application's Git repository).
 
 If you use an artifact repository, you can fetch the certificate directly using
@@ -100,7 +100,7 @@ the content digest of the certificate is correct.
 ```dockerfile
 FROM debian:bookworm
 ADD --checksum=sha256:24454f830cdb571e2c4ad15481119c43b3cafd48dd869a9b2945d1036d1dc68d \
-    https://artifacts.example/certs/zscaler-cert.pem /usr/local/share/ca-certificates/zscaler-cert.pem
+    https://artifacts.example/certs/zscaler-root-ca.crt /usr/local/share/ca-certificates/zscaler-root-ca.crt
 RUN apt-get update && \
     apt-get install -y ca-certificates && \
     update-ca-certificates
@@ -123,7 +123,7 @@ RUN --mount=target=. cmake -B output/
 
 FROM debian:bookworm-slim AS final
 ADD --checksum=sha256:24454f830cdb571e2c4ad15481119c43b3cafd48dd869a9b2945d1036d1dc68d \
-    https://artifacts.example/certs/zscaler-cert.pem /usr/local/share/ca-certificates/zscaler-cert.pem
+    https://artifacts.example/certs/zscaler-root-ca.crt /usr/local/share/ca-certificates/zscaler-root-ca.crt
 RUN apt-get update && \
     apt-get install -y ca-certificates && \
     update-ca-certificates


### PR DESCRIPTION
## Description

Use `.crt` extension for zscaler cert file to be correctly auto-added by `update-ca-certificates`.
I also took the liberty to rename the file to mention `root-ca` to make it more explicit.

ref: https://manpages.org/update-ca-certificates/8
> Certificates must have a .crt extension in order to be included by update-ca-certificates.
>
> Furthermore all certificates with a .crt extension found below /usr/local/share/ca-certificates are also included as implicitly trusted. 

## Related issues or tickets

Closes #21918 

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Technical review
- [ ] Editorial review
- [ ] Product review

/cc @dvdksn 