### PR TITLE
build: fix docker container driver name

### DIFF
--- a/content/manuals/build/builders/drivers/docker-container.md
+++ b/content/manuals/build/builders/drivers/docker-container.md
@@ -1,5 +1,5 @@
 ---
-title: Docker container build driver
+title: Docker container driver
 description: The Docker container driver runs BuildKit in a container image.
 keywords: build, buildx, driver, builder, docker-container
 aliases:

--- a/content/manuals/security/for-admins/hardened-desktop/enhanced-container-isolation/faq.md
+++ b/content/manuals/security/for-admins/hardened-desktop/enhanced-container-isolation/faq.md
@@ -82,7 +82,7 @@ Prior to Docker Desktop 4.19, ECI did not protect containers used implicitly
 by `docker build` during the build process.
 
 Since Docker Desktop 4.19, ECI protects containers used by `docker build`
-when using the [Docker container build driver](/manuals/build/builders/drivers/_index.md).
+when using the [Docker container driver](/manuals/build/builders/drivers/_index.md).
 
 In addition, since Docker Desktop 4.30, ECI also protects containers used by
 `docker build` when using the default "docker" build driver, on all


### PR DESCRIPTION
## Description

Correct name is `Docker container driver`.

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Technical review
- [ ] Editorial review
- [ ] Product review