### PR TITLE
kapa: change bot protection mechanism to hcaptcha

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -68,6 +68,7 @@ data-project-color="#1d63ed"
 data-project-logo="/assets/images/logo-icon-white.svg"
 data-project-name="Docker"
 data-user-analytics-fingerprint-enabled="true"
+data-bot-protection-mechanism="hcaptcha"
 data-website-id="{{ site.Params.kapa.id }}"
 ></script>
 {{/* preload Roboto Flex as it's a critical font: https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/rel/preload */}}


### PR DESCRIPTION
## Description

Kapa's default bot/abuse prevention mechanism uses Google reCAPTCHA service. This service has a dependency to Google infrastructure, which means that users in mainland China are most likely not able to use the Kapa widget unless they're using a VPN.

This PR changes the bot prevention mechanism to [hCaptcha](https://www.hcaptcha.com/), which works automatically for users in mainland China and everywhere else.