### PR TITLE
Update release-notes.md

### DIFF
--- a/content/manuals/compose/releases/release-notes.md
+++ b/content/manuals/compose/releases/release-notes.md
@@ -289,7 +289,7 @@ For more detailed information, see the [release notes in the Compose repo](https
 
 - Fixed the docs on `docker compose kill` usage.
 - Fixed redundant condition from `toAPIBuildOptions` in build.go.
-- Fixed initial Watch `sync` after Compose restarts with introduction of `x-initSync`.
+- Fixed initial Watch `sync` after Compose restarts with introduction of `x-initialSync`.
 - Fixed an issue which stopped the Compose process for a single container on `sync-restart` Watch action.
 
 ## 2.29.1


### PR DESCRIPTION
`x-initialSync` was misspelled as `x-initSync`, which can be frustrating for users. Ref https://github.com/docker/compose/blob/876ecc48be0fe0ab74b23c6333ed20271438c1b4/pkg/compose/watch.go#L170 and https://github.com/docker/compose/issues/11102#issuecomment-2327505438