### PR TITLE
Fix the incorrect info to use a space between orgs for registry signi…

### DIFF
--- a/content/manuals/security/for-admins/enforce-sign-in/methods.md
+++ b/content/manuals/security/for-admins/enforce-sign-in/methods.md
@@ -27,7 +27,7 @@ To enforce sign-in for Docker Desktop on Windows, you can configure a registry k
    > [!IMPORTANT]
    >
    > As of Docker Desktop version 4.36 and later, you can add more than one organization. With Docker Desktop version 4.35 and earlier, if you add more than one organization sign-in enforcement silently fails.
-3. Use your organization's name, all lowercase as string data. If you're adding more than one organization, make sure there is an empty space between each organization name.
+3. Use your organization's name, all lowercase as string data. If you're adding more than one organization, make sure they are all on their own line (don't use any other separators like spaces, commas or such).
 4. Restart Docker Desktop.
 5. When Docker Desktop restarts, verify that the **Sign in required!** prompt appears.
 


### PR DESCRIPTION
…n enforcement

## Description

We currently tell users to use a space between orgs when enforcing sign-in with multiple orgs via Windows registry. This is just not true. Multiple orgs have to be separated by being on multiple lines. Otherwise it will not work.

## Related issues or tickets

https://docker.atlassian.net/browse/DDB-227

## Reviews

@aevesdocker

- [ ] Technical review
- [x] Editorial review
- [ ] Product review