### PR TITLE
billing: docker hub pre-paid clarification

### DIFF
--- a/content/manuals/billing/docker-hub-pricing.md
+++ b/content/manuals/billing/docker-hub-pricing.md
@@ -49,7 +49,10 @@ There are two billing models for paying for additional Docker Hub storage:
 
     > [!NOTE]
     >
-    > Pre-purchased storage expires at the end of your subscription period.
+    > Pre-purchased storage expires at the end of your subscription period. Subscriptions
+    > periods are either monthly or annually. For example, if you are on a monthly plan,
+    > unused storage from each month does not roll over into the next. If you are on an
+    > annual plan, unused storage from each year does not roll over into the next.
 
 - Post-pay: Receive an overage invoice for storage usage that exceeds your subscription plan's included amount
 at the end of your billing cycle.

--- a/content/manuals/subscription/scale.md
+++ b/content/manuals/subscription/scale.md
@@ -66,8 +66,15 @@ charges, pre-purchase additional minutes.
 
 {{% include "hub-limits.md" %}}
 
-You can pre-purchase images pulls and storage by [contacting
-sales](https://www.docker.com/pricing/contact-sales/).
+You can pre-purchase image pulls and storage by [contacting
+sales](https://www.docker.com/pricing/contact-sales/). For more information on Docker
+Hub storage pricing, see [Docker Hub storage pricing](/manuals/billing/docker-hub-pricing.md).
+
+> [!WARNING]
+>
+> Once purchased, you can't adjust your pre-paid image pulls, only remove them. To change
+> the amount of pre-paid image pulls you must remove them, wait for the billing cycle to
+> end, and then purchase a new amount.
 
 In addition to pre-purchase, you are able to use as much resources as you need
 on-demand. On-demand usage is billed at a higher rate than pre-purchased


### PR DESCRIPTION
## Description
Two clarifications:
- Added examples to storage expiration callout to make things clear. Subscription periods are monthly or annually, and storage does not carry over.
- Added callout to scale your subscription about adjusting pre-paid image pulls. 

## Related issues or tickets
- [ENGDOCS-2430](https://docker.atlassian.net/browse/ENGDOCS-2430)

## Reviews
- [ ] Editorial review
- [ ] Product review @pmasonport @ob1dev 