### PR TITLE
fix go version in go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/docker/docs
 
-go 1.23.6
+go 1.23.0
 
 require (
 	github.com/docker/buildx v0.22.0 // indirect


### PR DESCRIPTION
## Description

We should keep minimal version in go.mod and avoid bumping patch.

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Technical review
- [ ] Editorial review
- [ ] Product review