### PR TITLE
docs: Add warning about using btrfs storage driver

### DIFF
--- a/content/manuals/engine/storage/drivers/btrfs-driver.md
+++ b/content/manuals/engine/storage/drivers/btrfs-driver.md
@@ -6,6 +6,15 @@ aliases:
   - /storage/storagedriver/btrfs-driver/
 ---
 
+> [!IMPORTANT]
+>
+> In most cases you should use the `overlay2` storage driver - it's not
+> required to use the `btrfs` storage driver simply because your system uses
+> Btrfs as its root filesystem.
+>
+> Btrfs driver has known issues - see [Moby issue #27653](https://github.com/moby/moby/issues/27653)
+> for more information.
+
 Btrfs is a copy-on-write filesystem that supports many advanced storage
 technologies, making it a good fit for Docker. Btrfs is included in the
 mainline Linux kernel.

--- a/content/manuals/engine/storage/drivers/select-storage-driver.md
+++ b/content/manuals/engine/storage/drivers/select-storage-driver.md
@@ -102,13 +102,19 @@ With regard to Docker, the backing filesystem is the filesystem where
 `/var/lib/docker/` is located. Some storage drivers only work with specific
 backing filesystems.
 
-| Storage driver   | Supported backing filesystems |
-| :--------------- | :---------------------------- |
-| `overlay2`       | `xfs` with ftype=1, `ext4`    |
-| `fuse-overlayfs` | any filesystem                |
-| `btrfs`          | `btrfs`                       |
-| `zfs`            | `zfs`                         |
-| `vfs`            | any filesystem                |
+| Storage driver   | Supported backing filesystems                         |
+| :--------------- | :-----------------------------------------------------|
+| `overlay2`       | `xfs` with ftype=1, `ext4`, `btrfs`, (and more\*)     |
+| `fuse-overlayfs` | any filesystem                                        |
+| `btrfs`          | `btrfs`                                               |
+| `zfs`            | `zfs`                                                 |
+| `vfs`            | any filesystem                                        |
+
+> [!NOTE]
+> \* Most filesystems should work if they have the required features.
+> Consult [OverlayFS](https://www.kernel.org/doc/html/latest/filesystems/overlayfs.html)
+> for more information.
+
 
 ## Other considerations
 


### PR DESCRIPTION

<!--Delete sections as needed -->

## Description


This has been a source of confusion for many users.

Recommend to use overlay2 and clarify that using btrfs filesystem doesn't require using the btrfs storage driver.

## Related issues or tickets

- https://github.com/moby/moby/issues/27653
<!-- Related issues, pull requests, or Jira tickets -->

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Technical review
- [ ] Editorial review
- [ ] Product review