### PR TITLE
Fix build example diff in multi-platform.md

### DIFF
--- a/content/manuals/build/building/multi-platform.md
+++ b/content/manuals/build/building/multi-platform.md
@@ -468,7 +468,7 @@ Steps:
    WORKDIR /app
    ADD https://github.com/dvdksn/buildme.git#eb6279e0ad8a10003718656c6867539bd9426ad8 .
    -RUN go build -o server .
-   RUN GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -o server .
+   +RUN GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -o server .
    
    FROM alpine
    COPY --from=build /app/server /server


### PR DESCRIPTION
<!--Delete sections as needed -->

## Description

<!-- Tell us what you did and why -->
The build example "Diff" tab at https://docs.docker.com/build/building/multi-platform/#cross-compiling-a-go-application did not correctly highlight the updated build command.

