### PR TITLE
updated CLI commands to use rm command

### DIFF
--- a/content/guides/databases.md
+++ b/content/guides/databases.md
@@ -256,7 +256,7 @@ the same Docker network.
 Before you begin, you must remove any containers you previously ran for this
 guide. To stop and remove a container, either:
 
-- In a terminal, run `docker remove --force my-mysql` to remove the container
+- In a terminal, run `docker rm --force my-mysql` to remove the container
   named `my-mysql`.
 - Or, in the Docker Desktop Dashboard, select the **Delete** icon next to your
   container in the **Containers** view.
@@ -311,7 +311,7 @@ CLI or the Docker Desktop GUI.
 Before you begin, you must remove any containers you previously ran for this
 guide. To stop and remove a container, either:
 
-- In a terminal, run `docker remove --force my-mysql` to remove the container
+- In a terminal, run `docker rm --force my-mysql` to remove the container
   named `my-mysql`.
 - Or, in the Docker Desktop Dashboard, select the **Delete** icon next to your
   container in the **Containers** view.
@@ -352,7 +352,7 @@ data persists:
    be lost when removing the container.
 
    ```console
-   $ docker remove --force my-mysql
+   $ docker rm --force my-mysql
    ```
 
 4. Start a new container with the volume attached. This time, you don't need to
@@ -486,7 +486,7 @@ run a custom MySQL image that includes a table initialization script.
 Before you begin, you must remove any containers you previously ran for this
 guide. To stop and remove a container, either:
 
-- In a terminal, run `docker remove --force my-mysql` to remove the container
+- In a terminal, run `docker rm --force my-mysql` to remove the container
   named `my-mysql`.
 - Or, in the Docker Desktop Dashboard, select the **Delete** icon next to your
   container in the **Containers** view.


### PR DESCRIPTION
<!--Delete sections as needed -->

## Updated guides/databases.md to consistently use `docker rm --force my-sql` in the guide instead of sometimes using `docker remove --force my-mysql`

<!-- Tell us what you did and why -->

## Updated for consistency so all commands use `rm` also I think `remove` is not a valid docker command? 

<!-- Related issues, pull requests, or Jira tickets -->

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Technical review
- [ ] Editorial review
- [ ] Product review