### PR TITLE
chore: exclude hidden pages from llms.txt

### DIFF
--- a/layouts/_default/index.llms.txt
+++ b/layouts/_default/index.llms.txt
@@ -1,4 +1,4 @@
-{{- $pages := .Site.RegularPages -}}
+{{- $pages := where site.RegularPages "Params.sitemap" "!=" false -}}
 {{- $sorted := sort $pages "RelPermalink" -}}
 {{- $grouped := $sorted.GroupBy "Section" -}}
 


### PR DESCRIPTION
## Description

I noticed that the `/llms.txt` file lists "hidden" pages (pages where the `page.Params.sitemap` is set to `false`).

This patch ensures those pages are excluded from the `llms.txt` file.
