### PR TITLE
Fix: update install guide

### DIFF
--- a/content/manuals/desktop/setup/install/linux/archlinux.md
+++ b/content/manuals/desktop/setup/install/linux/archlinux.md
@@ -33,7 +33,7 @@ To install Docker Desktop successfully, you must meet the [general system requir
 
    ```console
    $ wget https://download.docker.com/linux/static/stable/x86_64/docker-{{% param "docker_ce_version" %}}.tgz -qO- | tar xvfz - docker/docker --strip-components=1
-   $ mv ./docker /usr/local/bin
+   $ cp -rp ./docker /usr/local/bin/ && rm -r ./docker
    ```
 
 2. Download the latest Arch package from the [Release notes](/manuals/desktop/release-notes.md).


### PR DESCRIPTION
## Description

As seen in the [PR](https://github.com/docker/docs/issues/23244), the current documentation suggests the installation command might cause confusion in some scenarios. To ensure clarity and make the process more robust, I suggest updating the command as follows:

Before
```
mv ./docker /usr/local/bin
```

After
```
cp -rp ./docker /usr/local/bin/ && rm -r ./docker
```

I believe this will help users and improve the clarity of the instructions.

Thank you for considering this change! :)

## Related issues or tickets

#23244 

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Technical review
- [ ] Editorial review
- [ ] Product review