### PR TITLE
release-notes for Compose v2.37.1 version

### DIFF
--- a/_vendor/modules.txt
+++ b/_vendor/modules.txt
@@ -2,6 +2,6 @@
 # github.com/moby/buildkit v0.22.0
 # github.com/docker/buildx v0.24.0
 # github.com/docker/cli v28.2.2+incompatible
-# github.com/docker/compose/v2 v2.37.0
+# github.com/docker/compose/v2 v2.37.1
 # github.com/docker/model-cli v0.1.26-0.20250527144806-15d0078a3c01
 # github.com/docker/scout-cli v1.15.0

--- a/content/manuals/compose/releases/release-notes.md
+++ b/content/manuals/compose/releases/release-notes.md
@@ -13,6 +13,16 @@ aliases:
 
 For more detailed information, see the [release notes in the Compose repo](https://github.com/docker/compose/releases/).
 
+## 2.37.1
+
+{{< release-date date="2025-06-12" >}}
+
+### Bug fixes and enhancements
+
+- Fixed an issue permission issue on bake metadata file on Windows
+- Fixed a panic error on provider service startup
+- Reverted `compose images` JSON output to array format
+
 ## 2.37.0
 
 {{< release-date date="2025-06-05" >}}

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.24.0
 require (
 	github.com/docker/buildx v0.24.0 // indirect
 	github.com/docker/cli v28.2.2+incompatible // indirect
-	github.com/docker/compose/v2 v2.37.0 // indirect
+	github.com/docker/compose/v2 v2.37.1 // indirect
 	github.com/docker/model-cli v0.1.26-0.20250527144806-15d0078a3c01 // indirect
 	github.com/docker/scout-cli v1.15.0 // indirect
 	github.com/moby/buildkit v0.22.0 // indirect
@@ -15,7 +15,7 @@ require (
 replace (
 	github.com/docker/buildx => github.com/docker/buildx v0.24.0
 	github.com/docker/cli => github.com/docker/cli v28.2.1+incompatible
-	github.com/docker/compose/v2 => github.com/docker/compose/v2 v2.37.0
+	github.com/docker/compose/v2 => github.com/docker/compose/v2 v2.37.1
 	github.com/docker/model-cli => github.com/docker/model-cli v0.1.26-0.20250527144806-15d0078a3c01
 	github.com/docker/scout-cli => github.com/docker/scout-cli v1.15.0
 	github.com/moby/buildkit => github.com/moby/buildkit v0.22.0

--- a/go.sum
+++ b/go.sum
@@ -24,6 +24,8 @@ github.com/docker/compose/v2 v2.36.2 h1:rxk1PUUbhbAS6HkGsYo9xUmMBpKtVwFMNCQjE4+i
 github.com/docker/compose/v2 v2.36.2/go.mod h1:mZygkne+MAMu/e1B28PBFmG0Z0WefbxZ/IpcjSFdrw8=
 github.com/docker/compose/v2 v2.37.0 h1:R8Yik9ssiRz7T9BRfdOZy0xHDzOFPIJX40DrxzJ62dQ=
 github.com/docker/compose/v2 v2.37.0/go.mod h1:twDoqUBFO2L5+vccJjkR6shQOH8C50V8AAQPxlkFr2Q=
+github.com/docker/compose/v2 v2.37.1 h1:d/LO338bB7jxHvQwVHSBAjIgitDK2+Dl5IXJImL/bAA=
+github.com/docker/compose/v2 v2.37.1/go.mod h1:yyprfHgPYV+ydOoL1gp8nIIlZ730ughSvz8D1VamayU=
 github.com/docker/distribution v2.8.3+incompatible h1:AtKxIZ36LoNK51+Z6RpzLpddBirtxJnzDrHLEKxTAYk=
 github.com/docker/distribution v2.8.3+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
 github.com/docker/docker v28.2.2+incompatible h1:CjwRSksz8Yo4+RmQ339Dp/D2tGO5JxwYeqtMOEe0LDw=

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -140,7 +140,7 @@ params:
   # (Used to show e.g., "latest" and "latest"-1 in engine install examples
   docker_ce_version_prev: "28.1.0"
   # Latest Docker Compose version
-  compose_version: "v2.37.0"
+  compose_version: "v2.37.1"
   # Latest BuildKit version
   buildkit_version: "0.22.0"
 


### PR DESCRIPTION
<!--Delete sections as needed -->

## Description
Update release notes of Compose page to add new `v2.37.1` version

## Related issues or tickets
https://docker.atlassian.net/browse/APCLI-1171

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Technical review
- [x] Editorial review
- [ ] Product review