### PR TITLE
Fix release version header for 2.37.2.

### DIFF
--- a/content/manuals/compose/releases/release-notes.md
+++ b/content/manuals/compose/releases/release-notes.md
@@ -13,7 +13,7 @@ aliases:
 
 For more detailed information, see the [release notes in the Compose repo](https://github.com/docker/compose/releases/).
 
-## 2.37.1
+## 2.37.2
 
 {{< release-date date="2025-06-20" >}}
 


### PR DESCRIPTION
## Description

The description header for docker-compose 2.37.2 is mislabeled as 2.37.1, resulting in duplicate headings.

## Reviews

- [ ] Technical review
- [ ] Editorial review
- [ ] Product review