### PR TITLE
Update Docker Documentation to Use DNF5 for Fedora Installation with …

### DIFF
--- a/content/manuals/engine/install/fedora.md
+++ b/content/manuals/engine/install/fedora.md
@@ -81,7 +81,16 @@ Docker from the repository.
 #### Set up the repository
 
 Install the `dnf-plugins-core` package (which provides the commands to manage
-your DNF repositories) and set up the repository.
+your DNF repositories) and set up the repository. Note that Fedora 41 and later
+primarily use DNF5. For Fedora 40 and earlier, please use the commands below
+made specifically for Fedora <=40.
+
+```console
+$ sudo dnf -y install dnf-plugins-core
+$ sudo dnf config-manager addrepo --from-repofile={{% param "download-url-base" %}}/docker-ce.repo
+```
+
+For earlier versions such as Fedora 40 or earlier that use DNF4 or DNF3:
 
 ```console
 $ sudo dnf -y install dnf-plugins-core


### PR DESCRIPTION
## Description
With the widespread adoption of DNF5, I propose updating the Docker installation documentation to reflect modern package management standards on Fedora. I noticed a previous attempt to do DNF5 documentation (referencing https://github.com/docker/docs/pull/21037) ended in failure because the addrepo command was used incorrectly, referencing an older DNF3-4 notation instead of proper DNF5 `addrepo --from-repofile=` notation. I have corrected this mistake and suggest this quick documentation update since Fedora 42 will be in beta soon, encouraging more users to update to 41/42, where DNF5 will be the standard format going forward. _I have also included the older command for legacy systems so that both cases are covered._

I tested this change on a Fedora 41 KDE VM, and it works as expected. Since DNF5 is a complete rewrite in C++, replacing the Python-based DNF3/4, it offers improved performance and memory efficiency. Updating the documentation will help prevent confusion for users writing installation scripts while ensuring compatibility with the latest Fedora releases.

## Requested Review

Please double-check to verify that I completed the auto-formatting URL correctly following Fedora's documentation standards, so it will be formatted properly on the website! Thanks!