### PR TITLE
update: VAT faq and callouts

### DIFF
--- a/content/includes/tax-compliance.md
+++ b/content/includes/tax-compliance.md
@@ -1,8 +1,8 @@
 > [!IMPORTANT]
 >
-> Docker began collecting sales tax from United States customers on July 1, 2024.
+> For United States customers, Docker began collecting sales tax on July 1, 2024.
 > For European customers, Docker began collecting VAT on March 1, 2025.
-> For United Kingdom customers, VAT collection began on May 1, 2025.
+> For United Kingdom customers, Docker began collecting VAT on May 1, 2025.
 >
 > To ensure that tax assessments are correct, make sure that your
 [billing information](/billing/details/) and VAT/Tax ID, if applicable, are

--- a/content/includes/tax-compliance.md
+++ b/content/includes/tax-compliance.md
@@ -1,5 +1,10 @@
 > [!IMPORTANT]
 >
-> Starting July 1, 2024, Docker will begin collecting sales tax on subscription fees in compliance with state regulations for customers in the United States. For our global customers subject to VAT, the implementation will start rolling out on July 1, 2024. Note that while the roll out begins on this date, VAT charges may not apply to all applicable subscriptions immediately.
+> Docker began collecting sales tax from United States customers on July 1, 2024.
+> For European customers, Docker began collecting VAT on March 1, 2025.
+> For United Kingdom customers, VAT collection began on May 1, 2025.
 >
-> To ensure that tax assessments are correct, make sure that your [billing information](/billing/details/) and VAT/Tax ID, if applicable, are updated. If you're exempt from sales tax, see [Register a tax certificate](/billing/tax-certificate/).
+> To ensure that tax assessments are correct, make sure that your
+[billing information](/billing/details/) and VAT/Tax ID, if applicable, are
+updated. If you're exempt from sales tax, see
+[Register a tax certificate](/billing/tax-certificate/).

--- a/content/manuals/billing/faqs.md
+++ b/content/manuals/billing/faqs.md
@@ -45,9 +45,19 @@ updated. If you need to update your default payment method, see
 
 ### Does Docker collect sales tax and/or VAT?
 
-Docker began collecting sales tax on subscription fees for United States customers on July 1, 2024. For European customers, Docker will begin collecting VAT on March 1, 2025.
+Docker collects sales tax and/or VAT from the following:
 
-To ensure that tax assessments are correct, make sure that your billing information and VAT/Tax ID, if applicable, are updated. See [Update the billing information](/billing/details/).
+- Docker began collecting sales tax from United States
+customers on July 1, 2024.
+- For European customers, Docker began collecting VAT on March 1, 2025.
+- For United Kingdom customers, Docker began collecting VAT on May 1, 2025.
+
+To ensure that tax assessments are correct, make sure that your billing
+information and VAT/Tax ID, if applicable, are updated. See
+[Update the billing information](/billing/details/).
+
+If you're exempt from sales tax, see
+[Register a tax certificate](/billing/tax-certificate/).
 
 ### How do I certify my tax exempt status?
 

--- a/content/manuals/billing/faqs.md
+++ b/content/manuals/billing/faqs.md
@@ -47,8 +47,7 @@ updated. If you need to update your default payment method, see
 
 Docker collects sales tax and/or VAT from the following:
 
-- Docker began collecting sales tax from United States
-customers on July 1, 2024.
+- For United States customers, Docker began collecting sales tax on July 1, 2024.
 - For European customers, Docker began collecting VAT on March 1, 2025.
 - For United Kingdom customers, Docker began collecting VAT on May 1, 2025.
 


### PR DESCRIPTION
## Description
- Updated FAQ and callouts to include UK VAT collection date, May 1 2025

## Related issues or tickets
https://docker.atlassian.net/browse/ENGDOCS-2647

## Reviews
- [ ] Editorial review