### PR TITLE
admin: add FAQ and add deactivate org to org section

### DIFF
--- a/content/manuals/accounts/deactivate-user-account.md
+++ b/content/manuals/accounts/deactivate-user-account.md
@@ -5,7 +5,7 @@ description: Learn how to deactivate a Docker user account.
 keywords: Docker Hub, delete, deactivate, account, account management
 ---
 
-You can deactivate an account at any time. This section describes the prerequisites and steps to deactivate a user account. For information on deactivating an organization, see [Deactivating an organization](../admin/deactivate-account.md).
+You can deactivate an account at any time. This section describes the prerequisites and steps to deactivate a user account. For information on deactivating an organization, see [Deactivating an organization](../admin/organizations/deactivate-account.md).
 
 >[!WARNING]
 >

--- a/content/manuals/accounts/deactivate-user-account.md
+++ b/content/manuals/accounts/deactivate-user-account.md
@@ -5,7 +5,7 @@ description: Learn how to deactivate a Docker user account.
 keywords: Docker Hub, delete, deactivate, account, account management
 ---
 
-You can deactivate an account at any time. This section describes the prerequisites and steps to deactivate a user account. For information on deactivating an organization, see [Deactivating an organization](../admin/organizations/deactivate-account.md).
+You can deactivate an account at any time. This section describes the prerequisites and steps to deactivate a user account. For information on deactivating an organization, see [Deactivating an organization](../admin/organization/deactivate-account.md).
 
 >[!WARNING]
 >

--- a/content/manuals/admin/faqs/general-faqs.md
+++ b/content/manuals/admin/faqs/general-faqs.md
@@ -19,6 +19,12 @@ For more information, see [Docker ID](/accounts/create-account/). If your admini
 
 Developers may have multiple Docker IDs in order to separate their Docker IDs associated with an organization with a Docker Business or Team subscription, and their personal use Docker IDs.
 
+### Can I change my Docker ID?
+
+No. You can't change your Docker ID once it's created. If you need a different Docker ID, you must create a new Docker account with a new Docker ID.
+
+Additionally, you can't reuse a Docker ID in the future if you deactivate your account.
+
 ### What if my Docker ID is taken?
 
 All Docker IDs are first-come, first-served except for companies that have a US Trademark on a username. If you have a trademark for your namespace, [Docker Support](https://hub.docker.com/support/contact/) can retrieve the Docker ID for you.
@@ -73,7 +79,7 @@ A [service account](../../docker-hub/service-accounts.md) is a Docker ID used fo
 
 ### Can I delete or deactivate a Docker account for another user?
 
-Only someone with access to the Docker account can deactivate the account. For more details, see [Deactivating an account](../../admin/deactivate-account.md).
+Only someone with access to the Docker account can deactivate the account. For more details, see [Deactivating an account](../../admin/organization/deactivate-account.md).
 
 If the user is a member of your organization, you can remove the user from your organization. For more details, see [Remove a member or invitee](../../admin/organization/members.md#remove-a-member-from-a-team).
 

--- a/content/manuals/admin/organization/deactivate-account.md
+++ b/content/manuals/admin/organization/deactivate-account.md
@@ -2,13 +2,14 @@
 title: Deactivate an organization
 description: Learn how to deactivate a Docker organization.
 keywords: Docker Hub, delete, deactivate organization, account, organization management
+weight: 42
 aliases:
 - /docker-hub/deactivate-account/
 ---
 
 {{< summary-bar feature_name="General admin" >}}
 
-You can deactivate an account at any time. This section describes the prerequisites and steps to deactivate an organization account. For information on deactivating a user account, see [Deactivate a user account](../accounts/deactivate-user-account.md).
+You can deactivate an account at any time. This section describes the prerequisites and steps to deactivate an organization account. For information on deactivating a user account, see [Deactivate a user account](../../accounts/deactivate-user-account.md).
 
 > [!WARNING]
 >
@@ -21,13 +22,13 @@ Before deactivating an organization, complete the following:
 - Download any images and tags you want to keep:
   `docker pull -a <image>:<tag>`.
 
-- If you have an active Docker subscription, [downgrade it to a free subscription](../subscription/change.md).
+- If you have an active Docker subscription, [downgrade it to a free subscription](../../subscription/change.md).
 
 - Remove all other members within the organization.
 
-- Unlink your [Github and Bitbucket accounts](../docker-hub/repos/manage/builds/link-source.md#unlink-a-github-user-account).
+- Unlink your [Github and Bitbucket accounts](../../docker-hub/repos/manage/builds/link-source.md#unlink-a-github-user-account).
 
-- For Business organizations, [remove your SSO connection](../security/for-admins/single-sign-on/manage/#remove-an-organization).
+- For Business organizations, [remove your SSO connection](../../security/for-admins/single-sign-on/manage/#remove-an-organization).
 
 ## Deactivate
 

--- a/content/manuals/admin/organization/orgs.md
+++ b/content/manuals/admin/organization/orgs.md
@@ -127,7 +127,7 @@ configure your organization.
 - **Settings**: Displays information about your
   organization, and you to view and change your repository privacy
   settings, configure org permissions such as
-  [Image Access Management](/manuals/security/for-admins/hardened-desktop/image-access-management.md), configure notification settings, and [deactivate](../deactivate-account.md#deactivate-an-organization) You can also update your organization name and company name that appear on your organization landing page. You must be an owner to access the
+  [Image Access Management](/manuals/security/for-admins/hardened-desktop/image-access-management.md), configure notification settings, and [deactivate](/manuals/admin/organization/deactivate-account.md#deactivate-an-organization) You can also update your organization name and company name that appear on your organization landing page. You must be an owner to access the
    organization's **Settings** page.
 
 - **Billing**: Displays information about your existing
@@ -158,7 +158,7 @@ configure your organization.
 
 - **Security and access**: Manage security settings. For more information, see [Security](/manuals/security/_index.md).
 
-- **Organization settings**: Update general settings, manage your company settings, or [deactivate your organization](/manuals/admin/deactivate-account.md).
+- **Organization settings**: Update general settings, manage your company settings, or [deactivate your organization](/manuals/admin/organization/deactivate-account.md).
 
 {{< /tab >}}
 {{< /tabs >}}

--- a/layouts/shortcodes/admin-domain-audit.md
+++ b/layouts/shortcodes/admin-domain-audit.md
@@ -26,5 +26,5 @@ You can invite all the uncaptured users to your organization using the exported 
 >
 > Domain audit may identify accounts of users who are no longer a part of your organization. If you don't want to add a user to your organization and you don't want the user to appear in future domain audits, you must deactivate the account or update the associated email address.
 >
-> Only someone with access to the Docker account can deactivate the account or update the associated email address. For more details, see [Deactivating an account](/admin/deactivate-account/).
+> Only someone with access to the Docker account can deactivate the account or update the associated email address. For more details, see [Deactivating an account](/admin/organization/deactivate-account/).
 >


### PR DESCRIPTION
## Description
- Added an FAQ about changing your Docker ID (not possible)
- Noticed deactivate an org was out in its own section, so I moved it under Organization administration
- Fixed some broken links

## Related issues or tickets
- [ENGDOCS-2465](https://docker.atlassian.net/browse/ENGDOCS-2465)

## Reviews
- [ ] Editorial review

[ENGDOCS-2465]: https://docker.atlassian.net/browse/ENGDOCS-2465?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ