### PR TITLE
troubleshooting: remove docker feedback cli

### DIFF
--- a/content/manuals/compose/support-and-feedback/feedback.md
+++ b/content/manuals/compose/support-and-feedback/feedback.md
@@ -9,12 +9,6 @@ aliases:
 
 There are many ways you can provide feedback on Docker Compose.
 
-### In-product feedback
-
-If you have obtained Docker Compose through Docker Desktop, you can use the `docker feedback` command to submit feedback directly from the command line.
-
-<script async id="asciicast-KkC0fFrhV8nAzvXUGqay06UXx" src="https://asciinema.org/a/KkC0fFrhV8nAzvXUGqay06UXx.js"></script>
-
 ### Report bugs or problems on GitHub
 
 To report bugs or problems, visit [Docker Compose on GitHub](https://github.com/docker/compose/issues)

--- a/content/manuals/desktop/troubleshoot-and-support/feedback.md
+++ b/content/manuals/desktop/troubleshoot-and-support/feedback.md
@@ -14,10 +14,6 @@ There are many ways you can provide feedback on Docker Desktop or Docker Desktop
 
 On each Docker Desktop Dashboard view, there is a **Give feedback** link. This opens a feedback form where you can share ideas directly with the Docker team.
 
-You can also use the `docker feedback` command to submit feedback directly from the command line.
-
-<script async id="asciicast-KkC0fFrhV8nAzvXUGqay06UXx" src="https://asciinema.org/a/KkC0fFrhV8nAzvXUGqay06UXx.js"></script>
-
 ### Feedback via Docker Community forums
 
 To get help from the community, review current user topics, join or start a


### PR DESCRIPTION
<!--Delete sections as needed -->

## Description

`docker feedback` doesn't exit anymore.

<!-- Tell us what you did and why -->

## Related issues or tickets

<!-- Related issues, pull requests, or Jira tickets -->

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Technical review
- [ ] Editorial review
- [ ] Product review