### PR TITLE
Fix: make button shortcode fully clickable

### DIFF
--- a/layouts/shortcodes/button.html
+++ b/layouts/shortcodes/button.html
@@ -7,6 +7,4 @@
 {{- else -}}
   {{ $url = ref .Page $url }}
 {{- end -}}
-<div class="button not-prose">
-  <a href="{{ $url }}">{{ $text }}</a>
-</div>
+<a class="button not-prose" href="{{ $url }}">{{ $text }}</a>


### PR DESCRIPTION
## Description

This PR addresses the issue described in #22806, which I originally opened to highlight a UX inconsistency with the `{{< button >}}` shortcode. The current implementation renders a `<div>` wrapping an `<a>` element, causing only the text inside the anchor to be clickable. This creates a misleading user experience, as the rest of the styled "button" area is non-interactive.

**Fix**: Updated the `layouts/shortcodes/button.html` to render the `<a>` element directly with the required button classes (`button not-prose`), ensuring the full visual button area is clickable and behaves as expected.

## Related issues or tickets

Closes #22806

## Reviews

- [ ] Technical review
- [ ] Editorial review
- [ ] Product review

> Happy to iterate if there are style or implementation preferences. Thanks for your time reviewing this!
