### PR TITLE
Update Laravel guide (bump to Laravel 12 and php 8.4)

### DIFF
--- a/content/guides/frameworks/laravel/_index.md
+++ b/content/guides/frameworks/laravel/_index.md
@@ -31,7 +31,7 @@ The demonstrated examples can be found in [this GitHub repository](https://githu
 
 This guide is intended for educational purposes, helping developers adapt and optimize configurations for their specific use cases. Additionally, there are existing tools that support Laravel in containers:
 
-- [Laravel Sail](https://laravel.com/docs/11.x/sail): An official package for easily starting Laravel in Docker.
+- [Laravel Sail](https://laravel.com/docs/12.x/sail): An official package for easily starting Laravel in Docker.
 - [Laradock](https://github.com/laradock/laradock): A community project that helps run Laravel applications in Docker.
 
 ## What you’ll learn

--- a/content/guides/frameworks/laravel/development-setup.md
+++ b/content/guides/frameworks/laravel/development-setup.md
@@ -119,7 +119,7 @@ A workspace container provides a dedicated shell for asset compilation, Artisan/
 ```dockerfile
 # docker/development/workspace/Dockerfile
 # Use the official PHP CLI image as the base
-FROM php:8.3-cli
+FROM php:8.4-cli
 
 # Set environment variables for user and group ID
 ARG UID=1000

--- a/content/guides/frameworks/laravel/prerequisites.md
+++ b/content/guides/frameworks/laravel/prerequisites.md
@@ -19,7 +19,7 @@ A fundamental understanding of Docker and how containers work will be helpful. I
 
 ## Basic knowledge of Laravel
 
-This guide assumes you have a basic understanding of Laravel and PHP. Familiarity with Laravel’s command-line tools, such as [Artisan](https://laravel.com/docs/11.x/artisan), and its project structure is important for following the instructions.
+This guide assumes you have a basic understanding of Laravel and PHP. Familiarity with Laravel’s command-line tools, such as [Artisan](https://laravel.com/docs/12.x/artisan), and its project structure is important for following the instructions.
 
 - Laravel CLI: You should be comfortable using Laravel’s command-line tool (`artisan`).
 - Laravel Project Structure: Familiarize yourself with Laravel’s folder structure (`app`, `config`, `routes`, `tests`, etc.).

--- a/content/guides/frameworks/laravel/production-setup.md
+++ b/content/guides/frameworks/laravel/production-setup.md
@@ -45,7 +45,7 @@ For production, the `php-fpm` Dockerfile creates an optimized image with only th
 
 ```dockerfile
 # Stage 1: Build environment and Composer dependencies
-FROM php:8.3-fpm AS builder
+FROM php:8.4-fpm AS builder
 
 # Install system dependencies and PHP extensions for Laravel with MySQL/PostgreSQL support.
 # Dependencies in this stage are only required for building the final image.
@@ -98,7 +98,7 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local
     && composer install --no-dev --optimize-autoloader --no-interaction --no-progress --prefer-dist
 
 # Stage 2: Production environment
-FROM php:8.3-fpm
+FROM php:8.4-fpm
 
 # Install only runtime libraries needed in production
 # libfcgi-bin and procps are required for the php-fpm-healthcheck script
@@ -173,7 +173,7 @@ If you need a separate CLI container with different extensions or strict separat
 
 ```dockerfile
 # Stage 1: Build environment and Composer dependencies
-FROM php:8.3-cli AS builder
+FROM php:8.4-cli AS builder
 
 # Install system dependencies and PHP extensions required for Laravel + MySQL/PostgreSQL support
 # Some dependencies are required for PHP extensions only in the build stage
@@ -211,7 +211,7 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local
     && composer install --no-dev --optimize-autoloader --no-interaction --no-progress --prefer-dist
 
 # Stage 2: Production environment
-FROM php:8.3-cli
+FROM php:8.4-cli
 
 # Install client libraries required for php extensions in runtime
 RUN apt-get update && apt-get install -y --no-install-recommends \
@@ -244,7 +244,7 @@ USER www-data
 CMD ["bash"]
 ```
 
-This Dockerfile is similar to the PHP-FPM Dockerfile, but it uses the `php:8.3-cli` image as the base image and sets up the container for running CLI commands.
+This Dockerfile is similar to the PHP-FPM Dockerfile, but it uses the `php:8.4-cli` image as the base image and sets up the container for running CLI commands.
 
 ## Create a Dockerfile for Nginx (production)
 


### PR DESCRIPTION
<!--Delete sections as needed -->

## Description

Introduces small update of the Laravel framework guide (bump versions to the latest Laravel 12 and php 8.4 + updates the related examples repo - the fork needs to be synced).

## Related issues or tickets

#21268 

## Reviews

<!-- Notes for reviewers here -->
As was discussed on the last docs meeting, to simplify the process the review will be sent to the one of Docker Captains first.
@igor-alexandrov @ajeetraina 

- [ ] Technical review
- [ ] Editorial review
- [ ] Product review