### PR TITLE
billing: improve docs for manual payment retries

### DIFF
--- a/content/manuals/billing/faqs.md
+++ b/content/manuals/billing/faqs.md
@@ -33,6 +33,14 @@ Docker also sends an email notification `Action Required - Credit Card Payment F
 
 Once the grace period is over and the invoice is still not paid, the subscription downgrades to a free plan and all paid features are disabled.
 
+### Can I manually retry a failed payment?
+
+No. Docker retries failed payments on a [retry schedule](/manuals/billing/faqs.md#what-happens-if-my-subscription-payment-fails).
+
+To ensure a retired payment is successful, verify your default payment is
+updated. If you need to update your default payment method, see
+[Manage payment method](/manuals/billing/payment-method.md#manage-payment-method).
+
 ### Does Docker collect sales tax and/or VAT?
 
 Docker began collecting sales tax on subscription fees for United States customers on July 1, 2024. For European customers, Docker will begin collecting VAT on March 1, 2025.

--- a/content/manuals/billing/payment-method.md
+++ b/content/manuals/billing/payment-method.md
@@ -105,6 +105,11 @@ To add a payment method:
 
 ## Failed payments
 
+> [!NOTE]
+>
+> You can't manually retry a failed payment. Docker will retry failed payments
+based on the retry schedule.
+
 If your subscription payment fails, there is a grace period of 15 days, including the due date. Docker retries to collect the payment 3 times using the following schedule:
 
 - 3 days after the due date


### PR DESCRIPTION
## Description
- The question of whether users can manually retry failed payments has come up a few times in Kapa
- This adds an FAQ following the failed payment FAQ + a callout to the failed payments section of docs
- Will improve Kapa source content + future answers to this common question

## Related issues or tickets
- [ENGDOCS-2435](https://docker.atlassian.net/browse/ENGDOCS-2435)
- 
## Reviews
- [ ] Editorial review

[ENGDOCS-2435]: https://docker.atlassian.net/browse/ENGDOCS-2435?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ