### PR TITLE
fix: hugo includes rendering bug

### DIFF
--- a/content/includes/admin-early-access.md
+++ b/content/includes/admin-early-access.md
@@ -1,8 +1,0 @@
----
----
-
-{{% restricted title="Early Access" %}}
-The Docker Admin Console is an [early access](/release-lifecycle#early-access-ea) product.
-
-It's available to all company owners and organization owners. You can still manage organizations in Docker Hub, but the Admin Console includes company-level management and enhanced features for organization management.
-{{% /restricted %}}

--- a/content/manuals/admin/company/new-company.md
+++ b/content/manuals/admin/company/new-company.md
@@ -12,9 +12,9 @@ You can create a new company in the Docker Admin Console. Before you begin, you 
 - Be the owner of the organization you want to add to your company
 - Have a Docker Business subscription
 
-{{% include "admin-early-access.md" %}}
-
 ## Create a company
+
+{{< summary-bar feature_name="Admin console early access" >}}
 
 To create a new company:
 

--- a/content/manuals/admin/company/organizations.md
+++ b/content/manuals/admin/company/organizations.md
@@ -8,9 +8,9 @@ title: Manage company organizations
 
 You can manage the organizations in a company in the Docker Admin Console.
 
-{{% include "admin-early-access.md" %}}
-
 ## View all organizations
+
+{{< summary-bar feature_name="Admin console early access" >}}
 
 1. Sign in to the [Admin Console](https://admin.docker.com).
 2. Select your company on the **Choose profile** page.
@@ -26,6 +26,8 @@ For more information about adding seats, see [Manage seats](/manuals/subscriptio
 
 ## Add organizations to a company
 
+{{< summary-bar feature_name="Admin console early access" >}}
+
 You must be a company owner to add an organization to a company. You must also be an organization owner of the organization you want to add. There is no limit to the number of organizations you can have under a company layer. All organizations must have a Business subscription.
 
 > [!IMPORTANT]
@@ -40,6 +42,8 @@ You must be a company owner to add an organization to a company. You must also b
 6. Select **Add organization** to confirm.
 
 ## Manage an organization
+
+{{< summary-bar feature_name="Admin console early access" >}}
 
 1. Sign in to the [Admin Console](https://admin.docker.com).
 2. Select your company on the **Choose profile** page.

--- a/content/manuals/admin/company/owners.md
+++ b/content/manuals/admin/company/owners.md
@@ -15,9 +15,9 @@ owners for all associated organizations. Unlike organization owners, company
 owners don't need to be member of an organization. When company owners aren't a
 member in an organization, they don't occupy a seat.
 
-{{% include "admin-early-access.md" %}}
-
 ## Add a company owner
+
+{{< summary-bar feature_name="Admin console early access" >}}
 
 1. Sign in to the [Admin Console](https://admin.docker.com).
 2. Select your company on the **Choose profile** page.
@@ -27,6 +27,8 @@ member in an organization, they don't occupy a seat.
 6. After you find the user, select **Add company owner**.
 
 ## Remove a company owner
+
+{{< summary-bar feature_name="Admin console early access" >}}
 
 1. Sign in to the [Admin Console](https://admin.docker.com).
 2. Select your company on the **Choose profile** page.

--- a/content/manuals/admin/company/users.md
+++ b/content/manuals/admin/company/users.md
@@ -10,8 +10,8 @@ You can manage users at the company-level in the Docker Admin Console.
 
 {{% admin-users product="admin" layer="company" %}}
 
-{{% include "admin-early-access.md" %}}
-
 ## Manage members on a team
+
+{{< summary-bar feature_name="Admin console early access" >}}
 
 Use Docker Hub to add a member to a team or remove a member from a team. For more details, see [Manage members in Docker Hub](../organization/members.md#manage-members-on-a-team).

--- a/content/manuals/admin/company/users.md
+++ b/content/manuals/admin/company/users.md
@@ -12,6 +12,4 @@ You can manage users at the company-level in the Docker Admin Console.
 
 ## Manage members on a team
 
-{{< summary-bar feature_name="Admin console early access" >}}
-
 Use Docker Hub to add a member to a team or remove a member from a team. For more details, see [Manage members in Docker Hub](../organization/members.md#manage-members-on-a-team).

--- a/content/manuals/admin/deactivate-account.md
+++ b/content/manuals/admin/deactivate-account.md
@@ -31,6 +31,8 @@ Before deactivating an organization, complete the following:
 
 ## Deactivate
 
+{{< summary-bar feature_name="Admin console early access" >}}
+
 Once you have completed all the previous steps, you can deactivate your organization.
 
 > [!WARNING]

--- a/content/manuals/admin/organization/activity-logs.md
+++ b/content/manuals/admin/organization/activity-logs.md
@@ -22,6 +22,8 @@ Owners can also see the activity logs for their repository if the repository is 
 
 ## Manage activity logs
 
+{{< summary-bar feature_name="Admin console early access" >}}
+
 {{< tabs >}}
 {{< tab name="Docker Hub" >}}
 
@@ -29,8 +31,6 @@ Owners can also see the activity logs for their repository if the repository is 
 
 {{< /tab >}}
 {{< tab name="Admin Console" >}}
-
-{{% include "admin-early-access.md" %}}
 
 {{% admin-org-audit-log product="admin" %}}
 

--- a/content/manuals/admin/organization/general-settings.md
+++ b/content/manuals/admin/organization/general-settings.md
@@ -5,7 +5,7 @@ description: Learn how to manage settings for organizations using Docker Admin C
 keywords: organization, settings, Admin Console
 ---
 
-{{% include "admin-early-access.md" %}}
+{{< summary-bar feature_name="Admin console early access" >}}
 
 This section describes how to manage organization settings in the Docker Admin Console.
 

--- a/content/manuals/admin/organization/insights.md
+++ b/content/manuals/admin/organization/insights.md
@@ -30,7 +30,7 @@ Key benefits include:
 
 ## View Insights for organization users
 
-{{% include "admin-early-access.md" %}}
+{{< summary-bar feature_name="Admin console early access" >}}
 
 To access Insights, you must contact your Customer Success Manager to have the
 feature enabled. Once the feature is enabled, access Insights using the following

--- a/content/manuals/admin/organization/manage-a-team.md
+++ b/content/manuals/admin/organization/manage-a-team.md
@@ -34,6 +34,8 @@ The organization owner can also add additional organization owners to help them 
 
 ## Create a team
 
+{{< summary-bar feature_name="Admin console early access" >}}
+
 {{< tabs >}}
 {{< tab name="Docker Hub" >}}
 
@@ -45,8 +47,6 @@ The organization owner can also add additional organization owners to help them 
 
 {{< /tab >}}
 {{< tab name="Admin Console" >}}
-
-{{% include "admin-early-access.md" %}}
 
 1. In Admin Console, select your organization.
 2. In the **User management** section, select **Teams**.
@@ -117,6 +117,8 @@ To view a team's permissions across all repositories:
 
 ## Delete a team
 
+{{< summary-bar feature_name="Admin console early access" >}}
+
 Organization owners can delete a team in Docker Hub or Admin Console. When you remove a team from your organization, this action revokes the members' access to the team's permitted resources. It won't remove users from other teams that they belong to, nor will it delete any resources.
 
 {{< tabs >}}
@@ -132,8 +134,6 @@ Organization owners can delete a team in Docker Hub or Admin Console. When you r
 
 {{< /tab >}}
 {{< tab name="Admin Console" >}}
-
-{{% include "admin-early-access.md" %}}
 
 1. In the [Admin Console](https://app.docker.com/admin), select your organization.
 2. In the **User management** section, select **Teams**.

--- a/content/manuals/admin/organization/members.md
+++ b/content/manuals/admin/organization/members.md
@@ -19,7 +19,7 @@ Learn how to manage members for your organization in Docker Hub and the Docker A
 {{< /tab >}}
 {{< tab name="Admin Console" >}}
 
-{{% include "admin-early-access.md" %}}
+{{< summary-bar feature_name="Admin console early access" >}}
 
 {{% admin-users product="admin" %}}
 
@@ -66,7 +66,7 @@ To resend an invitation from Docker Hub:
 {{< /tab >}}
 {{< tab name="Admin Console" >}}
 
-{{% include "admin-early-access.md" %}}
+{{< summary-bar feature_name="Admin console early access" >}}
 
 To resend an invitation from the Admin Console:
 
@@ -93,7 +93,7 @@ To remove a member's invitation from Docker Hub:
 {{< /tab >}}
 {{< tab name="Admin Console" >}}
 
-{{% include "admin-early-access.md" %}}
+{{< summary-bar feature_name="Admin console early access" >}}
 
 To remove an invitation from the Admin Console:
 
@@ -132,7 +132,7 @@ To add a member to a team with Docker Hub:
 {{< /tab >}}
 {{< tab name="Admin Console" >}}
 
-{{% include "admin-early-access.md" %}}
+{{< summary-bar feature_name="Admin console early access" >}}
 
 To add a member to a team with the Admin Console:
 
@@ -164,7 +164,7 @@ To remove a member from a specific team with Docker Hub:
 {{< /tab >}}
 {{< tab name="Admin Console" >}}
 
-{{% include "admin-early-access.md" %}}
+{{< summary-bar feature_name="Admin console early access" >}}
 
 To remove a member from a specific team with the Admin Console:
 
@@ -219,7 +219,7 @@ To export a CSV file of your members:
 {{< /tab >}}
 {{< tab name="Admin Console" >}}
 
-{{% include "admin-early-access.md" %}}
+{{< summary-bar feature_name="Admin console early access" >}}
 
 To export a CSV file of your members:
 

--- a/content/manuals/admin/organization/members.md
+++ b/content/manuals/admin/organization/members.md
@@ -11,6 +11,8 @@ Learn how to manage members for your organization in Docker Hub and the Docker A
 
 ## Invite members
 
+{{< summary-bar feature_name="Admin console early access" >}}
+
 {{< tabs >}}
 {{< tab name="Docker Hub" >}}
 
@@ -18,8 +20,6 @@ Learn how to manage members for your organization in Docker Hub and the Docker A
 
 {{< /tab >}}
 {{< tab name="Admin Console" >}}
-
-{{< summary-bar feature_name="Admin console early access" >}}
 
 {{% admin-users product="admin" %}}
 
@@ -52,6 +52,8 @@ After inviting members, you can resend or remove invitations as needed.
 
 ### Resend an invitation
 
+{{< summary-bar feature_name="Admin console early access" >}}
+
 {{< tabs >}}
 {{< tab name="Docker Hub" >}}
 
@@ -66,8 +68,6 @@ To resend an invitation from Docker Hub:
 {{< /tab >}}
 {{< tab name="Admin Console" >}}
 
-{{< summary-bar feature_name="Admin console early access" >}}
-
 To resend an invitation from the Admin Console:
 
 1. In the [Admin Console](https://app.docker.com/admin), select your organization.
@@ -79,6 +79,8 @@ To resend an invitation from the Admin Console:
 {{< /tabs >}}
 
 ### Remove an invitation
+
+{{< summary-bar feature_name="Admin console early access" >}}
 
 {{< tabs >}}
 {{< tab name="Docker Hub" >}}
@@ -92,8 +94,6 @@ To remove a member's invitation from Docker Hub:
 
 {{< /tab >}}
 {{< tab name="Admin Console" >}}
-
-{{< summary-bar feature_name="Admin console early access" >}}
 
 To remove an invitation from the Admin Console:
 
@@ -110,6 +110,8 @@ To remove an invitation from the Admin Console:
 Use Docker Hub or the Admin Console to add or remove team members. Organization owners can add a member to one or more teams within an organization.
 
 ### Add a member to a team
+
+{{< summary-bar feature_name="Admin console early access" >}}
 
 {{< tabs >}}
 {{< tab name="Docker Hub" >}}
@@ -132,8 +134,6 @@ To add a member to a team with Docker Hub:
 {{< /tab >}}
 {{< tab name="Admin Console" >}}
 
-{{< summary-bar feature_name="Admin console early access" >}}
-
 To add a member to a team with the Admin Console:
 
 1. In the [Admin Console](https://app.docker.com/admin), select your organization.
@@ -149,6 +149,8 @@ To add a member to a team with the Admin Console:
 
 ### Remove a member from a team
 
+{{< summary-bar feature_name="Admin console early access" >}}
+
 Organization owners can remove a member from a team in Docker Hub or Admin Console. Removing the member from the team will revoke their access to the permitted resources.
 
 {{< tabs >}}
@@ -163,8 +165,6 @@ To remove a member from a specific team with Docker Hub:
 
 {{< /tab >}}
 {{< tab name="Admin Console" >}}
-
-{{< summary-bar feature_name="Admin console early access" >}}
 
 To remove a member from a specific team with the Admin Console:
 
@@ -218,8 +218,6 @@ To export a CSV file of your members:
 
 {{< /tab >}}
 {{< tab name="Admin Console" >}}
-
-{{< summary-bar feature_name="Admin console early access" >}}
 
 To export a CSV file of your members:
 

--- a/content/manuals/admin/organization/onboard.md
+++ b/content/manuals/admin/organization/onboard.md
@@ -13,8 +13,6 @@ aliases:
 
 {{< summary-bar feature_name="Admin orgs" >}}
 
-{{% include "admin-early-access.md" %}}
-
 Learn how to onboard your organization using Docker Hub or the Docker Admin Console.
 
 Onboarding your organization lets administrators gain visibility into user activity and enforce security settings. In addition, members of your organization receive increased pull limits and other organization wide benefits. For more details, see [Docker subscriptions and features](../../subscription/details.md).

--- a/content/manuals/admin/organization/orgs.md
+++ b/content/manuals/admin/organization/orgs.md
@@ -17,6 +17,8 @@ This section describes how to create an organization. Before you begin:
 
 ## Create an organization
 
+{{< summary-bar feature_name="Admin console early access" >}}
+
 There are multiple ways to create an organization. You can either:
 - Create a new organization using the **Create Organization** option in Docker Hub
 - Convert an existing user account to an organization
@@ -53,8 +55,6 @@ You've now created an organization.
 {{< /tab >}}
 {{< tab name="Admin Console" >}}
 
-{{% include "admin-early-access.md" %}}
-
 To create an organization:
 
 1. Sign in to [Docker Home](https://app.docker.com/).
@@ -84,6 +84,8 @@ You've now created an organization.
 {{< /tabs >}}
 
 ## View an organization
+
+{{< summary-bar feature_name="Admin console early access" >}}
 
 {{< tabs >}}
 {{< tab name="Docker Hub" >}}
@@ -137,8 +139,6 @@ configure your organization.
 
 {{< /tab >}}
 {{< tab name="Admin Console" >}}
-
-{{% include "admin-early-access.md" %}}
 
 To view an organization in the Admin Console:
 

--- a/content/manuals/security/for-admins/domain-audit.md
+++ b/content/manuals/security/for-admins/domain-audit.md
@@ -44,6 +44,8 @@ Before you audit your domains, review the following required prerequisites:
 
 ## Audit your domains for uncaptured users
 
+{{< summary-bar feature_name="Admin console early access" >}}
+
 {{< tabs >}}
 {{< tab name="Docker Hub" >}}
 
@@ -51,8 +53,6 @@ Before you audit your domains, review the following required prerequisites:
 
 {{< /tab >}}
 {{< tab name="Admin Console" >}}
-
-{{% include "admin-early-access.md" %}}
 
 {{% admin-domain-audit product="admin" %}}
 

--- a/content/manuals/security/for-admins/hardened-desktop/image-access-management.md
+++ b/content/manuals/security/for-admins/hardened-desktop/image-access-management.md
@@ -23,6 +23,8 @@ You first need to [enforce sign-in](/manuals/security/for-admins/enforce-sign-in
 
 ## Configure
 
+{{< summary-bar feature_name="Admin console early access" >}}
+
 {{< tabs >}}
 {{< tab name="Docker Hub" >}}
 
@@ -30,8 +32,6 @@ You first need to [enforce sign-in](/manuals/security/for-admins/enforce-sign-in
 
 {{< /tab >}}
 {{< tab name="Admin Console" >}}
-
-{{% include "admin-early-access.md" %}}
 
 {{% admin-image-access product="admin" %}}
 

--- a/content/manuals/security/for-admins/hardened-desktop/registry-access-management.md
+++ b/content/manuals/security/for-admins/hardened-desktop/registry-access-management.md
@@ -38,6 +38,8 @@ feature always takes effect.
 
 ## Configure Registry Access Management permissions
 
+{{< summary-bar feature_name="Admin console early access" >}}
+
 {{< tabs >}}
 {{< tab name="Docker Hub" >}}
 
@@ -45,8 +47,6 @@ feature always takes effect.
 
 {{< /tab >}}
 {{< tab name="Admin Console" >}}
-
-{{% include "admin-early-access.md" %}}
 
 {{% admin-registry-access product="admin" %}}
 

--- a/content/manuals/security/for-admins/provisioning/scim.md
+++ b/content/manuals/security/for-admins/provisioning/scim.md
@@ -48,12 +48,12 @@ For additional details about supported attributes and SCIM, see [Docker Hub API 
 
 ## Enable SCIM in Docker
 
+{{< summary-bar feature_name="Admin console early access" >}}
+
 You must [configure SSO](../single-sign-on/configure/_index.md) before you enable SCIM. Enforcing SSO isn't required to use SCIM.
 
 {{< tabs >}}
 {{< tab name="Admin Console" >}}
-
-{{% include "admin-early-access.md" %}}
 
 {{% admin-scim product="admin" %}}
 
@@ -245,7 +245,7 @@ If SCIM is disabled, any user provisioned through SCIM will remain in the organi
 {{< tabs >}}
 {{< tab name="Admin Console" >}}
 
-{{% include "admin-early-access.md" %}}
+{{< summary-bar feature_name="Admin console early access" >}}
 
 {{% admin-scim-disable product="admin" %}}
 

--- a/content/manuals/security/for-admins/provisioning/scim.md
+++ b/content/manuals/security/for-admins/provisioning/scim.md
@@ -240,12 +240,12 @@ See the documentation for your IdP for additional details:
 
 ## Disable SCIM
 
+{{< summary-bar feature_name="Admin console early access" >}}
+
 If SCIM is disabled, any user provisioned through SCIM will remain in the organization. Future changes for your users will not sync from your IdP. User de-provisioning is only possible when manually removing the user from the organization.
 
 {{< tabs >}}
 {{< tab name="Admin Console" >}}
-
-{{< summary-bar feature_name="Admin console early access" >}}
 
 {{% admin-scim-disable product="admin" %}}
 

--- a/content/manuals/security/for-admins/single-sign-on/configure.md
+++ b/content/manuals/security/for-admins/single-sign-on/configure.md
@@ -45,12 +45,12 @@ Get started creating a single sign-on (SSO) connection for your organization or 
 
 ## Step two: Verify your domain
 
+{{< summary-bar feature_name="Admin console early access" >}}
+
 Verifying your domain ensures Docker knows you own it. Domain verification is done by adding your Docker TXT Record Value to your domain host. The TXT Record Value proves ownership, which signals the Domain Name System (DNS) to add this record. It can take up to 72 hours for DNS to recognize the change. When the change is reflected in DNS, Docker will automatically check the record to confirm your ownership.
 
 {{< tabs >}}
 {{< tab name="Admin Console" >}}
-
-{{< summary-bar feature_name="Admin console early access" >}}
 
 1. Navigate to your domain host, create a new TXT record, and paste the **TXT Record Value** from Docker.
 2. TXT record verification can take 72 hours. Once you have waited for TXT record verification, return to the **Domain management** page of the Admin Console and select **Verify** next to your domain name.

--- a/content/manuals/security/for-admins/single-sign-on/configure.md
+++ b/content/manuals/security/for-admins/single-sign-on/configure.md
@@ -18,10 +18,10 @@ Get started creating a single sign-on (SSO) connection for your organization or 
 
 ## Step one: Add your domain
 
+{{< summary-bar feature_name="Admin console early access" >}}
+
 {{< tabs >}}
 {{< tab name="Admin Console" >}}
-
-{{% include "admin-early-access.md" %}}
 
 1. Sign in to the [Admin Console](https://admin.docker.com/).
 2. Select your organization or company from the **Choose profile** page. Note that when an organization is part of a company, you must select the company and configure the domain for the organization at the company level.
@@ -50,7 +50,7 @@ Verifying your domain ensures Docker knows you own it. Domain verification is do
 {{< tabs >}}
 {{< tab name="Admin Console" >}}
 
-{{% include "admin-early-access.md" %}}
+{{< summary-bar feature_name="Admin console early access" >}}
 
 1. Navigate to your domain host, create a new TXT record, and paste the **TXT Record Value** from Docker.
 2. TXT record verification can take 72 hours. Once you have waited for TXT record verification, return to the **Domain management** page of the Admin Console and select **Verify** next to your domain name.

--- a/content/manuals/security/for-admins/single-sign-on/connect.md
+++ b/content/manuals/security/for-admins/single-sign-on/connect.md
@@ -23,14 +23,14 @@ Make sure you have completed the following before you begin:
 
 ## Step one: Create an SSO connection in Docker
 
+{{< summary-bar feature_name="Admin console early access" >}}
+
 >[!NOTE]
 >
 > Before creating an SSO connection in Docker, you must verify at least one domain.
 
 {{< tabs >}}
 {{< tab name="Admin Console" >}}
-
-{{% include "admin-early-access.md" %}}
 
 1. Sign in to the [Admin Console](https://admin.docker.com/).
 2. Select your organization or company from the **Choose profile** page. Note that when an organization is part of a company, you must select the company and configure the domain for the organization at the company level.

--- a/content/manuals/security/for-admins/single-sign-on/manage.md
+++ b/content/manuals/security/for-admins/single-sign-on/manage.md
@@ -12,20 +12,20 @@ aliases:
 
 ## Manage organizations
 
+{{< summary-bar feature_name="Admin console early access" >}}
+
 > [!NOTE]
 >
 > You must have a [company](/admin/company/) to manage more than one organization.
-
-{{% include "admin-early-access.md" %}}
 
 {{% admin-sso-management-orgs product="admin" %}}
 
 ## Manage domains
 
+{{< summary-bar feature_name="Admin console early access" >}}
+
 {{< tabs >}}
 {{< tab name="Admin Console" >}}
-
-{{% include "admin-early-access.md" %}}
 
 {{% admin-sso-management product="admin" %}}
 
@@ -39,10 +39,10 @@ aliases:
 
 ## Manage SSO connections
 
+{{< summary-bar feature_name="Admin console early access" >}}
+
 {{< tabs >}}
 {{< tab name="Admin Console" >}}
-
-{{% include "admin-early-access.md" %}}
 
 {{% admin-sso-management-connections product="admin" %}}
 

--- a/content/manuals/security/for-admins/single-sign-on/manage.md
+++ b/content/manuals/security/for-admins/single-sign-on/manage.md
@@ -70,6 +70,8 @@ aliases:
 
 ### Add guest users when SSO is enabled
 
+{{< summary-bar feature_name="Admin console early access" >}}
+
 To add a guest that isn't verified through your IdP:
 
 1. Sign in to the [Admin Console](https://app.docker.com/admin).
@@ -78,6 +80,8 @@ To add a guest that isn't verified through your IdP:
 4. Follow the on-screen instructions to invite the user.
 
 ### Remove users from the SSO company
+
+{{< summary-bar feature_name="Admin console early access" >}}
 
 To remove a user:
 

--- a/data/summary.yaml
+++ b/data/summary.yaml
@@ -3,10 +3,10 @@ Activity logs:
   for: Administrators
 Admin Console:
   subscription: [Business]
-  availability: Early access
+  availability: Early Access
   for: Administrators
 Admin console early access:
-  availability: The Admin Console is in Early access
+  availability: The Admin Console is in Early Access
 Admin orgs:
   subscription: [Team, Business]
   for: Administrators
@@ -122,9 +122,8 @@ Docker Desktop CLI:
   requires: Docker Desktop [4.37](/manuals/desktop/release-notes.md#4370) and later
 Docker Desktop CLI update:
   requires: Docker Desktop 4.38 and later
-  requires: 
 Docker GitHub Copilot:
-  availability: Early access
+  availability: Early Access
 Docker Scout exceptions:
   availability: Experimental
   requires: Docker Scout CLI [1.15.0](/manuals/scout/release-notes/cli.md#1150) and later

--- a/data/summary.yaml
+++ b/data/summary.yaml
@@ -5,6 +5,8 @@ Admin Console:
   subscription: [Business]
   availability: Early access
   for: Administrators
+Admin console early access:
+  availability: The Admin Console is in Early access
 Admin orgs:
   subscription: [Team, Business]
   for: Administrators

--- a/layouts/shortcodes/summary-bar.html
+++ b/layouts/shortcodes/summary-bar.html
@@ -14,7 +14,7 @@
 {{ $availabilityIcons := dict
   "Experimental" "science"
   "Beta" "bolt"
-  "Early access" "rocket_launch"
+  "Early Access" "rocket_launch"
   "GA" "check_circle"
   "Retired" "package_2"
 }}

--- a/layouts/shortcodes/summary-bar.html
+++ b/layouts/shortcodes/summary-bar.html
@@ -40,19 +40,19 @@
   {{ end }}
 
   {{ with $feature.availability }}
+  {{ $availabilityText := . }}
   <div class="flex items-center gap-1">
       <span class="font-bold">Availability:</span>
-      <span>{{ . }}</span>
-      <span class="icon-svg">
-          {{ $icon := index $availabilityIcons . }}
-          {{ if $icon }}
-            {{ partial "icon" $icon }}
-          {{ else }}
-            {{ partial "icon" "default_icon" }}
+      <span>
+          {{ $availabilityText }}
+          {{ range $key, $icon := $availabilityIcons }}
+            {{ if in $availabilityText $key }}
+              <span class="icon-svg">{{ partial "icon" $icon }}</span>
+            {{ end }}
           {{ end }}
       </span>
   </div>
-  {{ end }}
+{{ end }}
 
   {{ with $feature.requires }}
   <div class="flex items-center gap-1">


### PR DESCRIPTION
## Description
- There is a bug in Hugo that is not parsing includes that begin with a shortcode correctly
- The fix here replaces the admin-early-access.md include with our summary bar solution
- Summary bar shortcode updated to support text in the `availability` field, this will allow us more flexibility with customizing this field while still supporting the iconography
- NOTE: We will not be able to add the summary bar inside {{tab}}/{{tabs}} layouts because it messes up the rendering

## Related issues or tickets

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Technical review
- [ ] Editorial review
- [ ] Product review