### PR TITLE
fix: hide page options on mobile

### DIFF
--- a/layouts/partials/content-default.html
+++ b/layouts/partials/content-default.html
@@ -11,9 +11,9 @@
     </div>
     {{ .Content }}
   </article>
-  <span class="ml-auto md-dropdown">
+  <div class="hidden lg:block ml-auto md-dropdown">
     {{ partial "md-dropdown.html" . }}
-  </span>
+  </div>
   <div class="-mr-8 -mt-8 hidden min-w-52 flex-1 lg:block">
     {{ partial "aside.html" . }}
   </div>


### PR DESCRIPTION
## Description
- Hide Page options on mobile, similar to hiding toc

## Related issues or tickets
- https://docker.atlassian.net/browse/ENGDOCS-2583

## Reviews
- [ ] Technical review
- [ ] Editorial review
- [ ] Product review