### PR TITLE
fix use of x-* attribute in go templates

### DIFF
--- a/content/manuals/compose/bridge/customize.md
+++ b/content/manuals/compose/bridge/customize.md
@@ -133,8 +133,8 @@ metadata:
 spec:
   rules:  
 {{ range $name, $service := .services }}
-{{ if $service.x-virtual-host }}
-  - host: ${{ $service.x-virtual-host }}
+{{ range index $service "x-virtual-host" }}
+  - host: ${{ . }}
     http:
       paths:
       - path: "/"


### PR DESCRIPTION
## Description

fix https://docs.docker.com/compose/bridge/customize/#add-your-own-templates as attributes with a `-` can't be accessed directly using dot-notation in a go template. See https://stackoverflow.com/questions/48146448/range-through-values-within-variable-containing-dashes-in-golang-templates

## Related issues or tickets

## Reviews

- [ ] Technical review
- [ ] Editorial review
- [ ] Product review