### PR TITLE
build: provenance is minimal by default

### DIFF
--- a/content/manuals/build/metadata/attestations/_index.md
+++ b/content/manuals/build/metadata/attestations/_index.md
@@ -70,7 +70,7 @@ $ docker buildx build --sbom=true --provenance=true .
 > You can disable provenance attestations using the `--provenance=false` flag,
 > or by setting the [`BUILDX_NO_DEFAULT_ATTESTATIONS`](/manuals/build/building/variables.md#buildx_no_default_attestations) environment variable.
 >
-> Using the `--provenance=true` flag attaches provenance attestations with `mode=max`
+> Using the `--provenance=true` flag attaches provenance attestations with `mode=min`
 > by default. See [Provenance attestation](./slsa-provenance.md) for more details.
 
 BuildKit generates the attestations when building the image. The attestation

--- a/content/manuals/build/metadata/attestations/slsa-provenance.md
+++ b/content/manuals/build/metadata/attestations/slsa-provenance.md
@@ -41,8 +41,8 @@ For an example on how to add provenance attestations with GitHub Actions, see
 ## Mode
 
 You can use the `mode` parameter to define the level of detail to be included in
-the provenance attestation. Supported values are `mode=min`, and `mode=max`
-(default).
+the provenance attestation. Supported values are `mode=min` (default) and
+`mode=max`.
 
 ### Min
 


### PR DESCRIPTION
## Description

Provenance is not max but minimal by default:
* https://github.com/docker/buildx/blob/ea2b7020a4645bff395eb49e4e87ef08ba24eb93/docs/reference/buildx_build.md?plain=1#L160-L161
* https://github.com/docker/buildx/blob/ea2b7020a4645bff395eb49e4e87ef08ba24eb93/build/opt.go#L153

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [x] Technical review
- [ ] Editorial review
- [ ] Product review