### PR TITLE
Update develop.md

### DIFF
--- a/content/guides/dotnet/develop.md
+++ b/content/guides/dotnet/develop.md
@@ -92,7 +92,7 @@ services:
       context: .
       target: final
     ports:
-      - 8080:80
+      - 8080:8080
     depends_on:
       db:
         condition: service_healthy


### PR DESCRIPTION
Server port is incorrect, due this issue server cannot be available at http://localhost:8080/

<!--Delete sections as needed -->

## Description

I modified the port number because I was not able to run the server on port 8080

## Related issues or tickets

<!-- Related issues, pull requests, or Jira tickets -->

N/A

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

N/A

- [ ] Technical review
- [x] Editorial review
- [ ] Product review