### PR TITLE
Add deb822 apt sources to install section in Debian manual

### DIFF
--- a/content/manuals/engine/install/debian.md
+++ b/content/manuals/engine/install/debian.md
@@ -114,11 +114,21 @@ Docker from the repository.
    sudo curl -fsSL {{% param "download-url-base" %}}/gpg -o /etc/apt/keyrings/docker.asc
    sudo chmod a+r /etc/apt/keyrings/docker.asc
 
-   # Add the repository to Apt sources:
+   # Add the repository to Apt sources (legacy format):
    echo \
      "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] {{% param "download-url-base" %}} \
      $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | \
      sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+
+   # Add the repository to Apt sources (new deb822 format, introduced with Trixie):
+   echo -e \
+     "Types: deb\n \
+	 URIs: https://download.docker.com/linux/debian/\n \
+	 Suites: $(. /etc/os-release && echo "$VERSION_CODENAME")\n \
+	 Components: stable\n \
+	 Signed-By: /etc/apt/keyrings/docker.gpg" | \
+	 sudo tee /etc/apt/sources.list.d/docker.sources > /dev/null
+
    sudo apt-get update
    ```
 

--- a/content/manuals/engine/install/debian.md
+++ b/content/manuals/engine/install/debian.md
@@ -122,12 +122,12 @@ Docker from the repository.
 
    # Add the repository to Apt sources (new deb822 format, introduced with Trixie):
    echo -e \
-     "Types: deb\n \
-	 URIs: https://download.docker.com/linux/debian/\n \
-	 Suites: $(. /etc/os-release && echo "$VERSION_CODENAME")\n \
-	 Components: stable\n \
-	 Signed-By: /etc/apt/keyrings/docker.gpg" | \
-	 sudo tee /etc/apt/sources.list.d/docker.sources > /dev/null
+   "Types: deb\n\
+   URIs: https://download.docker.com/linux/debian/\n\
+   Suites: $(. /etc/os-release && echo "$VERSION_CODENAME")\n\
+   Components: stable\n\
+   Signed-By: /etc/apt/keyrings/docker.gpg" | \
+   sudo tee /etc/apt/sources.list.d/docker.sources > /dev/null
 
    sudo apt-get update
    ```


### PR DESCRIPTION
## Description

With Debian Trixie released the new apt sources format [RFC822](https://manpages.debian.org/trixie/apt/sources.list.5.en.html) is now the default. 
This PR proposes a way to take this new format into account.

The goal would be to have the follwoing `docker.sources`:
```
$ cat /etc/apt/sources.list.d/docker.sources 
Types: deb
URIs: https://download.docker.com/linux/debian/
Suites: trixie
Components: stable
Signed-By: /etc/apt/keyrings/docker.gpg
```

## Related issues or tickets

#15382 and #23231 


## Reviews

I am happy to change my PR if needed. Currently I was not sure if we should keep both formats or make the new deb822 format as default. 
Maybe we could move the legacy format into an info box?