### PR TITLE
CLI: Add missing `pad` and `truncate` output formatting functions

### DIFF
--- a/content/manuals/engine/cli/formatting.md
+++ b/content/manuals/engine/cli/formatting.md
@@ -90,6 +90,26 @@ $ docker inspect --format "{{title .Name}}" container
 $ docker inspect --format "{{upper .Name}}" container
 ```
 
+## pad
+
+`pad` adds whitespace padding to a string. You can specify the number of spaces to add before and after the string.
+
+```console
+$ docker image list --format '{{pad .Repository 5 10}}'
+```
+
+This example will add 5 spaces before the image repository name and 10 spaces after.
+
+## truncate
+
+`truncate` shortens a string to a specified length. If the string is shorter than the specified length, it remains unchanged.
+
+```console
+$ docker image list --format '{{truncate .Repository 15}}'
+```
+
+This example will display the image repository name, truncating it to the first 15 characters if it's longer.
+
 ## println
 
 `println` prints each value on a new line.

--- a/content/manuals/engine/cli/formatting.md
+++ b/content/manuals/engine/cli/formatting.md
@@ -98,7 +98,7 @@ $ docker inspect --format "{{upper .Name}}" container
 $ docker image list --format '{{pad .Repository 5 10}}'
 ```
 
-This example will add 5 spaces before the image repository name and 10 spaces after.
+This example adds 5 spaces before the image repository name and 10 spaces after.
 
 ## truncate
 
@@ -108,7 +108,7 @@ This example will add 5 spaces before the image repository name and 10 spaces af
 $ docker image list --format '{{truncate .Repository 15}}'
 ```
 
-This example will display the image repository name, truncating it to the first 15 characters if it's longer.
+This example displays the image repository name, truncating it to the first 15 characters if it's longer.
 
 ## println
 


### PR DESCRIPTION
See https://github.com/docker/cli/blob/master/templates/templates.go
