### PR TITLE
build-cloud: add section on multi-architecture allocation

### DIFF
--- a/content/manuals/build-cloud/builder-settings.md
+++ b/content/manuals/build-cloud/builder-settings.md
@@ -6,7 +6,9 @@ keywords: build, cloud build, optimize, remote, local, cloud, registry, package 
 
 The **Builder settings** page in Docker Build Cloud lets you configure disk allocation, private resource access, and firewall settings for your cloud builders in your organization. These configurations help optimize storage, enable access to private registries, and secure outbound network traffic.
 
-## Disk allocation
+## Storage and cache management
+
+### Disk allocation
 
 The **Disk allocation** setting lets you control how much of the available
 storage is dedicated to the build cache. A lower allocation increases
@@ -29,11 +31,28 @@ Your subscription includes the following Build cache space:
 | Team         | 100GB             |
 | Business     | 200GB             |
 
-To get more Build cache space, [upgrade your subscription](/manuals/subscription/change.md).
+### Multi-architecture storage allocation
+
+Docker Build Cloud automatically provisions builders for both amd64 and arm64 architectures. Your total build cache space is split equally between these
+two builders:
+
+- Pro (50GB total): 25GB for amd64 builder + 25GB for arm64 builder
+- Team (100GB total): 50GB for amd64 builder + 50GB for arm64 builder
+- Business (200GB total): 100GB for amd64 builder + 100GB for arm64 builder
+
+> [!IMPORTANT]
+>
+> If you only build for one architecture, be aware that your effective cache
+space is half of your subscription's total allocation.
+
+### Get more build cache space
+
+To get more Build cache space, [upgrade your subscription](/manuals/subscription/scale.md).
 
 > [!TIP]
 >
-> If you build large images, consider allocating less storage for caching.
+> If you build large images, consider allocating less storage for caching to
+leave more space for active builds.
 
 ## Private resource access
 
@@ -67,7 +86,5 @@ $ docker build --builder <cloud-builder> --tag registry.example.com/<image> --pu
 Firewall settings let you restrict cloud builder egress traffic to specific IP addresses. This helps enhance security by limiting external network egress from the builder.
 
 1. Select the **Enable firewall: Restrict cloud builder egress to specific public IP address** checkbox.
-
 2. Enter the IP address you want to allow.
-
 3. Select **Add** to apply the restriction.


### PR DESCRIPTION
## Description
- Reworks Build Cloud storage management doc
- Adds section on multi-architecture builders/splitting storage allocation

## Related issues or tickets
https://docker.atlassian.net/browse/ENGDOCS-2730?atlOrigin=eyJpIjoiYjhkMDU4MjczODljNDMzMmI2MTNhYWM2MzkzOGY3NzUiLCJwIjoiaiJ9

## Reviews
- [ ] Technical review
- [ ] Editorial review
- [ ] Product review