### PR TITLE
Docker users update

### DIFF
--- a/content/manuals/desktop/setup/install/enterprise-deployment/msi-install-and-configure.md
+++ b/content/manuals/desktop/setup/install/enterprise-deployment/msi-install-and-configure.md
@@ -34,7 +34,7 @@ The MSI package supports various MDM (Mobile Device Management) solutions, makin
 7. Follow the instructions on the installation wizard to authorize the installer and proceed with the install.
 8. When the installation is successful, select **Finish** to complete the installation process.
 
-If your administrator account is different from your user account, you must add the user to the **docker-users** group:
+If your administrator account is different from your user account, you must add the user to the **docker-users** group to access features that require higher privileges, such as creating and managing the Hyper-V VM, or using Windows containers:
 1. Run **Computer Management** as an **administrator**.
 2. Navigate to **Local Users and Groups** > **Groups** > **docker-users**.
 3. Right-click to add the user to the group.

--- a/content/manuals/desktop/setup/install/windows-install.md
+++ b/content/manuals/desktop/setup/install/windows-install.md
@@ -180,7 +180,8 @@ again when you switch back.
 
 6. [Start Docker Desktop](#start-docker-desktop).
 
-If your administrator account is different to your user account, you must add the user to the **docker-users** group:
+If your administrator account is different to your user account, you must add the user to the **docker-users** group to access features that require higher privileges, such as creating and managing the Hyper-V VM, or using Windows containers:
+
 1. Run **Computer Management** as an **administrator**.
 2. Navigate to **Local Users and Groups** > **Groups** > **docker-users**. 
 3. Right-click to add the user to the group.
@@ -218,7 +219,9 @@ By default, Docker Desktop is installed at `C:\Program Files\Docker\Docker`.
 > Start-Process 'Docker Desktop Installer.exe' -Wait -ArgumentList 'install', '--accept-license'
 > ```
 
-If your admin account is different to your user account, you must add the user to the **docker-users** group:
+If your admin account is different to your user account, you must add the user to the **docker-users** group to access features that require higher privileges, such as creating and managing the Hyper-V VM, or using Windows containers.
+
+```powershell
 
 ```console
 $ net localgroup docker-users <user> /add

--- a/content/manuals/desktop/setup/install/windows-permission-requirements.md
+++ b/content/manuals/desktop/setup/install/windows-permission-requirements.md
@@ -18,11 +18,22 @@ Docker Desktop on Windows is designed with security in mind. Administrative righ
 
 ## Permission requirements
 
-While Docker Desktop on Windows can be run without having `Administrator` privileges, it does require them during installation. On installation you receive a UAC prompt which allows a privileged helper service to be installed. After that, Docker Desktop can be run without administrator privileges, provided you are members of the `docker-users` group. If you performed the installation, you are automatically added to this group, but other users must be added manually. This allows the administrator to control who has access to Docker Desktop.
+While Docker Desktop on Windows can be run without having `Administrator` privileges, it does require them during installation. On installation you receive a UAC prompt which allows a privileged helper service to be installed. After that, Docker Desktop can be run without administrator privileges. 
+
+Running Docker Desktop on Windows without the privilaged helper does not require users to have `docker-users` group membership. However,
+some features that require privillaged operations will have this requirement. 
+
+If you performed the installation, you are automatically added to this group, but other users must be added manually. This allows the administrator to control who has access to features that require higher privileges, such as creating and managing the Hyper-V VM, or using Windows containers.
+
+When Docker Desktop launches, all non-privileged named pipes will be created so that only the following users can access them:
+- The user that launched Docker Desktop.
+- Members of the local `Administrators` group.
+- The `LOCALSYSTEM` account.
+
+## Privileged helper
 
 The reason for this approach is that Docker Desktop needs to perform a limited set of privileged operations which are conducted by the privileged helper process `com.docker.service`. This approach allows, following the principle of least privilege, `Administrator` access to be used only for the operations for which it is absolutely necessary, while still being able to use Docker Desktop as an unprivileged user.
 
-## Privileged helper
 
 The privileged helper `com.docker.service` is a Windows service which runs in the background with `SYSTEM` privileges. It listens on the named pipe `//./pipe/dockerBackendV2`. The developer runs the Docker Desktop application, which connects to the named pipe and sends commands to the service. This named pipe is protected, and only users that are part of the `docker-users` group can have access to it.
 


### PR DESCRIPTION
<!--Delete sections as needed -->

## Description
This change updates permission requirements for Docker Desktop on Windows. It should explain that membership of the `docker-users` group is no longer required for running Docker Desktop, unless the privileged helper service is required.

<!-- Tell us what you did and why -->

## Related issues or tickets

<!-- Related issues, pull requests, or Jira tickets -->

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Technical review
- [ ] Editorial review
- [ ] Product review