### PR TITLE
add usage examples for building Bake files from remote Git and HTTP sources, and Raw HTTPS

### DIFF
--- a/content/manuals/build/bake/remote-definition.md
+++ b/content/manuals/build/bake/remote-definition.md
@@ -4,7 +4,7 @@ description: Build with Bake using a remote file definition using Git or HTTP
 keywords: build, buildx, bake, file, remote, git, http
 ---
 
-You can build Bake files directly from a remote Git repository or HTTPS URL:
+You can build Bake files directly from a remote [Git repository](../concepts/context.md#git-repositories):
 
 {{<tabs>}}
 

--- a/content/manuals/build/bake/remote-definition.md
+++ b/content/manuals/build/bake/remote-definition.md
@@ -6,14 +6,24 @@ keywords: build, buildx, bake, file, remote, git, http
 
 You can build Bake files directly from a remote Git repository or HTTPS URL:
 
+Using Git HTTPS
+
 ```console
-$ docker buildx bake "https://github.com/docker/cli.git#v20.10.11" --print
-#1 [internal] load git source https://github.com/docker/cli.git#v20.10.11
-#1 0.745 e8f1871b077b64bcb4a13334b7146492773769f7       refs/tags/v20.10.11
-#1 2.022 From https://github.com/docker/cli
-#1 2.022  * [new tag]         v20.10.11  -> v20.10.11
-#1 DONE 2.9s
+docker buildx bake "https://github.com/docker/cli.git#v20.10.11" --print
 ```
+
+Using GIT SSH
+
+```console
+docker buildx bake "git@github.com:docker/cli.git#v20.10.11" --print
+```
+
+Using Raw HTTP/HTTPS
+
+```console
+docker buildx bake "https://raw.githubusercontent.com/docker/cli/v20.10.11/docker-bake.hcl" --print
+```
+
 
 This fetches the Bake definition from the specified remote location and
 executes the groups or targets defined in that file. If the remote Bake

--- a/content/manuals/build/bake/remote-definition.md
+++ b/content/manuals/build/bake/remote-definition.md
@@ -6,11 +6,6 @@ keywords: build, buildx, bake, file, remote, git, http
 
 You can build Bake files directly from a remote Git repository or HTTPS URL:
 
-
-
-
-
-
 {{<tabs>}}
 
 {{<tab name="Git HTTPS">}}
@@ -35,6 +30,8 @@ docker buildx bake "git@github.com:docker/cli.git#v20.10.11" --print
 docker buildx bake "https://raw.githubusercontent.com/docker/cli/v20.10.11/docker-bake.hcl" --print
 ```
 {{</tab>}}
+
+{{</tabs>}}
 
 This fetches the Bake definition from the specified remote location and
 executes the groups or targets defined in that file. If the remote Bake

--- a/content/manuals/build/bake/remote-definition.md
+++ b/content/manuals/build/bake/remote-definition.md
@@ -6,32 +6,14 @@ keywords: build, buildx, bake, file, remote, git, http
 
 You can build Bake files directly from a remote [Git repository](../concepts/context.md#git-repositories):
 
-{{<tabs>}}
-
-{{<tab name="Git HTTPS">}}
-
 ```console
-docker buildx bake "https://github.com/docker/cli.git#v20.10.11" --print
+$ docker buildx bake "https://github.com/docker/cli.git#v20.10.11" --print
+#1 [internal] load git source https://github.com/docker/cli.git#v20.10.11
+#1 0.745 e8f1871b077b64bcb4a13334b7146492773769f7       refs/tags/v20.10.11
+#1 2.022 From https://github.com/docker/cli
+#1 2.022  * [new tag]         v20.10.11  -> v20.10.11
+#1 DONE 2.9s
 ```
-
-{{</tab>}}
-
-{{<tab name="Git SSH">}}
-
-```console
-docker buildx bake "git@github.com:docker/cli.git#v20.10.11" --print
-```
-
-{{</tab>}}
-
-{{<tab name="HTTP/HTTPS">}}
-
-```console
-docker buildx bake "https://raw.githubusercontent.com/docker/cli/v20.10.11/docker-bake.hcl" --print
-```
-{{</tab>}}
-
-{{</tabs>}}
 
 This fetches the Bake definition from the specified remote location and
 executes the groups or targets defined in that file. If the remote Bake

--- a/content/manuals/build/bake/remote-definition.md
+++ b/content/manuals/build/bake/remote-definition.md
@@ -12,13 +12,13 @@ Using Git HTTPS
 docker buildx bake "https://github.com/docker/cli.git#v20.10.11" --print
 ```
 
-Using GIT SSH
+Using Git SSH
 
 ```console
 docker buildx bake "git@github.com:docker/cli.git#v20.10.11" --print
 ```
 
-Using Raw HTTP/HTTPS
+Using HTTP/HTTPS
 
 ```console
 docker buildx bake "https://raw.githubusercontent.com/docker/cli/v20.10.11/docker-bake.hcl" --print

--- a/content/manuals/build/bake/remote-definition.md
+++ b/content/manuals/build/bake/remote-definition.md
@@ -6,24 +6,35 @@ keywords: build, buildx, bake, file, remote, git, http
 
 You can build Bake files directly from a remote Git repository or HTTPS URL:
 
-Using Git HTTPS
+
+
+
+
+
+{{<tabs>}}
+
+{{<tab name="Git HTTPS">}}
 
 ```console
 docker buildx bake "https://github.com/docker/cli.git#v20.10.11" --print
 ```
 
-Using Git SSH
+{{</tab>}}
+
+{{<tab name="Git SSH">}}
 
 ```console
 docker buildx bake "git@github.com:docker/cli.git#v20.10.11" --print
 ```
 
-Using HTTP/HTTPS
+{{</tab>}}
+
+{{<tab name="HTTP/HTTPS">}}
 
 ```console
 docker buildx bake "https://raw.githubusercontent.com/docker/cli/v20.10.11/docker-bake.hcl" --print
 ```
-
+{{</tab>}}
 
 This fetches the Bake definition from the specified remote location and
 executes the groups or targets defined in that file. If the remote Bake


### PR DESCRIPTION
## Description

Add usage examples for building Bake files from remote Git and HTTP/HTTPS sources.  
This improves the documentation by demonstrating how to use `docker buildx bake` directly with remote Bake files using Git (HTTPS and SSH) and raw HTTP/HTTPS URLs.

## Related issues or tickets

N/A

## Reviews

- [ ] Technical review
- [ ] Editorial review
- [ ] Product review