### PR TITLE
chore: remove plan from docs

### DIFF
--- a/content/guides/docker-build-cloud/common-questions.md
+++ b/content/guides/docker-build-cloud/common-questions.md
@@ -42,7 +42,7 @@ account and start a trial of Docker Build Cloud. Personal accounts are limited t
 single user.
 
 For teams to receive the shared cache benefit, they must either be on a Docker
-Team or Docker Business plan.
+Team or Docker Business subscription.
 
 ### Does Docker Build Cloud support CI platforms? Does it work with GitHub Actions?
 

--- a/content/manuals/admin/faqs/general-faqs.md
+++ b/content/manuals/admin/faqs/general-faqs.md
@@ -73,9 +73,9 @@ information, see [Configure SSO](../../security/for-admins/single-sign-on/config
 
 > [!IMPORTANT]
 >
-> As of December 10, 2024, service accounts are no longer available. Existing Service Account agreements will be honored until their current term expires, but new purchases or renewals of service accounts no longer available and customers must renew under a new subscription plan. It is recommended to transition to Organization Access Tokens (OATs), which can provide similar functionality. For more information, see [Organization access tokens (Beta)](/manuals/security/for-admins/access-tokens.md).
+> As of December 10, 2024, service accounts are no longer available. Existing Service Account agreements will be honored until their current term expires, but new purchases or renewals of service accounts no longer available and customers must renew under a new subscription. It is recommended to transition to Organization Access Tokens (OATs), which can provide similar functionality. For more information, see [Organization access tokens (Beta)](/manuals/security/for-admins/access-tokens.md).
 
-A [service account](../../docker-hub/service-accounts.md) is a Docker ID used for automated management of container images or containerized applications. Service accounts are typically used in automated workflows, and don't share Docker IDs with the members in the Team or Business plan. Common use cases for service accounts include mirroring content on Docker Hub, or tying in image pulls from your CI/CD process.
+A [service account](../../docker-hub/service-accounts.md) is a Docker ID used for automated management of container images or containerized applications. Service accounts are typically used in automated workflows, and don't share Docker IDs with the members in the Team or Business subscription. Common use cases for service accounts include mirroring content on Docker Hub, or tying in image pulls from your CI/CD process.
 
 ### Can I delete or deactivate a Docker account for another user?
 

--- a/content/manuals/admin/organization/activity-logs.md
+++ b/content/manuals/admin/organization/activity-logs.md
@@ -18,7 +18,7 @@ With activity logs, owners can view and track:
 
 For example, activity logs display activities such as the date when a repository was created or deleted, the member who created the repository, the name of the repository, and when there was a change to the privacy settings.
 
-Owners can also see the activity logs for their repository if the repository is part of the organization subscribed to a Docker Business or Team plan.
+Owners can also see the activity logs for their repository if the repository is part of the organization subscribed to a Docker Business or Team subscription.
 
 ## Manage activity logs
 

--- a/content/manuals/admin/organization/convert-account.md
+++ b/content/manuals/admin/organization/convert-account.md
@@ -11,7 +11,7 @@ aliases:
 
 You can convert an existing user account to an organization. This is useful if you need multiple users to access your account and the repositories that it’s connected to. Converting it to an organization gives you better control over permissions for these users through [teams](manage-a-team.md) and [roles](roles-and-permissions.md).
 
-When you convert a user account to an organization, the account is migrated to a Docker Team plan.
+When you convert a user account to an organization, the account is migrated to a Docker Team subscription.
 
 > [!IMPORTANT]
 >
@@ -40,7 +40,7 @@ Consider the following effects of converting your account:
 
 - This process removes the email address for the account, and organization owners will receive notification emails instead. You'll be able to reuse the removed email address for another account after converting.
 
-- The current plan will cancel and your new subscription will start.
+- The current subscription will cancel and your new subscription will start.
 
 - Repository namespaces and names won't change, but converting your account removes any repository collaborators. Once you convert the account, you'll need to add those users as team members.
 

--- a/content/manuals/admin/organization/orgs.md
+++ b/content/manuals/admin/organization/orgs.md
@@ -13,7 +13,7 @@ aliases:
 This section describes how to create an organization. Before you begin:
 
 - You need a [Docker ID](/accounts/create-account/)
-- Review the [Docker subscriptions and features](../../subscription/details.md) to determine what plan to choose for your organization
+- Review the [Docker subscriptions and features](../../subscription/details.md) to determine what subscription to choose for your organization
 
 ## Create an organization
 
@@ -33,7 +33,7 @@ To create an organization:
 1. Sign in to [Docker Home](https://app.docker.com/).
 2. Under Settings and administration, select **Go to Admin Console**.
 3. Select the **Organization** drop-down in the left-hand navigation and then **Create Organization**.
-4. Choose a plan for your organization, a billing cycle, and specify how many seats you need. See [Docker Pricing](https://www.docker.com/pricing/) for details on the features offered in the Team and Business plan.
+4. Choose a subscription for your organization, a billing cycle, and specify how many seats you need. See [Docker Pricing](https://www.docker.com/pricing/) for details on the features offered in the Team and Business subscription.
 5. Select **Continue to profile**.
 6. Enter an **Organization namespace**. This is the official, unique name for
 your organization in Docker Hub. It's not possible to change the name of the
@@ -60,7 +60,7 @@ You've now created an organization.
 
 1. Sign in to [Docker Hub](https://hub.docker.com/) using your Docker ID, your email address, or your social provider.
 2. Select **My Hub**, select the account drop-down, and then **Create Organization** to create a new organization.
-3. Choose a plan for your organization, a billing cycle, and specify how many seats you need. See [Docker Pricing](https://www.docker.com/pricing/) for details on the features offered in the Team and Business plan.
+3. Choose a subscription for your organization, a billing cycle, and specify how many seats you need. See [Docker Pricing](https://www.docker.com/pricing/) for details on the features offered in the Team and Business subscription.
 4. Select **Continue to profile**.
 5. Enter an **Organization namespace**. This is the official, unique name for
 your organization in Docker Hub. It's not possible to change the name of the
@@ -161,7 +161,7 @@ configure your organization.
    organization's **Settings** page.
 
 - **Billing**: Displays information about your existing
-[Docker subscription (plan)](../../subscription/_index.md), including the number of seats and next payment due date. For how to access the billing history and payment methods for your organization, see [View billing history](../../billing/history.md).
+[Docker subscription](../../subscription/_index.md), including the number of seats and next payment due date. For how to access the billing history and payment methods for your organization, see [View billing history](../../billing/history.md).
 
 {{< /tab >}}
 {{< /tabs >}}

--- a/content/manuals/billing/3d-secure.md
+++ b/content/manuals/billing/3d-secure.md
@@ -7,7 +7,7 @@ weight: 40
 
 > [!NOTE]
 >
-> [Docker plan](../subscription/setup.md) payments support 3D secure authentication.
+> [Docker subscription](../subscription/setup.md) payments support 3D secure authentication.
 
 3D Secure (3DS) authentication incorporates an additional security layer for credit card transactions. If you’re making payments for your Docker billing in a region that requires 3DS, or using a payment method that requires 3DS, you’ll need to verify your identity to complete any transactions. The method used to verify your identity varies depending on your banking institution.
 

--- a/content/manuals/billing/_index.md
+++ b/content/manuals/billing/_index.md
@@ -36,6 +36,6 @@ aliases:
   - /billing/docker-hub-pricing/
 ---
 
-Use the resources in this section to manage your billing and payment settings for your Docker subscription plans.
+Use the resources in this section to manage your billing and payment settings for your Docker subscriptions.
 
 {{< grid items="grid_core" >}}

--- a/content/manuals/billing/cycle.md
+++ b/content/manuals/billing/cycle.md
@@ -5,11 +5,11 @@ description: Learn to change your billing cycle for your Docker subscription
 keywords: billing, cycle, payments, subscription
 ---
 
-You can pay for a subscription plan on a monthly or yearly billing cycle. You select your preferred billing cycle when you buy your subscription.
+You can pay for a subscription on a monthly or yearly billing cycle. You select your preferred billing cycle when you buy your subscription.
 
 > [!NOTE]
 >
-> Business plan is available only on yearly billing cycle.
+> Business subscriptions are available only on yearly billing cycle.
 
 If you have a monthly billing cycle, you can choose to switch to an annual billing cycle.
 
@@ -21,14 +21,14 @@ When you change the billing cycle's duration:
 
 - The next billing date reflects the new cycle. To find your next billing date, see [View renewal date](history.md#view-renewal-date).
 - The subscription's start date resets. For example, if the start date of the monthly subscription is March 1st and the end date is April 1st, then after switching the billing duration to March 15th, 2024 the new start date is March 15th, 2024, and the new end date is March 15th, 2025.
-- Any unused monthly subscription is prorated and applied as credit towards the new annual period. For example, if you switch from a $10 monthly subscription to a $100 annual plan, deducting the unused monthly value (in this case $5), the migration cost becomes $95 ($100 - $5). The renewal cost after March 15, 2025 is $100.
+- Any unused monthly subscription is prorated and applied as credit towards the new annual period. For example, if you switch from a $10 monthly subscription to a $100 annual subscription, deducting the unused monthly value (in this case $5), the migration cost becomes $95 ($100 - $5). The renewal cost after March 15, 2025 is $100.
 
 {{% include "tax-compliance.md" %}}
 
 ## Personal account
 
 {{< tabs >}}
-{{< tab name="Docker plan" >}}
+{{< tab name="Docker subscription" >}}
 
 To change your billing cycle:
 
@@ -44,10 +44,10 @@ To change your billing cycle:
 > If you choose to pay using a US bank account, you must verify the account. For
 > more information, see [Verify a bank account](manuals/billing/payment-method.md#verify-a-bank-account).
 
-The billing plans and usage page will now reflect your new annual plan details.
+The billing plans and usage page will now reflect your new annual subscription details.
 
 {{< /tab >}}
-{{< tab name="Legacy Docker plan" >}}
+{{< tab name="Legacy Docker subscription" >}}
 
 To change your billing cycle:
 
@@ -67,7 +67,7 @@ To change your billing cycle:
 > You must be an organization owner to make changes to the payment information.
 
 {{< tabs >}}
-{{< tab name="Docker plan" >}}
+{{< tab name="Docker subscription" >}}
 
 To change your organization's billing cycle:
 
@@ -84,7 +84,7 @@ To change your organization's billing cycle:
 > more information, see [Verify a bank account](manuals/billing/payment-method.md#verify-a-bank-account).
 
 {{< /tab >}}
-{{< tab name="Legacy Docker plan" >}}
+{{< tab name="Legacy Docker subscription" >}}
 
 To change your organization's billing cycle:
 

--- a/content/manuals/billing/details.md
+++ b/content/manuals/billing/details.md
@@ -16,7 +16,7 @@ The billing information provided appears on all your billing invoices. The email
 ### Personal account
 
 {{< tabs >}}
-{{< tab name="Docker plan" >}}
+{{< tab name="Docker subscription" >}}
 
 To update your billing information:
 
@@ -35,7 +35,7 @@ To update your billing information:
 7. Select **Update**.
 
 {{< /tab >}}
-{{< tab name="Legacy Docker plan" >}}
+{{< tab name="Legacy Docker subscription" >}}
 
 To update your billing information:
 
@@ -62,7 +62,7 @@ To update your billing information:
 > You must be an organization owner to make changes to the billing information.
 
 {{< tabs >}}
-{{< tab name="Docker plan" >}}
+{{< tab name="Docker subscription" >}}
 
 To update your billing information:
 
@@ -81,7 +81,7 @@ To update your billing information:
 7. Select **Update**.
 
 {{< /tab >}}
-{{< tab name="Legacy Docker plan" >}}
+{{< tab name="Legacy Docker subscription" >}}
 
 To update your billing information:
 
@@ -118,7 +118,7 @@ You can update the email address that receives billing invoices at any time.
 ### Personal account
 
 {{< tabs >}}
-{{< tab name="Docker plan" >}}
+{{< tab name="Docker subscription" >}}
 
 To update your billing email address:
 
@@ -129,7 +129,7 @@ To update your billing email address:
 5. Update your billing contact information and select **Update**.
 
 {{< /tab >}}
-{{< tab name="Legacy Docker plan" >}}
+{{< tab name="Legacy Docker subscription" >}}
 
 To update your billing email address:
 
@@ -146,7 +146,7 @@ To update your billing email address:
 ### Organizations
 
 {{< tabs >}}
-{{< tab name="Docker plan" >}}
+{{< tab name="Docker subscription" >}}
 
 To update your billing email address:
 
@@ -157,7 +157,7 @@ To update your billing email address:
 5. Update your billing contact information and select **Update**.
 
 {{< /tab >}}
-{{< tab name="Legacy Docker plan" >}}
+{{< tab name="Legacy Docker subscription" >}}
 
 To update your billing email address:
 

--- a/content/manuals/billing/faqs.md
+++ b/content/manuals/billing/faqs.md
@@ -33,7 +33,7 @@ If your subscription payment fails, there is a grace period of 15 days, includin
 
 Docker also sends an email notification `Action Required - Credit Card Payment Failed` with an attached unpaid invoice after each failed payment attempt.
 
-Once the grace period is over and the invoice is still not paid, the subscription downgrades to a free plan and all paid features are disabled.
+Once the grace period is over and the invoice is still not paid, the subscription downgrades to a free subscription and all paid features are disabled.
 
 ### Can I manually retry a failed payment?
 

--- a/content/manuals/billing/history.md
+++ b/content/manuals/billing/history.md
@@ -35,13 +35,13 @@ You can’t make changes to a paid or unpaid billing invoice. When you update yo
 ### View renewal date
 
 {{< tabs >}}
-{{< tab name="Docker plan" >}}
+{{< tab name="Docker subscription" >}}
 
-You receive your invoice when the subscription renews. To verify your renewal date, sign in to the [Docker Home Billing](https://app.docker.com/billing). Your renewal date and amount are displayed on your subscription plan card.
+You receive your invoice when the subscription renews. To verify your renewal date, sign in to the [Docker Home Billing](https://app.docker.com/billing). Your renewal date and amount are displayed on your subscription card.
 
 
 {{< /tab >}}
-{{< tab name="Legacy Docker plan" >}}
+{{< tab name="Legacy Docker subscription" >}}
 
 You receive your invoice when the subscription renews. To verify your renewal date:
 
@@ -60,7 +60,7 @@ You receive your invoice when the subscription renews. To verify your renewal da
 > If the VAT number field is not available, complete the [Contact Support form](https://hub.docker.com/support/contact/). This field may need to be manually added.
 
 {{< tabs >}}
-{{< tab name="Docker plan" >}}
+{{< tab name="Docker subscription" >}}
 
 To add or update your VAT number:
 
@@ -81,7 +81,7 @@ To add or update your VAT number:
 Your VAT number will be included on your next invoice.
 
 {{< /tab >}}
-{{< tab name="Legacy Docker plan" >}}
+{{< tab name="Legacy Docker subscription" >}}
 
 To add or update your VAT number:
 
@@ -110,7 +110,7 @@ You can view the billing history and download past invoices for a personal accou
 ### Personal account
 
 {{< tabs >}}
-{{< tab name="Docker plan" >}}
+{{< tab name="Docker subscription" >}}
 
 To view billing history:
 
@@ -121,7 +121,7 @@ To view billing history:
 5. Optional. Select the **Download** button to download an invoice.
 
 {{< /tab >}}
-{{< tab name="Legacy Docker plan" >}}
+{{< tab name="Legacy Docker subscription" >}}
 
 To view billing history:
 
@@ -143,7 +143,7 @@ From here you can download an invoice.
 > You must be an owner of the organization to view the billing history.
 
 {{< tabs >}}
-{{< tab name="Docker plan" >}}
+{{< tab name="Docker subscription" >}}
 
 To view billing history:
 
@@ -154,7 +154,7 @@ To view billing history:
 5. Optional. Select the **download** button to download an invoice.
 
 {{< /tab >}}
-{{< tab name="Legacy Docker plan" >}}
+{{< tab name="Legacy Docker subscription" >}}
 
 To view billing history:
 

--- a/content/manuals/billing/payment-method.md
+++ b/content/manuals/billing/payment-method.md
@@ -13,7 +13,7 @@ You can add a payment method or update your account's existing payment method at
 
 > [!IMPORTANT]
 >
-> If you want to remove all payment methods, you must first downgrade your subscription to a free plan. See [Downgrade](../subscription/change.md).
+> If you want to remove all payment methods, you must first downgrade your subscription to a free subscription. See [Downgrade](../subscription/change.md).
 
 The following payment methods are supported:
 
@@ -39,7 +39,7 @@ All currency, for example the amount listed on your billing invoice, is in Unite
 ### Personal account
 
 {{< tabs >}}
-{{< tab name="Docker plan" >}}
+{{< tab name="Docker subscription" >}}
 
 To add a payment method:
 
@@ -69,7 +69,7 @@ To add a payment method:
 > verify the account first.
 
 {{< /tab >}}
-{{< tab name="Legacy Docker plan" >}}
+{{< tab name="Legacy Docker subscription" >}}
 
 To add a payment method:
 
@@ -98,7 +98,7 @@ To add a payment method:
 > You must be an organization owner to make changes to the payment information.
 
 {{< tabs >}}
-{{< tab name="Docker plan" >}}
+{{< tab name="Docker subscription" >}}
 
 To add a payment method:
 
@@ -130,7 +130,7 @@ To add a payment method:
 > verify the account first.
 
 {{< /tab >}}
-{{< tab name="Legacy Docker plan" >}}
+{{< tab name="Legacy Docker subscription" >}}
 
 To add a payment method:
 
@@ -204,7 +204,7 @@ If your subscription payment fails, there is a grace period of 15 days, includin
 
 Docker also sends an email notification `Action Required - Credit Card Payment Failed` with an attached unpaid invoice after each failed payment attempt.
 
-Once the grace period is over and the invoice is still not paid, the subscription downgrades to a free plan and all paid features are disabled.
+Once the grace period is over and the invoice is still not paid, the subscription downgrades to a free subscription and all paid features are disabled.
 
 ## Redeem a coupon
 

--- a/content/manuals/desktop/enterprise/_index.md
+++ b/content/manuals/desktop/enterprise/_index.md
@@ -18,6 +18,6 @@ aliases:
 
 Docker Desktop Enterprise (DDE) has been deprecated and is no longer in active development. Please use [Docker Desktop](../_index.md) Community instead.
 
-If you are an existing DDE customer, use our [Support form](https://hub.docker.com/support/desktop/) to request a transition to one of our new [subscription plans](https://www.docker.com/pricing).
+If you are an existing DDE customer, use our [Support form](https://hub.docker.com/support/desktop/) to request a transition to one of our new [subscriptions](https://www.docker.com/pricing).
 
 If you are looking to deploy Docker Desktop at scale, contact us on [pricingquestions@docker.com](mailto:pricingquestions@docker.com).

--- a/content/manuals/desktop/previous-versions/2.x-mac.md
+++ b/content/manuals/desktop/previous-versions/2.x-mac.md
@@ -28,7 +28,7 @@ Docker Desktop 2.5.0.0 contains a Kubernetes upgrade. Your local Kubernetes clus
 
 ### New
 
-- Users with a paid Docker subscription plan can now see the vulnerability scan report on the Remote repositories tab in Docker Desktop.
+- Users with a paid Docker subscription can now see the vulnerability scan report on the Remote repositories tab in Docker Desktop.
 - Docker Desktop introduces a support option for users with a paid Docker subscription.
 
 ### Security

--- a/content/manuals/desktop/troubleshoot-and-support/support.md
+++ b/content/manuals/desktop/troubleshoot-and-support/support.md
@@ -85,7 +85,7 @@ For Pro and Team customers, Docker only offers support for the latest version of
 ### How many machines can I get support for Docker Desktop on?
 
 As a Pro user you can get support for Docker Desktop on a single machine.
-As a Team, you can get support for Docker Desktop for the number of machines equal to the number of seats as part of your plan.
+As a Team, you can get support for Docker Desktop for the number of machines equal to the number of seats as part of your subscription.
 
 ### What OS’s are supported?
 

--- a/content/manuals/docker-hub/release-notes.md
+++ b/content/manuals/docker-hub/release-notes.md
@@ -281,7 +281,6 @@ Each organization page now breaks down into these tabs:
 
 * Scan results don't appear for some official images.
 
-
 ## 2019-09-05
 
 ### Enhancements

--- a/content/manuals/docker-hub/service-accounts.md
+++ b/content/manuals/docker-hub/service-accounts.md
@@ -13,7 +13,7 @@ weight: 50
 > available. Existing Service Account agreements will be honored until their
 > current term expires, but new purchases or renewals of Enhanced Service
 > Account add-ons are no longer available and customers must renew under a new
-> subscription plan.
+> subscription.
 >
 > Docker recommends transitioning to [Organization Access Tokens
 > (OATs)](../security/for-admins/access-tokens.md), which can provide similar

--- a/content/manuals/docker-hub/usage/pulls.md
+++ b/content/manuals/docker-hub/usage/pulls.md
@@ -209,6 +209,6 @@ To view your current pull rate and limit:
    If you don't see any `ratelimit` header, it could be because the image or your IP
    is unlimited in partnership with a publisher, provider, or an open source
    organization. It could also mean that the user you are pulling as is part of a
-   paid Docker plan. Pulling that image won't count toward pull rate limits if you
+   paid Docker subscription. Pulling that image won't count toward pull rate limits if you
    don't see these headers.
 

--- a/content/manuals/scout/_index.md
+++ b/content/manuals/scout/_index.md
@@ -40,7 +40,7 @@ grid:
   - title: Upgrade
     link: /subscription/change/
     description: |
-      The free plan includes up to 1 repository. Upgrade for more.
+      A Personal subscription includes up to 1 repository. Upgrade for more.
     icon: upgrade
 ---
 

--- a/content/manuals/security/faqs/single-sign-on/enforcement-faqs.md
+++ b/content/manuals/security/faqs/single-sign-on/enforcement-faqs.md
@@ -41,7 +41,7 @@ Guest users who are not part of your registered domain but have been invited to 
 
 ### Is there a way to test this functionality in a test tenant with Okta before going to production?
 
-Yes, you can create a test organization. Companies can set up a new 5 seat Business plan on a new organization to test with. To do this, make sure to only enable SSO, not enforce it, or all domain email users will be forced to sign in to that test tenant.
+Yes, you can create a test organization. Companies can set up a new 5 seat Business subscription on a new organization to test with. To do this, make sure to only enable SSO, not enforce it, or all domain email users will be forced to sign in to that test tenant.
 
 ### Is the sign in required tracking at runtime or install time?
 

--- a/content/manuals/subscription/_index.md
+++ b/content/manuals/subscription/_index.md
@@ -1,7 +1,7 @@
 ---
 title: Subscription
 description: Learn about subscription features and how to manage your subscription
-keywords: Docker, pricing, billing, Pro, Team, business, subscription, tier, plan
+keywords: Docker, pricing, billing, Pro, Team, business, subscription, tier
 weight: 50
 params:
   sidebar:
@@ -20,7 +20,7 @@ grid_subscriptions:
   link: /subscription/scale/
   icon: leaderboard
 - title: Change your subscription
-  description: Learn how to upgrade or downgrade your plan.
+  description: Learn how to upgrade or downgrade your subscription.
   link: /subscription/change/
   icon: upgrade
 - title: Manage seats

--- a/content/manuals/subscription/change.md
+++ b/content/manuals/subscription/change.md
@@ -1,6 +1,6 @@
 ---
 description: Learn how to change your Docker subscription
-keywords: Docker Hub, upgrade, downgrade, subscription, Pro, Team, business, pricing plan
+keywords: Docker Hub, upgrade, downgrade, subscription, Pro, Team, business, pricing
 title: Change your subscription
 aliases:
 - /docker-hub/upgrade/
@@ -19,13 +19,13 @@ weight: 30
 {{% include "tax-compliance.md" %}}
 
 The following sections describe how to change plans when you have a Docker
-subscription plan or legacy Docker subscription plan.
+subscription or legacy Docker subscription.
 
 > [!NOTE]
 >
 > Legacy Docker plans apply to Docker subscribers who last purchased or renewed
 > their subscription before December 10, 2024. These subscribers will keep
-> their current plan and pricing until their next renewal date that falls on or
+> their current subscription and pricing until their next renewal date that falls on or
 > after December 10, 2024. To see purchase or renewal history, view your
 > [billing history](../billing/history.md). For more details about legacy
 > subscriptions, see [Announcing Upgraded Docker
@@ -33,16 +33,16 @@ subscription plan or legacy Docker subscription plan.
 
 ## Upgrade your subscription
 
-When you upgrade a Docker plan, you immediately have access to all the features and entitlements available in your Docker subscription plan. For detailed information on features available in each subscription, see [Docker Pricing](https://www.docker.com/pricing).
+When you upgrade a Docker subscription, you immediately have access to all the features and entitlements available in your Docker subscription. For detailed information on features available in each subscription, see [Docker Pricing](https://www.docker.com/pricing).
 
 {{< tabs >}}
-{{< tab name="Docker plan" >}}
+{{< tab name="Docker subscription" >}}
 
 To upgrade your Docker subscription:
 
 1. Sign in to [Docker Home](https://app.docker.com/).
 2. Under Settings and administration, select **Billing**.
-3. Optional. If you're upgrading from a free Personal plan to a Team plan and want to keep your username, [convert your user account into an organization](../admin/organization/convert-account.md).
+3. Optional. If you're upgrading from a free Personal subscription to a Team subscription and want to keep your username, [convert your user account into an organization](../admin/organization/convert-account.md).
 4. Select the account you want to upgrade in the drop-down at the top-left of the page.
 5. Select **Upgrade**.
 6. Follow the on-screen instructions to complete your upgrade.
@@ -53,11 +53,11 @@ To upgrade your Docker subscription:
 > more information, see [Verify a bank account](manuals/billing/payment-method.md#verify-a-bank-account).
 
 {{< /tab >}}
-{{< tab name="Legacy Docker plan" >}}
+{{< tab name="Legacy Docker subscription" >}}
 
-You can upgrade a legacy Docker Core, Docker Build Cloud, or Docker Scout subscription plan to a Docker subscription plan that includes access to all tools.
+You can upgrade a legacy Docker Core, Docker Build Cloud, or Docker Scout subscription to a Docker subscription that includes access to all tools.
 
-Contact [Docker sales](https://www.docker.com/pricing/contact-sales/) to upgrade your legacy Docker plan.
+Contact [Docker sales](https://www.docker.com/pricing/contact-sales/) to upgrade your legacy Docker subscription.
 
 {{< /tab >}}
 {{< /tabs >}}
@@ -76,7 +76,7 @@ When you downgrade your subscription, access to paid features is available until
 > - SSO and SCIM: If you want to downgrade a Docker Business subscription and your organization uses single sign-on (SSO) for user authentication, you need to remove your SSO connection and verified domains before downgrading. After removing the SSO connection, any organization members that were auto-provisioned (for example, with SCIM) need to set up a password to sign in without SSO. To do this, users can [reset their password at sign in](/accounts/create-account/#reset-your-password-at-sign-in).
 
 {{< tabs >}}
-{{< tab name="Docker plan" >}}
+{{< tab name="Docker subscription" >}}
 
 If you have a [sales-assisted Docker Business subscription](details.md#sales-assisted), contact your account manager to downgrade your subscription.
 
@@ -89,11 +89,11 @@ To downgrade your Docker subscription:
 5. Fill out the feedback survey to continue with cancellation.
 
 {{< /tab >}}
-{{< tab name="Legacy Docker plan" >}}
+{{< tab name="Legacy Docker subscription" >}}
 
 If you have a [sales-assisted Docker Business subscription](details.md#sales-assisted), contact your account manager to downgrade your subscription.
 
-### Downgrade Legacy Docker plan
+### Downgrade Legacy Docker subscription
 
 To downgrade your legacy Docker subscription:
 

--- a/content/manuals/subscription/details.md
+++ b/content/manuals/subscription/details.md
@@ -8,7 +8,7 @@ aliases:
 weight: 10
 ---
 
-Docker subscription plans empower development teams by providing the tools they need to ship secure, high-quality apps — fast. These plans include access to Docker's suite of products:
+Docker subscriptions empower development teams by providing the tools they need to ship secure, high-quality apps — fast. These plans include access to Docker's suite of products:
 
 - [Docker Desktop](../desktop/_index.md): The industry-leading container-first
   development solution that includes, Docker Engine, Docker CLI, Docker Compose,
@@ -23,14 +23,14 @@ Docker subscription plans empower development teams by providing the tools they 
   and more.
 
 The following sections describe some of the key features included with your
-Docker subscription plan or Legacy Docker plan.
+Docker subscription or Legacy Docker subscription.
 
 > [!NOTE]
 >
-> Legacy Docker plans apply to Docker subscribers who last purchased or renewed their subscription before December 10, 2024. These subscribers will keep their current plan and pricing until their next renewal date that falls on or after December 10, 2024. To see purchase or renewal history, view your [billing history](../billing/history.md). For more details about Docker legacy plans, see [Announcing Upgraded Docker Plans](https://www.docker.com/blog/november-2024-updated-plans-announcement/).
+> Legacy Docker plans apply to Docker subscribers who last purchased or renewed their subscription before December 10, 2024. These subscribers will keep their current subscription and pricing until their next renewal date that falls on or after December 10, 2024. To see purchase or renewal history, view your [billing history](../billing/history.md). For more details about Docker Legacy subscriptions, see [Announcing Upgraded Docker Plans](https://www.docker.com/blog/november-2024-updated-plans-announcement/).
 
 {{< tabs >}}
-{{< tab name="Docker plan" >}}
+{{< tab name="Docker subscription" >}}
 
 ## Docker Personal
 
@@ -47,7 +47,7 @@ Docker Personal includes:
 - 7-day Testcontainers Cloud trial
 
 Docker Personal users who want to continue using Docker Build Cloud or Docker
-Testcontainers Cloud after their trial can upgrade to a Docker Pro plan at any
+Testcontainers Cloud after their trial can upgrade to a Docker Pro subscription at any
 time.
 
 All unauthenticated users, including unauthenticated Docker Personal users, get
@@ -145,7 +145,7 @@ You can:
 
 ## Sales-assisted
 
-A sales-assisted plan refers to a Docker Business or Team subscription where everything is set up and
+A sales-assisted subscription refers to a Docker Business or Team subscription where everything is set up and
 managed by a dedicated Docker account manager.
 
 {{< /tab >}}
@@ -154,7 +154,7 @@ managed by a dedicated Docker account manager.
 > [!IMPORTANT]
 >
 > As of December 10, 2024, Docker Core, Docker Build Cloud, and Docker Scout
-> subscription plans are no longer available and have been replaced by Docker subscription
+> subscriptions are no longer available and have been replaced by Docker subscription
 > plans that provide access to all tools. If you subscribed or renewed
 > your subscriptions before December 10, 2024, your legacy Docker
 > plans still apply to your account until you renew. For more details,
@@ -186,9 +186,9 @@ Legacy Docker Pro includes:
 
 For a list of features available in each legacy tier, see [Legacy Docker Pricing](https://www.docker.com/legacy-pricing/).
 
-#### Upgrade your Legacy Docker Pro plan
+#### Upgrade your Legacy Docker Pro subscription
 
-When you upgrade your Legacy Docker Pro plan to a Docker Pro subscription plan, your plan includes the following changes:
+When you upgrade your Legacy Docker Pro subscription to a Docker Pro subscription, your subscription includes the following changes:
 
 - Docker Build Cloud build minutes increased from 100/month to 200/month and no monthly fee. Docker Build Cloud minutes do not rollover month to month.
 - 2 included repositories with continuous vulnerability analysis in Docker Scout.
@@ -217,11 +217,11 @@ There are also advanced collaboration and management tools, including organizati
 
 For a list of features available in each legacy tier, see [Legacy Docker Pricing](https://www.docker.com/legacy-pricing/).
 
-#### Upgrade your Legacy Docker Team plan
+#### Upgrade your Legacy Docker Team subscription
 
-When you upgrade your Legacy Docker Team plan to a Docker Team subscription plan, your plan includes the following changes:
+When you upgrade your Legacy Docker Team subscription to a Docker Team subscription, your subscription includes the following changes:
 
-- Instead of paying an additional per-seat fee, Docker Build Cloud is now available to all users in your Docker plan.
+- Instead of paying an additional per-seat fee, Docker Build Cloud is now available to all users in your Docker subscription.
 - Docker Build Cloud build minutes increase from 400/mo to 500/mo. Docker Build Cloud minutes do not rollover month to month.
 - Docker Scout now includes unlimited repositories with continuous vulnerability analysis, an increase from 3.
 - 500 Testcontainers Cloud runtime minutes are now included for use either in Docker Desktop or for CI. Testcontainers Cloud runtime minutes do not rollover month to month.
@@ -249,11 +249,11 @@ Legacy Docker Business includes:
 
 For a list of features available in each tier, see [Legacy Docker Pricing](https://www.docker.com/legacy-pricing/).
 
-#### Upgrade your Legacy Docker Business plan
+#### Upgrade your Legacy Docker Business subscription
 
-When you upgrade your Legacy Docker Business plan to a Docker Business subscription plan, your plan includes the following changes:
+When you upgrade your Legacy Docker Business subscription to a Docker Business subscription, your subscription includes the following changes:
 
-- Instead of paying an additional per-seat fee, Docker Build Cloud is now available to all users in your Docker plan.
+- Instead of paying an additional per-seat fee, Docker Build Cloud is now available to all users in your Docker subscription.
 - Docker Build Cloud included minutes increase from 800/mo to 1500/mo. Docker Build Cloud minutes do not rollover month to month.
 - Docker Scout now includes unlimited repositories with continuous vulnerability analysis, an increase from 3.
 - 1500 Testcontainers Cloud runtime minutes are now included for use either in Docker Desktop or for CI. Testcontainers Cloud runtime minutes do not rollover month to month.
@@ -276,20 +276,20 @@ A sales-assisted Docker Business subscription where everything is set up and man
 
 ## Legacy Docker Scout subscriptions
 
-This section provides an overview of the legacy subscription plans for Docker
+This section provides an overview of the legacy subscriptions for Docker
 Scout.
 
 > [!IMPORTANT]
 >
 > As of December 10, 2024, Docker Scout subscriptions are no longer available
-> and have been replaced by Docker subscription plans that provide access to
+> and have been replaced by Docker subscriptions that provide access to
 > all tools. If you subscribed or renewed your subscriptions before December 10, 2024, your legacy Docker subscriptions still apply to your account until
 > you renew. For more details, see [Announcing Upgraded Docker
 > Plans](https://www.docker.com/blog/november-2024-updated-plans-announcement/).
 
 ### Legacy Docker Scout Free
 
-Legacy Docker Scout Free is available for organizations. If you have a Legacy Docker plan, you automatically have access to legacy Docker Scout Free.
+Legacy Docker Scout Free is available for organizations. If you have a Legacy Docker subscription, you automatically have access to legacy Docker Scout Free.
 
 Legacy Docker Scout Free includes:
 
@@ -313,10 +313,10 @@ Legacy Docker Scout Business includes:
 - All the features available in legacy Docker Scout Team
 - Unlimited Docker Scout-enabled repositories
 
-### Upgrade your Legacy Docker Scout plan
+### Upgrade your Legacy Docker Scout subscription
 
-When you upgrade your Legacy Docker Scout plan to a Docker subscription plan, your
-plan includes the following changes:
+When you upgrade your Legacy Docker Scout subscription to a Docker subscription, your
+subscription includes the following changes:
 
 - Docker Business: Unlimited repositories with continuous vulnerability analysis, an increase from 3.
 - Docker Team: Unlimited repositories with continuous vulnerability analysis, an increase from 3
@@ -333,16 +333,16 @@ For a list of features available in each tier, see [Docker Pricing](https://www.
 > [!IMPORTANT]
 >
 > As of December 10, 2024, Docker Build Cloud is only available with the
-> new Docker Pro, Team, and Business plans. When your plan renews on or after
+> new Docker Pro, Team, and Business plans. When your subscription renews on or after
 > December 10, 2024, you will see an increase in your included Build Cloud
 > minutes each month. For more details, see [Announcing Upgraded Docker
 > Plans](https://www.docker.com/blog/november-2024-updated-plans-announcement/).
 
 ### Legacy Docker Build Cloud Starter
 
-If you have a Legacy Docker plan, a base level of Build Cloud
+If you have a Legacy Docker subscription, a base level of Build Cloud
 minutes and cache are included. The features available vary depending on your
-Legacy Docker plan subscription tier.
+Legacy Docker subscription tier.
 
 #### Legacy Docker Pro
 
@@ -378,11 +378,11 @@ the organization associated with the subscription. See Manage seats and invites.
 
 For more details about your enterprise subscription, [contact sales](https://www.docker.com/products/build-cloud/#contact_sales).
 
-### Upgrade your Legacy Docker Build Cloud plan
+### Upgrade your Legacy Docker Build Cloud subscription
 
-You no longer need to subscribe to a separate Docker Build Cloud plan to access
-Docker Build Cloud or to scale your minutes. When you upgrade your Legacy Docker plan to
-a Docker subscription plan, your plan includes the following changes:
+You no longer need to subscribe to a separate Docker Build Cloud subscription to access
+Docker Build Cloud or to scale your minutes. When you upgrade your Legacy Docker subscription to
+a Docker subscription, your subscription includes the following changes:
 
 - Docker Business: Included minutes are increased from 800/mo to 1500/mo with the option to scale more minutes.
 - Docker Team: Included minutes are increased from 400/mo to 500/mo with the option to scale more minutes.

--- a/content/manuals/subscription/manage-seats.md
+++ b/content/manuals/subscription/manage-seats.md
@@ -22,7 +22,7 @@ When you add seats to your subscription in the middle of your billing cycle, you
 ## Add seats
 
 {{< tabs >}}
-{{< tab name="Docker plan" >}}
+{{< tab name="Docker subscription" >}}
 
 > [!IMPORTANT]
 >
@@ -44,13 +44,13 @@ To add seats to your subscription:
 You can now add more members to your organization. For more information, see [Manage organization members](../admin/organization/members.md).
 
 {{< /tab >}}
-{{< tab name="Legacy Docker plan" >}}
+{{< tab name="Legacy Docker subscription" >}}
 
 > [!IMPORTANT]
 >
 > If you have a [sales-assisted Docker Business subscription](details.md#sales-assisted), contact your account manager to add seats to your subscription.
 
-### Add seats to Legacy Docker plan
+### Add seats to Legacy Docker subscription
 
 1. Sign in to [Docker Hub](https://hub.docker.com).
 2. Select your avatar in the top-left, and select **Billing** from the drop-down menu.
@@ -79,7 +79,7 @@ If you remove seats in the middle of the billing cycle, changes apply in the nex
 For example, if you receive your billing on the 8th of every month for 10 seats and you want to remove 2 seats on the 15th of the month, the 2 seats will be removed from your subscription the next month. Your payment for 8 seats begins on the next billing cycle. If you're on the annual subscription, the 2 seats are still available until the next year, and your payment for the 8 seats begins on the next billing cycle.
 
 {{< tabs >}}
-{{< tab name="Docker plan" >}}
+{{< tab name="Docker subscription" >}}
 
 > [!IMPORTANT]
 >
@@ -96,13 +96,13 @@ To remove seats:
 You can cancel the removal of seats before your next billing cycle. To do so, select **Cancel change**.
 
 {{< /tab >}}
-{{< tab name="Legacy Docker plan" >}}
+{{< tab name="Legacy Docker subscription" >}}
 
 > [!IMPORTANT]
 >
 > If you have a [sales-assisted Docker Business subscription](details.md#sales-assisted), contact your account manager to remove seats from your subscription.
 
-### Remove seats from Legacy Docker plan
+### Remove seats from Legacy Docker subscription
 
 1. Sign in to [Docker Hub](https://hub.docker.com).
 2. Select your avatar in the top-left, and select **Billing** from the drop-down menu.

--- a/content/manuals/subscription/scale.md
+++ b/content/manuals/subscription/scale.md
@@ -1,18 +1,18 @@
 ---
 description: Learn how to scale your Docker subscription
-keywords: subscription, Pro, Team, business, pricing plan, build minutes, test container minutes, pull limit
+keywords: subscription, Pro, Team, business, pricing, build minutes, test container minutes, pull limit
 title: Scale your subscription
 weight: 17
 ---
 
 > [!NOTE]
 >
-> Owners of legacy Docker subscription plans must upgrade their subscription to a new
-> Docker subscription plan in order to scale their subscription.
+> Owners of legacy Docker subscriptions must upgrade their subscription to a new
+> Docker subscription in order to scale their subscription.
 >
-> Legacy Docker plans apply to Docker subscribers who last purchased or renewed
+> Legacy Docker subscriptions apply to Docker subscribers who last purchased or renewed
 > their subscription before December 10, 2024. These subscribers will keep
-> their current plan and pricing until their next renewal date that falls on or
+> their current subscription and pricing until their next renewal date that falls on or
 > after December 10, 2024. To see purchase or renewal history, view your
 > [billing history](../billing/history.md). For more details about legacy
 > after December 10, 2024. For more details about legacy
@@ -20,7 +20,7 @@ weight: 17
 > Plans](https://www.docker.com/blog/november-2024-updated-plans-announcement/).
 
 Docker subscriptions let you scale your consumption as your needs evolve. Except
-for legacy Docker subscription plans, all paid Docker subscriptions come with
+for legacy Docker subscriptions, all paid Docker subscriptions come with
 access to Docker Hub, Docker Build Cloud, and Testcontainers Cloud with a base
 amount of consumption. See [Docker subscriptions and features](./details.md) to
 learn how much base consumption comes with each subscription. You can scale your
@@ -50,7 +50,7 @@ You can pre-purchase Docker Build Cloud build minutes in the Docker Build Cloud 
 
 1. Sign in to [Docker Home](https://app.docker.com/).
 2. Under Settings and administration, select **Billing**.
-3. On the plans and usage page, select **View build minutes**.
+3. On the plan and usage page, select **View build minutes**.
     This will launch the Docker Build Cloud settings page.
 4. Select **Add minutes**.
 5. Select your additional minute amount, then **Continue to payment**.

--- a/content/manuals/subscription/setup.md
+++ b/content/manuals/subscription/setup.md
@@ -1,6 +1,6 @@
 ---
 description: Learn how to set up your Docker subscription
-keywords: subscription, Pro, Team, Business, pricing plan
+keywords: subscription, Pro, Team, Business, pricing
 title: Set up your subscription
 weight: 15
 ---
@@ -13,14 +13,14 @@ In this section, learn how to get started with a Docker subscription for individ
 
 ## Set up a Docker subscription for a personal account
 
-After you [create your Docker ID](../accounts/create-account.md), you have a Docker Personal subscription. To continue using this plan, no further action is necessary. For additional features, you can upgrade to a Docker Pro plan.
+After you [create your Docker ID](../accounts/create-account.md), you have a Docker Personal subscription. To continue using this subscription, no further action is necessary. For additional features, you can upgrade to a Docker Pro subscription.
 
 To upgrade from Docker Personal to Docker Pro, see [Upgrade your subscription](./change.md#upgrade-your-subscription).
 
 ## Set up a Docker subscription for an organization
 
-You can subscribe a new or existing organization to a Docker plan. Only organization owners can manage billing for the organization.
+You can subscribe a new or existing organization to a Docker subscription. Only organization owners can manage billing for the organization.
 
-After you [create your Docker ID](../accounts/create-account.md), you have a Docker Personal plan. You must then create an organization and choose a subscription for it. For more details, see [Create your organization](../admin/organization/orgs.md).
+After you [create your Docker ID](../accounts/create-account.md), you have a Docker Personal subscription. You must then create an organization and choose a subscription for it. For more details, see [Create your organization](../admin/organization/orgs.md).
 
 To learn how to upgrade a Docker subscription for an existing organization, see [Upgrade your subscription](./change.md#upgrade-your-subscription).

--- a/content/reference/api/hub/latest.yaml
+++ b/content/reference/api/hub/latest.yaml
@@ -51,9 +51,9 @@ tags:
     description: |
       Most Docker Hub API endpoints require you to authenticate using your Docker credentials before using them.
 
-      Additionally, similar to the Docker Hub UI features, API endpoint responses may vary depending on your plan (Personal, Pro, or Team) and your account's permissions.
+      Additionally, similar to the Docker Hub UI features, API endpoint responses may vary depending on your subscription (Personal, Pro, or Team) and your account's permissions.
 
-      To learn more about the features available in each plan and to upgrade your existing plan, see [Docker Pricing](https://www.docker.com/pricing).
+      To learn more about the features available in each subscription and to upgrade your existing subscription, see [Docker Pricing](https://www.docker.com/pricing).
 
       # Types
 
@@ -641,11 +641,11 @@ paths:
     put:
       summary: Update organization settings
       description: |
-        Updates an organization's settings. Some settings are only used when the organization is on a business plan.
+        Updates an organization's settings. Some settings are only used when the organization is on a business subscription.
 
         ***Only users with administrative privileges for the organization (owner role) can modify these settings.***
 
-        The following settings are only used on a business plan:
+        The following settings are only used on a business subscription:
         - `restricted_images`
       tags:
         - org-settings


### PR DESCRIPTION
## Description
- Removes mention of "plan" from docs, in favor of "subscription" w/ the caveat that the UI still says plan (this update will come later)
- Updating UI steps in a PR to follow to sync w/ frontend team

## Related issues or tickets
https://docker.atlassian.net/browse/ENGDOCS-2695

## Reviews
- [ ] Technical review
- [ ] Editorial review
- [ ] Product review