### PR TITLE
docs: Correct package manager usage in uninstall guide

### DIFF
--- a/content/manuals/desktop/uninstall.md
+++ b/content/manuals/desktop/uninstall.md
@@ -187,20 +187,18 @@ To uninstall Docker Desktop for Arch:
 1. Remove the Docker Desktop application. Run:
 
    ```console
-   $ sudo pacman remove docker-desktop
+   $ sudo pacman -Rns docker-desktop
    ```
 
-   This removes the Docker Desktop package itself but doesn’t delete all of its files or settings.
+   This removes the Docker Desktop package along with its configuration files and dependencies not required by other packages.
 
-2. Manually remove leftover file.
+2. Manually remove leftover files.
 
    ```console
    $ rm -r $HOME/.docker/desktop
-   $ sudo rm /usr/local/bin/com.docker.cli
-   $ sudo apt purge docker-desktop
    ```
 
-   This removes configuration and data files at `$HOME/.docker/desktop`, the symlink at `/usr/local/bin/com.docker.cli`, and purges the remaining systemd service files.
+   This removes configuration and data files at `$HOME/.docker/desktop`.
 
 3. Clean up Docker config settings. In `$HOME/.docker/config.json`, remove the `credsStore` and `currentContext` properties.
 


### PR DESCRIPTION
- Arch Linux does not have a seperate 'remove' and 'purge' command, instead the package is removed in one go.  
- Replaces 'pacman remove' with 'pacman -Rns' for a more complete removal, including configuration and dependencies.
- The 'com.docker.cli' symlink does not exist.
- Ensures all steps are accurate for an Arch Linux environment using pacman. The command explained:
-R - removes packages
-n - removes configuration files related to the package -s - Removes Dependencies that are not required by other packages

<!--Delete sections as needed -->

## Description

The uninstallation steps for Arch Linux were wrong. I replaced the steps with the correct commands.

Here is the [Arch Wiki](https://wiki.archlinux.org/title/Pacman) page for reference.

Feel free to recommend changes. Thank you!
