### PR TITLE
Standardize indention to four spaces in golang code snippet

### DIFF
--- a/content/reference/api/engine/sdk/_index.md
+++ b/content/reference/api/engine/sdk/_index.md
@@ -80,14 +80,14 @@ Docker API directly, or using the Python or Go SDK.
 package main
 
 import (
-	"context"
-	"io"
-	"os"
+    "context"
+    "io"
+    "os"
 
-	"github.com/docker/docker/api/types/container"
-        "github.com/docker/docker/api/types/image"
-	"github.com/docker/docker/client"
-	"github.com/docker/docker/pkg/stdcopy"
+    "github.com/docker/docker/api/types/container"
+    "github.com/docker/docker/api/types/image"
+    "github.com/docker/docker/client"
+    "github.com/docker/docker/pkg/stdcopy"
 )
 
 func main() {


### PR DESCRIPTION
<!--Delete sections as needed -->

## Description

<!-- Tell us what you did and why -->
Fix alignment of imports in golang code snippet to use four spaces like the rest of the snippet.

## Related issues or tickets

<!-- Related issues, pull requests, or Jira tickets -->
Fixes https://github.com/docker/docs/issues/22568

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Technical review
- [ ] Editorial review
- [ ] Product review