### PR TITLE
docs: fix mcp configuration location in vscode

### DIFF
--- a/content/manuals/ai/mcp-catalog-and-toolkit/toolkit.md
+++ b/content/manuals/ai/mcp-catalog-and-toolkit/toolkit.md
@@ -165,7 +165,7 @@ You can interact with all your installed MCP servers in VS Code:
    {{< tabs group="" >}}
    {{< tab name="Enable globally">}}
 
-   1. Insert the following in your VS Code's User`settings.json`:
+   1. Insert the following in your VS Code's User`mcp.json`:
 
       ```json
       "mcp": {


### PR DESCRIPTION
MCP settings in VSCode is no longer in settings.json but mcp.json

<!--Delete sections as needed -->

## Description

<!-- Tell us what you did and why -->

## Related issues or tickets

<!-- Related issues, pull requests, or Jira tickets -->

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Technical review
- [ ] Editorial review
- [ ] Product review