### PR TITLE
Fix example usage of `COMPOSE_ENV_FILES`

### DIFF
--- a/content/manuals/compose/how-tos/environment-variables/envvars.md
+++ b/content/manuals/compose/how-tos/environment-variables/envvars.md
@@ -119,7 +119,7 @@ Specifies which environment files Compose should use if `--env-file` isn't used.
 When using multiple environment files, use a comma as a separator. For example: 
 
 ```console
-COMPOSE_ENV_FILES=.env.envfile1, .env.envfile2
+COMPOSE_ENV_FILES=.env.envfile1,.env.envfile2
 ```
 
 If `COMPOSE_ENV_FILES` is not set, and you don't provide `--env-file` in the CLI, Docker Compose uses the default behavior, which is to look for an `.env` file in the project directory.


### PR DESCRIPTION
## Description
The example results in the second file being a command to be executed and not part of the environment variable's value.

Quoting  the value would address it as well, but thought it far more likely the space was an accident rather than trying to show an example of files containing spaces.
