### PR TITLE
Fix the link to the "Running containers" documentation in the "Using lifecycle hooks with Compose" manual

### DIFF
--- a/content/manuals/compose/how-tos/lifecycle.md
+++ b/content/manuals/compose/how-tos/lifecycle.md
@@ -11,7 +11,7 @@ keywords: cli, compose, lifecycle, hooks reference
 ## Services lifecycle hooks
 
 When Docker Compose runs a container, it uses two elements, 
-[ENTRYPOINT and COMMAND](https://github.com/manuals//engine/containers/run.md#default-command-and-options), 
+[ENTRYPOINT and COMMAND](https://docs.docker.com/engine/containers/run/#default-command-and-options), 
 to manage what happens when the container starts and stops.
 
 However, it can sometimes be easier to handle these tasks separately with lifecycle hooks - 


### PR DESCRIPTION
## Description

[The current documentation link](https://github.com/manuals//engine/containers/run.md#default-command-and-options) responds with `Not Found`.
See the available manuals for containers [here](https://github.com/docker/docs/tree/main/content/manuals/engine/containers). 


