### PR TITLE
ISSUE-22453: Update Debian, RPI, Ubuntu apt config

### DIFF
--- a/content/manuals/engine/install/debian.md
+++ b/content/manuals/engine/install/debian.md
@@ -116,7 +116,7 @@ Docker from the repository.
    # Add the repository to Apt sources:
    echo \
      "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] {{% param "download-url-base" %}} \
-     $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | \
+     $(awk -F= '/VERSION_CODENAME/ { print $2 }' /etc/os-release) stable" | \
      sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
    sudo apt-get update
    ```

--- a/content/manuals/engine/install/raspberry-pi-os.md
+++ b/content/manuals/engine/install/raspberry-pi-os.md
@@ -117,7 +117,7 @@ Docker from the repository.
    # Add the repository to Apt sources:
    echo \
      "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] {{% param "download-url-base" %}} \
-     $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | \
+     $(awk -F= '/VERSION_CODENAME/ { print $2 }' /etc/os-release) stable" | \
      sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
    sudo apt-get update
    ```

--- a/content/manuals/engine/install/ubuntu.md
+++ b/content/manuals/engine/install/ubuntu.md
@@ -133,7 +133,7 @@ Docker from the repository.
    # Add the repository to Apt sources:
    echo \
      "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] {{% param "download-url-base" %}} \
-     $(. /etc/os-release && echo "${UBUNTU_CODENAME:-$VERSION_CODENAME}") stable" | \
+     $(awk -F= '/VERSION_CODENAME/ { print $2 }' /etc/os-release) stable" | \
      sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
    sudo apt-get update
    ```


### PR DESCRIPTION
## Description

The installation instructions for Debian, Ubuntu and Raspberry PI all use a complicated `$(. /etc/os-release && echo "VERSION_CODENAME")` command to set the VERSION_CODENAME for the apt source configuration. It would be much simpler and straightforward to use `awk` to get this from the target file and pass to the subsequent `tee` command.

This commit updates the installation instructions for each of the deb-based operating systems to use `awk -F '/VERSION_CODENAME' { print $2 } /etc/os-release` instead of the current, somewhat confusing and complicated sourcing of the file and subsequent `echo` to produce the same result using a single command invocation and built-in utility (awk).

## Related issues or tickets

I created an issue for this before creating this PR.

https://github.com/docker/docs/issues/22453

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [X] Technical review
- [X] Editorial review
- [ ] Product review