### PR TITLE
Add CVE-2025-4095 to release notes of Docker Desktop 4.41

### DIFF
--- a/content/manuals/desktop/release-notes.md
+++ b/content/manuals/desktop/release-notes.md
@@ -54,6 +54,7 @@ For more frequently asked questions, see the [FAQs](/manuals/desktop/troubleshoo
 ### Security 
 
 - Fixed [CVE-2025-3224](https://www.cve.org/CVERecord?id=CVE-2025-3224) allowing an attacker with access to a user machine to perform an elevation of privilege when Docker Desktop updates.
+- Fixed [CVE-2025-4095](https://www.cve.org/CVERecord?id=CVE-2025-4095) where Registry Access Management (RAM) policies were not enforced when using a MacOS configuration profile, allowing users to pull images from unapproved registries.
 
 ### Bug fixes and enhancements
 


### PR DESCRIPTION
## Description

Add CVE-2025-4095 to release notes of Docker Desktop 4.41

## Related issues or tickets

<!-- Related issues, pull requests, or Jira tickets -->

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Technical review
- [ ] Editorial review
- [ ] Product review