### PR TITLE
Update image source for kafbat

### DIFF
--- a/content/guides/kafka.md
+++ b/content/guides/kafka.md
@@ -235,7 +235,7 @@ To add it to your own project (it’s already in the demo application), you only
 ```yaml
 services:
   kafka-ui:
-    image: ghcr.io/kafbat/kafka-ui:latest
+    image: kafbat/kafka-ui:main
     ports:
       - 8080:8080
     environment:


### PR DESCRIPTION
## Description

Kafbat publishes its images to Docker Hub, so changing the registry source to Hub instead of GHCR. Also, instead of using the latest tag, they publish merged changes onto a `main` tag.

This will also help our AI agent to use the correct image source, as it is currently using the GHCR-based image.