### PR TITLE
fix: only render admin icon for keyword in summary bar

### DIFF
--- a/layouts/shortcodes/summary-bar.html
+++ b/layouts/shortcodes/summary-bar.html
@@ -4,74 +4,79 @@
   {{ errorf "[summary-bar] invalid feature: %s %v" $featureName .Position }}
 {{ end }}
 {{ if $feature }}
-{{ $subscriptionIcons := dict
-  "Business" "domain"
-  "Team" "groups"
-  "Pro" "person_add"
-  "Personal" "person"
-  "Available to all" "public"
-}}
-{{ $availabilityIcons := dict
-  "Experimental" "science"
-  "Beta" "bolt"
-  "Early Access" "rocket_launch"
-  "GA" "check_circle"
-  "Retired" "package_2"
-}}
-{{ $requiresIcon := "browser_updated" }}
-{{ $forIcon := "admin_panel_settings" }}
+  {{ $subscriptionIcons := dict
+    "Business" "domain"
+    "Team" "groups"
+    "Pro" "person_add"
+    "Personal" "person"
+    "Available to all" "public"
+  }}
+  {{ $availabilityIcons := dict
+    "Experimental" "science"
+    "Beta" "bolt"
+    "Early Access" "rocket_launch"
+    "GA" "check_circle"
+    "Retired" "package_2"
+  }}
+  {{ $requiresIcon := "browser_updated" }}
+  {{ $forIcon := "admin_panel_settings" }}
 
-<div class="flex flex-col bg-gray-light-200 bg-opacity-75 dark:bg-gray-dark-300 dark:bg-opacity-75 border-l-4 border-gray-light-200 px-4 py-1 my-1 not-prose">
-  {{ with $feature.subscription }}
-  <div class="flex flex-wrap gap-1">
-      <span class="font-bold">Subscription:</span>
-      {{ range . }}
-      <span>{{ . }}</span>
-      <span class="icon-svg">
-          {{ $icon := index $subscriptionIcons . }}
-          {{ if $icon }}
-            {{ partial "icon" $icon }}
-          {{ else }}
-            {{ partial "icon" "default_icon" }}
-          {{ end }}
-      </span>
-      {{ end }}
-  </div>
-  {{ end }}
 
-  {{ with $feature.availability }}
-  {{ $availabilityText := . }}
-  <div class="flex flex-wrap gap-1">
-      <span class="font-bold">Availability:</span>
-      <span>
+  <div
+    class="not-prose my-1 flex flex-col border-l-4 border-gray-light-200 bg-gray-light-200 bg-opacity-75 px-4 py-1 dark:bg-gray-dark-300 dark:bg-opacity-75"
+  >
+    {{ with $feature.subscription }}
+      <div class="flex flex-wrap gap-1">
+        <span class="font-bold">Subscription:</span>
+        {{ range . }}
+          <span>{{ . }}</span>
+          <span class="icon-svg">
+            {{ $icon := index $subscriptionIcons . }}
+            {{ if $icon }}
+              {{ partial "icon" $icon }}
+            {{ else }}
+              {{ partial "icon" "default_icon" }}
+            {{ end }}
+          </span>
+        {{ end }}
+      </div>
+    {{ end }}
+
+    {{ with $feature.availability }}
+      {{ $availabilityText := . }}
+      <div class="flex flex-wrap gap-1">
+        <span class="font-bold">Availability:</span>
+        <span>
           {{ $availabilityText }}
           {{ range $key, $icon := $availabilityIcons }}
             {{ if in $availabilityText $key }}
               <span class="icon-svg">{{ partial "icon" $icon }}</span>
             {{ end }}
           {{ end }}
-      </span>
-  </div>
-{{ end }}
+        </span>
+      </div>
+    {{ end }}
 
-  {{ with $feature.requires }}
-  <div class="flex flex-wrap gap-1">
-      <span class="font-bold">Requires:</span>
-      <span>{{ . | markdownify }}</span>
-      <span class="icon-svg">
+    {{ with $feature.requires }}
+      <div class="flex flex-wrap gap-1">
+        <span class="font-bold">Requires:</span>
+        <span>{{ . | markdownify }}</span>
+        <span class="icon-svg">
           {{ partial "icon" $requiresIcon }}
-      </span>
-  </div>
-  {{ end }}
+        </span>
+      </div>
+    {{ end }}
 
-  {{ with $feature.for }}
-  <div class="flex flex-wrap gap-1">
-      <span class="font-bold">For:</span>
-      <span>{{ . }}</span>
-      <span class="icon-svg">
-          {{ partial "icon" $forIcon }}
-      </span>
+    {{ with $feature.for }}
+      <div class="flex flex-wrap gap-1">
+        <span class="font-bold">For:</span>
+        <span>{{ . }}</span>
+        {{ if eq . "Administrators" }}
+          <span class="icon-svg">
+            {{ partial "icon" $forIcon }}
+          </span>
+        {{ end }}
+      </div>
+    {{ end }}
   </div>
-  {{ end }}
-</div>
 {{ end }}


### PR DESCRIPTION
## Description
- adds an if statement that will only render the admin icon if the keyword "Administrators" is present
- gives us flexibility to use this line for other strings/use cases, without rendering the admin icon

## Related issues or tickets
- https://docker.atlassian.net/browse/ENGDOCS-2507
- https://github.com/docker/docs/pull/22296

## Reviews
@aevesdocker to fix the summary bar for models PR
- [ ] Technical review
- [ ] Editorial review
- [ ] Product review