### PR TITLE
services: add notice of broken feature

### DIFF
--- a/content/reference/compose-file/services.md
+++ b/content/reference/compose-file/services.md
@@ -451,7 +451,8 @@ expressed in the short form.
   - `service_started`: An equivalent of the short syntax described previously
   - `service_healthy`: Specifies that a dependency is expected to be "healthy"
     (as indicated by [`healthcheck`](#healthcheck)) before starting a dependent
-    service.
+    service. Note that since v3 dependent services will be started regardless of the
+    healthcheck status.
   - `service_completed_successfully`: Specifies that a dependency is expected to run
     to successful completion before starting a dependent service.
 - `required`: When set to `false` Compose only warns you when the dependency service isn't started or available. If it's not defined


### PR DESCRIPTION
## Description

Waiting for healthy dependencies is not supported in version 3 of docker compose, as explained in: 
https://docs.docker.com/compose/releases/release-notes/#1100

The `version` key is also ignored now, so this whole feature is actually broken. I think at the very least, this should be mentioned in the documentation.

This took me 2 days of debugging to figure out, and a notice here would've saved me a lot of time.

## Related issues or tickets

- https://docs.docker.com/compose/releases/release-notes/#1100

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Technical review
- [ ] Editorial review
- [ ] Product review