### PR TITLE
accounts: add callout for invitation expiration

### DIFF
--- a/content/manuals/admin/organization/members.md
+++ b/content/manuals/admin/organization/members.md
@@ -33,6 +33,14 @@ To accept an invitation:
 1. Navigate to your email inbox and open the Docker email with an invitation to
 join the Docker organization.
 2. To open the link to Docker Hub, select the **click here** link.
+
+   > [!WARNING]
+   >
+   > Invitation links expire after 14 days. If a user's invitation has expired,
+   > they can sign in to [Docker Hub](https://hub.docker.com/) with the email
+   > address the link was sent to and accept the invite from the
+   > **Notifications** panel.
+
 3. The Docker create an account page will open. If you already have an account, select **Already have an account? Sign in**.
 If you do not have an account yet, create an account using the same email
 address you received the invitation through.


### PR DESCRIPTION
## Description
- Invitation email links expire after 14 days, but we don't call this out in docs
- Added a callout to the **Accept invitation** steps to clarify when invitations expire

## Related issues or tickets
- [Slack thread](https://docker.slack.com/archives/C027X59V596/p1740383810156199)

## Reviews
- [ ] Technical review
- [ ] Editorial review
- [ ] Product review