### PR TITLE
Update outdated url to ubuntu source code

### DIFF
--- a/content/manuals/build/building/best-practices.md
+++ b/content/manuals/build/building/best-practices.md
@@ -442,7 +442,7 @@ reduces the image size, since the apt cache isn't stored in a layer. Since the
 `RUN` statement starts with `apt-get update`, the package cache is always
 refreshed prior to `apt-get install`.
 
-Official Debian and Ubuntu images [automatically run `apt-get clean`](https://github.com/moby/moby/blob/03e2923e42446dbb830c654d0eec323a0b4ef02a/contrib/mkimage/debootstrap#L82-L105), so explicit invocation is not required.
+Official Debian and Ubuntu images [automatically run `apt-get clean`](https://git.launchpad.net/livecd-rootfs/tree/live-build/functions#n1003), so explicit invocation is not required.
 
 #### Using pipes
 


### PR DESCRIPTION
<!--Delete sections as needed -->

## Description

I set a new URL for the source code because the old ones refer to the commit of the file, which is not used now, because Ubuntu for Docker is built from livecd scripts.

## Related issues or tickets

<!-- Related issues, pull requests, or Jira tickets -->

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Technical review
- [x] Editorial review
- [ ] Product review