### PR TITLE
fix: release-notes/27: make 27.5.1 headings match other subreleases.

### DIFF
--- a/content/manuals/engine/release-notes/27.md
+++ b/content/manuals/engine/release-notes/27.md
@@ -23,7 +23,7 @@ For more information about:
 
 Release notes for Docker Engine version 27.5 releases.
 
-## 27.5.1
+### 27.5.1
 
 {{< release-date date="2025-01-22" >}}
 
@@ -33,12 +33,12 @@ For a full list of pull requests and changes in this release, refer to the relev
 - [moby/moby, 27.5.1 milestone](https://github.com/moby/moby/issues?q=is%3Aclosed+milestone%3A27.5.1)
 
 
-### Bug fixes and enhancements
+#### Bug fixes and enhancements
 
 - Fix an issue that could persistently prevent daemon startup after failure to initialize the default bridge. [moby/moby#49307](https://github.com/moby/moby/pull/49307)
 - Add a `DOCKER_IGNORE_BR_NETFILTER_ERROR` environment variable. Setting it to `1` allows running on hosts that cannot load `br_netfilter`. Some things won't work, including disabling inter-container communication in a bridge network. With the userland proxy disabled, it won't be possible to access one container's published ports from another container on the same network.  [moby/moby#49306](https://github.com/moby/moby/pull/49306)
 
-### Packaging updates
+#### Packaging updates
 
 - Update Go runtime to 1.22.11 (fix CVE-2024-45341, CVE-2024-45336). [moby/moby#49312](https://github.com/moby/moby/pull/49312), [docker/docker-ce-packaging#1147](https://github.com/docker/docker-ce-packaging/pull/1147), [docker/cli#5762](https://github.com/docker/cli/pull/5762)
 - Update RootlessKit to v2.3.2 to support `passt` >= 2024_10_30.ee7d0b6. [moby/moby#49304](https://github.com/moby/moby/pull/49304)


### PR DESCRIPTION
## Description

The Release Notes for v27 have different header sizes for latest 27.5.1 release. This triggers my OCD, so I opened a PR to address it ;),

<img width="258" alt="Screenshot 2025-02-27 at 09 10 33" src="https://github.com/user-attachments/assets/19f21cc5-8f0b-4770-af2b-973775ebbaf3" />

## Reviews

Header sizes are consistent between versions on other release pages.

- [ ] Technical review
- [ ] Editorial review
- [ ] Product review