### PR TITLE
ci: remove gha cache exports

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,9 +36,6 @@ jobs:
           files: |
             docker-bake.hcl
           targets: releaser-build
-          set: |
-            *.cache-from=type=gha,scope=releaser
-            *.cache-to=type=gha,scope=releaser,mode=max
 
   build:
     runs-on: ubuntu-24.04
@@ -59,9 +56,6 @@ jobs:
           files: |
             docker-bake.hcl
           targets: release
-          set: |
-            *.cache-from=type=gha,scope=build
-            *.cache-to=type=gha,scope=build,mode=max
       -
         name: Check Cloudfront config
         uses: docker/bake-action@v6
@@ -110,6 +104,3 @@ jobs:
           targets: ${{ matrix.target }}
           set: |
             *.args.BUILDKIT_CONTEXT_KEEP_GIT_DIR=1
-            *.cache-to=type=gha,scope=validate-${{ matrix.target }},mode=max
-            *.cache-from=type=gha,scope=validate-${{ matrix.target }}
-            *.cache-from=type=gha,scope=build

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -96,9 +96,6 @@ jobs:
           files: |
             docker-bake.hcl
           targets: release
-          set: |
-            *.cache-from=type=gha,scope=deploy-${{ env.BRANCH_NAME }}
-            *.cache-to=type=gha,scope=deploy-${{ env.BRANCH_NAME }},mode=max
           provenance: false
       -
         name: Configure AWS Credentials
@@ -134,8 +131,6 @@ jobs:
           files: |
             docker-bake.hcl
           targets: aws-s3-update-config
-          set: |
-            *.cache-from=type=gha,scope=releaser
         env:
           AWS_REGION: ${{ env.DOCS_AWS_REGION }}
           AWS_S3_BUCKET: ${{ env.DOCS_S3_BUCKET }}

--- a/.github/workflows/validate-upstream.yml
+++ b/.github/workflows/validate-upstream.yml
@@ -97,9 +97,6 @@ jobs:
             docker-bake.hcl
           targets: validate-upstream
           provenance: false
-          set: |
-            *.cache-from=type=gha,scope=docs-upstream
-            *.cache-to=type=gha,scope=docs-upstream
         env:
           UPSTREAM_MODULE_NAME: ${{ inputs.module-name }}
           UPSTREAM_REPO: ${{ github.repository }}


### PR DESCRIPTION
## Description

It takes more time to import/export the cache on ci than it takes to just build our tiny Dockerfile. So let's just remove these cache exporters. It should improve build time on ci.

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Technical review
- [ ] Editorial review
- [ ] Product review