### PR TITLE
Remove links to the public roadmap

### DIFF
--- a/content/manuals/docker-hub/release-notes.md
+++ b/content/manuals/docker-hub/release-notes.md
@@ -13,8 +13,6 @@ tags: [Release notes]
 Here you can learn about the latest changes, new features, bug fixes, and
 known issues for each Docker Hub release.
 
-Take a look at the [Docker Public Roadmap](https://github.com/orgs/docker/projects/51/views/1?filterQuery=) to see what's coming next.
-
 ## 2025-02-18
 
 ### New

--- a/content/manuals/platform-release-notes.md
+++ b/content/manuals/platform-release-notes.md
@@ -12,8 +12,6 @@ tags: [Release notes, admin]
 
 This page provides details on new features, enhancements, known issues, and bug fixes across Docker Home, the Admin Console, billing, security, and subscription functionalities.
 
-Take a look at the [Docker Public Roadmap](https://github.com/orgs/docker/projects/51/views/1?filterQuery=) to see what's coming next.
-
 ## 2025-01-30
 
 ### New

--- a/content/manuals/scout/release-notes/platform.md
+++ b/content/manuals/scout/release-notes/platform.md
@@ -15,9 +15,6 @@ issues, and bug fixes in Docker Scout releases. These release notes cover the
 Docker Scout platform, including the Dashboard. For CLI release notes, refer to
 [Docker Scout CLI release notes](./cli.md).
 
-Take a look at the [Docker Public Roadmap](https://github.com/docker/roadmap/projects/1)
-for what's coming next.
-
 ## Q4 2024
 
 New features and enhancements released in the fourth quarter of 2024.


### PR DESCRIPTION
## Description

Removed links to the public roadmap as it's not currently maintained.

## Related issues or tickets

https://docker.atlassian.net/browse/ENGDOCS-2436

