### PR TITLE
Standardize phrasing to "at runtime" in Compose documentation

### DIFF
--- a/content/manuals/compose/how-tos/environment-variables/variable-interpolation.md
+++ b/content/manuals/compose/how-tos/environment-variables/variable-interpolation.md
@@ -12,9 +12,9 @@ aliases:
 
 A Compose file can use variables to offer more flexibility. If you want to quickly switch 
 between image tags to test multiple versions, or want to adjust a volume source to your local
-environment, you don't need to edit the Compose file each time, you can just set variables that insert values into your Compose file at run time.
+environment, you don't need to edit the Compose file each time, you can just set variables that insert values into your Compose file at runtime.
 
-Interpolation can also be used to insert values into your Compose file at run time, which is then used to pass variables into your container's environment
+Interpolation can also be used to insert values into your Compose file at runtime, which is then used to pass variables into your container's environment
 
 Below is a simple example: 
 


### PR DESCRIPTION
<!--Delete sections as needed -->

## Description

<!-- Tell us what you did and why -->
Standardized the phrasing from **"at run time"** to **"at runtime"** for consistency with other Docker documentation. No technical content changes.
## Related issues or tickets

<!-- Related issues, pull requests, or Jira tickets -->
None.
## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Technical review
- [x] Editorial review
- [ ] Product review