### PR TITLE
Update services.md

### DIFF
--- a/content/reference/compose-file/services.md
+++ b/content/reference/compose-file/services.md
@@ -1572,6 +1572,11 @@ in the form:
 - `CONTAINER` is `port | range`.
 - `PROTOCOL` restricts ports to a specified protocol either `tcp` or `udp`(optional). Default is `tcp`.
 
+>[!CAUTION]
+>
+>If you do not specify an IP address (such as 127.0.0.1) and it binds to all interfaces then any machine on the same network could
+>potentially have access to the container. This could be especially dangerous if the container is exposed to the internet.
+
 Ports can be either a single value or a range. `HOST` and `CONTAINER` must use equivalent ranges. 
 
 You can either specify both ports (`HOST:CONTAINER`), or just the container port. In the latter case,
@@ -1579,6 +1584,8 @@ the container runtime automatically allocates any unassigned port of the host.
 
 `HOST:CONTAINER` should always be specified as a (quoted) string, to avoid conflicts
 with [YAML base-60 float](https://yaml.org/type/float.html).
+
+
 
 IPv6 addresses can be enclosed in square brackets.
 


### PR DESCRIPTION
Explicitly state the dangers if a port mapping binds to all interfaces

## Description

<!-- Tell us what you did and why -->

We recently discovered that docker was bypassing our firewall rules when forwarding ports from a container using the standard `<host port>:<container port>` syntax. What this meant was that the container was effectively visible to the entire internet. It was only after some digging did we discover that it is possible and even recommended to explicitly bind the host port to localhost so it doesn't accept connections from everywhere. This PR updates the docs to explicitly state the potential dangers.

## Reviews

- [ ] Technical review
- [ ] Editorial review
- [ ] Product review