### PR TITLE
Update configure-github-actions.md

### DIFF
--- a/content/guides/python/configure-github-actions.md
+++ b/content/guides/python/configure-github-actions.md
@@ -21,8 +21,9 @@ If you didn't create a [GitHub repository](https://github.com/new) for your proj
 2. Under the **Variables** tab, create a new **Repository variable** named `DOCKER_USERNAME` and your Docker ID as a value.
 
 3. Create a new [Personal Access Token (PAT)](/manuals/security/access-tokens.md#create-an-access-token) for Docker Hub. You can name this token `docker-tutorial`. Make sure access permissions include Read and Write.
+4. Create DockerHub repository use the **same name** as your GitHub repository
 
-4. Add the PAT as a **Repository secret** in your GitHub repository, with the name
+5. Add the PAT as a **Repository secret** in your GitHub repository, with the name
    `DOCKERHUB_TOKEN`.
 
 ## Overview


### PR DESCRIPTION
The user needs to create a DockerHub repository which has the same name as the GitHub repository  for example, if my GitHub repository is my-proj  so the DockerHub needs to be the same name which is my-proj
The tag yaml elements needs to give an example which show the mirror on the DockerHub


<!--Delete sections as needed -->

## Description

<!-- Tell us what you did and why -->
The github actions does not work if the repository name are not the same 


## Related issues or tickets

<!-- Related issues, pull requests, or Jira tickets -->

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Technical review
- [ ] Editorial review
- [ ] Product review