### PR TITLE
billing: update VAT docs to include country prefix

### DIFF
--- a/content/manuals/billing/details.md
+++ b/content/manuals/billing/details.md
@@ -26,6 +26,12 @@ To update your billing information:
 4. On your billing information card, select **Change**.
 5. Update your billing contact and billing address information.
 6. Optional. To add or update a VAT ID, select the **I'm purchasing as a business** checkbox and enter your Tax ID.
+
+    > [!IMPORTANT]
+    >
+    > Your VAT number must include your country prefix. For example, if you are
+    entering a VAT number for Germany, you would enter `DE123456789`.
+
 7. Select **Update**.
 
 {{< /tab >}}
@@ -38,6 +44,12 @@ To update your billing information:
 3. From the drop-down menu, select **Billing**.
 4. Select **Billing Address** and enter your updated billing information.
 5. Optional. To add or update a VAT ID, enter your **Tax ID/VAT**.
+
+    > [!IMPORTANT]
+    >
+    > Your VAT number must include your country prefix. For example, if you are
+    entering a VAT number for Germany, you would enter `DE123456789`.
+
 6. Select **Submit**.
 
 {{< /tab >}}
@@ -60,6 +72,12 @@ To update your billing information:
 4. On your billing information card, select **Change**.
 5. Update your billing contact and billing address information.
 6. Optional. To add or update a VAT ID, select the **I'm purchasing as a business** checkbox and enter your Tax ID.
+
+    > [!IMPORTANT]
+    >
+    > Your VAT number must include your country prefix. For example, if you are
+    entering a VAT number for Germany, you would enter `DE123456789`.
+
 7. Select **Update**.
 
 {{< /tab >}}
@@ -73,6 +91,12 @@ To update your billing information:
 4. Select the organization that you want to change the payment method for.
 5. Select **Billing Address**.
 6. Optional. To add or update a VAT ID, enter your **Tax ID/VAT**.
+
+    > [!IMPORTANT]
+    >
+    > Your VAT number must include your country prefix. For example, if you are
+    entering a VAT number for Germany, you would enter `DE123456789`.
+
 7. Select **Submit**.
 
 {{< /tab >}}

--- a/content/manuals/billing/history.md
+++ b/content/manuals/billing/history.md
@@ -68,6 +68,12 @@ To add or update your VAT number:
 4. Select **Change** on your billing information card.
 5. Ensure the **I'm purchasing as a business** checkbox is checked.
 6. Enter your VAT number in the Tax ID section.
+
+    > [!IMPORTANT]
+    >
+    > Your VAT number must include your country prefix. For example, if you are
+    entering a VAT number for Germany, you would enter `DE123456789`.
+
 7. Select **Update**.
 
 Your VAT number will be included on your next invoice.
@@ -82,6 +88,12 @@ To add or update your VAT number:
 3. Select the **Billing address** link.
 4. In the **Billing Information** section, select **Update information**.
 5. Enter your VAT number in the Tax ID section.
+
+    > [!IMPORTANT]
+    >
+    > Your VAT number must include your country prefix. For example, if you are
+    entering a VAT number for Germany, you would enter `DE123456789`.
+
 6. Select **Save**.
 
 Your VAT number will be included on your next invoice.

--- a/content/manuals/billing/tax-certificate.md
+++ b/content/manuals/billing/tax-certificate.md
@@ -5,7 +5,7 @@ keywords: billing, renewal, payments, tax
 weight: 50
 ---
 
-If you're a customer in the United States and you're exempt from sales tax, you can register a valid tax exemption certificate with Docker's Support team. If you're a global customer subject to VAT, make sure that you provide your [VAT number](/billing/history/#include-your-vat-number-on-your-invoice).
+If you're a customer in the United States and you're exempt from sales tax, you can register a valid tax exemption certificate with Docker's Support team. If you're a global customer subject to VAT, make sure that you provide your [VAT number](/billing/history/#include-your-vat-number-on-your-invoice) including your VAT country prefix.
 
 {{% include "tax-compliance.md" %}}
 


### PR DESCRIPTION
## Description
- TSE reported issues/friction with customers entering VAT in billing flow, I have also seen this in Kapa feedback
- Added callout to specify that VAT must include country prefix in each touchpoint across billing docs

## Related issues or tickets
- [ENGDOCS-2477](https://docker.atlassian.net/browse/ENGDOCS-2477)

## Reviews
- [ ] Editorial review

[ENGDOCS-2477]: https://docker.atlassian.net/browse/ENGDOCS-2477?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ