### PR TITLE
Update example in the Compose Build Specification (additional_contexts) to ease it's understanding

### DIFF
--- a/content/reference/compose-file/build.md
+++ b/content/reference/compose-file/build.md
@@ -130,7 +130,7 @@ services:
     dockerfile_inline: |
       FROM alpine
       RUN ...
- base:
+ my-service:
   build:
     context: .
     dockerfile_inline: |


### PR DESCRIPTION
There might by a slight error when illustrating the `additional_contexts` attribute. The compose file declares two services with the same name. It might induce misunderstanding, especially since the second service's image uses the first one to build upon.

## Description

I replaced the key defining the second service of the compose file used to illustrate the `additional_contexts` attribute, since the key `base` is used twice. Of course, any better replacement could be used, instead of `my-service`.

It is invalid to use the same key twice (the error: `mapping key "base" already defined at line 2` is expected on `docker compose up`), and it does harm the understanding of the illustrated point of building a service's image using another one to share layers.

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Technical review
- [ ] Editorial review
- [ ] Product review