### PR TITLE
subscription: add callout about TCC minutes rollovers

### DIFF
--- a/content/guides/testcontainers-cloud/_index.md
+++ b/content/guides/testcontainers-cloud/_index.md
@@ -38,7 +38,7 @@ Testcontainers Cloud is a cloud-based solution designed to streamline and enhanc
 
 Works well with Docker Desktop, GitHub Actions, Jenkins, Kubernetes, and other CI solutions
 
-Docker Pro, Team, and Business subscriptions come with Testcontainers Cloud runtime minutes, and additional minutes are available via consumption pricing.
+Docker Pro, Team, and Business subscriptions come with Testcontainers Cloud runtime minutes, and additional minutes are available via consumption pricing. Testcontainers Cloud runtime minutes do not rollover month to month.
 
 ## Who’s this for?
 

--- a/content/manuals/subscription/details.md
+++ b/content/manuals/subscription/details.md
@@ -71,7 +71,7 @@ Docker Pro includes:
 
 - 200 Docker Build Cloud build minutes per month.
 - 2 included repositories with continuous vulnerability analysis in Docker Scout.
-- 100 Testcontainers Cloud runtime minutes per month for use either in Docker Desktop or for CI.
+- 100 Testcontainers Cloud runtime minutes per month for use either in Docker Desktop or for CI. Testcontainers Cloud runtime minutes do not rollover month to month.
 - No Docker Hub image pull rate limits.
 
 For a list of features available in each tier, see [Docker
@@ -92,7 +92,7 @@ Docker Team includes:
 
 - 500 Docker Build Cloud build minutes per month.
 - Unlimited Docker Scout repositories with continuous vulnerability analysis.
-- 500 Testcontainers Cloud runtime minutes per month for use either in Docker Desktop or for CI.
+- 500 Testcontainers Cloud runtime minutes per month for use either in Docker Desktop or for CI. Testcontainers Cloud runtime minutes do not rollover month to month.
 - No Docker Hub image pull rate limits.
 
 There are also advanced collaboration and management tools, including
@@ -117,8 +117,7 @@ Docker Business includes:
 
 - 1500 Docker Build Cloud build minutes per month.
 - Unlimited Docker Scout repositories with continuous vulnerability analysis.
-- 1500 Testcontainers Cloud runtime minutes per month for use either in Docker Desktop or
-  for CI.
+- 1500 Testcontainers Cloud runtime minutes per month for use either in Docker Desktop or for CI. Testcontainers Cloud runtime minutes do not rollover month to month.
 - No Docker Hub image pull rate limits.
 
 In addition, you gain access to enterprise-grade features, such as:
@@ -196,7 +195,7 @@ When you upgrade your Legacy Docker Pro plan to a Docker Pro subscription plan, 
 
 - Docker Build Cloud build minutes increased from 100/month to 200/month and no monthly fee.
 - 2 included repositories with continuous vulnerability analysis in Docker Scout.
-- 100 Testcontainers Cloud runtime minutes are now included for use either in Docker Desktop or for CI.
+- 100 Testcontainers Cloud runtime minutes are now included for use either in Docker Desktop or for CI. Testcontainers Cloud runtime minutes do not rollover month to month.
 - Docker Hub image pull rate limits are removed.
 
 For a list of features available in each tier, see [Docker Pricing](https://www.docker.com/pricing/).
@@ -228,7 +227,7 @@ When you upgrade your Legacy Docker Team plan to a Docker Team subscription plan
 - Instead of paying an additional per-seat fee, Docker Build Cloud is now available to all users in your Docker plan.
 - Docker Build Cloud build minutes increase from 400/mo to 500/mo.
 - Docker Scout now includes unlimited repositories with continuous vulnerability analysis, an increase from 3.
-- 500 Testcontainers Cloud runtime minutes are now included for use either in Docker Desktop or for CI.
+- 500 Testcontainers Cloud runtime minutes are now included for use either in Docker Desktop or for CI. Testcontainers Cloud runtime minutes do not rollover month to month.
 - Docker Hub image pull rate limits are removed.
 - The minimum number of users is 1 (lowered from 5).
 
@@ -260,7 +259,7 @@ When you upgrade your Legacy Docker Business plan to a Docker Business subscript
 - Instead of paying an additional per-seat fee, Docker Build Cloud is now available to all users in your Docker plan.
 - Docker Build Cloud included minutes increase from 800/mo to 1500/mo.
 - Docker Scout now includes unlimited repositories with continuous vulnerability analysis, an increase from 3.
-- 1500 Testcontainers Cloud runtime minutes are now included for use either in Docker Desktop or for CI.
+- 1500 Testcontainers Cloud runtime minutes are now included for use either in Docker Desktop or for CI. Testcontainers Cloud runtime minutes do not rollover month to month.
 - Docker Hub image pull rate limits are removed.
 
 For a list of features available in each tier, see [Docker Pricing](https://www.docker.com/pricing/).

--- a/content/manuals/subscription/details.md
+++ b/content/manuals/subscription/details.md
@@ -69,7 +69,8 @@ Testcontainers Cloud.
 
 Docker Pro includes:
 
-- 200 Docker Build Cloud build minutes per month.
+- 200 Docker Build Cloud build minutes per month. Docker Build Cloud minutes do not
+rollover month to month.
 - 2 included repositories with continuous vulnerability analysis in Docker Scout.
 - 100 Testcontainers Cloud runtime minutes per month for use either in Docker Desktop or for CI. Testcontainers Cloud runtime minutes do not rollover month to month.
 - No Docker Hub image pull rate limits.
@@ -90,7 +91,8 @@ Docker Hub, Docker Scout, Docker Build Cloud, and Testcontainers Cloud.
 
 Docker Team includes:
 
-- 500 Docker Build Cloud build minutes per month.
+- 500 Docker Build Cloud build minutes per month. Docker Build Cloud minutes do not
+rollover month to month.
 - Unlimited Docker Scout repositories with continuous vulnerability analysis.
 - 500 Testcontainers Cloud runtime minutes per month for use either in Docker Desktop or for CI. Testcontainers Cloud runtime minutes do not rollover month to month.
 - No Docker Hub image pull rate limits.
@@ -115,7 +117,8 @@ Build Cloud, and Testcontainers Cloud.
 
 Docker Business includes:
 
-- 1500 Docker Build Cloud build minutes per month.
+- 1500 Docker Build Cloud build minutes per month. Docker Build Cloud minutes do not
+rollover month to month.
 - Unlimited Docker Scout repositories with continuous vulnerability analysis.
 - 1500 Testcontainers Cloud runtime minutes per month for use either in Docker Desktop or for CI. Testcontainers Cloud runtime minutes do not rollover month to month.
 - No Docker Hub image pull rate limits.
@@ -193,7 +196,7 @@ For a list of features available in each legacy tier, see [Legacy Docker Pricing
 
 When you upgrade your Legacy Docker Pro plan to a Docker Pro subscription plan, your plan includes the following changes:
 
-- Docker Build Cloud build minutes increased from 100/month to 200/month and no monthly fee.
+- Docker Build Cloud build minutes increased from 100/month to 200/month and no monthly fee. Docker Build Cloud minutes do not rollover month to month.
 - 2 included repositories with continuous vulnerability analysis in Docker Scout.
 - 100 Testcontainers Cloud runtime minutes are now included for use either in Docker Desktop or for CI. Testcontainers Cloud runtime minutes do not rollover month to month.
 - Docker Hub image pull rate limits are removed.
@@ -225,7 +228,7 @@ For a list of features available in each legacy tier, see [Legacy Docker Pricing
 When you upgrade your Legacy Docker Team plan to a Docker Team subscription plan, your plan includes the following changes:
 
 - Instead of paying an additional per-seat fee, Docker Build Cloud is now available to all users in your Docker plan.
-- Docker Build Cloud build minutes increase from 400/mo to 500/mo.
+- Docker Build Cloud build minutes increase from 400/mo to 500/mo. Docker Build Cloud minutes do not rollover month to month.
 - Docker Scout now includes unlimited repositories with continuous vulnerability analysis, an increase from 3.
 - 500 Testcontainers Cloud runtime minutes are now included for use either in Docker Desktop or for CI. Testcontainers Cloud runtime minutes do not rollover month to month.
 - Docker Hub image pull rate limits are removed.
@@ -257,7 +260,7 @@ For a list of features available in each tier, see [Legacy Docker Pricing](https
 When you upgrade your Legacy Docker Business plan to a Docker Business subscription plan, your plan includes the following changes:
 
 - Instead of paying an additional per-seat fee, Docker Build Cloud is now available to all users in your Docker plan.
-- Docker Build Cloud included minutes increase from 800/mo to 1500/mo.
+- Docker Build Cloud included minutes increase from 800/mo to 1500/mo. Docker Build Cloud minutes do not rollover month to month.
 - Docker Scout now includes unlimited repositories with continuous vulnerability analysis, an increase from 3.
 - 1500 Testcontainers Cloud runtime minutes are now included for use either in Docker Desktop or for CI. Testcontainers Cloud runtime minutes do not rollover month to month.
 - Docker Hub image pull rate limits are removed.

--- a/content/manuals/subscription/scale.md
+++ b/content/manuals/subscription/scale.md
@@ -53,6 +53,12 @@ Your additional minutes will now display on the Build minutes page.
 
 ## Add Docker Testcontainers Cloud runtime minutes
 
+> [!NOTE]
+>
+> Testcontainers Cloud runtime minutes do not rollover. If you do not use
+> your allocated minutes, you can't roll them over to the next month or
+> subscription period.
+
 You can pre-purchase Testcontainers Cloud runtime minutes by [contacting
  sales](https://www.docker.com/pricing/contact-sales/). In addition to
 pre-purchase, you are able to use as many minutes as you need on-demand. The

--- a/content/manuals/subscription/scale.md
+++ b/content/manuals/subscription/scale.md
@@ -37,7 +37,12 @@ usage](../admin/organization/manage-products.md#view-docker-product-usage).
 
 > [!WARNING]
 >
-> Docker Build Cloud and Testcontainers minutes do not rollover. If you do not use the allocated minutes from your subscription plan, you can't roll them over to the next month or subscription period.
+> The number of Docker Build Cloud and Testcontainers minutes included in your
+subscription do not rollover. Additional minutes expire at the end of your
+subscription period (monthly or annually). For example, if you have an annual
+Docker Team subscription with 500 included minutes, and purchase 500 additional
+minutes, only the 500 additional minutes rollover until the end of your annual
+subscription period.
 
 ## Add Docker Build Cloud build minutes
 

--- a/content/manuals/subscription/scale.md
+++ b/content/manuals/subscription/scale.md
@@ -24,8 +24,7 @@ for legacy Docker subscription plans, all paid Docker subscriptions come with
 access to Docker Hub, Docker Build Cloud, and Testcontainers Cloud with a base
 amount of consumption. See [Docker subscriptions and features](./details.md) to
 learn how much base consumption comes with each subscription. You can scale your
-consumption at any time during your subscription period. All purchased
-consumption expires at the end of your subscription term.
+consumption at any time during your subscription period.
 
 You can scale consumption for the following:
 
@@ -35,6 +34,10 @@ You can scale consumption for the following:
 To better understand your needs, you can view your consumption at any time. For
 more details, see [View Docker product
 usage](../admin/organization/manage-products.md#view-docker-product-usage).
+
+> [!WARNING]
+>
+> Docker Build Cloud and Testcontainers minutes do not rollover. If you do not use the allocated minutes from your subscription plan, you can't roll them over to the next month or subscription period.
 
 ## Add Docker Build Cloud build minutes
 
@@ -52,12 +55,6 @@ You can pre-purchase Docker Build Cloud build minutes in the Docker Build Cloud 
 Your additional minutes will now display on the Build minutes page.
 
 ## Add Docker Testcontainers Cloud runtime minutes
-
-> [!NOTE]
->
-> Testcontainers Cloud runtime minutes do not rollover. If you do not use
-> your allocated minutes, you can't roll them over to the next month or
-> subscription period.
 
 You can pre-purchase Testcontainers Cloud runtime minutes by [contacting
  sales](https://www.docker.com/pricing/contact-sales/). In addition to


### PR DESCRIPTION
## Description
- Addresses Kapa uncertain answer about TCC runtime minutes and rollovers
- Confirmed w/ Billing team TCC runtime minutes don't roll over
- Added a callout to scale.md
- Added clarifying language to subscription details.md page
- Will improve Kapa response w/ new sources

## Related issues or tickets
- [ENGDOCS-2434](https://docker.atlassian.net/browse/ENGDOCS-2434)

## Reviews
- [ ] Editorial review

[ENGDOCS-2434]: https://docker.atlassian.net/browse/ENGDOCS-2434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ