### PR TITLE
engine/install: update supported OS versions

### DIFF
--- a/content/manuals/engine/install/debian.md
+++ b/content/manuals/engine/install/debian.md
@@ -42,9 +42,9 @@ To get started with Docker Engine on Debian, make sure you
 To install Docker Engine, you need the 64-bit version of one of these Debian
 versions:
 
-- Debian Trixie 13 (testing)
-- Debian Bookworm 12 (stable)
-- Debian Bullseye 11 (oldstable)
+- Debian Trixie 13 (stable)
+- Debian Bookworm 12 (oldstable)
+- Debian Bullseye 11 (oldoldstable)
 
 Docker Engine for Debian is compatible with x86_64 (or amd64), armhf, arm64,
 and ppc64le (ppc64el) architectures.

--- a/content/manuals/engine/install/fedora.md
+++ b/content/manuals/engine/install/fedora.md
@@ -26,6 +26,7 @@ To get started with Docker Engine on Fedora, make sure you
 To install Docker Engine, you need a maintained version of one of the following
 Fedora versions:
 
+- Fedora 43
 - Fedora 42
 - Fedora 41
 

--- a/content/manuals/engine/install/rhel.md
+++ b/content/manuals/engine/install/rhel.md
@@ -31,6 +31,7 @@ RHEL versions:
 
 - RHEL 8
 - RHEL 9
+- RHEL 10
 
 ### Uninstall old versions
 


### PR DESCRIPTION
- closes: https://github.com/docker/docs/issues/23463
- closes: https://github.com/docker/docs/issues/23263

Adds support for newly supported versions:
- Fedora 43
- RHEL 10

For Debian, updates version labels to reflect the new stable release cycle:
- Trixie 13 is now stable (previously testing)
- Bookworm 12 moved to oldstable
- Bullseye 11 moved to oldoldstable

<!--Delete sections as needed -->

## Description

<!-- Tell us what you did and why -->

## Related issues or tickets

<!-- Related issues, pull requests, or Jira tickets -->

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Technical review
- [ ] Editorial review
- [ ] Product review