### PR TITLE
Fix 28.2.0 rel notes, trusted_interfaces separator ':' not space

### DIFF
--- a/content/manuals/engine/release-notes/28.md
+++ b/content/manuals/engine/release-notes/28.md
@@ -82,7 +82,7 @@ For a full list of pull requests and changes in this release, refer to the relev
 
 ### Networking
 
-- Add bridge network option `"com.docker.network.bridge.trusted_host_interfaces"`, accepting a space-separated list of interface names. These interfaces have direct access to published ports on container IP addresses. [moby/moby#49832](https://github.com/moby/moby/pull/49832)
+- Add bridge network option `"com.docker.network.bridge.trusted_host_interfaces"`, accepting a colon-separated list of interface names. These interfaces have direct access to published ports on container IP addresses. [moby/moby#49832](https://github.com/moby/moby/pull/49832)
 - Add daemon option `"allow-direct-routing"` to disable filtering of packets from outside the host addressed directly to containers. [moby/moby#49832](https://github.com/moby/moby/pull/49832)
 - Do not display network options `com.docker.network.enable_ipv4` or `com.docker.network.enable_ipv6` in inspect output if they have been overridden by `EnableIPv4` or `EnableIPv6` in the network create request. [moby/moby#49866](https://github.com/moby/moby/pull/49866)
 - Fix an issue that could cause network deletion to fail after a daemon restart, with error "has active endpoints" listing empty endpoint names. [moby/moby#49901](https://github.com/moby/moby/pull/49901)


### PR DESCRIPTION
## Description

Fix release notes for moby 28.2.0 ... the separator for option `com.docker.network.bridge.trusted_host_interfaces` changed from space to colon following review - but I forgot to update the description release notes.

## Related issues or tickets

- https://github.com/moby/moby/pull/49832
- https://github.com/docker/docs/pull/22660

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Technical review
- [ ] Editorial review
- [ ] Product review