### PR TITLE
Docker installation tutorial does not work with DNF5

### DIFF
--- a/content/manuals/engine/install/fedora.md
+++ b/content/manuals/engine/install/fedora.md
@@ -85,7 +85,7 @@ your DNF repositories) and set up the repository.
 
 ```console
 $ sudo dnf -y install dnf-plugins-core
-$ sudo dnf-3 config-manager --add-repo {{% param "download-url-base" %}}/docker-ce.repo
+$ sudo dnf config-manager addrepo --overwrite --from-repofile={{% param "download-url-base" %}}/docker-ce.repo
 ```
 
 #### Install Docker Engine


### PR DESCRIPTION
## Description

Current command 

```
 sudo dnf-3 config-manager --add-repo https://download.docker.com/linux/fedora/docker-ce.repo
```
Which results on the following when using DNF5 (I'm using Fedora 41):

```
Unknown argument "--add-repo" for command "config-manager". Add "--help" for more information about the arguments.
```

This happens because [DNF5 config-manager no longer utilizes the argument --add-repo](https://dnf5.readthedocs.io/en/latest/dnf5_plugins/config-manager.8.html), instead it uses [addrepo](https://github.com/rpm-software-management/dnf5/blob/d4c74147df7764bf3f80facea8ece9907e7618a4/dnf5-plugins/config-manager_plugin/addrepo.hpp#L33). The following is the new correct syntax:

```
sudo dnf config-manager addrepo --from-repofile=https://download.docker.com/linux/fedora/docker-ce.repo
```