### PR TITLE
add "go" redirect for DCT deprecation

### DIFF
--- a/data/redirects.yml
+++ b/data/redirects.yml
@@ -65,6 +65,10 @@
   - /go/daemon-access/
 "/engine/deprecated/#deprecated-engine-features-1":
   - /go/deprecated/
+"https://www.docker.com/blog/retiring-docker-content-trust/":
+  # Details about the deprecation of Docker Content Trust. This URL can be used
+  # for in-product links to the deprecation, and is used by the Docker CLI.
+  - /go/dct-deprecation/
 "/engine/reference/commandline/cli/#experimental-features":
   - /go/experimental/
 "/reference/cli/docker/login/#credential-stores":


### PR DESCRIPTION
- relates to https://github.com/docker/cli/pull/6508

Add a redirect to details about the deprecation of Docker Content Trust. This URL can be used for in-product links to the deprecation, and is used by the Docker CLI.

<!--Delete sections as needed -->

## Description

<!-- Tell us what you did and why -->

## Related issues or tickets

<!-- Related issues, pull requests, or Jira tickets -->

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Technical review
- [ ] Editorial review
- [ ] Product review