### PR TITLE
engine: install: remove Ubuntu 20.04, Fedora 40 (EOL)

### DIFF
--- a/content/manuals/engine/install/fedora.md
+++ b/content/manuals/engine/install/fedora.md
@@ -28,7 +28,6 @@ Fedora versions:
 
 - Fedora 42
 - Fedora 41
-- Fedora 40
 
 ### Uninstall old versions
 

--- a/content/manuals/engine/install/ubuntu.md
+++ b/content/manuals/engine/install/ubuntu.md
@@ -54,7 +54,6 @@ versions:
 - Ubuntu Oracular 24.10
 - Ubuntu Noble 24.04 (LTS)
 - Ubuntu Jammy 22.04 (LTS)
-- Ubuntu Focal 20.04 (LTS)
 
 Docker Engine for Ubuntu is compatible with x86_64 (or amd64), armhf, arm64,
 s390x, and ppc64le (ppc64el) architectures.


### PR DESCRIPTION
Ubuntu 20.04 and Fedora 40 reached EOL, so remove mentions of it in the installation docs.

<!--Delete sections as needed -->

## Description

<!-- Tell us what you did and why -->

## Related issues or tickets

<!-- Related issues, pull requests, or Jira tickets -->

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Technical review
- [ ] Editorial review
- [ ] Product review