### PR TITLE
Update garbage-collection.md

### DIFF
--- a/content/manuals/build/cache/garbage-collection.md
+++ b/content/manuals/build/cache/garbage-collection.md
@@ -122,7 +122,7 @@ default GC policies resolve to:
           "reservedSpace": "2.764GB",
           "keepDuration": "48h",
           "filter": [
-            "type=source.local,type=exec.cachemount,type=source.git.checkout"
+            "type=source.local,type==exec.cachemount,type==source.git.checkout"
           ]
         },
         { "reservedSpace": "20GB", "keepDuration": ["1440h"] },


### PR DESCRIPTION
Using the filter suggested by the docs causing error in Docker 29.2.1 preventing GC from working.
Docs: https://docs.docker.com/build/cache/garbage-collection/#docker-daemon-configuration-file

Solution:
- Appending double equals (==) fix the problem.
   `type=source.local,type==exec.cachemount,type==source.git.checkout `

Related error log:
Mar 09 14:39:58 gitRunner04 dockerd[1238772]: time="2026-03-09T14:39:58.005793998+07:00" level=error msg="gc error: filters: parse error: [type==source.local,type >|=|< exec.cachemount,type=source.git.checkout]: unsupported operator \"=\": invalid argument\nfailed to parse prune filters [type==source.local,type=exec.cachemount,type=source.git.checkout]\ngithub.com/moby/buildkit/cache.(*cacheManager).prune\n\t/root/rpmbuild/BUILD/src/engine/vendor/github.com/moby/buildkit/cache/manager.go:1039\ngithub.com/moby/buildkit/cache.(*cacheManager).Prune\n\t/root/rpmbuild/BUILD/src/engine/vendor/github.com/moby/buildkit/cache/manager.go:1019\ngithub.com/moby/buildkit/worker/base.(*Worker).Prune\n\t/root/rpmbuild/BUILD/src/engine/vendor/github.com/moby/buildkit/worker/base/worker.go:507\ngithub.com/moby/buildkit/control.(*Controller).gc.func2\n\t/root/rpmbuild/BUILD/src/engine/vendor/github.com/moby/buildkit/control/control.go:656\ngolang.org/x/sync/errgroup.(*Group).Go.func1\n\t/root/rpmbuild/BUILD/src/engine/vendor/golang.org/x/sync/errgroup/errgroup.go:93\nruntime.goexit\n\t/usr/local/go/src/runtime/asm_amd64.s:1693"

<!--Delete sections as needed -->

## Description

<!-- Tell us what you did and why -->

## Related issues or tickets

<!-- Related issues, pull requests, or Jira tickets -->

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Technical review
- [ ] Editorial review
- [ ] Product review