### PR TITLE
fix: remove EA badge from admin console doc

### DIFF
--- a/content/manuals/security/for-admins/hardened-desktop/settings-management/configure-admin-console.md
+++ b/content/manuals/security/for-admins/hardened-desktop/settings-management/configure-admin-console.md
@@ -4,11 +4,6 @@ keywords: admin, controls, rootless, enhanced container isolation
 title: Configure Settings Management with the Admin Console
 linkTitle: Use the Admin Console
 weight: 20
-params:
-  sidebar:
-    badge:
-      color: violet
-      text: EA
 ---
 
 {{< summary-bar feature_name="Admin Console" >}}


### PR DESCRIPTION
## Description
- Noticed I forgot to remove the EA badge from the admin console Settings Management doc

## Related issues or tickets
https://github.com/docker/docs/pull/21999

## Reviews
- [ ] Editorial review