### PR TITLE
Allow baking documentation for offline self-hosting

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -149,3 +149,7 @@ EOT
 FROM scratch AS release
 COPY --from=build /project/public /
 COPY --from=pagefind /pagefind /pagefind
+
+# nginx is an image containing release compiled assets for static serving
+FROM nginx AS nginx
+COPY --from=release / /usr/share/nginx/html

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -35,6 +35,16 @@ target "release" {
   provenance = false
 }
 
+target "nginx" {
+  args = {
+    HUGO_ENV = "production"
+    DOCS_URL = "/"
+  }
+  target = "nginx"
+  provenance = false
+  tags = ["docker/docs:latest"]
+}
+
 group "validate" {
   targets = ["lint", "test", "unused-media", "test-go-redirects", "dockerfile-lint", "path-warnings"]
 }


### PR DESCRIPTION
## Description

This feature utilizes the artifacts generated by the `release` build stage to generate an `nginx` image suitable for offline self-hosting.

Needed this for offline documentation hosting, figured I'd open a PR.