### PR TITLE
Prevent Hugo from outputting its version

### DIFF
--- a/hugo.yaml
+++ b/hugo.yaml
@@ -4,6 +4,7 @@ refLinksErrorLevel: ERROR
 enableGitInfo: true
 disablePathToLower: true
 enableInlineShortcodes: true
+disableHugoGeneratorInject: true
 ignoreLogs:
   - cascade-pattern-with-extension
 


### PR DESCRIPTION
By default (without this), it will add this to your home page in the `<head>` section:

`<meta name=generator content="Hugo 0.141.0">`

Where 0.141.0 is whatever version you generated the site with.

This PR configures Hugo to prevent that output.

## Related issues or tickets

This got sign off in https://github.com/docker/docs/issues/22499.

## Reviews

- [x] Technical review
- [ ] Editorial review
- [ ] Product review

### Tests

- `curl -s https://docs.docker.com 2>&1 | grep 0.141.0` will return back `<meta name=generator content="Hugo 0.141.0">`
- `curl -s https://deploy-preview-22500--docsdocker.netlify.app/ 2>&1 | grep 0.141.0` will not return it
- After this gets merged and the site is live, `curl -s https://docs.docker.com 2>&1 | grep 0.141.0` should not return it