### PR TITLE
Fix typo: cif-volume → cifs-volume

### DIFF
--- a/content/manuals/engine/storage/volumes.md
+++ b/content/manuals/engine/storage/volumes.md
@@ -625,7 +625,7 @@ $ docker volume create \
 	--opt type=cifs \
 	--opt device=//uxxxxx.your-server.de/backup \
 	--opt o=addr=uxxxxx.your-server.de,username=uxxxxxxx,password=*****,file_mode=0777,dir_mode=0777 \
-	--name cif-volume
+	--name cifs-volume
 ```
 
 The `addr` option is required if you specify a hostname instead of an IP.


### PR DESCRIPTION
Fixes #22340

Fixed typo in CIFS volume example where "cif-volume" should be "cifs-volume" to match the CIFS naming convention.