### PR TITLE
docs: update uninstall.md to fix Arch uninstall commands

### DIFF
--- a/content/manuals/desktop/uninstall.md
+++ b/content/manuals/desktop/uninstall.md
@@ -187,7 +187,7 @@ To uninstall Docker Desktop for Arch:
 1. Remove the Docker Desktop application. Run:
 
    ```console
-   $ sudo pacman remove docker-desktop
+   $ sudo pacman -Rsn docker-desktop
    ```
 
    This removes the Docker Desktop package itself but doesn’t delete all of its files or settings.
@@ -197,7 +197,6 @@ To uninstall Docker Desktop for Arch:
    ```console
    $ rm -r $HOME/.docker/desktop
    $ sudo rm /usr/local/bin/com.docker.cli
-   $ sudo apt purge docker-desktop
    ```
 
    This removes configuration and data files at `$HOME/.docker/desktop`, the symlink at `/usr/local/bin/com.docker.cli`, and purges the remaining systemd service files.


### PR DESCRIPTION
## Description

Arch uninstall commands are invalid. there is no `pacman remove`, maybe they wanted to write `pacman --remove`. but its better to use `pacman -Rsn` as it will also purge files. and down there there is an `apt purge` which is also not available in Arch linux.
 

## Reviews

- [ ] Technical review
- [ ] Editorial review
- [ ] Product review