### PR TITLE
ci(build): update bake-action to v6.5.0 and remove redundant checkout

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -90,7 +90,7 @@ jobs:
           driver-opts: image=${{ env.SETUP_BUILDKIT_IMAGE }}
       -
         name: Build website
-        uses: docker/bake-action@v6
+        uses: docker/bake-action@v6.5.0
         with:
           source: .
           files: |
@@ -128,7 +128,7 @@ jobs:
       -
         name: Update S3 config
         if: ${{ env.DOCS_S3_BUCKET != '' && env.DOCS_S3_CONFIG != '' }}
-        uses: docker/bake-action@v6
+        uses: docker/bake-action@v6.5.0
         with:
           source: .
           files: |


### PR DESCRIPTION
Description:
Updated `docker/bake-action` to v6.5.0 for better performance and compatibility. Removed redundant `checkout` step to streamline the workflow.

<!--Delete sections as needed -->

## Description

<!-- Tell us what you did and why -->

## Related issues or tickets

<!-- Related issues, pull requests, or Jira tickets -->

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Technical review
- [ ] Editorial review
- [ ] Product review