### PR TITLE
draft: sso session limit

### DIFF
--- a/content/manuals/security/faqs/general.md
+++ b/content/manuals/security/faqs/general.md
@@ -31,13 +31,12 @@ You can configure this through SSO using your IdP. Check with your IdP if they s
 
 ### How are sessions managed and do they expire?
 
-Docker uses tokens to manage sessions after a user signs in:
+By default, Docker uses tokens to manage sessions after a user signs in:
 
 - Docker Desktop signs you out after 90 days, or 30 days of inactivity.
 - Docker Hub and Docker Home sign you out after 24 hours.
 
-Custom settings per organization for sessions aren't supported. Currently,
-Docker does not support your IdP's default session timeout for SSO users.
+Docker also supports your IdP's default session timeout. You can configure this by setting a Docker session minutes SAML attribute. For more information, see [SSO attributes](/manuals/security/for-admins/provisioning/_index.md#sso-attributes).
 
 ### How does Docker attribute downloads to us and what data is used to classify or verify the user is part of our organization?
 

--- a/content/manuals/security/faqs/single-sign-on/faqs.md
+++ b/content/manuals/security/faqs/single-sign-on/faqs.md
@@ -65,10 +65,4 @@ No. There are no specific firewall rules required for configuring SSO, as long a
 
 ### Does Docker use my IdP's default session timeout?
 
-No. Currently, Docker does not support your IdP's default session timeout for
-SSO users.
-
-Docker's default user session timeouts are as follows:
-
-- Docker Desktop signs you out after 90 days, or 30 days of inactivity.
-- Docker Hub and Docker Home sign you out after 24 hours.
+Yes, Docker supports your IdP's default session timeout. You can configure this by setting a Docker session minutes SAML attribute. For more information, see [SSO attributes](/manuals/security/for-admins/provisioning/_index.md#sso-attributes).

--- a/content/manuals/security/for-admins/provisioning/_index.md
+++ b/content/manuals/security/for-admins/provisioning/_index.md
@@ -38,6 +38,9 @@ When a user signs in through SSO, Docker obtains several attributes from your Id
 - **Docker Org**: Optional. Specifies the organization the user belongs to
 - **Docker Team**: Optional. Defines the team the user belongs to within the organization
 - **Docker Role**: Optional. Determines the user's permission within Docker
+- **Docker session minutes**: Optional. Determine's the user's session limit. You can set the session minutes to support your IdP's default session timeout. If this is attribute is not provided, by default:
+    - Docker Desktop signs you out after 90 days, or 30 days of inactivity.
+    - Docker Hub and Docker Home sign you out after 24 hours.
 
 If your organization uses SAML for SSO, Docker retrieves these attributes from the SAML assertion message. Keep in mind that different IdPs may use different names for these attributes. The following reference table outlines possible SAML attributes used by Docker:
 
@@ -49,6 +52,7 @@ If your organization uses SAML for SSO, Docker retrieves these attributes from t
 | Docker Org (optional)	| `dockerOrg` |
 | Docker Team (optional) |	`dockerTeam` |
 | Docker Role (optional) |	`dockerRole` |
+| Docker session minutes (optional) | `dockerSessionMinutes` |
 
 ## What's next?
 


### PR DESCRIPTION
## Description
- IAM is adding an SSO attribute `dockerSessionMinutes` to support IdP default session timeout
- This PR adds the attribute, and fixes FAQs that says Docker does not support IdP default timeout

## Related issues or tickets
- [IAM-1046](https://docker.atlassian.net/browse/IAM-1046)

## Reviews
- [ ] Technical review
- [ ] Editorial review
- [ ] Product review