### PR TITLE
Fix extra argument in example

### DIFF
--- a/content/manuals/build/bake/overrides.md
+++ b/content/manuals/build/bake/overrides.md
@@ -63,7 +63,7 @@ If more than one Bake file is found, all files are loaded and merged into a
 single definition. Files are merged according to the lookup order.
 
 ```console
-$ docker buildx bake bake --print
+$ docker buildx bake --print
 [+] Building 0.0s (1/1) FINISHED                                                                                                                                                                                            
  => [internal] load local bake definitions                                                                                                                                                                             0.0s
  => => reading compose.yaml 45B / 45B                                                                                                                                                                                  0.0s


### PR DESCRIPTION
<!--Delete sections as needed -->

## Description

<!-- Tell us what you did and why -->


The extra `bake` argument causes error:

```
$ docker buildx bake bake --print
[+] Building 0.0s (1/1) FINISHED                                                                                                                                                                                                    
 => [internal] load local bake definitions                                                                                                                                                                                     0.0s
 => => reading docker-compose.yaml 1.68kB / 1.68kB                                                                                                                                                                             0.0s
ERROR: failed to find target bake
exit status 1
```

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Technical review
- [ ] Editorial review
- [ ] Product review