### PR TITLE
New engine options, "allow-direct-routing" and "trusted_host_interfaces"

### DIFF
--- a/content/manuals/engine/network/packet-filtering-firewalls.md
+++ b/content/manuals/engine/network/packet-filtering-firewalls.md
@@ -150,15 +150,51 @@ But, particularly with IPv6 you may prefer to avoid using NAT and instead
 arrange for external routing to container addresses ("direct routing").
 
 To access containers on a bridge network from outside the Docker host,
-you must set up routing to the bridge network via an address on the Docker
-host. This can be achieved using static routes, Border Gateway Protocol
-(BGP), or any other means appropriate for your network.
+you must first set up routing to the bridge network via an address on the
+Docker host. This can be achieved using static routes, Border Gateway Protocol
+(BGP), or any other means appropriate for your network. For example, within
+a local layer 2 network, remote hosts can set up static routes to a container
+network via the Docker daemon host's address on the local network.
 
-Within a local layer 2 network, remote hosts can set up static routes
-to a container network using the Docker daemon host's address on the local
-network. Those hosts can access containers directly. For remote hosts
-outside the local network, direct access to containers requires router
-configuration to enable the necessary routing.
+#### Direct routing to containers in bridge networks
+
+By default, remote hosts are not allowed direct access to container IP
+addresses in Docker's Linux bridge networks. They can only access ports
+published to host IP addresses.
+
+To allow direct access to any published port, on any container, in any
+Linux bridge network, use daemon option `--allow-direct-routing` or the
+equivalent `"allow-direct-routing": true` in `/etc/docker/daemon.json`.
+
+To allow direct routing from anywhere to containers in a specific bridge
+network, see [Gateway modes](#gateway-modes).
+
+Or, to allow direct routing via specific host interfaces, to a specific
+bridge network, use the following option when creating the network:
+- `com.docker.network.bridge.trusted_host_interfaces`
+
+#### Example
+
+Create a network where published ports on container IP addresses can be
+accessed directly from interfaces `vxlan.1` and `eth3`:
+
+```console
+$ docker network create --subnet 192.0.2.0/24 --ip-range 192.0.2.0/29 -o com.docker.network.bridge.trusted_host_interfaces="vxlan.1:eth3" mynet
+```
+
+Run a container in that network, publishing its port 80 to the port
+8080 on host's loopback interface:
+
+```console
+docker run -d --ip 192.0.2.100 -p 127.0.0.1:8080:80 nginx
+```
+
+The web server running on the container's port 80 can now be accessed
+from the Docker host at `http://127.0.0.1:8080`, or directly at
+`http://192.0.2.100:80`. If remote hosts on networks connected to
+interfaces `vxlan.1` and `eth3` have a route to the `192.0.2.0/24`
+network inside the Docker host, they can also access the web server
+via `http://192.0.2.100:80`.
 
 #### Gateway modes
 


### PR DESCRIPTION
## Description

**This update is for moby 28.2.0 - do not merge until it ships.**

Add description for daemon option `--allow-direct-routing` and network option `com.docker.network.bridge.trusted_host_interfaces`.

## Related issues or tickets

https://github.com/moby/moby/pull/49832

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Technical review
- [ ] Editorial review
- [ ] Product review