### PR TITLE
Fix the link to the compose CLI docs in the Using profiles manual

### DIFF
--- a/content/manuals/compose/how-tos/profiles.md
+++ b/content/manuals/compose/how-tos/profiles.md
@@ -177,7 +177,7 @@ $ COMPOSE_PROFILES=dev docker compose up phpmyadmin
 
 ## Stop application and services with specific profiles
 
-As with starting specific profiles, you can use the `--profile` [command-line option](/reference/cli/docker/compose.md#use--p-to-specify-a-project-name) or
+As with starting specific profiles, you can use the `--profile` [command-line option](/reference/cli/docker/compose.md) or
 use the [`COMPOSE_PROFILES` environment variable](environment-variables/envvars.md#compose_profiles):
 
 ```console


### PR DESCRIPTION
## Description

We could use the same link to the compose CLI docs as in [the "Start specific profiles" section](https://docs.docker.com/compose/how-tos/profiles/#start-specific-profiles).