### PR TITLE
security: add required note to admin-settings.json parameter

### DIFF
--- a/content/manuals/security/for-admins/hardened-desktop/settings-management/configure-json-file.md
+++ b/content/manuals/security/for-admins/hardened-desktop/settings-management/configure-json-file.md
@@ -5,8 +5,8 @@ title: Configure Settings Management with a JSON file
 linkTitle: Use a JSON file
 weight: 10
 aliases:
- - /desktop/hardened-desktop/settings-management/configure/
- - /security/for-admins/hardened-desktop/settings-management/configure/
+  - /desktop/hardened-desktop/settings-management/configure/
+  - /security/for-admins/hardened-desktop/settings-management/configure/
 ---
 
 {{< summary-bar feature_name="Hardened Docker Desktop" >}}
@@ -24,8 +24,10 @@ You first need to [enforce sign-in](/manuals/security/for-admins/enforce-sign-in
 You can either use the `--admin-settings` installer flag on [macOS](/manuals/desktop/setup/install/mac-install.md#install-from-the-command-line) or [Windows](/manuals/desktop/setup/install/windows-install.md#install-from-the-command-line) to automatically create the `admin-settings.json` and save it in the correct location, or set it up manually.
 
 To set it up manually:
+
 1. Create a new, empty JSON file and name it `admin-settings.json`.
 2. Save the `admin-settings.json` file on your developers' machines in the following locations:
+
    - Mac: `/Library/Application\ Support/com.docker.docker/admin-settings.json`
    - Windows: `C:\ProgramData\DockerDesktop\admin-settings.json`
    - Linux: `/usr/share/docker-desktop/admin-settings.json`
@@ -47,9 +49,10 @@ The `admin-settings.json` file requires a nested list of configuration parameter
 If `locked: true`, users aren't able to edit this setting from Docker Desktop or the CLI.
 
 If `locked: false`, it's similar to setting a factory default in that:
-   - For new installs, `locked: false` pre-populates the relevant settings in the Docker Desktop Dashboard, but users are able to modify it.
 
-   - If Docker Desktop is already installed and being used, `locked: false` is ignored. This is because existing users of Docker Desktop may have already updated a setting, which in turn will have been written to the relevant config file, for example the `settings-store.json` (or `settings.json` for Docker Desktop versions 4.34 and earlier) or `daemon.json`. In these instances, the user's preferences are respected and the values aren't altered. These can be controlled by setting `locked: true`.
+- For new installs, `locked: false` pre-populates the relevant settings in the Docker Desktop Dashboard, but users are able to modify it.
+
+- If Docker Desktop is already installed and being used, `locked: false` is ignored. This is because existing users of Docker Desktop may have already updated a setting, which in turn will have been written to the relevant config file, for example the `settings-store.json` (or `settings.json` for Docker Desktop versions 4.34 and earlier) or `daemon.json`. In these instances, the user's preferences are respected and the values aren't altered. These can be controlled by setting `locked: true`.
 
 The following `admin-settings.json` code and table provides an example of the required syntax and descriptions for parameters and values:
 
@@ -75,7 +78,7 @@ The following `admin-settings.json` code and table provides an example of the re
     "http": "",
     "https": "",
     "exclude": [],
-    "pac":"",
+    "pac": "",
     "transparentPorts": ""
   },
   "enhancedContainerIsolation": {
@@ -101,23 +104,23 @@ The following `admin-settings.json` code and table provides an example of the re
     },
     "dockerDaemonOptions": {
       "locked": false,
-      "value":"{\"debug\": false}"
+      "value": "{\"debug\": false}"
     },
     "vpnkitCIDR": {
       "locked": false,
-      "value":"192.168.65.0/24"
+      "value": "192.168.65.0/24"
     }
   },
   "kubernetes": {
-     "locked": false,
-     "enabled": false,
-     "showSystemContainers": false,
-     "imagesRepository": ""
+    "locked": false,
+    "enabled": false,
+    "showSystemContainers": false,
+    "imagesRepository": ""
   },
   "windowsContainers": {
     "dockerDaemonOptions": {
       "locked": false,
-      "value":"{\"debug\": false}"
+      "value": "{\"debug\": false}"
     }
   },
   "disableUpdate": {
@@ -155,7 +158,7 @@ The following `admin-settings.json` code and table provides an example of the re
       "sharedByDefault": true
     },
     {
-      "path":"$TMP",
+      "path": "$TMP",
       "sharedByDefault": false
     }
   ],
@@ -182,90 +185,90 @@ The following `admin-settings.json` code and table provides an example of the re
 }
 ```
 
-### General 
+### General
 
-|Parameter|OS|Description|Version|
-|:-------------------------------|---|:-------------------------------|---|
-|`configurationFileVersion`|   |Specifies the version of the configuration file format.|   |
-|`analyticsEnabled`|  |If `value` is set to false, Docker Desktop doesn't send usage statistics to Docker. |  |
-|`disableUpdate`|  |If `value` is set to true, checking for and notifications about Docker Desktop updates is disabled.|  |
-|`extensionsEnabled`|  |If `value` is set to false, Docker extensions are disabled. |  |
-| `blockDockerLoad` | | If `value` is set to `true`, users are no longer able to run [`docker load`](/reference/cli/docker/image/load/) and receive an error if they try to.|  |
-| `displayedOnboarding` |  | If `value` is set to `true`, the onboarding survey will not be displayed to new users. Setting `value` to `false` has no effect. |  Docker Desktop version 4.30 and later |
-| `desktopTerminalEnabled` |  | If `value` is set to `false`, developers cannot use the Docker terminal to interact with the host machine and execute commands directly from Docker Desktop. |  |
-|`exposeDockerAPIOnTCP2375`| Windows only| Exposes the Docker API on a specified port. If `value` is set to true, the Docker API is exposed on port 2375. Note: This is unauthenticated and should only be enabled if protected by suitable firewall rules.|  |
+| Parameter                  | OS           | Description                                                                                                                                                                                                      | Version                               |
+| :------------------------- | ------------ | :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------- |
+| `configurationFileVersion` |              | Specifies the version of the configuration file format.                                                                                                                                                          | Required for Docker Desktop 4.37.0 and later                                       |
+| `analyticsEnabled`         |              | If `value` is set to false, Docker Desktop doesn't send usage statistics to Docker.                                                                                                                              |                                       |
+| `disableUpdate`            |              | If `value` is set to true, checking for and notifications about Docker Desktop updates is disabled.                                                                                                              |                                       |
+| `extensionsEnabled`        |              | If `value` is set to false, Docker extensions are disabled.                                                                                                                                                      |                                       |
+| `blockDockerLoad`          |              | If `value` is set to `true`, users are no longer able to run [`docker load`](/reference/cli/docker/image/load/) and receive an error if they try to.                                                             |                                       |
+| `displayedOnboarding`      |              | If `value` is set to `true`, the onboarding survey will not be displayed to new users. Setting `value` to `false` has no effect.                                                                                 | Docker Desktop version 4.30 and later |
+| `desktopTerminalEnabled`   |              | If `value` is set to `false`, developers cannot use the Docker terminal to interact with the host machine and execute commands directly from Docker Desktop.                                                     |                                       |
+| `exposeDockerAPIOnTCP2375` | Windows only | Exposes the Docker API on a specified port. If `value` is set to true, the Docker API is exposed on port 2375. Note: This is unauthenticated and should only be enabled if protected by suitable firewall rules. |                                       |
 
-### File sharing and emulation 
+### File sharing and emulation
 
-|Parameter|OS|Description|Version|
-|:-------------------------------|---|:-------------------------------|---|
-| `filesharingAllowedDirectories` |  | Specify which paths your developers can add file shares to. Also accepts `$HOME`, `$TMP`, or `$TEMP` as `path` variables. When a path is added, its subdirectories are allowed. If `sharedByDefault` is set to `true`, that path will be added upon factory reset or when Docker Desktop first starts. |  |
-| `useVirtualizationFrameworkVirtioFS`|  macOS only | If `value` is set to `true`, VirtioFS is set as the file sharing mechanism. Note: If both `useVirtualizationFrameworkVirtioFS` and `useGrpcfuse` have `value` set to `true`, VirtioFS takes precedence. Likewise, if both `useVirtualizationFrameworkVirtioFS` and `useGrpcfuse` have `value` set to `false`, osxfs is set as the file sharing mechanism. |  |
-| `useGrpcfuse` | macOS only | If `value` is set to `true`, gRPC Fuse is set as the file sharing mechanism. |  |
-| `useVirtualizationFrameworkRosetta`|  macOS only | If `value` is set to `true`, Docker Desktop turns on Rosetta to accelerate x86_64/amd64 binary emulation on Apple Silicon. Note: This also automatically enables `Use Virtualization framework`. | Docker Desktop version 4.29 and later. |
+| Parameter                            | OS         | Description                                                                                                                                                                                                                                                                                                                                               | Version                                |
+| :----------------------------------- | ---------- | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------- |
+| `filesharingAllowedDirectories`      |            | Specify which paths your developers can add file shares to. Also accepts `$HOME`, `$TMP`, or `$TEMP` as `path` variables. When a path is added, its subdirectories are allowed. If `sharedByDefault` is set to `true`, that path will be added upon factory reset or when Docker Desktop first starts.                                                    |                                        |
+| `useVirtualizationFrameworkVirtioFS` | macOS only | If `value` is set to `true`, VirtioFS is set as the file sharing mechanism. Note: If both `useVirtualizationFrameworkVirtioFS` and `useGrpcfuse` have `value` set to `true`, VirtioFS takes precedence. Likewise, if both `useVirtualizationFrameworkVirtioFS` and `useGrpcfuse` have `value` set to `false`, osxfs is set as the file sharing mechanism. |                                        |
+| `useGrpcfuse`                        | macOS only | If `value` is set to `true`, gRPC Fuse is set as the file sharing mechanism.                                                                                                                                                                                                                                                                              |                                        |
+| `useVirtualizationFrameworkRosetta`  | macOS only | If `value` is set to `true`, Docker Desktop turns on Rosetta to accelerate x86_64/amd64 binary emulation on Apple Silicon. Note: This also automatically enables `Use Virtualization framework`.                                                                                                                                                          | Docker Desktop version 4.29 and later. |
 
 ### Docker Scout
 
-|Parameter|OS|Description|Version|
-|:-------------------------------|---|:-------------------------------|---|
-|`scout`| | Setting `useBackgroundIndexing` to `false` disables automatic indexing of images loaded to the image store. Setting `sbomIndexing` to `false` prevents users from being able to index image by inspecting them in Docker Desktop or using `docker scout` CLI commands. |  |
+| Parameter | OS  | Description                                                                                                                                                                                                                                                            | Version |
+| :-------- | --- | :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- |
+| `scout`   |     | Setting `useBackgroundIndexing` to `false` disables automatic indexing of images loaded to the image store. Setting `sbomIndexing` to `false` prevents users from being able to index image by inspecting them in Docker Desktop or using `docker scout` CLI commands. |         |
 
 ### Proxy
 
-|Parameter|OS|Description|Version|
-|:-------------------------------|---|:-------------------------------|---|
-|`proxy`|   |If `mode` is set to `system` instead of `manual`, Docker Desktop gets the proxy values from the system and ignores and values set for `http`, `https` and `exclude`. Change `mode` to `manual` to manually configure proxy servers. If the proxy port is custom, specify it in the `http` or `https` property, for example `"https": "http://myotherproxy.com:4321"`. The `exclude` property specifies a comma-separated list of hosts and domains to bypass the proxy. |  |
-|&nbsp; &nbsp; &nbsp; &nbsp;`windowsDockerdPort`| Windows only | Exposes Docker Desktop's internal proxy locally on this port for the Windows Docker daemon to connect to. If it is set to 0, a random free port is chosen. If the value is greater than 0, use that exact value for the port. The default value is -1 which disables the option. |  |
-|&nbsp; &nbsp; &nbsp; &nbsp;`enableKerberosNtlm`|  |When set to `true`, Kerberos and NTLM authentication is enabled. Default is `false`. For more information, see the settings documentation. | Docker Desktop version 4.32 and later. |
+| Parameter                                       | OS           | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                             | Version                                |
+| :---------------------------------------------- | ------------ | :---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------- |
+| `proxy`                                         |              | If `mode` is set to `system` instead of `manual`, Docker Desktop gets the proxy values from the system and ignores and values set for `http`, `https` and `exclude`. Change `mode` to `manual` to manually configure proxy servers. If the proxy port is custom, specify it in the `http` or `https` property, for example `"https": "http://myotherproxy.com:4321"`. The `exclude` property specifies a comma-separated list of hosts and domains to bypass the proxy. |                                        |
+| &nbsp; &nbsp; &nbsp; &nbsp;`windowsDockerdPort` | Windows only | Exposes Docker Desktop's internal proxy locally on this port for the Windows Docker daemon to connect to. If it is set to 0, a random free port is chosen. If the value is greater than 0, use that exact value for the port. The default value is -1 which disables the option.                                                                                                                                                                                        |                                        |
+| &nbsp; &nbsp; &nbsp; &nbsp;`enableKerberosNtlm` |              | When set to `true`, Kerberos and NTLM authentication is enabled. Default is `false`. For more information, see the settings documentation.                                                                                                                                                                                                                                                                                                                              | Docker Desktop version 4.32 and later. |
 
 ### Container proxy
 
-|Parameter|OS|Description|Version|
-|:-------------------------------|---|:-------------------------------|---|
-|`containersProxy` | | Creates air-gapped containers. For more information see [Air-Gapped Containers](../air-gapped-containers.md).| Docker Desktop version 4.29 and later. |
+| Parameter         | OS  | Description                                                                                                   | Version                                |
+| :---------------- | --- | :------------------------------------------------------------------------------------------------------------ | -------------------------------------- |
+| `containersProxy` |     | Creates air-gapped containers. For more information see [Air-Gapped Containers](../air-gapped-containers.md). | Docker Desktop version 4.29 and later. |
 
 ### Linux VM
 
-|Parameter|OS|Description|Version|
-|:-------------------------------|---|:-------------------------------|---|
-| `linuxVM` |   |Parameters and settings related to Linux VM options - grouped together here for convenience. |  |
-| &nbsp; &nbsp; &nbsp; &nbsp;`wslEngineEnabled`  | Windows only | If `value` is set to true, Docker Desktop uses the WSL 2 based engine. This overrides anything that may have been set at installation using the `--backend=<backend name>` flag. |  |
-| &nbsp; &nbsp; &nbsp; &nbsp;`dockerDaemonOptions` |  |If `value` is set to true, it overrides the options in the Docker Engine config file. See the [Docker Engine reference](/reference/cli/dockerd/#daemon-configuration-file). Note that for added security, a few of the config attributes may be overridden when Enhanced Container Isolation is enabled. |  |
-| &nbsp; &nbsp; &nbsp; &nbsp;`vpnkitCIDR` |  |Overrides the network range used for vpnkit DHCP/DNS for `*.docker.internal`  |  |
+| Parameter                                        | OS           | Description                                                                                                                                                                                                                                                                                              | Version |
+| :----------------------------------------------- | ------------ | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- |
+| `linuxVM`                                        |              | Parameters and settings related to Linux VM options - grouped together here for convenience.                                                                                                                                                                                                             |         |
+| &nbsp; &nbsp; &nbsp; &nbsp;`wslEngineEnabled`    | Windows only | If `value` is set to true, Docker Desktop uses the WSL 2 based engine. This overrides anything that may have been set at installation using the `--backend=<backend name>` flag.                                                                                                                         |         |
+| &nbsp; &nbsp; &nbsp; &nbsp;`dockerDaemonOptions` |              | If `value` is set to true, it overrides the options in the Docker Engine config file. See the [Docker Engine reference](/reference/cli/dockerd/#daemon-configuration-file). Note that for added security, a few of the config attributes may be overridden when Enhanced Container Isolation is enabled. |         |
+| &nbsp; &nbsp; &nbsp; &nbsp;`vpnkitCIDR`          |              | Overrides the network range used for vpnkit DHCP/DNS for `*.docker.internal`                                                                                                                                                                                                                             |         |
 
 ### Windows containers
 
-|Parameter|OS|Description|Version|
-|:-------------------------------|---|:-------------------------------|---|
-| `windowsContainers` |  | Parameters and settings related to `windowsContainers` options - grouped together here for convenience.  |  |
-| &nbsp; &nbsp; &nbsp; &nbsp;`dockerDaemonOptions` |  | Overrides the options in the Linux daemon config file. See the [Docker Engine reference](/reference/cli/dockerd/#daemon-configuration-file).|  |
+| Parameter                                        | OS  | Description                                                                                                                                  | Version |
+| :----------------------------------------------- | --- | :------------------------------------------------------------------------------------------------------------------------------------------- | ------- |
+| `windowsContainers`                              |     | Parameters and settings related to `windowsContainers` options - grouped together here for convenience.                                      |         |
+| &nbsp; &nbsp; &nbsp; &nbsp;`dockerDaemonOptions` |     | Overrides the options in the Linux daemon config file. See the [Docker Engine reference](/reference/cli/dockerd/#daemon-configuration-file). |         |
 
 > [!NOTE]
-> 
+>
 > This setting is not available to configure via the Docker Admin Console.
 
 ### Kubernetes
 
-|Parameter|OS|Description|Version|
-|:-------------------------------|---|:-------------------------------|---|
-|`kubernetes`|  | If `enabled` is set to true, a Kubernetes single-node cluster is started when Docker Desktop starts. If `showSystemContainers` is set to true, Kubernetes containers are displayed in the Docker Desktop Dashboard and when you run `docker ps`.  `imagesRepository` lets you specify which repository Docker Desktop pulls the Kubernetes images from. For example, `"imagesRepository": "registry-1.docker.io/docker"`.  |  |
+| Parameter    | OS  | Description                                                                                                                                                                                                                                                                                                                                                                                                              | Version |
+| :----------- | --- | :----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- |
+| `kubernetes` |     | If `enabled` is set to true, a Kubernetes single-node cluster is started when Docker Desktop starts. If `showSystemContainers` is set to true, Kubernetes containers are displayed in the Docker Desktop Dashboard and when you run `docker ps`. `imagesRepository` lets you specify which repository Docker Desktop pulls the Kubernetes images from. For example, `"imagesRepository": "registry-1.docker.io/docker"`. |         |
 
-### Features in development 
+### Features in development
 
-|Parameter|OS|Description|Version|
-|:-------------------------------|---|:-------------------------------|---|
-| `allowExperimentalFeatures`| | If `value` is set to `false`, experimental features are disabled.|  |
-| `allowBetaFeatures`| | If `value` is set to `false`, beta features are disabled.|  |
-| `enableDockerAI` | | If `value` is set to `false`, Docker AI (Ask Gordon) features are disabled. |  |
+| Parameter                   | OS  | Description                                                                 | Version |
+| :-------------------------- | --- | :-------------------------------------------------------------------------- | ------- |
+| `allowExperimentalFeatures` |     | If `value` is set to `false`, experimental features are disabled.           |         |
+| `allowBetaFeatures`         |     | If `value` is set to `false`, beta features are disabled.                   |         |
+| `enableDockerAI`            |     | If `value` is set to `false`, Docker AI (Ask Gordon) features are disabled. |         |
 
-### Enhanced Container Isolation 
+### Enhanced Container Isolation
 
-|Parameter|OS|Description|Version|
-|:-------------------------------|---|:-------------------------------|---|
-|`enhancedContainerIsolation`|  | If `value` is set to true, Docker Desktop runs all containers as unprivileged, via the Linux user-namespace, prevents them from modifying sensitive configurations inside the Docker Desktop VM, and uses other advanced techniques to isolate them. For more information, see [Enhanced Container Isolation](../enhanced-container-isolation/_index.md).|  |
-| &nbsp; &nbsp; &nbsp; &nbsp;`dockerSocketMount` |  | By default, enhanced container isolation blocks bind-mounting the Docker Engine socket into containers (e.g., `docker run -v /var/run/docker.sock:/var/run/docker.sock ...`). This lets you relax this in a controlled way. See [ECI Configuration](../enhanced-container-isolation/config.md) for more info. |  |
-| &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; `imageList` |  | Indicates which container images are allowed to bind-mount the Docker Engine socket. |  |
-| &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; `commandList` |  | Restricts the commands that containers can issue via the bind-mounted Docker Engine socket. |  |
+| Parameter                                                      | OS  | Description                                                                                                                                                                                                                                                                                                                                               | Version |
+| :------------------------------------------------------------- | --- | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- |
+| `enhancedContainerIsolation`                                   |     | If `value` is set to true, Docker Desktop runs all containers as unprivileged, via the Linux user-namespace, prevents them from modifying sensitive configurations inside the Docker Desktop VM, and uses other advanced techniques to isolate them. For more information, see [Enhanced Container Isolation](../enhanced-container-isolation/_index.md). |         |
+| &nbsp; &nbsp; &nbsp; &nbsp;`dockerSocketMount`                 |     | By default, enhanced container isolation blocks bind-mounting the Docker Engine socket into containers (e.g., `docker run -v /var/run/docker.sock:/var/run/docker.sock ...`). This lets you relax this in a controlled way. See [ECI Configuration](../enhanced-container-isolation/config.md) for more info.                                             |         |
+| &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; `imageList`   |     | Indicates which container images are allowed to bind-mount the Docker Engine socket.                                                                                                                                                                                                                                                                      |         |
+| &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; `commandList` |     | Restricts the commands that containers can issue via the bind-mounted Docker Engine socket.                                                                                                                                                                                                                                                               |         |
 
 ## Step three: Re-launch Docker Desktop
 
@@ -274,8 +277,10 @@ The following `admin-settings.json` code and table provides an example of the re
 > Test the changes made through the `admin-settings.json` file locally to see if the settings work as expected.
 
 For settings to take effect:
+
 - On a new install, developers need to launch Docker Desktop and authenticate to their organization.
 - On an existing install, developers need to quit Docker Desktop through the Docker menu, and then re-launch Docker Desktop. If they are already signed in, they don't need to sign in again for the changes to take effect.
+
   > [!IMPORTANT]
   >
   > Selecting **Restart** from the Docker menu isn't enough as it only restarts some components of Docker Desktop.


### PR DESCRIPTION
## Description
- In DD 4.37.0 and later, `configurationFileVersion` is required. In the next DD version this will be optional, so I made a note to come back and update this after that release

## Related issues or tickets
- [ENGDOCS-2550](https://docker.atlassian.net/browse/ENGDOCS-2550)

## Reviews
- [ ] Editorial review