### PR TITLE
get-started: update link to training to avoid redirect

### DIFF
--- a/content/get-started/resources.md
+++ b/content/get-started/resources.md
@@ -9,7 +9,7 @@ Docker and the broader community of Docker experts have put together many differ
 
 ## Docker Training
 
-Expand your knowledge on all things Docker with [basic to advanced trainings from Docker experts](https://www.docker.com/resources/trainings/). 
+Expand your knowledge on all things Docker with [basic to advanced trainings from Docker experts](https://www.docker.com/trainings/). 
 
 You can find recorded content at your own convenience, or register for a live session to participate in Q&A.
 


### PR DESCRIPTION
- fixes https://github.com/docker/docs/issues/22727

Looks like this page moved

    curl -sI https://www.docker.com/resources/trainings/ | grep location:
    location: /trainings/

<!--Delete sections as needed -->

## Description

<!-- Tell us what you did and why -->

## Related issues or tickets

<!-- Related issues, pull requests, or Jira tickets -->

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Technical review
- [ ] Editorial review
- [ ] Product review