### PR TITLE
Updated fedora add repo instructions to the new dnf version

### DIFF
--- a/content/manuals/engine/install/fedora.md
+++ b/content/manuals/engine/install/fedora.md
@@ -87,7 +87,7 @@ your DNF repositories) and set up the repository.
 
 ```console
 $ sudo dnf -y install dnf-plugins-core
-$ sudo dnf-3 config-manager --add-repo {{% param "download-url-base" %}}/docker-ce.repo
+$ sudo dnf config-manager addrepo --from-repofile={{% param "download-url-base" %}}/docker-ce.repo
 ```
 
 #### Install Docker Engine


### PR DESCRIPTION
<!--Delete sections as needed -->

## Description

the instructions for adding the repo on fedora were using an old version of dnf.