### PR TITLE
Fix spurious 'to' after 'lets you' in guides and Scout docs

### DIFF
--- a/content/get-started/docker-concepts/running-containers/overriding-container-defaults.md
+++ b/content/get-started/docker-concepts/running-containers/overriding-container-defaults.md
@@ -3,8 +3,8 @@ title: Overriding container defaults
 weight: 2
 keywords: concepts, build, images, container, docker desktop
 description: This concept page will teach you how to override the container defaults using the `docker run` command.
-aliases: 
- - /guides/docker-concepts/running-containers/overriding-container-defaults/
+aliases:
+  - /guides/docker-concepts/running-containers/overriding-container-defaults/
 ---
 
 {{< youtube-embed PFszWK3BB8I >}}
@@ -15,7 +15,7 @@ When a Docker container starts, it executes an application or command. The conta
 
 For example, if you have an existing database container that listens on the standard port and you want to run a new instance of the same database container, then you might want to change the port settings the new container listens on so that it doesn’t conflict with the existing container. Sometimes you might want to increase the memory available to the container if the program needs more resources to handle a heavy workload or set the environment variables to provide specific configuration details the program needs to function properly.
 
-The `docker run` command offers a powerful way to override these defaults and tailor the container's behavior to your liking. The command offers several flags that let you to customize container behavior on the fly.
+The `docker run` command offers a powerful way to override these defaults and tailor the container's behavior to your liking. The command offers several flags that let you customize container behavior on the fly.
 
 Here's a few ways you can achieve this.
 
@@ -45,6 +45,7 @@ foo=bar
 > [!TIP]
 >
 > The `.env` file acts as a convenient way to set environment variables for your Docker containers without cluttering your command line with numerous `-e` flags. To use a `.env` file, you can pass `--env-file` option with the `docker run` command.
+>
 > ```console
 > $ docker run --env-file .env postgres env
 > ```
@@ -55,7 +56,7 @@ You can use the `--memory` and `--cpus` flags with the `docker run` command to r
 
 ```console
 $ docker run -e POSTGRES_PASSWORD=secret --memory="512m" --cpus="0.5" postgres
- ```
+```
 
 This command limits container memory usage to 512 MB and defines the CPU quota of 0.5 for half a core.
 
@@ -74,14 +75,14 @@ In this hands-on guide, you'll see how to use the `docker run` command to overri
 ### Run multiple instances of the Postgres database
 
 1.  Start a container using the [Postgres image](https://hub.docker.com/_/postgres) with the following command:
-    
+
     ```console
     $ docker run -d -e POSTGRES_PASSWORD=secret -p 5432:5432 postgres
     ```
 
     This will start the Postgres database in the background, listening on the standard container port `5432` and mapped to port `5432` on the host machine.
 
-2. Start a second Postgres container mapped to a different port. 
+2.  Start a second Postgres container mapped to a different port.
 
     ```console
     $ docker run -d -e POSTGRES_PASSWORD=secret -p 5433:5432 postgres
@@ -89,7 +90,7 @@ In this hands-on guide, you'll see how to use the `docker run` command to overri
 
     This will start another Postgres container in the background, listening on the standard postgres port `5432` in the container, but mapped to port `5433` on the host machine. You override the host port just to ensure that this new container doesn't conflict with the existing running container.
 
-3. Verify that both containers are running by going to the **Containers** view in the Docker Desktop Dashboard.
+3.  Verify that both containers are running by going to the **Containers** view in the Docker Desktop Dashboard.
 
     ![A screenshot of the Docker Desktop Dashboard showing the running instances of Postgres containers](images/running-postgres-containers.webp?border=true)
 
@@ -103,31 +104,30 @@ Follow the steps to see how to connect a Postgres container to a custom network.
 
 1. Create a new custom network by using the following command:
 
-    ```console
-    $ docker network create mynetwork
-    ```
+   ```console
+   $ docker network create mynetwork
+   ```
 
 2. Verify the network by running the following command:
 
-    ```console
-    $ docker network ls
-    ```
+   ```console
+   $ docker network ls
+   ```
 
-    This command lists all networks, including the newly created "mynetwork".
+   This command lists all networks, including the newly created "mynetwork".
 
 3. Connect Postgres to the custom network by using the following command:
 
-    ```console
-    $ docker run -d -e POSTGRES_PASSWORD=secret -p 5434:5432 --network mynetwork postgres
-    ```
+   ```console
+   $ docker run -d -e POSTGRES_PASSWORD=secret -p 5434:5432 --network mynetwork postgres
+   ```
 
-    This will start Postgres container in the background, mapped to the host port 5434 and attached to the `mynetwork` network. You passed the `--network` parameter to override the container default by connecting the container to custom Docker network for better isolation and communication with other containers. You can use `docker network inspect` command to see if the container is tied to this new bridge network.
+   This will start Postgres container in the background, mapped to the host port 5434 and attached to the `mynetwork` network. You passed the `--network` parameter to override the container default by connecting the container to custom Docker network for better isolation and communication with other containers. You can use `docker network inspect` command to see if the container is tied to this new bridge network.
 
-
-    > **Key difference between default bridge and custom networks**
-    >
-    > 1. DNS resolution: By default, containers connected to the default bridge network can communicate with each other, but only by IP address. (unless you use `--link` option which is considered legacy). It is not recommended for production use due to the various [technical shortcomings](/engine/network/drivers/bridge/#differences-between-user-defined-bridges-and-the-default-bridge). On a custom network, containers can resolve each other by name or alias.
-    > 2. Isolation: All containers without a `--network` specified are attached to the default bridge network, hence can be a risk, as unrelated containers are then able to communicate. Using a custom network provides a scoped network in which only containers attached to that network are able to communicate, hence providing better isolation.
+   > **Key difference between default bridge and custom networks**
+   >
+   > 1. DNS resolution: By default, containers connected to the default bridge network can communicate with each other, but only by IP address. (unless you use `--link` option which is considered legacy). It is not recommended for production use due to the various [technical shortcomings](/engine/network/drivers/bridge/#differences-between-user-defined-bridges-and-the-default-bridge). On a custom network, containers can resolve each other by name or alias.
+   > 2. Isolation: All containers without a `--network` specified are attached to the default bridge network, hence can be a risk, as unrelated containers are then able to communicate. Using a custom network provides a scoped network in which only containers attached to that network are able to communicate, hence providing better isolation.
 
 ### Manage the resources
 
@@ -143,67 +143,61 @@ The `--cpus` flag specifies the CPU quota for the container. Here, it's set to h
 
 ### Override the default CMD and ENTRYPOINT in Docker Compose
 
-
-
 Sometimes, you might need to override the default commands (`CMD`) or entry points (`ENTRYPOINT`) defined in a Docker image, especially when using Docker Compose.
 
 1. Create a `compose.yml` file with the following content:
 
-    ```yaml
-    services:
-      postgres:
-        image: postgres:18
-        entrypoint: ["docker-entrypoint.sh", "postgres"]
-        command: ["-h", "localhost", "-p", "5432"]
-        environment:
-          POSTGRES_PASSWORD: secret 
-    ```
+   ```yaml
+   services:
+     postgres:
+       image: postgres:18
+       entrypoint: ["docker-entrypoint.sh", "postgres"]
+       command: ["-h", "localhost", "-p", "5432"]
+       environment:
+         POSTGRES_PASSWORD: secret
+   ```
 
-
-    The Compose file defines a service named `postgres` that uses the official Postgres image, sets an entrypoint script, and starts the container with password authentication.
+   The Compose file defines a service named `postgres` that uses the official Postgres image, sets an entrypoint script, and starts the container with password authentication.
 
 2. Bring up the service by running the following command:
 
-    ```console
-    $ docker compose up -d
-    ```
+   ```console
+   $ docker compose up -d
+   ```
 
-    This command starts the Postgres service defined in the Docker Compose file.
+   This command starts the Postgres service defined in the Docker Compose file.
 
 3. Verify the authentication with Docker Desktop Dashboard.
 
-    Open the Docker Desktop Dashboard, select the **Postgres** container and select **Exec** to enter into the container shell. You can type the following command to connect to the Postgres database:
+   Open the Docker Desktop Dashboard, select the **Postgres** container and select **Exec** to enter into the container shell. You can type the following command to connect to the Postgres database:
 
-    ```console
-    # psql -U postgres
-    ```
+   ```console
+   # psql -U postgres
+   ```
 
-    ![A screenshot of the Docker Desktop Dashboard selecting the Postgres container and entering into its shell using EXEC button](images/exec-into-postgres-container.webp?border=true)
+   ![A screenshot of the Docker Desktop Dashboard selecting the Postgres container and entering into its shell using EXEC button](images/exec-into-postgres-container.webp?border=true)
 
-
-    > [!NOTE]
-    > 
-    > The PostgreSQL image sets up trust authentication locally so you may notice a password isn't required when connecting from localhost (inside the same container). However, a password will be required if connecting from a different host/container.
+   > [!NOTE]
+   >
+   > The PostgreSQL image sets up trust authentication locally so you may notice a password isn't required when connecting from localhost (inside the same container). However, a password will be required if connecting from a different host/container.
 
 ### Override the default CMD and ENTRYPOINT with `docker run`
 
 You can also override defaults directly using the `docker run` command with the following command:
 
-```console 
+```console
 $ docker run -e POSTGRES_PASSWORD=secret postgres docker-entrypoint.sh -h localhost -p 5432
 ```
 
 This command runs a Postgres container, sets an environment variable for password authentication, overrides the default startup commands and configures hostname and port mapping.
 
-
 ## Additional resources
 
-* [Ways to set environment variables with Compose](/compose/how-tos/environment-variables/set-environment-variables/)
-* [What is a container](/get-started/docker-concepts/the-basics/what-is-a-container/)
+- [Ways to set environment variables with Compose](/compose/how-tos/environment-variables/set-environment-variables/)
+- [What is a container](/get-started/docker-concepts/the-basics/what-is-a-container/)
 
 ## Next steps
 
 Now that you have learned about overriding container defaults, it's time to learn how to persist container data.
 
 {{< button text="Persisting container data" url="persisting-container-data" >}}
-

--- a/content/get-started/docker-concepts/the-basics/what-is-a-container.md
+++ b/content/get-started/docker-concepts/the-basics/what-is-a-container.md
@@ -4,19 +4,19 @@ weight: 10
 keywords: concepts, build, images, container, docker desktop
 description: What is a container? This concept page will teach you about containers and provide a quick hands-on where you will run your first container.
 aliases:
-- /guides/walkthroughs/what-is-a-container/
-- /guides/walkthroughs/run-a-container/
-- /guides/walkthroughs/
-- /get-started/run-your-own-container/
-- /get-started/what-is-a-container/
-- /guides/docker-concepts/the-basics/what-is-a-container/
+  - /guides/walkthroughs/what-is-a-container/
+  - /guides/walkthroughs/run-a-container/
+  - /guides/walkthroughs/
+  - /get-started/run-your-own-container/
+  - /get-started/what-is-a-container/
+  - /guides/docker-concepts/the-basics/what-is-a-container/
 ---
 
 {{< youtube-embed W1kWqFkiu7k >}}
 
 ## Explanation
 
-Imagine you're developing a killer web app that has three main components - a React frontend, a Python API, and a PostgreSQL database. If you wanted to work on this project, you'd have to install Node, Python, and PostgreSQL. 
+Imagine you're developing a killer web app that has three main components - a React frontend, a Python API, and a PostgreSQL database. If you wanted to work on this project, you'd have to install Node, Python, and PostgreSQL.
 
 How do you make sure you have the same versions as the other developers on your team? Or your CI/CD system? Or what's used in production?
 
@@ -24,7 +24,7 @@ How do you ensure the version of Python (or Node or the database) your app needs
 
 Enter containers!
 
-What is a container? Simply put, containers are isolated processes for each of your app's components. Each component - the frontend React app, the Python API engine, and the database - runs in its own isolated environment, completely isolated from everything else on your machine. 
+What is a container? Simply put, containers are isolated processes for each of your app's components. Each component - the frontend React app, the Python API engine, and the database - runs in its own isolated environment, completely isolated from everything else on your machine.
 
 Here's what makes them awesome. Containers are:
 
@@ -43,7 +43,6 @@ A container is simply an isolated process with all of the files it needs to run.
 >
 > Quite often, you will see containers and VMs used together. As an example, in a cloud environment, the provisioned machines are typically VMs. However, instead of provisioning one machine to run one application, a VM with a container runtime can run multiple containerized applications, increasing resource utilization and reducing costs.
 
-
 ## Try it out
 
 In this hands-on, you will see how to run a Docker container using the Docker Desktop GUI.
@@ -57,7 +56,7 @@ Use the following instructions to run a container.
 
 2. Specify `welcome-to-docker` in the search input and then select the **Pull** button.
 
-    ![A screenshot of the Docker Desktop Dashboard showing the search result for welcome-to-docker Docker image ](images/search-the-docker-image.webp?border=true&w=1000&h=700)
+   ![A screenshot of the Docker Desktop Dashboard showing the search result for welcome-to-docker Docker image ](images/search-the-docker-image.webp?border=true&w=1000&h=700)
 
 3. Once the image is successfully pulled, select the **Run** button.
 
@@ -67,12 +66,12 @@ Use the following instructions to run a container.
 
 6. In the **Host port**, specify `8080`.
 
-    ![A screenshot of Docker Desktop Dashboard showing the container run dialog with welcome-to-docker typed in as the container name and 8080 specified as the port number](images/run-a-new-container.webp?border=true&w=550&h=400)
+   ![A screenshot of Docker Desktop Dashboard showing the container run dialog with welcome-to-docker typed in as the container name and 8080 specified as the port number](images/run-a-new-container.webp?border=true&w=550&h=400)
 
 7. Select **Run** to start your container.
 
 Congratulations! You just ran your first container! 🎉
- 
+
 ### View your container
 
 You can view all of your containers by going to the **Containers** view of the Docker Desktop Dashboard.
@@ -83,7 +82,7 @@ This container runs a web server that displays a simple website. When working wi
 
 ### Access the frontend
 
-When you launched the container, you exposed one of the container's ports onto your machine. Think of this as creating configuration to let you to connect through the isolated environment of the container. 
+When you launched the container, you exposed one of the container's ports onto your machine. Think of this as creating configuration to let you connect through the isolated environment of the container.
 
 For this container, the frontend is accessible on port `8080`. To open the website, select the link in the **Port(s)** column of your container or visit [http://localhost:8080](http://localhost:8080) in your browser.
 
@@ -91,7 +90,7 @@ For this container, the frontend is accessible on port `8080`. To open the websi
 
 ### Explore your container
 
-Docker Desktop lets you explore and interact with different aspects of your container. Try it out yourself. 
+Docker Desktop lets you explore and interact with different aspects of your container. Try it out yourself.
 
 1. Go to the **Containers** view in the Docker Desktop Dashboard.
 
@@ -99,11 +98,11 @@ Docker Desktop lets you explore and interact with different aspects of your cont
 
 3. Select the **Files** tab to explore your container's isolated file system.
 
-    ![Screenshot of the Docker Desktop Dashboard showing the files and directories inside a running container](images/explore-your-container.webp?border)
+   ![Screenshot of the Docker Desktop Dashboard showing the files and directories inside a running container](images/explore-your-container.webp?border)
 
 ### Stop your container
 
-The `docker/welcome-to-docker` container continues to run until you stop it. 
+The `docker/welcome-to-docker` container continues to run until you stop it.
 
 1. Go to the **Containers** view in the Docker Desktop Dashboard.
 
@@ -111,7 +110,7 @@ The `docker/welcome-to-docker` container continues to run until you stop it.
 
 3. Select the **Stop** action in the **Actions** column.
 
-    ![Screenshot of the Docker Desktop Dashboard with the welcome container selected and being prepared to stop](images/stop-your-container.webp?border)
+   ![Screenshot of the Docker Desktop Dashboard with the welcome container selected and being prepared to stop](images/stop-your-container.webp?border)
 
 {{< /tab >}}
 {{< tab name="Using the CLI" >}}
@@ -120,11 +119,11 @@ Follow the instructions to run a container using the CLI:
 
 1. Open your CLI terminal and start a container by using the [`docker run`](/reference/cli/docker/container/run/) command:
 
-    ```console
-    $ docker run -d -p 8080:80 docker/welcome-to-docker
-    ```
+   ```console
+   $ docker run -d -p 8080:80 docker/welcome-to-docker
+   ```
 
-    The output from this command is the full container ID. 
+   The output from this command is the full container ID.
 
 Congratulations! You just fired up your first container! 🎉
 
@@ -149,10 +148,9 @@ This container runs a web server that displays a simple website. When working wi
 >
 > The `docker ps` command will show you _only_ running containers. To view stopped containers, add the `-a` flag to list all containers: `docker ps -a`
 
-
 ### Access the frontend
 
-When you launched the container, you exposed one of the container's ports onto your machine. Think of this as creating configuration to let you to connect through the isolated environment of the container. 
+When you launched the container, you exposed one of the container's ports onto your machine. Think of this as creating configuration to let you connect through the isolated environment of the container.
 
 For this container, the frontend is accessible on port `8080`. To open the website, select the link in the **Port(s)** column of your container or visit [http://localhost:8080](http://localhost:8080) in your browser.
 
@@ -166,9 +164,9 @@ The `docker/welcome-to-docker` container continues to run until you stop it. You
 
 2. Provide the container ID or name to the [`docker stop`](/reference/cli/docker/container/stop/) command:
 
-    ```console
-    docker stop <the-container-id>
-    ```
+   ```console
+   docker stop <the-container-id>
+   ```
 
 > [!TIP]
 >

--- a/content/get-started/docker-concepts/the-basics/what-is-an-image.md
+++ b/content/get-started/docker-concepts/the-basics/what-is-an-image.md
@@ -24,7 +24,7 @@ There are two important principles of images:
 
 2. Container images are composed of layers. Each layer represents a set of file system changes that add, remove, or modify files.
 
-These two principles let you to extend or add to existing images. For example, if you are building a Python app, you can start from the [Python image](https://hub.docker.com/_/python) and add additional layers to install your app's dependencies and add your code. This lets you focus on your app, rather than Python itself.
+These two principles let you extend or add to existing images. For example, if you are building a Python app, you can start from the [Python image](https://hub.docker.com/_/python) and add additional layers to install your app's dependencies and add your code. This lets you focus on your app, rather than Python itself.
 
 ### Finding images
 

--- a/content/guides/localstack.md
+++ b/content/guides/localstack.md
@@ -111,7 +111,7 @@ Now it’s time to connect your app to LocalStack. The `index.js` file, located 
 
 The code interacts with LocalStack’s S3 service, which is accessed via the endpoint defined by the `S3_ENDPOINT_URL` environment variable, typically set to `http://localhost:4556` for local development.
 
-The `S3Client` from the AWS SDK is configured to use this LocalStack endpoint, along with test credentials (`AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`) that are also sourced from environment variables. This setup lets the application to perform operations on the locally simulated S3 service as if it were interacting with the real AWS S3, making the code flexible for different environments.
+The `S3Client` from the AWS SDK is configured to use this LocalStack endpoint, along with test credentials (`AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`) that are also sourced from environment variables. This setup lets the application perform operations on the locally simulated S3 service as if it were interacting with the real AWS S3, making the code flexible for different environments.
 
 The code uses `multer` and `multer-s3` to handle file uploads. When a user uploads an image through the /upload route, the file is stored directly in the S3 bucket simulated by LocalStack. The bucket name is retrieved from the environment variable `S3_BUCKET_NAME`. Each uploaded file is given a unique name by appending the current timestamp to the original filename. The route then returns the URL of the uploaded file within the local S3 service, making it accessible just as it would be if hosted on a real AWS S3 bucket.
 

--- a/content/guides/localstack.md
+++ b/content/guides/localstack.md
@@ -12,7 +12,7 @@ params:
   time: 20 minutes
 ---
 
-In modern application development, testing cloud applications locally before deploying them to a live environment helps you ship faster and with more confidence. This approach involves simulating services locally, identifying and fixing issues early, and iterating quickly without incurring costs or facing the complexities of a full cloud environment. Tools like [LocalStack](https://www.localstack.cloud/) have become invaluable in this process, enabling you to emulate AWS services and containerize applications for consistent, isolated testing environments. 
+In modern application development, testing cloud applications locally before deploying them to a live environment helps you ship faster and with more confidence. This approach involves simulating services locally, identifying and fixing issues early, and iterating quickly without incurring costs or facing the complexities of a full cloud environment. Tools like [LocalStack](https://www.localstack.cloud/) have become invaluable in this process, enabling you to emulate AWS services and containerize applications for consistent, isolated testing environments.
 
 In this guide, you'll learn how to:
 
@@ -22,7 +22,7 @@ In this guide, you'll learn how to:
 
 ## What is LocalStack?
 
-LocalStack is a cloud service emulator that runs in a single container on your laptop. It provides a powerful, flexible, and cost-effective way to test and develop AWS-based applications locally. 
+LocalStack is a cloud service emulator that runs in a single container on your laptop. It provides a powerful, flexible, and cost-effective way to test and develop AWS-based applications locally.
 
 ## Why use LocalStack?
 
@@ -40,7 +40,7 @@ The [official Docker image for LocalStack](https://hub.docker.com/r/localstack/l
 
 The following prerequisites are required to follow along with this how-to guide:
 
-- [Docker Desktop](https://www.docker.com/products/docker-desktop/) 
+- [Docker Desktop](https://www.docker.com/products/docker-desktop/)
 - [Node.js](https://nodejs.org/en/download/package-manager)
 - [Python and pip](https://www.python.org/downloads/)
 - Basic knowledge of Docker
@@ -58,7 +58,7 @@ Launch a quick demo of LocalStack by using the following steps:
 
 2. Bring up LocalStack
 
-   Run the following command to bring up LocalStack.   
+   Run the following command to bring up LocalStack.
 
    ```console
    $ docker compose -f compose-native.yml up -d
@@ -74,25 +74,25 @@ Launch a quick demo of LocalStack by using the following steps:
 
 4. Creating a Local Amazon S3 Bucket
 
-   When you create a local S3 bucket using LocalStack, you're essentially simulating the creation of an S3 bucket on AWS. This lets you to test and develop applications that interact with S3 without needing an actual AWS account.
+   When you create a local S3 bucket using LocalStack, you're essentially simulating the creation of an S3 bucket on AWS. This lets you test and develop applications that interact with S3 without needing an actual AWS account.
 
-   To create Local Amazon S3 bucket, install the [`awscli-local` CLI](https://github.com/localstack/awscli-local) on your system. The `awslocal` command is a thin wrapper around the AWS command line interface for use with LocalStack. It lets you to test and develop against a simulated environment on your local machine without needing to access the real AWS services.
+   To create Local Amazon S3 bucket, install the [`awscli-local` CLI](https://github.com/localstack/awscli-local) on your system. The `awslocal` command is a thin wrapper around the AWS command line interface for use with LocalStack. It lets you test and develop against a simulated environment on your local machine without needing to access the real AWS services.
 
-    ```console
-    $ pip install awscli-local
-    ```
+   ```console
+   $ pip install awscli-local
+   ```
 
-    Create a new S3 bucket within the LocalStack environment with the following command:
+   Create a new S3 bucket within the LocalStack environment with the following command:
 
-    ```console
-    $ awslocal s3 mb s3://mysamplebucket
-    ```
+   ```console
+   $ awslocal s3 mb s3://mysamplebucket
+   ```
 
-    The command `s3 mb s3://mysamplebucket` tells the AWS CLI to create a new S3 bucket (mb stands for `make bucket`) named `mysamplebucket`.
+   The command `s3 mb s3://mysamplebucket` tells the AWS CLI to create a new S3 bucket (mb stands for `make bucket`) named `mysamplebucket`.
 
-    You can verify if the S3 bucket gets created or not by selecting the LocalStack container on the Docker Desktop Dashboard and viewing the logs. The logs indicates that your LocalStack environment is configured correctly and you can now use the `mysamplebucket` for storing and retrieving objects.
+   You can verify if the S3 bucket gets created or not by selecting the LocalStack container on the Docker Desktop Dashboard and viewing the logs. The logs indicates that your LocalStack environment is configured correctly and you can now use the `mysamplebucket` for storing and retrieving objects.
 
-    ![Diagram showing the logs of LocalStack that highlights the S3 bucket being created successfully ](./images/localstack-s3put.webp)
+   ![Diagram showing the logs of LocalStack that highlights the S3 bucket being created successfully ](./images/localstack-s3put.webp)
 
 ## Using LocalStack in development
 
@@ -104,7 +104,6 @@ Now that you've familiarized yourself with LocalStack, it's time to see it in ac
 - LocalStack: Emulates the Amazon S3 service and stores and retrieve images.
 
 ![Diagram showing the tech stack of the sample todo-list application that includes LocalStack, frontend and backend services ](images/localstack-arch.webp)
-
 
 ## Connecting to LocalStack from a non-containerized app
 
@@ -125,19 +124,18 @@ Let’s see it in action. Start by launching the Node.js backend service.
    ```
 
 2. Install the required dependencies:
-  
+
    ```console
    $ npm install
    ```
 
 3. Setting up AWS environment variables
 
-
    The `.env` file located in the backend/ directory already contains placeholder credentials and configuration values that LocalStack uses to emulate AWS services. The `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` are placeholder credentials, while `S3_BUCKET_NAME` and `S3_ENDPOINT_URL` are configuration settings. No changes are needed as these values are already correctly set for LocalStack.
 
    > [!TIP]
    >
-   > Given that you’re running Mongo in a Docker container and the backend Node app is running natively on your host, ensure that  `MONGODB_URI=mongodb://localhost:27017/todos` is set in your `.env` file.
+   > Given that you’re running Mongo in a Docker container and the backend Node app is running natively on your host, ensure that `MONGODB_URI=mongodb://localhost:27017/todos` is set in your `.env` file.
 
    ```plaintext
    MONGODB_URI=mongodb://localhost:27017/todos
@@ -148,14 +146,15 @@ Let’s see it in action. Start by launching the Node.js backend service.
    AWS_REGION=us-east-1
    ```
 
-   While the AWS SDK might typically use environment variables starting with `AWS_`, this specific application directly references the following `S3_*` variables in the index.js file (under the `backend/` directory) to configure the S3Client. 
+   While the AWS SDK might typically use environment variables starting with `AWS_`, this specific application directly references the following `S3_*` variables in the index.js file (under the `backend/` directory) to configure the S3Client.
 
    ```js
    const s3 = new S3Client({
      endpoint: process.env.S3_ENDPOINT_URL, // Use the provided endpoint or fallback to defaults
      credentials: {
-       accessKeyId: process.env.AWS_ACCESS_KEY_ID || 'default_access_key', // Default values for development
-       secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY || 'default_secret_key',  
+       accessKeyId: process.env.AWS_ACCESS_KEY_ID || "default_access_key", // Default values for development
+       secretAccessKey:
+         process.env.AWS_SECRET_ACCESS_KEY || "default_secret_key",
      },
    });
    ```
@@ -166,7 +165,7 @@ Let’s see it in action. Start by launching the Node.js backend service.
    $ node index.js
    ```
 
-    You will see the message that the backend service has successfully started at port 5000.
+   You will see the message that the backend service has successfully started at port 5000.
 
 ## Start the frontend service
 
@@ -179,7 +178,7 @@ To start the frontend service, open a new terminal and follow these steps:
    ```
 
 2. Install the required dependencies
-  
+
    ```console
    $ npm install
    ```
@@ -189,7 +188,7 @@ To start the frontend service, open a new terminal and follow these steps:
    ```console
    $ npm run dev
    ```
-   
+
    By now, you should see the following message:
 
    ```console
@@ -207,8 +206,7 @@ To start the frontend service, open a new terminal and follow these steps:
 
    ![Diagram showing the logs of the LocalStack that highlights image uploaded to the emulated S3 bucket](images/localstack-todolist-s3put.webp)
 
-   The `200` status code signifies that the `putObject` operation, which involves uploading an object to the S3 bucket, was executed successfully within the LocalStack environment. LocalStack logs this entry to provide visibility into the operations being performed. It helps debug and confirm that your application is interacting correctly with the emulated AWS services. 
-
+   The `200` status code signifies that the `putObject` operation, which involves uploading an object to the S3 bucket, was executed successfully within the LocalStack environment. LocalStack logs this entry to provide visibility into the operations being performed. It helps debug and confirm that your application is interacting correctly with the emulated AWS services.
 
    Since LocalStack is designed to simulate AWS services locally, this log entry shows that your application is functioning as expected when performing cloud operations in a local sandbox environment.
 
@@ -216,11 +214,11 @@ To start the frontend service, open a new terminal and follow these steps:
 
 Now that you have learnt how to connect a non-containerized Node.js application to LocalStack, it's time to explore the necessary changes to run the complete application stack in a containerized environment. To achieve this, you will create a Compose file specifying all required services - frontend, backend, database, and LocalStack.
 
-1. Examine the Docker Compose file. 
+1. Examine the Docker Compose file.
 
    The following Docker Compose file defines four services: `backend`, `frontend`, `mongodb`, and `localstack`. The `backend` and `frontend` services are your Node.js applications, while `mongodb` provides a database and `localstack` simulates AWS services like S3.
 
-   The `backend` service depends on `localstack` and `mongodb` services, ensuring they are running before it starts. It also uses a .env file for environment variables. The frontend service depends on the backend and sets the API URL. The `mongodb` service uses a persistent volume for data storage, and `localstack` is configured to run the S3 service. This setup lets you to develop and test your application locally with AWS-like services.
+   The `backend` service depends on `localstack` and `mongodb` services, ensuring they are running before it starts. It also uses a .env file for environment variables. The frontend service depends on the backend and sets the API URL. The `mongodb` service uses a persistent volume for data storage, and `localstack` is configured to run the S3 service. This setup lets you develop and test your application locally with AWS-like services.
 
    ```yaml
    services:
@@ -274,7 +272,7 @@ Now that you have learnt how to connect a non-containerized Node.js application 
 
    > [!TIP]
    > Given the previous Compose file, the app would connect to LocalStack using the hostname `localstack` while Mongo would connect using the hostname `mongodb`.
- 
+
    ```plaintext
    MONGODB_URI=mongodb://mongodb:27017/todos
    AWS_ACCESS_KEY_ID=test
@@ -286,8 +284,7 @@ Now that you have learnt how to connect a non-containerized Node.js application 
 
 3. Stop the running services
 
-   Ensure that you stop the Node frontend and backend service from the previous step by pressing “Ctrl+C” in the terminal. Also, you'll need to stop the LocalStack and Mongo containers by selecting them in the Docker Desktop Dashboard and selecting the "Delete" button. 
-
+   Ensure that you stop the Node frontend and backend service from the previous step by pressing “Ctrl+C” in the terminal. Also, you'll need to stop the LocalStack and Mongo containers by selecting them in the Docker Desktop Dashboard and selecting the "Delete" button.
 
 4. Start the application stack by executing the following command at the root of your cloned project directory:
 
@@ -301,18 +298,16 @@ Now that you have learnt how to connect a non-containerized Node.js application 
 
    The AWS S3 bucket is not created beforehand by the Compose file. Run the following command to create a new bucket within the LocalStack environment:
 
-
    ```console
    $ awslocal s3 mb s3://mysamplebucket
    ```
 
    The command creates an S3 bucket named `mysamplebucket`.
 
-   Open [http://localhost:5173](http://localhost:5173) to access the complete to-do list application and start uploading images to the Amazon S3 bucket. 
+   Open [http://localhost:5173](http://localhost:5173) to access the complete to-do list application and start uploading images to the Amazon S3 bucket.
 
    > [!TIP]
    > To optimize performance and reduce upload times during development, consider uploading smaller image files. Larger images may take longer to process and could impact the overall responsiveness of the application.
-
 
 ## Recap
 

--- a/content/guides/pre-seeding.md
+++ b/content/guides/pre-seeding.md
@@ -34,7 +34,7 @@ Launch a quick demo of Postgres by using the following steps:
 
 1. Open the terminal and run the following command to start a Postgres container.
 
-   This example will launch a Postgres container, expose port `5432` onto the host to let a native-running application to connect to it with the password `mysecretpassword`.
+   This example will launch a Postgres container, expose port `5432` onto the host to let a native-running application connect to it with the password `mysecretpassword`.
 
    ```console
    $ docker run -d --name postgres -p 5432:5432 -e POSTGRES_PASSWORD=mysecretpassword postgres

--- a/content/guides/pre-seeding.md
+++ b/content/guides/pre-seeding.md
@@ -1,6 +1,6 @@
 ---
 title: Pre-seeding database with schema and data at startup for development environment
-linktitle: Pre-seeding database  
+linktitle: Pre-seeding database
 description: &desc Pre-seeding database with schema and data at startup for development environment
 keywords: Pre-seeding, database, postgres, container-supported development
 summary: *desc
@@ -26,7 +26,7 @@ The [official Docker image for Postgres](https://hub.docker.com/_/postgres) prov
 
 The following prerequisites are required to follow along with this how-to guide:
 
-- [Docker Desktop](https://www.docker.com/products/docker-desktop/) 
+- [Docker Desktop](https://www.docker.com/products/docker-desktop/)
 
 ## Launching Postgres
 
@@ -44,7 +44,7 @@ Launch a quick demo of Postgres by using the following steps:
 
    ```plaintext
    PostgreSQL Database directory appears to contain a database; Skipping initialization
- 
+
    2024-09-08 09:09:47.136 UTC [1] LOG:  starting PostgreSQL 16.4 (Debian 16.4-1.pgdg120+1) on aarch64-unknown-linux-gnu, compiled by gcc (Debian 12.2.0-14) 12.2.0, 64-bit
    2024-09-08 09:09:47.137 UTC [1] LOG:  listening on IPv4 address "0.0.0.0", port 5432
    2024-09-08 09:09:47.137 UTC [1] LOG:  listening on IPv6 address "::", port 5432
@@ -87,7 +87,7 @@ Assuming that you have an existing Postgres database instance up and running, fo
    INSERT INTO users (name, email) VALUES
      ('Alpha', 'alpha@example.com'),
      ('Beta', 'beta@example.com'),
-     ('Gamma', 'gamma@example.com');  
+     ('Gamma', 'gamma@example.com');
    ```
 
    The SQL script creates a new database called `sampledb`, connects to it, and creates a `users` table. The table includes an auto-incrementing `id` as the primary key, a `name` field with a maximum length of 50 characters, and a unique `email` field with up to 100 characters.
@@ -96,7 +96,7 @@ Assuming that you have an existing Postgres database instance up and running, fo
 
 2. Seed the database.
 
-   It’s time to feed the content of the `seed.sql` directly into the database by using the `<` operator. The command is used to execute a SQL script named `seed.sql` against a Postgres database named `sampledb`. 
+   It’s time to feed the content of the `seed.sql` directly into the database by using the `<` operator. The command is used to execute a SQL script named `seed.sql` against a Postgres database named `sampledb`.
 
    ```console
    $ cat seed.sql | docker exec -i postgres psql -h localhost -U postgres -f-
@@ -111,7 +111,7 @@ Assuming that you have an existing Postgres database instance up and running, fo
    INSERT 0 3
    ```
 
-3. Run the following `psql` command to verify if the table named users is populated in the database `sampledb` or not. 
+3. Run the following `psql` command to verify if the table named users is populated in the database `sampledb` or not.
 
    ```console
    $ docker exec -it postgres psql -h localhost -U postgres sampledb
@@ -144,12 +144,12 @@ Assuming that you have an existing Postgres database instance up and running, fo
     3 | Gamma | gamma@example.com
    (3 rows)
    ```
-  
+
    Use `\q` or `\quit` to exit from the Postgres interactive shell.
 
 ## Pre-seed the database by bind-mounting a SQL script
 
-In Docker, mounting refers to making files or directories from the host system accessible within a container. This let you to share data or configuration files between the host and the container, enabling greater flexibility and persistence.
+In Docker, mounting refers to making files or directories from the host system accessible within a container. This lets you share data or configuration files between the host and the container, enabling greater flexibility and persistence.
 
 Now that you have learned how to launch Postgres and pre-seed the database using an SQL script, it’s time to learn how to mount an SQL file directly into the Postgres containers’ initialization directory (`/docker-entrypoint-initdb.d`). The `/docker-entrypoint-initdb.d` is a special directory in PostgreSQL Docker containers that is used for initializing the database when the container is first started
 
@@ -174,7 +174,7 @@ $ docker container stop postgres
     ('Gamma', 'gamma@example.com')
    ON CONFLICT (email) DO NOTHING;
    ```
-   
+
 2. Create a text file named `Dockerfile` and copy the following content.
 
    ```plaintext
@@ -184,11 +184,10 @@ $ docker container stop postgres
    ```
 
    This Dockerfile copies the `seed.sql` script directly into the PostgreSQL container's initialization directory.
-   
 
 3. Use Docker Compose.
-   
-   Using Docker Compose makes it even easier to manage and deploy the PostgreSQL container with the seeded database. This compose.yml file defines a Postgres service named `db` using the latest Postgres image, which sets up a database with the name `sampledb`, along with a user `postgres` and a password `mysecretpassword`. 
+
+   Using Docker Compose makes it even easier to manage and deploy the PostgreSQL container with the seeded database. This compose.yml file defines a Postgres service named `db` using the latest Postgres image, which sets up a database with the name `sampledb`, along with a user `postgres` and a password `mysecretpassword`.
 
    ```yaml
    services:
@@ -204,47 +203,45 @@ $ docker container stop postgres
        ports:
          - "5432:5432"
        volumes:
-         - data_sql:/var/lib/postgresql   # Persistent data storage
+         - data_sql:/var/lib/postgresql # Persistent data storage
 
    volumes:
      data_sql:
-    ```
-  
-    It maps port `5432` on the host to the container's `5432`, let you access to the Postgres database from outside the container. It also define `data_sql` for persisting the database data, ensuring that data is not lost when the container is stopped.
+   ```
 
-    It is important to note that the port mapping to the host is only necessary if you want to connect to the database from non-containerized programs. If you containerize the service that connects to the DB, you should connect to the database over a custom bridge network.
+   It maps port `5432` on the host to the container's `5432`, let you access to the Postgres database from outside the container. It also define `data_sql` for persisting the database data, ensuring that data is not lost when the container is stopped.
 
-4.  Bring up the Compose service.
+   It is important to note that the port mapping to the host is only necessary if you want to connect to the database from non-containerized programs. If you containerize the service that connects to the DB, you should connect to the database over a custom bridge network.
 
-    Assuming that you've placed the `seed.sql` file in the same directory as the Dockerfile, execute the following command:
+4. Bring up the Compose service.
 
-    ```console
-    $ docker compose up -d --build
-    ```
+   Assuming that you've placed the `seed.sql` file in the same directory as the Dockerfile, execute the following command:
 
-5.  It’s time to verify if the table `users` get populated with the data. 
+   ```console
+   $ docker compose up -d --build
+   ```
 
-    ```console
-    $ docker exec -it my_postgres_db psql -h localhost -U postgres sampledb
-    ```
+5. It’s time to verify if the table `users` get populated with the data.
 
-    ```sql 
-    sampledb=# SELECT * FROM users;
-      id | name  |       email
-    ----+-------+-------------------
-       1 | Alpha | alpha@example.com
-       2 | Beta  | beta@example.com
-       3 | Gamma | gamma@example.com
-     (3 rows)
+   ```console
+   $ docker exec -it my_postgres_db psql -h localhost -U postgres sampledb
+   ```
 
-    sampledb=#
-    ```
+   ```sql
+   sampledb=# SELECT * FROM users;
+     id | name  |       email
+   ----+-------+-------------------
+      1 | Alpha | alpha@example.com
+      2 | Beta  | beta@example.com
+      3 | Gamma | gamma@example.com
+    (3 rows)
 
+   sampledb=#
+   ```
 
 ## Pre-seed the database using JavaScript code
 
-
-Now that you have learned how to seed the database using various methods like SQL script, mounting volumes etc., it's time to try to achieve it using JavaScript code. 
+Now that you have learned how to seed the database using various methods like SQL script, mounting volumes etc., it's time to try to achieve it using JavaScript code.
 
 1. Create a .env file with the following:
 
@@ -258,12 +255,12 @@ Now that you have learned how to seed the database using various methods like SQ
 
 2. Create a new JavaScript file called seed.js with the following content:
 
-   The following JavaScript code imports the `dotenv` package which is used to load environment variables from an `.env` file. The `.config()` method reads the `.env` file and sets the environment variables as properties of the `process.env` object. This let you to securely store sensitive information like database credentials outside of your code.
+   The following JavaScript code imports the `dotenv` package which is used to load environment variables from an `.env` file. The `.config()` method reads the `.env` file and sets the environment variables as properties of the `process.env` object. This lets you securely store sensitive information like database credentials outside of your code.
 
    Then, it creates a new Pool instance from the pg library, which provides a connection pool for efficient database interactions. The `seedData` function is defined to perform the database seeding operations.
-It is called at the end of the script to initiate the seeding process. The try...catch...finally block is used for error handling. 
+   It is called at the end of the script to initiate the seeding process. The try...catch...finally block is used for error handling.
 
-   ```plaintext
+   ````plaintext
    require('dotenv').config();  // Load environment variables from .env file
    const { Pool } = require('pg');
 
@@ -309,35 +306,36 @@ It is called at the end of the script to initiate the seeding process. The try..
      seedData();
      ```
 
-3.  Kick off the seeding process
+   ````
 
-    ```console
-    $ node seed.js
-    ```
+3. Kick off the seeding process
 
-    You should see the following command:
+   ```console
+   $ node seed.js
+   ```
 
-    ```plaintext
-    Database seeded successfully!
-    ```
+   You should see the following command:
 
-4.  Verify if the database is seeded correctly:
+   ```plaintext
+   Database seeded successfully!
+   ```
 
-    ```console
-    $ docker exec -it postgres psql -h localhost -U postgres sampledb
-    ```
+4. Verify if the database is seeded correctly:
 
-    ```console
-    sampledb=# SELECT * FROM todos;
-    id |      task      | completed
-    ----+----------------+-----------
-    1 | Watch netflix  | f
-    2 | Finish podcast | f
-    3 | Pick up kid    | f
-    (3 rows)  
-    ```
+   ```console
+   $ docker exec -it postgres psql -h localhost -U postgres sampledb
+   ```
+
+   ```console
+   sampledb=# SELECT * FROM todos;
+   id |      task      | completed
+   ----+----------------+-----------
+   1 | Watch netflix  | f
+   2 | Finish podcast | f
+   3 | Pick up kid    | f
+   (3 rows)
+   ```
 
 ## Recap
 
-Pre-seeding a database with schema and data at startup is essential for creating a consistent and realistic testing environment, which helps in identifying issues early in development and aligning frontend and backend work. This guide has equipped you with the knowledge and practical steps to achieve pre-seeding using various methods, including SQL script, Docker integration, and JavaScript code. 
-
+Pre-seeding a database with schema and data at startup is essential for creating a consistent and realistic testing environment, which helps in identifying issues early in development and aligning frontend and backend work. This guide has equipped you with the knowledge and practical steps to achieve pre-seeding using various methods, including SQL script, Docker integration, and JavaScript code.

--- a/content/guides/ruby/deploy.md
+++ b/content/guides/ruby/deploy.md
@@ -16,7 +16,7 @@ aliases:
 
 ## Overview
 
-In this section, you'll learn how to use Docker Desktop to deploy your application to a fully-featured Kubernetes environment on your development machine. This lets you to test and debug your workloads on Kubernetes locally before deploying.
+In this section, you'll learn how to use Docker Desktop to deploy your application to a fully-featured Kubernetes environment on your development machine. This lets you test and debug your workloads on Kubernetes locally before deploying.
 
 ## Create a Kubernetes YAML file
 

--- a/content/guides/rust/deploy.md
+++ b/content/guides/rust/deploy.md
@@ -16,7 +16,7 @@ aliases:
 
 ## Overview
 
-In this section, you'll learn how to use Docker Desktop to deploy your application to a fully-featured Kubernetes environment on your development machine. This lets you to test and debug your workloads on Kubernetes locally before deploying.
+In this section, you'll learn how to use Docker Desktop to deploy your application to a fully-featured Kubernetes environment on your development machine. This lets you test and debug your workloads on Kubernetes locally before deploying.
 
 ## Create a Kubernetes YAML file
 

--- a/content/manuals/admin/organization/orgs.md
+++ b/content/manuals/admin/organization/orgs.md
@@ -12,16 +12,16 @@ aliases:
 There are multiple ways to create an organization. You can either:
 
 - Create a new organization using the **Create Organization** option in the
-Admin Console or Docker Hub
+  Admin Console or Docker Hub
 - Convert an existing user account to an organization
 
-These procedures walk you through creating an organization from the Admin Console. 
+These procedures walk you through creating an organization from the Admin Console.
 
 ## Prerequisites
 
-* Before you create an organization, you need a [Docker ID](/accounts/create-account/). 
-* For prerequisites and detailed instructions on converting an existing user account to an organization, see
-[Convert an account into an organization](/manuals/admin/organization/convert-account.md).
+- Before you create an organization, you need a [Docker ID](/accounts/create-account/).
+- For prerequisites and detailed instructions on converting an existing user account to an organization, see
+  [Convert an account into an organization](/manuals/admin/organization/convert-account.md).
 
 > [!TIP]
 > Need a different plan for your team's needs? Review different [Docker subscriptions and features](https://www.docker.com/pricing?ref=Docs&refAction=DocsAdminOrgs) to choose a subscription for your organization.
@@ -29,18 +29,18 @@ These procedures walk you through creating an organization from the Admin Consol
 ## Create an organization
 
 1. Sign in to [Docker Home](https://app.docker.com/) and navigate to the bottom
-of the organization list. Select **Create new organization**.
+   of the organization list. Select **Create new organization**.
 1. Choose a subscription for your organization, a billing cycle, and specify how many seats you need. See [Docker Pricing](https://www.docker.com/pricing?ref=Docs&refAction=DocsAdminOrgs) for details on the features offered in the Team and Business subscription.
 1. Select **Continue to profile**, then **Create an organization** to create a new organization.
 1. Enter an **Organization namespace**. This is the official, unique name for
-your organization in Docker Hub. 
-   * It's not possible to change the name of the organization after you've created it.
-   * Your Docker ID and organization can't share the same name. 
-   * If you want to use your Docker ID as the organization name, then you must first [convert your account into an organization](/manuals/admin/organization/convert-account.md).
-1. Enter your **Company name**. This is the full name of your company. 
-   * Docker displays the company name on your organization page and in the details of any
-   public images you publish. 
-   * You can update the company name anytime by navigating to your organization's **Settings** page.
+   your organization in Docker Hub.
+   - It's not possible to change the name of the organization after you've created it.
+   - Your Docker ID and organization can't share the same name.
+   - If you want to use your Docker ID as the organization name, then you must first [convert your account into an organization](/manuals/admin/organization/convert-account.md).
+1. Enter your **Company name**. This is the full name of your company.
+   - Docker displays the company name on your organization page and in the details of any
+     public images you publish.
+   - You can update the company name anytime by navigating to your organization's **Settings** page.
 1. Select **Continue to billing** to continue, then enter your organization's billing information. Select **Continue to payment** to continue to the billing portal.
 1. Provide your payment details and select **Purchase**.
 
@@ -51,10 +51,10 @@ You've now created an organization.
 To view an organization in the Admin Console:
 
 1. Sign in to [Docker Home](https://app.docker.com) and select your
-organization.
+   organization.
 1. From the left-hand navigation menu, select **Admin Console**.
 
-The Admin Console contains many options that let you to
+The Admin Console contains many options that let you
 configure your organization.
 
 ## Merge organizations

--- a/content/manuals/scout/policy/configure.md
+++ b/content/manuals/scout/policy/configure.md
@@ -32,7 +32,6 @@ To add a policy:
 2. Select the **Add policy** button to open the policy configuration screen.
 3. On the policy configuration screen, locate the policy type that you want to
    configure, and select **Configure** to open the policy configuration page.
-
    - If the **Configure** button is grayed out, it means the current policy
      has no configurable parameters.
    - If the button reads **Integrate**, it indicates that setup is required
@@ -41,7 +40,6 @@ To add a policy:
 
 4. Update the policy parameters.
 5. Save the changes:
-
    - Select **Save policy** to commit the changes and enable the policy for
      your current organization.
    - Select **Save and disable** to save the policy configuration without enabling
@@ -49,8 +47,8 @@ To add a policy:
 
 ## Edit a policy
 
-Editing a policy lets you to modify its configuration without creating 
-a new one from scratch. This can be useful when policy parameters need adjustments 
+Editing a policy lets you modify its configuration without creating
+a new one from scratch. This can be useful when policy parameters need adjustments
 due to evolving requirements or changes in your organization's compliance goals.
 
 To edit a policy:


### PR DESCRIPTION
Fixes a repeated grammatical error where "lets you to <verb>" appears instead of the correct "lets you <verb>" (the causative construction doesn't take an infinitive marker).

Changes:
- guides/ruby/deploy.md: "lets you to test" → "lets you test"
- guides/rust/deploy.md: "lets you to test" → "lets you test"
- guides/localstack.md: three instances fixed
- manuals/scout/policy/configure.md: "lets you to modify" → "lets you modify"