### PR TITLE
typo in local cache storage backend

### DIFF
--- a/content/manuals/build/cache/backends/local.md
+++ b/content/manuals/build/cache/backends/local.md
@@ -81,7 +81,7 @@ and kept indefinitely. Therefore, the size of the local cache will continue to
 grow (see [`moby/buildkit#1896`](https://github.com/moby/buildkit/issues/1896)
 for more information).
 
-When importing cache using `--cache-to`, you can specify the `digest` parameter
+When importing cache using `--cache-from`, you can specify the `digest` parameter
 to force loading an older version of the cache, for example:
 
 ```console


### PR DESCRIPTION
<!--Delete sections as needed -->

## Description

there is a typo when describing the usage of `digest` on importing caches specifying the flag as `--cache-to` which is wrong.

this is a simple change modifying the mentioned flag to `--cache-from`

<!-- Tell us what you did and why -->

