### PR TITLE
feat: support for embedding code snippets

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,9 +33,16 @@ WORKDIR /out
 ADD https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_linux-${TARGETARCH}.tar.gz .
 RUN tar xvf hugo_extended_${HUGO_VERSION}_linux-${TARGETARCH}.tar.gz
 
+# git-src clones the OSS projects in order to include
+# code snippets into the docs.
+FROM base AS git-src-oss
+WORKDIR /git-src
+RUN git clone https://github.com/testcontainers/testcontainers-go.git
+
 # build-base is the base stage used for building the site
 FROM base AS build-base
 WORKDIR /project
+COPY --from=git-src-oss /git-src /project/git-src
 COPY --from=hugo /out/hugo /bin/hugo
 COPY --from=npm /out/node_modules node_modules
 COPY . .

--- a/content/manuals/testcontainers.md
+++ b/content/manuals/testcontainers.md
@@ -42,6 +42,8 @@ Testcontainers provide support for the most popular languages, and Docker sponso
 
 The rest are community-driven and maintained by independent contributors.
 
+{{< embedded language="go" source="/git-src/testcontainers-go/modules/redis/examples_test.go" id="runRedisContainer" >}}
+
 ### Prerequisites
 
 Testcontainers requires a Docker-API compatible container runtime. 

--- a/layouts/shortcodes/embedded.html
+++ b/layouts/shortcodes/embedded.html
@@ -1,0 +1,65 @@
+{{ $language := .Get "language" }}
+{{ $source := .Get "source" }}
+{{ $options := .Get "options" }}
+{{ $id := .Get "id" }}
+{{ $startTag := printf "START %s" $id }}
+{{ $endTag := printf "END %s" $id }}
+
+{{ if and $source (strings.Contains $source "testcontainers-go") }}
+    {{/*
+        If the source is a testcontainers-go file, we need to use a different tag. In example:
+
+        // runRedisContainer {
+        //     ...
+        // }
+    */}}
+    {{ $startTag = printf "// %s {" $id }}
+    {{ $endTag = printf "// }" }}
+{{ end }}
+
+{{ with $source | readFile }}
+    {{ $snippet := . }}
+
+    {{ if $id }}
+        {{ $lines := split $snippet "\n" }}
+
+        {{ $startl := -1 }}
+        {{ $endl := -1 }}
+
+        {{/* Find the lines that ends with the start and end tags. */}}
+        {{ range $index, $line := $lines }}
+            {{ if hasSuffix (strings.TrimSpace $line) $startTag }}
+                {{ $startl = $index }}
+            {{ else if hasSuffix (strings.TrimSpace $line) $endTag }}
+                {{ $endl = $index }}
+            {{ end }}
+        {{ end }}
+ 
+        {{/* Let's add some basic assertions. */}}
+        {{ if lt $startl 0 }}
+            {{ errorf "Named snippet '%s' is missing START tag (searched %d lines)" $id (len $lines) }}
+        {{ end }}
+
+        {{ if lt $endl 0 }}
+            {{ errorf "Named snippet '%s' is missing END tag (searched %d lines)" $id (len $lines) }}
+        {{ end }}
+
+        {{ if le $endl $startl }}
+            {{ errorf "Named snippet '%s': END tag (line %d) must come after START tag (line %d)" $id $endl $startl }}
+        {{ end }}
+
+        {{/* Size of the snippet in number of lines. */}}
+        {{ $snippetLen := sub (sub $endl $startl) 1 }}
+
+        {{/* Create slice with only the lines between the tags. */}}
+        {{ $includedLines := first $snippetLen (after (add $startl 1) $lines) }}
+
+        {{/* Join the lines into the final snippet. */}}
+        {{ $snippet = delimit $includedLines "\n" }}
+        {{ $markdown := printf "```%s\n%s\n```" $language $snippet }}
+        {{ $markdown | markdownify }}
+    {{ else }}
+        {{ $markdown := printf "```%s\n%s\n```" $language . }}
+        {{ $markdown | markdownify }}
+    {{ end }}
+{{ end }}


### PR DESCRIPTION
<!--Delete sections as needed -->

## Description

This pull request includes changes to the Dockerfile, documentation, and template files to support embedding code snippets from the `testcontainers-go` repository into the documentation. The most important changes include adding a new build stage to clone the `testcontainers-go` repository, updating the documentation to include an embedded code snippet, and modifying the shortcode template to handle these embedded snippets.

### Dockerfile changes:

* Added a new build stage `git-src-oss` to clone the `testcontainers-go` repository and copy it to the project directory (`[DockerfileR36-R45](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557R36-R45)`).

### Documentation changes:

* Updated `content/manuals/testcontainers.md` to include an embedded Go code snippet from the `testcontainers-go` repository (`[content/manuals/testcontainers.mdR45-R46](diffhunk://#diff-7905b168f0bee5db6711b541f42c48f5d0901c8cdc17f323e3c1725a5445a3dcR45-R46)`).

IMPORTANT: this change is a demonstration on how to use the embedding shortcode.

### Template changes:

* Created `layouts/shortcodes/embedded.html` to handle embedded code snippets, including logic to identify and extract specific code sections based on custom tags (`[layouts/shortcodes/embedded.htmlR1-R65](diffhunk://#diff-dc256c151d3b9c325236dc0c38d0ef5155ce617bb93d44b669b7641a00fbe42aR1-R65)`).

The tag is using the following format:

- start tag: `// START $id`
- end tag: `// END $id`

Exception: for testcontainers-go, where this mechanism already exists, we are using different start/end tags:
- start tag: `// $id {`
- end tag: `// }`


## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [x] Technical review
- [ ] Editorial review
- [ ] Product review