### PR TITLE
engine/api: add missing API version for v28.1

### DIFF
--- a/content/reference/api/engine/_index.md
+++ b/content/reference/api/engine/_index.md
@@ -73,21 +73,21 @@ To see the highest version of the API your Docker daemon and client support, use
 ```console
 $ docker version
 Client: Docker Engine - Community
- Version:           28.0.0
- API version:       1.48
- Go version:        go1.23.6
- Git commit:        f9ced58
- Built:             Wed Feb 19 22:11:04 2025
+ Version:           28.1.1
+ API version:       1.49
+ Go version:        go1.23.8
+ Git commit:        4eba377
+ Built:             Fri Apr 18 09:49:45 2025
  OS/Arch:           linux/amd64
  Context:           default
 
 Server: Docker Engine - Community
  Engine:
-  Version:          28.0.0
-  API version:      1.48 (minimum version 1.24)
-  Go version:       go1.23.6
-  Git commit:       af898ab
-  Built:            Wed Feb 19 22:11:04 2025
+  Version:          28.1.1
+  API version:      1.49 (minimum version 1.24)
+  Go version:       go1.23.8
+  Git commit:       01f442b
+  Built:            Fri Apr 18 09:52:08 2025
   OS/Arch:          linux/amd64
   ...
 ```
@@ -132,6 +132,7 @@ You can specify the API version to use in any of the following ways:
 
 | Docker version | Maximum API version                          | Change log                                                         |
 |:---------------|:---------------------------------------------|:-------------------------------------------------------------------|
+| 28.1           | [1.49](/reference/api/engine/version/v1.49/) | [changes](/reference/api/engine/version-history/#v149-api-changes) |
 | 28.0           | [1.48](/reference/api/engine/version/v1.48/) | [changes](/reference/api/engine/version-history/#v148-api-changes) |
 | 27.5           | [1.47](/reference/api/engine/version/v1.47/) | [changes](/reference/api/engine/version-history/#v147-api-changes) |
 | 27.4           | [1.47](/reference/api/engine/version/v1.47/) | [changes](/reference/api/engine/version-history/#v147-api-changes) |


### PR DESCRIPTION
Looks like we didn't update the table and example version


<!--Delete sections as needed -->

## Description

<!-- Tell us what you did and why -->

## Related issues or tickets

<!-- Related issues, pull requests, or Jira tickets -->

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Technical review
- [ ] Editorial review
- [ ] Product review