### PR TITLE
Change directory after pulling a sample Docker application

### DIFF
--- a/content/guides/bun/containerize.md
+++ b/content/guides/bun/containerize.md
@@ -36,7 +36,7 @@ directory to a directory that you want to work in, and run the following
 command to clone the repository:
 
 ```console
-$ git clone https://github.com/dockersamples/bun-docker.git
+$ git clone https://github.com/dockersamples/bun-docker.git && cd bun-docker
 ```
 
 You should now have the following contents in your `bun-docker` directory.

--- a/content/guides/bun/develop.md
+++ b/content/guides/bun/develop.md
@@ -23,7 +23,7 @@ In this section, you'll learn how to set up a development environment for your c
 Clone the sample application to use with this guide. Open a terminal, change directory to a directory that you want to work in, and run the following command to clone the repository:
 
 ```console
-$ git clone https://github.com/dockersamples/bun-docker.git
+$ git clone https://github.com/dockersamples/bun-docker.git && cd bun-docker
 ```
 
 ## Automatically update services

--- a/content/guides/cpp/develop.md
+++ b/content/guides/cpp/develop.md
@@ -24,7 +24,7 @@ In this section, you'll learn how to set up a development environment for your c
 Clone the sample application to use with this guide. Open a terminal, change directory to a directory that you want to work in, and run the following command to clone the repository:
 
 ```console
-$ git clone https://github.com/dockersamples/c-plus-plus-docker.git
+$ git clone https://github.com/dockersamples/c-plus-plus-docker.git && cd c-plus-plus-docker
 ```
 
 ## Automatically update services

--- a/content/guides/deno/containerize.md
+++ b/content/guides/deno/containerize.md
@@ -25,7 +25,7 @@ directory to a directory that you want to work in, and run the following
 command to clone the repository:
 
 ```console
-$ git clone https://github.com/dockersamples/docker-deno.git
+$ git clone https://github.com/dockersamples/docker-deno.git && cd docker-deno
 ```
 
 You should now have the following contents in your `deno-docker` directory.

--- a/content/guides/deno/develop.md
+++ b/content/guides/deno/develop.md
@@ -23,7 +23,7 @@ In this section, you'll learn how to set up a development environment for your c
 Clone the sample application to use with this guide. Open a terminal, change directory to a directory that you want to work in, and run the following command to clone the repository:
 
 ```console
-$ git clone https://github.com/dockersamples/docker-deno.git
+$ git clone https://github.com/dockersamples/docker-deno.git && cd docker-deno
 ```
 
 ## Automatically update services

--- a/content/guides/nodejs/containerize.md
+++ b/content/guides/nodejs/containerize.md
@@ -31,7 +31,7 @@ directory to a directory that you want to work in, and run the following command
 to clone the repository:
 
 ```console
-$ git clone https://github.com/docker/docker-nodejs-sample
+$ git clone https://github.com/docker/docker-nodejs-sample && cd docker-nodejs-sample
 ```
 
 ## Initialize Docker assets

--- a/content/guides/python/containerize.md
+++ b/content/guides/python/containerize.md
@@ -27,7 +27,7 @@ The sample application uses the popular [FastAPI](https://fastapi.tiangolo.com) 
 Clone the sample application to use with this guide. Open a terminal, change directory to a directory that you want to work in, and run the following command to clone the repository:
 
 ```console
-$ git clone https://github.com/estebanx64/python-docker-example
+$ git clone https://github.com/estebanx64/python-docker-example && cd python-docker-example
 ```
 
 ## Initialize Docker assets

--- a/content/guides/r/containerize.md
+++ b/content/guides/r/containerize.md
@@ -26,7 +26,7 @@ The sample application uses the popular [Shiny](https://shiny.posit.co/) framewo
 Clone the sample application to use with this guide. Open a terminal, change directory to a directory that you want to work in, and run the following command to clone the repository:
 
 ```console
-$ git clone https://github.com/mfranzon/r-docker-dev.git
+$ git clone https://github.com/mfranzon/r-docker-dev.git && cd r-docker-dev
 ```
 
 You should now have the following contents in your `r-docker-dev`

--- a/content/guides/rust/build-images.md
+++ b/content/guides/rust/build-images.md
@@ -25,7 +25,7 @@ dependencies, and any other file system objects required.
 Clone the sample application to use with this guide. Open a terminal, change directory to a directory that you want to work in, and run the following command to clone the repository:
 
 ```console
-$ git clone https://github.com/docker/docker-rust-hello
+$ git clone https://github.com/docker/docker-rust-hello && cd docker-rust-hello
 ```
 
 ## Create a Dockerfile for Rust


### PR DESCRIPTION
## Description

This PR updates `git clone` command for sample repositories with `&& cd <repo name>`. Forcing to change the working directory should reduce the risk of forgetting to do.

## Related issues or tickets

## Reviews

@usha-mandya 

- [ ] Technical review
- [x] Editorial review
- [ ] Product review