### PR TITLE
fix: update min. version for settings management

### DIFF
--- a/content/manuals/security/for-admins/hardened-desktop/settings-management/configure-admin-console.md
+++ b/content/manuals/security/for-admins/hardened-desktop/settings-management/configure-admin-console.md
@@ -14,7 +14,7 @@ and secure Docker Desktop environments across your organization.
 
 ## Prerequisites
 
-- [Install Docker Desktop 4.37.0 or later](/manuals/desktop/release-notes.md).
+- [Install Docker Desktop 4.37.1 or later](/manuals/desktop/release-notes.md).
 - [Verify your domain](/manuals/security/for-admins/single-sign-on/configure.md#step-one-add-and-verify-your-domain).
 - [Enforce sign-in](/manuals/security/for-admins/enforce-sign-in/_index.md) to
 ensure users authenticate to your organization.


### PR DESCRIPTION
## Description
- To support backwards compatibility, users must use DD version 4.37.1

## Related issues or tickets
https://docker.slack.com/archives/C06SJCMBD9B/p1750968839480359

## Reviews
- [ ] Technical review
- [ ] Editorial review
- [ ] Product review