### PR TITLE
quick fix: add tags to build code sample

### DIFF
--- a/content/manuals/build/ci/github-actions/multi-platform.md
+++ b/content/manuals/build/ci/github-actions/multi-platform.md
@@ -175,7 +175,7 @@ jobs:
         with:
           platforms: ${{ matrix.platform }}
           labels: ${{ steps.meta.outputs.labels }}
-          outputs: type=image,"name=${{ env.DOCKERHUB_REPO }},${{ env.GHCR_REPO }}",push-by-digest=true,name-canonical=true,push=true
+          outputs: type=image,"name=${{ env.DOCKERHUB_REPO }}:latest,${{ env.GHCR_REPO }}:latest",push-by-digest=true,name-canonical=true,push=true
 
       - name: Export digest
         run: |


### PR DESCRIPTION
<!--Delete sections as needed -->

## Description
- User reported the following error `Error: buildx failed with: ERROR: tag is needed when pushing to registry` when using our code sample in [https://docs.docker.com/build/ci/github-actions/multi-platform/#distribute-build-across-multiple-runners](https://docs.docker.com/build/ci/github-actions/multi-platform/#distribute-build-across-multiple-runners)
- Added `:latest` tags to code sample, this is the most general approach and not version specific, which will work for most users who are just trying things out using our code samples

## Related issues or tickets
- https://github.com/docker/docs/issues/22014

## Reviews
- [ ] Technical review