### PR TITLE
correct release notes of Compose v2.39.0

### DIFF
--- a/content/manuals/compose/releases/release-notes.md
+++ b/content/manuals/compose/releases/release-notes.md
@@ -23,7 +23,7 @@ For more detailed information, see the [release notes in the Compose repo](https
 
 - Added `--models` flag to `config` command to list models
 - Added `--since` and `--until` flags to `events`
-- Introduced `provenance` and `sbom` attributes to `develop` section
+- Introduced `provenance` and `sbom` attributes to `build` section
 - Fixed `bridge convert` issue on Windows 
 - Fixed multiple issues with `bake` builds
 


### PR DESCRIPTION
<!--Delete sections as needed -->

## Description
Correct release notes of Compose v2.39.0 which was mentioning `develop` section instead of `build` for the new attributes `sbom` and `provenance`

## Related issues or tickets
N/A
## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Technical review
- [x] Editorial review
- [ ] Product review