### PR TITLE
Fix link to release note for Compose model runner feature

### DIFF
--- a/data/summary.yaml
+++ b/data/summary.yaml
@@ -108,7 +108,7 @@ Compose mac address:
 Compose menu:
   requires: Docker Compose [2.26.0](/manuals/compose/releases/release-notes.md#2260) and later
 Compose model runner:
-  requires: Docker Compose [2.35.0](/manuals/compose/releases/release-notes.md#2300) and later, and Docker Desktop 4.41 and later
+  requires: Docker Compose [2.35.0](/manuals/compose/releases/release-notes.md#2350) and later, and Docker Desktop 4.41 and later
 Compose OCI artifact:
   requires: Docker Compose [2.34.0](/manuals/compose/releases/release-notes.md#2340) and later
 Compose provider services:


### PR DESCRIPTION
## Description

This pull request fixes a stale link to compose release notes in the "Use Docker Model Runner" manual.
https://docs.docker.com/compose/how-tos/model-runner/
https://github.com/duffuniverse/docs/blob/main/content/manuals/compose/how-tos/model-runner.md