### PR TITLE
admin: add API option to manage members

### DIFF
--- a/content/manuals/admin/organization/members.md
+++ b/content/manuals/admin/organization/members.md
@@ -69,6 +69,9 @@ To resend an invitation from Docker Hub:
 **Resend invitation**.
 4. Select **Invite** to confirm.
 
+You can also resend an invitation using the Docker Hub API. For more information,
+see the [Resend an invite](https://docs.docker.com/reference/api/hub/latest/#tag/invites/paths/~1v2~1invites~1%7Bid%7D~1resend/patch) API endpoint.
+
 {{< /tab >}}
 {{< tab name="Admin Console" >}}
 
@@ -93,6 +96,9 @@ To remove a member's invitation from Docker Hub:
 2. Select **Organizations**, your organization, and then **Members**.
 3. In the table, select the **Action** icon, and then select **Remove member** or **Remove invitee**.
 4. Follow the on-screen instructions to remove the member or invitee.
+
+You can also remove an invitation using the Docker Hub API. For more information,
+see the [Cancel an invite](https://docs.docker.com/reference/api/hub/latest/#tag/invites/paths/~1v2~1invites~1%7Bid%7D/delete) API endpoint.
 
 {{< /tab >}}
 {{< tab name="Admin Console" >}}

--- a/layouts/shortcodes/admin-users.html
+++ b/layouts/shortcodes/admin-users.html
@@ -124,3 +124,8 @@ To invite multiple members to an organization via a CSV file containing email ad
 
 Pending invitations appear in the table. The invitees receive an email with a link to Docker Hub where they can accept
 or decline the invitation.
+
+### Invite members via API
+
+You can bulk invite members using the Docker Hub API. For more information, see
+the [Bulk create invites](https://docs.docker.com/reference/api/hub/latest/#tag/invites/paths/~1v2~1invites~1bulk/post) API endpoint.


### PR DESCRIPTION
## Description
- Kapa searches show that users are looking for API options to manage user invites
- This adds the option to invite users and manage them via Docker Hub API, with a redirect to the API reference
- This also just surfaces the API as an option for enterprise users, who might be more interested in managing bulk actions via the DH API

## Related issues or tickets
- [ENGDOCS-2460](https://docker.atlassian.net/browse/ENGDOCS-2460)

## Reviews
- [ ] Editorial review

[ENGDOCS-2460]: https://docker.atlassian.net/browse/ENGDOCS-2460?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ