### PR TITLE
Add CVE-2025-3911 to release notes of Docker Desktop 4.41

### DIFF
--- a/content/manuals/desktop/release-notes.md
+++ b/content/manuals/desktop/release-notes.md
@@ -51,9 +51,10 @@ For more frequently asked questions, see the [FAQs](/manuals/desktop/troubleshoo
 - [Docker Scout CLI v1.17.1](https://github.com/docker/scout-cli/releases/tag/v1.17.1)
 - [Compose Bridge v0.0.19](https://github.com/docker/compose-bridge-binaries/releases/tag/v0.0.19)
 
-### Security 
+### Security
 
 - Fixed [CVE-2025-3224](https://www.cve.org/CVERecord?id=CVE-2025-3224) allowing an attacker with access to a user machine to perform an elevation of privilege when Docker Desktop updates.
+- Fixed [CVE-2025-3911](https://www.cve.org/CVERecord?id=CVE-2025-3911) allowing an attacker with read access to a user machine to obtain sensitive information from Docker Desktop log files containing environment variables configured for running containers.
 
 ### Bug fixes and enhancements
 


### PR DESCRIPTION
## Description

Added CVE-2025-3911 to the release notes Security section for Docker Desktop 4.41

## Related issues or tickets

https://github.com/docker-security/cve-records/pull/13

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Technical review
- [ ] Editorial review
- [ ] Product review