### PR TITLE
security: fix air gapped containers example

### DIFF
--- a/content/manuals/security/for-admins/hardened-desktop/air-gapped-containers.md
+++ b/content/manuals/security/for-admins/hardened-desktop/air-gapped-containers.md
@@ -34,7 +34,7 @@ Assuming [enforced sign-in](/manuals/security/for-admins/enforce-sign-in/_index.
     "mode": "manual",
     "http": "",
     "https": "",
-    "exclude": "",
+    "exclude": [],
     "pac": "http://192.168.1.16:62039/proxy.pac",
     "transparentPorts": "*"
   }


### PR DESCRIPTION
## Description
- The example in the air gapped containers guide needs to be an array, not a string https://docs.docker.com/security/for-admins/hardened-desktop/air-gapped-containers/

## Related issues or tickets
- https://docker.slack.com/archives/C04300R4G5U/p1741027918035939

## Reviews
- [ ] Editorial review