### PR TITLE
BuildKit supports multiple cache exporters

### DIFF
--- a/content/manuals/build/cache/backends/_index.md
+++ b/content/manuals/build/cache/backends/_index.md
@@ -81,12 +81,11 @@ $ docker buildx build --push -t <registry>/<image> \
 
 ## Multiple caches
 
-BuildKit currently only supports
-[a single cache exporter](https://github.com/moby/buildkit/pull/3024). But you
-can import from as many remote caches as you like. For example, a common pattern
-is to use the cache of both the current branch and the main branch. The
-following example shows importing cache from multiple locations using the
-registry cache backend:
+BuildKit supports multiple cache exporters, allowing you to push cache to more 
+than one destination. You can also import from as many remote caches as you'd 
+like. For example, a common pattern is to use the cache of both the current 
+branch and the main branch. The following example shows importing cache from 
+multiple locations using the registry cache backend:
 
 ```console
 $ docker buildx build --push -t <registry>/<image> \


### PR DESCRIPTION

<!--Delete sections as needed -->

## Description

The doc seems outdated. It can be reworded, but as it stands, it's currently confusing and outdated.

## Related issues or tickets

- fixes https://github.com/docker/docs/issues/18590
- https://github.com/moby/buildkit/pull/3024
- https://github.com/moby/buildkit/issues/2818

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Technical review
- [ ] Editorial review
- [ ] Product review