### PR TITLE
ci: update bake-action to v6.5.0 and optimize build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,7 +31,7 @@ jobs:
           driver-opts: image=${{ env.SETUP_BUILDKIT_IMAGE }}
       -
         name: Build
-        uses: docker/bake-action@v6
+        uses: docker/bake-action@v6.5.0
         with:
           files: |
             docker-bake.hcl
@@ -53,7 +53,7 @@ jobs:
         uses: docker/setup-buildx-action@v3
       -
         name: Build
-        uses: docker/bake-action@v6
+        uses: docker/bake-action@v6.5.0
         with:
           source: .
           files: |


### PR DESCRIPTION
Updated docker/bake-action to v6.5.0 for better performance and compatibility. Removed redundant checkout step to streamline the workflow.

<!--Delete sections as needed -->

## Description

<!-- Tell us what you did and why -->

## Related issues or tickets

<!-- Related issues, pull requests, or Jira tickets -->

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Technical review
- [ ] Editorial review
- [ ] Product review