### PR TITLE
fix: replace docker-compose with docker compose CLI

### DIFF
--- a/content/guides/java/containerize.md
+++ b/content/guides/java/containerize.md
@@ -204,7 +204,7 @@ services:
 # start the database before your application. The `db-data` volume persists the
 # database data between container restarts. The `db-password` secret is used
 # to set the database password. You must create `db/password.txt` and add
-# a password of your choosing to it before running `docker-compose up`.
+# a password of your choosing to it before running `docker compose up`.
 #     depends_on:
 #       db:
 #         condition: service_healthy

--- a/content/guides/nodejs/containerize.md
+++ b/content/guides/nodejs/containerize.md
@@ -141,7 +141,7 @@ services:
 # start the database before your application. The `db-data` volume persists the
 # database data between container restarts. The `db-password` secret is used
 # to set the database password. You must create `db/password.txt` and add
-# a password of your choosing to it before running `docker-compose up`.
+# a password of your choosing to it before running `docker compose up`.
 #     depends_on:
 #       db:
 #         condition: service_healthy

--- a/content/guides/nodejs/develop.md
+++ b/content/guides/nodejs/develop.md
@@ -58,7 +58,7 @@ You can use containers to set up local services, like a database. In this sectio
        # start the database before your application. The `db-data` volume persists the
        # database data between container restarts. The `db-password` secret is used
        # to set the database password. You must create `db/password.txt` and add
-       # a password of your choosing to it before running `docker-compose up`.
+       # a password of your choosing to it before running `docker compose up`.
 
        depends_on:
          db:
@@ -128,7 +128,7 @@ You can use containers to set up local services, like a database. In this sectio
        # start the database before your application. The `db-data` volume persists the
        # database data between container restarts. The `db-password` secret is used
        # to set the database password. You must create `db/password.txt` and add
-       # a password of your choosing to it before running `docker-compose up`.
+       # a password of your choosing to it before running `docker compose up`.
 
        depends_on:
          db:
@@ -188,7 +188,7 @@ You can use containers to set up local services, like a database. In this sectio
        # start the database before your application. The `db-data` volume persists the
        # database data between container restarts. The `db-password` secret is used
        # to set the database password. You must create `db/password.txt` and add
-       # a password of your choosing to it before running `docker-compose up`.
+       # a password of your choosing to it before running `docker compose up`.
 
        depends_on:
          db:


### PR DESCRIPTION
## Description

Replace `docker-compose` with `docker compose` CLI in the Java and Node.js guides to align with the latest Docker standards and ensure consistency across the docs.

## Related issues or tickets

#22319

<!-- Related issues, pull requests, or Jira tickets -->