### PR TITLE
Build self-hosted documentation container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -149,3 +149,7 @@ EOT
 FROM scratch AS release
 COPY --from=build /project/public /
 COPY --from=pagefind /pagefind /pagefind
+
+# nginx is an image containing release compiled assets for static serving
+FROM nginx AS nginx
+COPY --from=release / /usr/share/nginx/html

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -35,6 +35,16 @@ target "release" {
   provenance = false
 }
 
+target "nginx" {
+  args = {
+    HUGO_ENV = "production"
+    DOCS_URL = "/"
+  }
+  target = "nginx"
+  provenance = false
+  tags = ["docker/docs:latest"]
+}
+
 group "validate" {
   targets = ["lint", "test", "unused-media", "test-go-redirects", "dockerfile-lint", "path-warnings"]
 }


### PR DESCRIPTION
## Description

This PR adds a docker bake target and Dockerfile stage to build an `nginx` based container to host the documentation offline.

## Related issues or tickets

This is a resubmission of https://github.com/docker/docs/pull/22402, which was closed without reasoning.