### PR TITLE
Add auth.docker.com in Desktop firewall allow list

### DIFF
--- a/content/manuals/desktop/setup/allow-list.md
+++ b/content/manuals/desktop/setup/allow-list.md
@@ -24,6 +24,7 @@ This page contains the domain URLs that you need to add to a firewall allowlist 
 | https://auth.docker.io                                                               | Authentication                               |
 | https://cdn.auth0.com                                                                | Authentication                               |
 | https://login.docker.com                                                             | Authentication                               |
+| https://auth.docker.com                                                              | Authentication                               |
 | https://desktop.docker.com                                                           | Update                                       |
 | https://hub.docker.com                                                               | Docker Hub                                   |
 | https://registry-1.docker.io                                                         | Docker Pull/Push                             |


### PR DESCRIPTION
<!--Delete sections as needed -->

## Description

The flow for Desktop auth has changed and follows some redirects to auth.docker.com

## Related issues or tickets

<!-- Related issues, pull requests, or Jira tickets -->

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Technical review
- [ ] Editorial review
- [ ] Product review