### PR TITLE
fix: links for moby apparmor/seccomp security profiles

### DIFF
--- a/content/manuals/engine/security/apparmor.md
+++ b/content/manuals/engine/security/apparmor.md
@@ -28,7 +28,7 @@ in the Docker Engine source repository.
 The `docker-default` profile is the default for running containers. It is
 moderately protective while providing wide application compatibility. The
 profile is generated from the following
-[template](https://github.com/moby/moby/blob/master/profiles/apparmor/template.go).
+[template](https://github.com/moby/profiles/blob/main/apparmor/template.go).
 
 When you run a container, it uses the `docker-default` policy unless you
 override it with the `security-opt` option. For example, the following
@@ -280,4 +280,4 @@ Advanced users and package managers can find a profile for `/usr/bin/docker`
 in the Docker Engine source repository.
 
 The `docker-default` profile for containers lives in
-[profiles/apparmor](https://github.com/moby/moby/tree/master/profiles/apparmor).
+[profiles/apparmor](https://github.com/moby/profiles/blob/main/apparmor).

--- a/content/manuals/engine/security/seccomp.md
+++ b/content/manuals/engine/security/seccomp.md
@@ -24,7 +24,7 @@ The default `seccomp` profile provides a sane default for running containers wit
 seccomp and disables around 44 system calls out of 300+. It is moderately
 protective while providing wide application compatibility. The default Docker
 profile can be found
-[here](https://github.com/moby/moby/blob/master/profiles/seccomp/default.json).
+[here](https://github.com/moby/profiles/blob/main/seccomp/default.json).
 
 In effect, the profile is an allowlist that denies access to system calls by
 default and then allows specific system calls. The profile works by defining a


### PR DESCRIPTION
## Description

This change updates the apparmor/seccomp related links for content that has moved from the [moby/moby](https://github.com/moby/moby) repository to the new [moby/profiles](https://github.com/moby/profiles) repository.

## Related issues or tickets

#23158
#23157 

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Technical review
- [ ] Editorial review
- [ ] Product review