### PR TITLE
Fix the link to the related docs in the "Manage builders" manual

### DIFF
--- a/content/manuals/build/builders/manage.md
+++ b/content/manuals/build/builders/manage.md
@@ -100,7 +100,7 @@ Total:        2.01GB
 ## Remove a builder
 
 Use the
-[`docker buildx remove`](/reference/cli/docker/buildx/create.md)
+[`docker buildx rm`](/reference/cli/docker/buildx/rm.md)
 command to remove a builder.
 
 ```console


### PR DESCRIPTION
## Description

This pull request fixes the `buildx rm` CLI documentation URL in the "Manage builders" manual.

