### PR TITLE
set github contribution links to open in new tab

### DIFF
--- a/layouts/partials/github-links.html
+++ b/layouts/partials/github-links.html
@@ -8,7 +8,7 @@
 {{ if not (in .Filename "/_vendor/") }}
 <p class="flex items-center gap-2">
   <span class="icon-svg">{{ partialCached "icon" "edit" "edit" }}</span>
-  <a class="link" rel="noopener"
+  <a class="link" rel="noopener" target="_blank"
     href="{{ site.Params.repo }}/edit/main/content/{{ .Path }}">{{- T "editPage" -}}
     <span class="icon-svg icon-sm">
       {{ partialCached "icon" "open_in_new" "open_in_new" }}
@@ -18,7 +18,7 @@
 {{ end }}
 <p class="flex items-center gap-2">
   <span class="icon-svg">{{ partialCached "icon" "check" "check" }}</span>
-  <a class="link" rel="noopener"
+  <a class="link" rel="noopener" target="_blank"
     href="{{ site.Params.repo }}/issues/new?template=doc_issue.yml&location={{ .Permalink }}&labels=status%2Ftriage">{{- T "requestChanges" -}}
     <span class="icon-svg icon-sm">
       {{ partialCached "icon" "open_in_new" "open_in_new" }}


### PR DESCRIPTION
<!--Delete sections as needed -->

## Description

<!-- Tell us what you did and why -->
 GitHub contribution links on right-hand side of production site should open in a new tab

Note - this part of the layout doesn't deploy unless it's prod, so couldn't test on preview.

## Related issues or tickets

<!-- Related issues, pull requests, or Jira tickets -->
- Fixes https://github.com/docker/docs/issues/22566

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Technical review
- [ ] Editorial review
- [ ] Product review