### PR TITLE
Update pulls.md

### DIFF
--- a/content/manuals/docker-hub/usage/pulls.md
+++ b/content/manuals/docker-hub/usage/pulls.md
@@ -65,9 +65,6 @@ Attribution is based on the following:
   organizations under the company, the pull is attributed to the user's personal
   namespace.
 
-When pulling Docker Verified Publisher images, attribution towards rate limiting
-is not applied. For more details, see [Docker Verified Publisher
-Program](/manuals/docker-hub/repos/manage/trusted-content/dvp-program.md).
 
 ### Authentication
 


### PR DESCRIPTION
Removing the DVP statement because not all DVPs have rate limit removal. The publisher must pay for it, and there is not visual indication of this for users at this time of what images have rate limits removed.

<!--Delete sections as needed -->

## Description

<!-- Tell us what you did and why -->

## Related issues or tickets

<!-- Related issues, pull requests, or Jira tickets -->

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Technical review
- [ ] Editorial review
- [ ] Product review