### PR TITLE
Fix docker compose release notes heading for release 2.36.2

### DIFF
--- a/content/manuals/compose/releases/release-notes.md
+++ b/content/manuals/compose/releases/release-notes.md
@@ -13,7 +13,7 @@ aliases:
 
 For more detailed information, see the [release notes in the Compose repo](https://github.com/docker/compose/releases/).
 
-## 2.36.1
+## 2.36.2
 
 {{< release-date date="2025-05-23" >}}
 


### PR DESCRIPTION
## Description

Heading for release 2.36.2 showed 2.36.1

## Reviews

- [ ] Technical review
- [X] Editorial review
- [ ] Product review