### PR TITLE
docs: use == operator in node.labels constraint

### DIFF
--- a/content/reference/compose-file/deploy.md
+++ b/content/reference/compose-file/deploy.md
@@ -98,7 +98,7 @@ For more detailed information about job options and behavior, see the [Docker CL
 deploy:
   placement:
     constraints:
-      - disktype=ssd
+      - node.labels.disktype==ssd
 ```
 
 #### `preferences`


### PR DESCRIPTION
## Description

https://docs.docker.com/reference/compose-file/deploy/#placement

In this section, `node.labels` must be specified. Also, it must be `==` and not a simple `=`, an error occurs without it:

```bash
failed to update service myapp_redis: Error response from daemon: rpc error: code = Unknown desc = constraint expected one operator from ==, !=
```
