### PR TITLE
Remote access to container ports

### DIFF
--- a/content/manuals/engine/network/_index.md
+++ b/content/manuals/engine/network/_index.md
@@ -160,8 +160,8 @@ Here are some examples:
 >
 > > [!WARNING]
 > >
-> > Hosts within the same L2 segment (for example, hosts connected to the same
-> > network switch) can reach ports published to localhost.
+> > In releases older than 28.0.0, hosts within the same L2 segment (for example,
+> > hosts connected to the same network switch) can reach ports published to localhost.
 > > For more information, see
 > > [moby/moby#45610](https://github.com/moby/moby/issues/45610)
 

--- a/content/manuals/engine/network/packet-filtering-firewalls.md
+++ b/content/manuals/engine/network/packet-filtering-firewalls.md
@@ -234,14 +234,14 @@ $ docker run --network=mynet -p 8080:80 myimage
 ```
 
 Then:
-- Only container port 80 will be open, for IPv4 and IPv6. It is accessible
-  from anywhere, if there is routing to the container's address, and access
-  is not blocked by the host's firewall.
+- Only container port 80 will be open, for IPv4 and IPv6.
 - For IPv6, using `routed` mode, port 80 will be open on the container's IP
   address. Port 8080 will not be opened on the host's IP addresses, and
   outgoing packets will use the container's IP address.
 - For IPv4, using the default `nat` mode, the container's port 80 will be
-  accessible via port 8080 on the host's IP addresses, as well as directly.
+  accessible via port 8080 on the host's IP addresses, as well as directly
+  from within the Docker host. But, container port 80 cannot be accessed
+  directly from outside the host.
   Connections originating from the container will masquerade, using the 
   host's IP address.
 


### PR DESCRIPTION
## Description

(These updates are for current moby releases.)

### Update warning about ports published to 127.0.0.1

Align a warning on the [engine/network](https://docs.docker.com/engine/network/) page with the one on [engine/network/packet-filtering-firewalls](https://docs.docker.com/engine/network/packet-filtering-firewalls/) - which has already been updated, in https://github.com/docker/docs/commit/2090e5bcbbdf38fa1004caa0488e555497ae8a39

### Update text about direct routing

Update the text about direct routing, to note that without direct routing it's not (any longer) possible to access ports on container addresses directly.

## Related issues or tickets

<!-- Related issues, pull requests, or Jira tickets -->

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Technical review
- [ ] Editorial review
- [ ] Product review