### PR TITLE
Replace braced expressions list with a table

### DIFF
--- a/content/reference/compose-file/interpolation.md
+++ b/content/reference/compose-file/interpolation.md
@@ -10,17 +10,16 @@ weight: 90
 {{% include "compose/interpolation.md" %}}
 
 For braced expressions, the following formats are supported:
-- Direct substitution
-  - `${VAR}` -> value of `VAR`
-- Default value
-  - `${VAR:-default}` -> value of `VAR` if set and non-empty, otherwise `default`
-  - `${VAR-default}` -> value of `VAR` if set, otherwise `default`
-- Required value
-  - `${VAR:?error}` -> value of `VAR` if set and non-empty, otherwise exit with error
-  - `${VAR?error}` -> value of `VAR` if set, otherwise exit with error
-- Alternative value
-  - `${VAR:+replacement}` -> `replacement` if `VAR` is set and non-empty, otherwise empty
-  - `${VAR+replacement}` -> `replacement` if `VAR` is set, otherwise empty
+ 
+| Syntax                | `VAR` has value     | `VAR` is empty      | `VAR` has nonexist |
+|-----------------------|---------------------|---------------------|--------------------|
+| `${VAR}`              | `VAR` value         | empty string        | nonsense error     |
+| `${VAR:-default}`     | `VAR` value         | `default` value     | `default` value    |
+| `${VAR-default}`      | `VAR` value         | empty string        | `default` value    |
+| `${VAR:?error}`       | `VAR` value         | exit with `error`   | exit with `error`  |
+| `${VAR?error}`        | `VAR` value         | empty string        | exit with `error`  |
+| `${VAR:+replacement}` | `replacement` value | empty string        | empty string       |
+| `${VAR+replacement}`  | `replacement` value | `replacement` value | empty string       |
 
 Interpolation can also be nested:
 


### PR DESCRIPTION
## Description

The table can offer better comparision experience. While the keywords for purpose ("Direct substitution", "Default value", "Required value") is useful but I don't think it is neccessary as the purpose can improvise with the nesting case, so let devs go creative is ok.

(if the keywords are required, I can add another colum on the left for it though)

## Related issues or tickets

none

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Technical review
- [ ] Editorial review
- [ ] Product review