### PR TITLE
Fix link to related docs in the "Building best practices" manual

### DIFF
--- a/content/manuals/build/building/best-practices.md
+++ b/content/manuals/build/building/best-practices.md
@@ -147,7 +147,7 @@ Limiting each container to one process is a good rule of thumb, but it's not a
 hard and fast rule. For example, not only can containers be
 [spawned with an init process](/manuals/engine/containers/multi-service_container.md),
 some programs might spawn additional processes of their own accord. For
-instance, [Celery](https://docs.celeryproject.org/) can spawn multiple worker
+instance, [Celery](https://docs.celeryq.dev/) can spawn multiple worker
 processes, and [Apache](https://httpd.apache.org/) can create one process per
 request.
 


### PR DESCRIPTION
## Description

The pull request fixes the stale Celery documentation URL.