### PR TITLE
Fix link to release note for multiple exporters feature

### DIFF
--- a/data/summary.yaml
+++ b/data/summary.yaml
@@ -30,7 +30,7 @@ Build dockerfile inline:
 Build entitlements:
   requires: Docker Compose [2.27.1](/manuals/compose/releases/release-notes.md#2271) and later
 Build multiple exporters:
-  requires: Docker Buildx [0.13.0]((/manuals/build/release-notes.md#0130) and later
+  requires: Docker Buildx [0.13.0](/build/release-notes.md#0130) and later
 Buildkit host:
   requires: Docker Buildx [0.9.0](/manuals/build/release-notes.md#090) and later
 Build privileged:


### PR DESCRIPTION
## Description

This pull request fixes a stale link to build release notes in the "Exporters overview" manual.
https://docs.docker.com/build/exporters/#multiple-exporters
https://github.com/duffuniverse/docs/blob/main/content/manuals/build/exporters/_index.md#multiple-exporters

![Screenshot from 2025-05-16 15-35-17](https://github.com/user-attachments/assets/f1262c3c-c831-4536-b3ca-604d3bcd9268)




