### PR TITLE
Clarify deprecated API endpoints

### DIFF
--- a/content/reference/api/hub/deprecated.md
+++ b/content/reference/api/hub/deprecated.md
@@ -6,12 +6,14 @@ weight: 3
 aliases:
   - /docker-hub/api/deprecated/
 ---
-
 > **Deprecated**
->
-> Docker Hub API v1 has been deprecated. Please use Docker Hub API v2 instead.
+
+Docker Hub API v1 has been deprecated. Please use [Docker Hub API v2](reference/api/hub/latest.md) instead.
+
+## Deprecated Routes
 
 The following API routes within the v1 path will no longer work and will return a 410 status code:
+
 * `/v1/repositories/{name}/images`
 * `/v1/repositories/{name}/tags`
 * `/v1/repositories/{name}/tags/{tag_name}`
@@ -19,13 +21,16 @@ The following API routes within the v1 path will no longer work and will return 
 * `/v1/repositories/{namespace}/{name}/tags`
 * `/v1/repositories/{namespace}/{name}/tags/{tag_name}`
 
-If you want to continue using the Docker Hub API in your current applications, update your clients to use v2 endpoints.
+### Images
 
-| **OLD**                                                                                                                                                              | **NEW**                                                                                                                                                                                                              |
-|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| [/v1/repositories/{name}/images](https://github.com/moby/moby/blob/v1.3.0/docs/sources/reference/api/docker-io_api.md#list-user-repository-images)                   | [/v2/namespaces/{namespace}/repositories/{repository}/images](/reference/api/hub/latest.md#tag/images/operation/GetNamespacesRepositoriesImages)                                                              |
-| [/v1/repositories/{namespace}/{name}/images](https://github.com/moby/moby/blob/v1.3.0/docs/sources/reference/api/docker-io_api.md#list-user-repository-images)       | [/v2/namespaces/{namespace}/repositories/{repository}/images](/reference/api/hub/latest.md#tag/images/operation/GetNamespacesRepositoriesImages)                                                              |
-| [/v1/repositories/{name}/tags](https://github.com/moby/moby/blob/v1.8.3/docs/reference/api/registry_api.md#list-repository-tags)                                     | [/v2/namespaces/{namespace}/repositories/{repository}/tags](/reference/api/hub/latest.md#tag/repositories/paths/~1v2~1namespaces~1%7Bnamespace%7D~1repositories~1%7Brepository%7D~1tags/get)                  |
-| [/v1/repositories/{namespace}/{name}/tags](https://github.com/moby/moby/blob/v1.8.3/docs/reference/api/registry_api.md#list-repository-tags)                         | [/v2/namespaces/{namespace}/repositories/{repository}/tags](/reference/api/hub/latest.md#tag/repositories/paths/~1v2~1namespaces~1%7Bnamespace%7D~1repositories~1%7Brepository%7D~1tags/get)                  |
-| [/v1/repositories/{namespace}/{name}/tags](https://github.com/moby/moby/blob/v1.8.3/docs/reference/api/registry_api.md#get-image-id-for-a-particular-tag)            | [/v2/namespaces/{namespace}/repositories/{repository}/tags/{tag}](/reference/api/hub/latest.md#tag/repositories/paths/~1v2~1namespaces~1%7Bnamespace%7D~1repositories~1%7Brepository%7D~1tags~1%7Btag%7D/get) |
-| [/v1/repositories/{namespace}/{name}/tags/{tag_name}](https://github.com/moby/moby/blob/v1.8.3/docs/reference/api/registry_api.md#get-image-id-for-a-particular-tag) | [/v2/namespaces/{namespace}/repositories/{repository}/tags/{tag}](/reference/api/hub/latest.md#tag/repositories/paths/~1v2~1namespaces~1%7Bnamespace%7D~1repositories~1%7Brepository%7D~1tags~1%7Btag%7D/get) |
+Accessing images by repository is no longer possible through the Docker Hub API. but this functionality is [available through the Docker CLI](reference/cli/docker/image/ls/#list-images-by-name-and-tag).
+
+### Tags
+
+To continue using the Docker Hub API for tags, update your clients to use these v2 endpoints:
+
+| v1 (deprecated) | v2 |
+| --- | --- |
+| [/v1/repositories/{name}/tags](https://github.com/moby/moby/blob/v1.8.3/docs/reference/api/registry_api.md#list-repository-tags) | [/v2/namespaces/{namespace}/repositories/{repository}/tags](https://github.com/docker/docs/blob/main/reference/api/hub/latest.md#tag/repositories/paths/~1v2~1namespaces~1%7Bnamespace%7D~1repositories~1%7Brepository%7D~1tags/get) |
+| [/v1/repositories/{namespace}/{name}/tags](https://github.com/moby/moby/blob/v1.8.3/docs/reference/api/registry_api.md#list-repository-tags) | [/v2/namespaces/{namespace}/repositories/{repository}/tags](https://github.com/docker/docs/blob/main/reference/api/hub/latest.md#tag/repositories/paths/~1v2~1namespaces~1%7Bnamespace%7D~1repositories~1%7Brepository%7D~1tags/get) |
+| [/v1/repositories/{namespace}/{name}/tags/{tag_name}](https://github.com/moby/moby/blob/v1.8.3/docs/reference/api/registry_api.md#get-image-id-for-a-particular-tag) | [/v2/namespaces/{namespace}/repositories/{repository}/tags/{tag}](https://github.com/docker/docs/blob/main/reference/api/hub/latest.md#tag/repositories/paths/~1v2~1namespaces~1%7Bnamespace%7D~1repositories~1%7Brepository%7D~1tags~1%7Btag%7D/get) |


### PR DESCRIPTION
<!--Delete sections as needed -->

## Description

- Removes table entries that link to endpoints that do not exist.
- Removes table entry that points to an API endpoint that is not equivalent
- Adds link to CLI alternative for missing functionality
- Renames table headers for specificity.

## Related issues or tickets

https://github.com/docker/docs/issues/22546

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Technical review
- [ ] Editorial review
- [ ] Product review