### PR TITLE
docs: Update incorrect port in Docker Compose the go-prometheus-monitoring guide

### DIFF
--- a/content/guides/go-prometheus-monitoring/compose.md
+++ b/content/guides/go-prometheus-monitoring/compose.md
@@ -27,7 +27,7 @@ services:
     networks:
       - go-network
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8080/health"]
+      test: ["CMD", "curl", "-f", "http://localhost:8000/health"]
       interval: 30s
       timeout: 10s
       retries: 5


### PR DESCRIPTION
<!--Delete sections as needed -->

## Description

The service port is `8000`, and I mistakenly mentioned `8080` for health check while creating this guide. 

- [ ] Technical review
- [x] Editorial review
- [ ] Product review