### PR TITLE
update Docker Desktop minimum WSL 2 version to 2.1.5

### DIFF
--- a/content/manuals/desktop/features/wsl/_index.md
+++ b/content/manuals/desktop/features/wsl/_index.md
@@ -23,7 +23,7 @@ Additionally, with WSL 2, the time required to start a Docker daemon after a col
 
 Before you turn on the Docker Desktop WSL 2 feature, ensure you have:
 
-- At a minimum WSL version 1.1.3.0., but ideally the latest version of WSL to [avoid Docker Desktop not working as expected](best-practices.md).
+- At a minimum WSL version 2.1.5, but ideally the latest version of WSL to [avoid Docker Desktop not working as expected](best-practices.md).
 - Met the Docker Desktop for Windows' [system requirements](/manuals/desktop/setup/install/windows-install.md#system-requirements).
 - Installed the WSL 2 feature on Windows. For detailed instructions, refer to the [Microsoft documentation](https://docs.microsoft.com/en-us/windows/wsl/install-win10).
 

--- a/content/manuals/desktop/features/wsl/best-practices.md
+++ b/content/manuals/desktop/features/wsl/best-practices.md
@@ -7,7 +7,7 @@ aliases:
 - /desktop/wsl/best-practices/
 ---
 
-- Always use the latest version of WSL. At a minimum you must use WSL version 1.1.3.0., otherwise Docker Desktop may not work as expected. Testing, development, and documentation is based on the newest kernel versions. Older versions of WSL can cause:
+- Always use the latest version of WSL. At a minimum you must use WSL version 2.1.5, otherwise Docker Desktop may not work as expected. Testing, development, and documentation is based on the newest kernel versions. Older versions of WSL can cause:
     - Docker Desktop to hang periodically or when upgrading
     - Deployment via SCCM to fail
     - The `vmmem.exe` to consume all memory 


### PR DESCRIPTION


<!--Delete sections as needed -->

## Description

Update the minimum WSL 2 version to 2.1.5 (released in [March 2024](https://github.com/microsoft/WSL/releases/tag/2.1.5) available in the Microsoft Store via `wsl --install` and `wsl --update`). Note there is no change to the minimum Windows OS versions.

Using an older version of WSL 2 causes startup failures e.g. https://github.com/docker/for-win/issues/14714#issuecomment-2880418211

In Docker Desktop 4.42 there will be an explicit version check for 2.1.5 to guide the user to updated prevent the startup failures.

/cc @chelnak 

<!-- Tell us what you did and why -->

## Related issues or tickets

https://github.com/docker/for-win/issues/14714#issuecomment-2880418211

<!-- Related issues, pull requests, or Jira tickets -->

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Technical review
- [ ] Editorial review
- [ ] Product review