### PR TITLE
docs: correct typo in DockerDesktopClient entrypoint reference

### DIFF
--- a/content/manuals/extensions/extensions-sdk/dev/api/overview.md
+++ b/content/manuals/extensions/extensions-sdk/dev/api/overview.md
@@ -14,7 +14,7 @@ and communicate with the Docker Desktop dashboard or the underlying system.
 
 JavaScript API libraries, with Typescript support, are available in order to get all the API definitions in to your extension code.
 
-- [@docker/extension-api-client](https://www.npmjs.com/package/@docker/extension-api-client) gives access to the extension API entrypoint `DockerDesktopCLient`.
+- [@docker/extension-api-client](https://www.npmjs.com/package/@docker/extension-api-client) gives access to the extension API entrypoint `DockerDesktopClient`.
 - [@docker/extension-api-client-types](https://www.npmjs.com/package/@docker/extension-api-client-types) can be added as a dev dependency in order to get types auto-completion in your IDE.
 
 ```Typescript


### PR DESCRIPTION
<!--Delete sections as needed -->

## Description
Fix typo `DockerDesktopCLient` -> `DockerDesktopClient`


<!-- Tell us what you did and why -->

## Related issues or tickets

<!-- Related issues, pull requests, or Jira tickets -->

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Technical review
- [ ] Editorial review
- [ ] Product review