### PR TITLE
bake: remove experimental callout

### DIFF
--- a/content/manuals/build/bake/_index.md
+++ b/content/manuals/build/bake/_index.md
@@ -6,8 +6,6 @@ aliases:
   - /build/customize/bake/
 ---
 
-{{< summary-bar feature_name="Build bake" >}}
-
 Bake is a feature of Docker Buildx that lets you define your build configuration
 using a declarative file, as opposed to specifying a complex CLI expression. It
 also lets you run multiple builds concurrently with a single invocation.

--- a/data/summary.yaml
+++ b/data/summary.yaml
@@ -25,8 +25,6 @@ Azure blob:
   availability: Experimental
 Build additional contexts:
   requires: Docker Compose [2.17.0](/manuals/compose/releases/release-notes.md#2170) and later
-Build bake:
-  availability: Experimental
 Build checks:
   availability: Beta
   requires: Docker Buildx [0.15.0](/manuals/compose/releases/release-notes.md#0150) and later


### PR DESCRIPTION
## Description

Bake is GA since Buildx 0.20.0, seems this change didn't take into account this commit: https://github.com/docker/docs/pull/21858/commits/705190702afe041272281bd56275fa3a387d98c9

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Technical review
- [ ] Editorial review
- [ ] Product review