### PR TITLE
release-notes for Compose v2.36.2 version

### DIFF
--- a/_vendor/modules.txt
+++ b/_vendor/modules.txt
@@ -2,5 +2,5 @@
 # github.com/moby/buildkit v0.22.0
 # github.com/docker/buildx v0.24.0
 # github.com/docker/cli v28.1.1+incompatible
-# github.com/docker/compose/v2 v2.36.1
+# github.com/docker/compose/v2 v2.36.2
 # github.com/docker/scout-cli v1.15.0

--- a/content/manuals/compose/releases/release-notes.md
+++ b/content/manuals/compose/releases/release-notes.md
@@ -15,6 +15,22 @@ For more detailed information, see the [release notes in the Compose repo](https
 
 ## 2.36.1
 
+{{< release-date date="2025-05-23" >}}
+
+### Bug fixes and enhancements
+
+- Fixed an issue with random port allocation
+- Fixed an issue recreating containers when not needed during inner loop
+- Fixed a problem during `up --build` wiht `additional_context`
+
+### Update
+
+- Dependencies upgrade: bump compose-go to v2.6.4
+- Dependencies upgrade: bump buildx to v0.24.0
+- Dependencies upgrade: bump buildkit to v0.22.0
+
+## 2.36.1
+
 {{< release-date date="2025-05-19" >}}
 
 ### Bug fixes and enhancements

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.24.0
 require (
 	github.com/docker/buildx v0.24.0 // indirect
 	github.com/docker/cli v28.1.1+incompatible // indirect
-	github.com/docker/compose/v2 v2.36.1 // indirect
+	github.com/docker/compose/v2 v2.36.2 // indirect
 	github.com/docker/scout-cli v1.15.0 // indirect
 	github.com/moby/buildkit v0.22.0 // indirect
 	github.com/moby/moby v28.1.0-rc.2+incompatible // indirect
@@ -14,7 +14,7 @@ require (
 replace (
 	github.com/docker/buildx => github.com/docker/buildx v0.24.0
 	github.com/docker/cli => github.com/docker/cli v28.1.0-rc.2+incompatible
-	github.com/docker/compose/v2 => github.com/docker/compose/v2 v2.36.1
+	github.com/docker/compose/v2 => github.com/docker/compose/v2 v2.36.2
 	github.com/docker/scout-cli => github.com/docker/scout-cli v1.15.0
 	github.com/moby/buildkit => github.com/moby/buildkit v0.22.0-rc1
 	github.com/moby/moby => github.com/moby/moby v28.1.0-rc.2+incompatible

--- a/go.sum
+++ b/go.sum
@@ -239,6 +239,8 @@ github.com/docker/compose/v2 v2.36.0 h1:MACSfQ2xqcwgCwAtsHVoQkFbHi2nNfNAsd5EWFg1
 github.com/docker/compose/v2 v2.36.0/go.mod h1:kFPppTinl2Q0Lv3Dy9titIL41oWYoUkNxoKQZb/lfSU=
 github.com/docker/compose/v2 v2.36.1 h1:BmTE1Ps6XDOuubyL97ucPvIn8Nq2XprRylE2dgCtTXw=
 github.com/docker/compose/v2 v2.36.1/go.mod h1:w6fj+dvMW9W0gFaTpIwJ2PYstqiGIC07Cajp5wPukO0=
+github.com/docker/compose/v2 v2.36.2 h1:rxk1PUUbhbAS6HkGsYo9xUmMBpKtVwFMNCQjE4+i5fk=
+github.com/docker/compose/v2 v2.36.2/go.mod h1:mZygkne+MAMu/e1B28PBFmG0Z0WefbxZ/IpcjSFdrw8=
 github.com/docker/distribution v2.8.2+incompatible h1:T3de5rq0dB1j30rp0sA2rER+m322EBzniBPB6ZIzuh8=
 github.com/docker/distribution v2.8.2+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
 github.com/docker/distribution v2.8.3+incompatible h1:AtKxIZ36LoNK51+Z6RpzLpddBirtxJnzDrHLEKxTAYk=

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -140,7 +140,7 @@ params:
   # (Used to show e.g., "latest" and "latest"-1 in engine install examples
   docker_ce_version_prev: "28.1.0"
   # Latest Docker Compose version
-  compose_version: "v2.36.1"
+  compose_version: "v2.36.2"
   # Latest BuildKit version
   buildkit_version: "0.21.0"
 


### PR DESCRIPTION
<!--Delete sections as needed -->

## Description
Add release notes for Compose `v2.36.2` version

## Related issues or tickets
https://docker.atlassian.net/browse/APCLI-1138

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Technical review
- [ ] Editorial review
- [ ] Product review