### PR TITLE
Added clarification text in _index.md

### DIFF
--- a/content/manuals/engine/install/_index.md
+++ b/content/manuals/engine/install/_index.md
@@ -38,7 +38,9 @@ Docker CE. Docker Engine is also available for Windows, macOS, and Linux,
 through Docker Desktop. For instructions on how to install Docker Desktop,
 see: [Overview of Docker Desktop](/manuals/desktop/_index.md).
 
-## Supported platforms
+## Installation procedures for supported platforms
+
+Click on a platform's link to view the relevant installation procedure.
 
 | Platform                                       | x86_64 / amd64 | arm64 / aarch64 | arm (32-bit) | ppc64le | s390x |
 | :--------------------------------------------- | :------------: | :-------------: | :----------: | :-----: | :---: |


### PR DESCRIPTION
Added clarification text for the supported platforms table

## Description

The table does not only list the "supported platforms" but actually contains links to installation procedures.
This wasn't clear enough. The clarification text verbosely states what the user might want to do.
