### PR TITLE
docs: replace "allows/enables you to" with "lets you" in get-started

### DIFF
--- a/content/get-started/docker-concepts/building-images/multi-stage-builds.md
+++ b/content/get-started/docker-concepts/building-images/multi-stage-builds.md
@@ -9,8 +9,8 @@ summary: |
   Docker images, essential for minimizing overhead and enhancing deployment in
   production environments.
 weight: 5
-aliases: 
- - /guides/docker-concepts/building-images/multi-stage-builds/
+aliases:
+  - /guides/docker-concepts/building-images/multi-stage-builds/
 ---
 
 {{< youtube-embed vR185cjwxZ8 >}}
@@ -26,30 +26,26 @@ Multi-stage builds are recommended for all types of applications.
 - For interpreted languages, like JavaScript or Ruby or Python, you can build and minify your code in one stage, and copy the production-ready files to a smaller runtime image. This optimizes your image for deployment.
 - For compiled languages, like C or Go or Rust, multi-stage builds let you compile in one stage and copy the compiled binaries into a final runtime image. No need to bundle the entire compiler in your final image.
 
-
 Here's a simplified example of a multi-stage build structure using pseudo-code. Notice there are multiple `FROM` statements and a new `AS <stage-name>`. In addition, the `COPY` statement in the second stage is copying `--from` the previous stage.
-
 
 ```dockerfile
 # Stage 1: Build Environment
-FROM builder-image AS build-stage 
+FROM builder-image AS build-stage
 # Install build tools (e.g., Maven, Gradle)
 # Copy source code
 # Build commands (e.g., compile, package)
 
 # Stage 2: Runtime environment
-FROM runtime-image AS final-stage  
+FROM runtime-image AS final-stage
 #  Copy application artifacts from the build stage (e.g., JAR file)
 COPY --from=build-stage /path/in/build/stage /path/to/place/in/final/stage
-# Define runtime configuration (e.g., CMD, ENTRYPOINT) 
+# Define runtime configuration (e.g., CMD, ENTRYPOINT)
 ```
-
 
 This Dockerfile uses two stages:
 
 - The build stage uses a base image containing build tools needed to compile your application. It includes commands to install build tools, copy source code, and execute build commands.
 - The final stage uses a smaller base image suitable for running your application. It copies the compiled artifacts (a JAR file, for example) from the build stage. Finally, it defines the runtime configuration (using `CMD` or `ENTRYPOINT`) for starting your application.
-
 
 ## Try it out
 
@@ -57,139 +53,130 @@ In this hands-on guide, you'll unlock the power of multi-stage builds to create 
 
 1. [Download and install](https://www.docker.com/products/docker-desktop/) Docker Desktop.
 
-
 2. Open this [pre-initialized project](https://start.spring.io/#!type=maven-project&language=java&platformVersion=4.0.1&packaging=jar&configurationFileFormat=properties&jvmVersion=21&groupId=com.example&artifactId=spring-boot-docker&name=spring-boot-docker&description=Demo%20project%20for%20Spring%20Boot&packageName=com.example.spring-boot-docker&dependencies=web) to generate a ZIP file. Here’s how that looks:
 
+   ![A screenshot of Spring Initializr tool selected with Java 21, Spring Web and Spring Boot 3.4.0](images/multi-stage-builds-spring-initializer.webp?border=true)
 
-    ![A screenshot of Spring Initializr tool selected with Java 21, Spring Web and Spring Boot 3.4.0](images/multi-stage-builds-spring-initializer.webp?border=true)
+   [Spring Initializr](https://start.spring.io/) is a quickstart generator for Spring projects. It provides an extensible API to generate JVM-based projects with implementations for several common concepts — like basic language generation for Java, Kotlin, Groovy, and Maven.
 
+   Select **Generate** to create and download the zip file for this project.
 
-    [Spring Initializr](https://start.spring.io/) is a quickstart generator for Spring projects. It provides an extensible API to generate JVM-based projects with implementations for several common concepts — like basic language generation for Java, Kotlin, Groovy, and Maven. 
-
-    Select **Generate** to create and download the zip file for this project.
-
-    For this demonstration, you’ve paired Maven build automation with Java, a Spring Web dependency, and Java 21 for your metadata.
-
+   For this demonstration, you’ve paired Maven build automation with Java, a Spring Web dependency, and Java 21 for your metadata.
 
 3. Navigate the project directory. Once you unzip the file, you'll see the following project directory structure:
 
+   ```plaintext
+   spring-boot-docker
+   ├── HELP.md
+   ├── mvnw
+   ├── mvnw.cmd
+   ├── pom.xml
+   └── src
+       ├── main
+       │   ├── java
+       │   │   └── com
+       │   │       └── example
+       │   │           └── spring_boot_docker
+       │   │               └── SpringBootDockerApplication.java
+       │   └── resources
+       │       ├── application.properties
+       │       ├── static
+       │       └── templates
+       └── test
+           └── java
+               └── com
+                   └── example
+                       └── spring_boot_docker
+                           └── SpringBootDockerApplicationTests.java
 
-    ```plaintext
-    spring-boot-docker
-    ├── HELP.md
-    ├── mvnw
-    ├── mvnw.cmd
-    ├── pom.xml
-    └── src
-        ├── main
-        │   ├── java
-        │   │   └── com
-        │   │       └── example
-        │   │           └── spring_boot_docker
-        │   │               └── SpringBootDockerApplication.java
-        │   └── resources
-        │       ├── application.properties
-        │       ├── static
-        │       └── templates
-        └── test
-            └── java
-                └── com
-                    └── example
-                        └── spring_boot_docker
-                            └── SpringBootDockerApplicationTests.java
-    
-    15 directories, 7 files
-    ```
+   15 directories, 7 files
+   ```
 
-   The `src/main/java` directory contains your project's source code, the `src/test/java` directory   
+   The `src/main/java` directory contains your project's source code, the `src/test/java` directory  
    contains the test source, and the `pom.xml` file is your project’s Project Object Model (POM).
 
-   The `pom.xml` file is the core of a Maven project's configuration. It's a single configuration file that   
-   contains most of the information needed to build a customized project. The POM is huge and can seem    
-   daunting. Thankfully, you don't yet need to understand every intricacy to use it effectively. 
+   The `pom.xml` file is the core of a Maven project's configuration. It's a single configuration file that  
+   contains most of the information needed to build a customized project. The POM is huge and can seem  
+   daunting. Thankfully, you don't yet need to understand every intricacy to use it effectively.
 
-4. Create a RESTful web service that displays "Hello World!". 
+4. Create a RESTful web service that displays "Hello World!".
 
-    
-    Under the `src/main/java/com/example/spring_boot_docker/` directory, you can modify your  
-    `SpringBootDockerApplication.java` file with the following content:
+   Under the `src/main/java/com/example/spring_boot_docker/` directory, you can modify your  
+   `SpringBootDockerApplication.java` file with the following content:
 
+   ```java
+   package com.example.spring_boot_docker;
 
-    ```java
-    package com.example.spring_boot_docker;
-
-    import org.springframework.boot.SpringApplication;
-    import org.springframework.boot.autoconfigure.SpringBootApplication;
-    import org.springframework.web.bind.annotation.RequestMapping;
-    import org.springframework.web.bind.annotation.RestController;
+   import org.springframework.boot.SpringApplication;
+   import org.springframework.boot.autoconfigure.SpringBootApplication;
+   import org.springframework.web.bind.annotation.RequestMapping;
+   import org.springframework.web.bind.annotation.RestController;
 
 
-    @RestController
-    @SpringBootApplication
-    public class SpringBootDockerApplication {
+   @RestController
+   @SpringBootApplication
+   public class SpringBootDockerApplication {
 
-        @RequestMapping("/")
-            public String home() {
-            return "Hello World";
-        }
+       @RequestMapping("/")
+           public String home() {
+           return "Hello World";
+       }
 
-    	public static void main(String[] args) {
-    		SpringApplication.run(SpringBootDockerApplication.class, args);
-    	}
+   	public static void main(String[] args) {
+   		SpringApplication.run(SpringBootDockerApplication.class, args);
+   	}
 
-    }
-    ```
+   }
+   ```
 
-    The `SpringbootDockerApplication.java` file starts by declaring your `com.example.spring_boot_docker` package and importing necessary Spring frameworks. This Java file creates a simple Spring Boot web application that responds with "Hello World" when a user visits its homepage. 
-
+   The `SpringbootDockerApplication.java` file starts by declaring your `com.example.spring_boot_docker` package and importing necessary Spring frameworks. This Java file creates a simple Spring Boot web application that responds with "Hello World" when a user visits its homepage.
 
 ### Create the Dockerfile
 
 Now that you have the project, you’re ready to create the `Dockerfile`.
 
- 1. Create a file named `Dockerfile` in the same folder that contains all the other folders and files (like src, pom.xml, etc.).
+1.  Create a file named `Dockerfile` in the same folder that contains all the other folders and files (like src, pom.xml, etc.).
 
- 2. In the `Dockerfile`, define your base image by adding the following line:
+2.  In the `Dockerfile`, define your base image by adding the following line:
 
-     ```dockerfile
-     FROM eclipse-temurin:21.0.8_9-jdk-jammy
-     ```
+    ```dockerfile
+    FROM eclipse-temurin:21.0.8_9-jdk-jammy
+    ```
 
- 3. Now, define the working directory by using the `WORKDIR` instruction. This will specify where future commands will run and the directory files will be copied inside the container image.
+3.  Now, define the working directory by using the `WORKDIR` instruction. This will specify where future commands will run and the directory files will be copied inside the container image.
 
-     ```dockerfile
-     WORKDIR /app
-     ```
+    ```dockerfile
+    WORKDIR /app
+    ```
 
- 4. Copy both the Maven wrapper script and your project's `pom.xml` file into the current working directory `/app` within the Docker container.
+4.  Copy both the Maven wrapper script and your project's `pom.xml` file into the current working directory `/app` within the Docker container.
 
-     ```dockerfile
-     COPY .mvn/ .mvn
-     COPY mvnw pom.xml ./
-     ```
+    ```dockerfile
+    COPY .mvn/ .mvn
+    COPY mvnw pom.xml ./
+    ```
 
- 5. Execute a command within the container. It runs the `./mvnw dependency:go-offline` command, which uses the Maven wrapper (`./mvnw`) to download all dependencies for your project without building the final JAR file (useful for faster builds).
+5.  Execute a command within the container. It runs the `./mvnw dependency:go-offline` command, which uses the Maven wrapper (`./mvnw`) to download all dependencies for your project without building the final JAR file (useful for faster builds).
 
-     ```dockerfile
-     RUN ./mvnw dependency:go-offline
-     ```
+    ```dockerfile
+    RUN ./mvnw dependency:go-offline
+    ```
 
- 6. Copy the `src` directory from your project on the host machine to the `/app` directory within the container. 
+6.  Copy the `src` directory from your project on the host machine to the `/app` directory within the container.
 
-     ```dockerfile
-     COPY src ./src
-     ```
+    ```dockerfile
+    COPY src ./src
+    ```
 
+7.  Set the default command to be executed when the container starts. This command instructs the container to run the Maven wrapper (`./mvnw`) with the `spring-boot:run` goal, which will build and execute your Spring Boot application.
 
- 7. Set the default command to be executed when the container starts. This command instructs the container to run the Maven wrapper (`./mvnw`) with the `spring-boot:run` goal, which will build and execute your Spring Boot application.
-
-     ```dockerfile
-     CMD ["./mvnw", "spring-boot:run"]
-     ```
+    ```dockerfile
+    CMD ["./mvnw", "spring-boot:run"]
+    ```
 
     And with that, you should have the following Dockerfile:
 
-    ```dockerfile 
+    ```dockerfile
     FROM eclipse-temurin:21.0.8_9-jdk-jammy
     WORKDIR /app
     COPY .mvn/ .mvn
@@ -201,15 +188,13 @@ Now that you have the project, you’re ready to create the `Dockerfile`.
 
 ### Build the container image
 
-
- 1. Execute the following command to build the Docker image:
-
+1.  Execute the following command to build the Docker image:
 
     ```console
     $ docker build -t spring-helloworld .
     ```
 
- 2. Check the size of the Docker image by using the `docker images` command:
+2.  Check the size of the Docker image by using the `docker images` command:
 
     ```console
     $ docker images
@@ -222,115 +207,105 @@ Now that you have the project, you’re ready to create the `Dockerfile`.
     spring-helloworld   latest    ff708d5ee194   3 minutes ago    880MB
     ```
 
-
     This output shows that your image is 880MB in size. It contains the full JDK, Maven toolchain, and more. In production, you don’t need that in your final image.
-
 
 ### Run the Spring Boot application
 
 1. Now that you have an image built, it's time to run the container.
 
-    ```console
-    $ docker run -p 8080:8080 spring-helloworld
-    ```
+   ```console
+   $ docker run -p 8080:8080 spring-helloworld
+   ```
 
-    You'll then see output similar to the following in the container log:
+   You'll then see output similar to the following in the container log:
 
-    ```plaintext
-    [INFO] --- spring-boot:3.3.4:run (default-cli) @ spring-boot-docker ---
-    [INFO] Attaching agents: []
-    
-         .   ____          _            __ _ _
-        /\\ / ___'_ __ _ _(_)_ __  __ _ \ \ \ \
-       ( ( )\___ | '_ | '_| | '_ \/ _` | \ \ \ \
-        \\/  ___)| |_)| | | | | || (_| |  ) ) ) )
-         '  |____| .__|_| |_|_| |_\__, | / / / /
-        =========|_|==============|___/=/_/_/_/
-    
-        :: Spring Boot ::                (v3.3.4)
-    
-    2024-09-29T23:54:07.157Z  INFO 159 --- [spring-boot-docker] [           main]
-    c.e.s.SpringBootDockerApplication        : Starting SpringBootDockerApplication using Java
-    21.0.2 with PID 159 (/app/target/classes started by root in /app)
-     ….
-     ```
+   ```plaintext
+   [INFO] --- spring-boot:3.3.4:run (default-cli) @ spring-boot-docker ---
+   [INFO] Attaching agents: []
 
+        .   ____          _            __ _ _
+       /\\ / ___'_ __ _ _(_)_ __  __ _ \ \ \ \
+      ( ( )\___ | '_ | '_| | '_ \/ _` | \ \ \ \
+       \\/  ___)| |_)| | | | | || (_| |  ) ) ) )
+        '  |____| .__|_| |_|_| |_\__, | / / / /
+       =========|_|==============|___/=/_/_/_/
+
+       :: Spring Boot ::                (v3.3.4)
+
+   2024-09-29T23:54:07.157Z  INFO 159 --- [spring-boot-docker] [           main]
+   c.e.s.SpringBootDockerApplication        : Starting SpringBootDockerApplication using Java
+   21.0.2 with PID 159 (/app/target/classes started by root in /app)
+    ….
+   ```
 
 2. Access your “Hello World” page through your web browser at [http://localhost:8080](http://localhost:8080), or via this curl command:
 
-    ```console
-    $ curl localhost:8080
-    Hello World
-    ```
+   ```console
+   $ curl localhost:8080
+   Hello World
+   ```
 
 ### Use multi-stage builds
 
 1. Consider the following Dockerfile:
 
-    ```dockerfile
-    FROM eclipse-temurin:21.0.8_9-jdk-jammy AS builder
-    WORKDIR /opt/app
-    COPY .mvn/ .mvn
-    COPY mvnw pom.xml ./
-    RUN ./mvnw dependency:go-offline
-    COPY ./src ./src
-    RUN ./mvnw clean install
+   ```dockerfile
+   FROM eclipse-temurin:21.0.8_9-jdk-jammy AS builder
+   WORKDIR /opt/app
+   COPY .mvn/ .mvn
+   COPY mvnw pom.xml ./
+   RUN ./mvnw dependency:go-offline
+   COPY ./src ./src
+   RUN ./mvnw clean install
 
-    FROM eclipse-temurin:21.0.8_9-jre-jammy AS final
-    WORKDIR /opt/app
-    EXPOSE 8080
-    COPY --from=builder /opt/app/target/*.jar /opt/app/*.jar
-    ENTRYPOINT ["java", "-jar", "/opt/app/*.jar"]
-    ```
+   FROM eclipse-temurin:21.0.8_9-jre-jammy AS final
+   WORKDIR /opt/app
+   EXPOSE 8080
+   COPY --from=builder /opt/app/target/*.jar /opt/app/*.jar
+   ENTRYPOINT ["java", "-jar", "/opt/app/*.jar"]
+   ```
 
-    Notice that this Dockerfile has been split into two stages. 
+   Notice that this Dockerfile has been split into two stages.
+   - The first stage remains the same as the previous Dockerfile, providing a Java Development Kit (JDK) environment for building the application. This stage is given the name of builder.
 
-    - The first stage remains the same as the previous Dockerfile, providing a Java Development Kit (JDK) environment for building the application. This stage is given the name of builder.
+   - The second stage is a new stage named `final`. It uses a slimmer `eclipse-temurin:21.0.2_13-jre-jammy` image, containing just the Java Runtime Environment (JRE) needed to run the application. This image provides a Java Runtime Environment (JRE) which is enough for running the compiled application (JAR file).
 
-    - The second stage is a new stage named `final`. It uses a slimmer `eclipse-temurin:21.0.2_13-jre-jammy` image, containing just the Java Runtime Environment (JRE) needed to run the application. This image provides a Java Runtime Environment (JRE) which is enough for running the compiled application (JAR file). 
+   > For production use, it's highly recommended that you produce a custom JRE-like runtime using jlink. JRE images are available for all versions of Eclipse Temurin, but `jlink` lets you create a minimal runtime containing only the necessary Java modules for your application. This can significantly reduce the size and improve the security of your final image. [Refer to this page](https://hub.docker.com/_/eclipse-temurin) for more information.
 
-    
-   > For production use, it's highly recommended that you produce a custom JRE-like runtime using jlink. JRE images are available for all versions of Eclipse Temurin, but `jlink` allows you to create a minimal runtime containing only the necessary Java modules for your application. This can significantly reduce the size and improve the security of your final image. [Refer to this page](https://hub.docker.com/_/eclipse-temurin) for more information.
+   With multi-stage builds, a Docker build uses one base image for compilation, packaging, and unit tests and then a separate image for the application runtime. As a result, the final image is smaller in size since it doesn’t contain any development or debugging tools. By separating the build environment from the final runtime environment, you can significantly reduce the image size and increase the security of your final images.
 
-   With multi-stage builds, a Docker build uses one base image for compilation, packaging, and unit tests and then a separate image for the application runtime. As a result, the final image is smaller in size since it doesn’t contain any development or debugging tools. By separating the build environment from the final runtime environment, you can significantly reduce the image size and increase the security of your final images. 
+2. Now, rebuild your image and run your ready-to-use production build.
 
+   ```console
+   $ docker build -t spring-helloworld-builder .
+   ```
 
-2. Now, rebuild your image and run your ready-to-use production build. 
+   This command builds a Docker image named `spring-helloworld-builder` using the final stage from your `Dockerfile` file located in the current directory.
 
-    ```console
-    $ docker build -t spring-helloworld-builder .
-    ```
-
-    This command builds a Docker image named `spring-helloworld-builder` using the final stage from your `Dockerfile` file located in the current directory.
-
-
-     > [!NOTE]
-     >
-     > In your multi-stage Dockerfile, the final stage (final) is the default target for building. This means that if you don't explicitly specify a target stage using the `--target` flag in the `docker build` command, Docker will automatically build the last stage by default. You could use `docker build -t spring-helloworld-builder --target builder .` to build only the builder stage with the JDK environment.
-
+   > [!NOTE]
+   >
+   > In your multi-stage Dockerfile, the final stage (final) is the default target for building. This means that if you don't explicitly specify a target stage using the `--target` flag in the `docker build` command, Docker will automatically build the last stage by default. You could use `docker build -t spring-helloworld-builder --target builder .` to build only the builder stage with the JDK environment.
 
 3. Look at the image size difference by using the `docker images` command:
 
-    ```console
-    $ docker images
-    ```
+   ```console
+   $ docker images
+   ```
 
-    You'll get output similar to the following:
+   You'll get output similar to the following:
 
-    ```console
-    spring-helloworld-builder latest    c5c76cb815c0   24 minutes ago      428MB
-    spring-helloworld         latest    ff708d5ee194   About an hour ago   880MB
-    ```
+   ```console
+   spring-helloworld-builder latest    c5c76cb815c0   24 minutes ago      428MB
+   spring-helloworld         latest    ff708d5ee194   About an hour ago   880MB
+   ```
 
-    Your final image is just 428 MB, compared to the original build size of 880 MB.
+   Your final image is just 428 MB, compared to the original build size of 880 MB.
 
-
-    By optimizing each stage and only including what's necessary, you were able to significantly reduce the overall image size while still achieving the same functionality. This not only improves performance but also makes your Docker images more lightweight, more secure, and easier to manage.
+   By optimizing each stage and only including what's necessary, you were able to significantly reduce the overall image size while still achieving the same functionality. This not only improves performance but also makes your Docker images more lightweight, more secure, and easier to manage.
 
 ## Additional resources
 
-* [Multi-stage builds](/build/building/multi-stage/)
-* [Dockerfile best practices](/develop/develop-images/dockerfile_best-practices/)
-* [Base images](/build/building/base-images/)
-* [Spring Boot Docker](https://spring.io/guides/topicals/spring-boot-docker)
-
+- [Multi-stage builds](/build/building/multi-stage/)
+- [Dockerfile best practices](/develop/develop-images/dockerfile_best-practices/)
+- [Base images](/build/building/base-images/)
+- [Spring Boot Docker](https://spring.io/guides/topicals/spring-boot-docker)

--- a/content/get-started/docker-concepts/building-images/understanding-image-layers.md
+++ b/content/get-started/docker-concepts/building-images/understanding-image-layers.md
@@ -8,8 +8,8 @@ summary: |
   images. You'll gain a comprehensive understanding of how layers are created,
   stacked, and utilized to ensure efficient and optimized containers.
 weight: 1
-aliases: 
- - /guides/docker-concepts/building-images/understanding-image-layers/
+aliases:
+  - /guides/docker-concepts/building-images/understanding-image-layers/
 ---
 
 {{< youtube-embed wJwqtAkmtQA >}}
@@ -42,11 +42,11 @@ Layers let you extend images of others by reusing their base layers, allowing yo
 
 Layering is made possible by content-addressable storage and union filesystems. While this will get technical, here’s how it works:
 
-1. After each layer is downloaded, it is extracted into its own directory on the host filesystem. 
+1. After each layer is downloaded, it is extracted into its own directory on the host filesystem.
 2. When you run a container from an image, a union filesystem is created where layers are stacked on top of each other, creating a new and unified view.
 3. When the container starts, its root directory is set to the location of this unified directory, using `chroot`.
 
-When the union filesystem is created, in addition to the image layers, a directory is created specifically for the running container. This allows the container to make filesystem changes while allowing the original image layers to remain untouched. This enables you to run multiple containers from the same underlying image.
+When the union filesystem is created, in addition to the image layers, a directory is created specifically for the running container. This allows the container to make filesystem changes while allowing the original image layers to remain untouched. This lets you run multiple containers from the same underlying image.
 
 ## Try it out
 
@@ -58,75 +58,74 @@ In this first step, you will create your own base image that you will then use f
 
 1. [Download and install](https://www.docker.com/products/docker-desktop/) Docker Desktop.
 
-
 2. In a terminal, run the following command to start a new container:
 
-    ```console
-    $ docker run --name=base-container -ti ubuntu
-    ```
+   ```console
+   $ docker run --name=base-container -ti ubuntu
+   ```
 
-    Once the image has been downloaded and the container has started, you should see a new shell prompt. This is running inside your container. It will look similar to the following (the container ID will vary):
+   Once the image has been downloaded and the container has started, you should see a new shell prompt. This is running inside your container. It will look similar to the following (the container ID will vary):
 
-    ```console
-    root@d8c5ca119fcd:/#
-    ```
+   ```console
+   root@d8c5ca119fcd:/#
+   ```
 
 3. Inside the container, run the following command to install Node.js:
 
-    ```console
-    $ apt update && apt install -y nodejs
-    ```
+   ```console
+   $ apt update && apt install -y nodejs
+   ```
 
-    When this command runs, it downloads and installs Node inside the container. In the context of the union filesystem, these filesystem changes occur within the directory unique to this container. 
+   When this command runs, it downloads and installs Node inside the container. In the context of the union filesystem, these filesystem changes occur within the directory unique to this container.
 
 4. Validate if Node is installed by running the following command:
 
-    ```console
-    $ node -e 'console.log("Hello world!")'
-    ```
+   ```console
+   $ node -e 'console.log("Hello world!")'
+   ```
 
-    You should then see a “Hello world!” appear in the console.
+   You should then see a “Hello world!” appear in the console.
 
 5. Now that you have Node installed, you’re ready to save the changes you’ve made as a new image layer, from which you can start new containers or build new images. To do so, you will use the [`docker container commit`](https://docs.docker.com/reference/cli/docker/container/commit/) command. Run the following command in a new terminal:
 
-    ```console
-    $ docker container commit -m "Add node" base-container node-base
-    ```
+   ```console
+   $ docker container commit -m "Add node" base-container node-base
+   ```
 
 6. View the layers of your image using the `docker image history` command:
 
-    ```console
-    $ docker image history node-base
-    ```
+   ```console
+   $ docker image history node-base
+   ```
 
-    You will see output similar to the following:
+   You will see output similar to the following:
 
-    ```console
-    IMAGE          CREATED          CREATED BY                                      SIZE      COMMENT
-    9e274734bb25   10 seconds ago   /bin/bash                                       157MB     Add node
-    cd1dba651b30   7 days ago       /bin/sh -c #(nop)  CMD ["/bin/bash"]            0B
-    <missing>      7 days ago       /bin/sh -c #(nop) ADD file:6089c6bede9eca8ec…   110MB
-    <missing>      7 days ago       /bin/sh -c #(nop)  LABEL org.opencontainers.…   0B
-    <missing>      7 days ago       /bin/sh -c #(nop)  LABEL org.opencontainers.…   0B
-    <missing>      7 days ago       /bin/sh -c #(nop)  ARG LAUNCHPAD_BUILD_ARCH     0B
-    <missing>      7 days ago       /bin/sh -c #(nop)  ARG RELEASE                  0B
-    ```
+   ```console
+   IMAGE          CREATED          CREATED BY                                      SIZE      COMMENT
+   9e274734bb25   10 seconds ago   /bin/bash                                       157MB     Add node
+   cd1dba651b30   7 days ago       /bin/sh -c #(nop)  CMD ["/bin/bash"]            0B
+   <missing>      7 days ago       /bin/sh -c #(nop) ADD file:6089c6bede9eca8ec…   110MB
+   <missing>      7 days ago       /bin/sh -c #(nop)  LABEL org.opencontainers.…   0B
+   <missing>      7 days ago       /bin/sh -c #(nop)  LABEL org.opencontainers.…   0B
+   <missing>      7 days ago       /bin/sh -c #(nop)  ARG LAUNCHPAD_BUILD_ARCH     0B
+   <missing>      7 days ago       /bin/sh -c #(nop)  ARG RELEASE                  0B
+   ```
 
-    Note the “Add node” comment on the top line. This layer contains the Node.js install you just made.
+   Note the “Add node” comment on the top line. This layer contains the Node.js install you just made.
 
 7. To prove your image has Node installed, you can start a new container using this new image:
 
-    ```console
-    $ docker run node-base node -e "console.log('Hello again')"
-    ```
+   ```console
+   $ docker run node-base node -e "console.log('Hello again')"
+   ```
 
-    With that, you should get a “Hello again” output in the terminal, showing Node was installed and working.
+   With that, you should get a “Hello again” output in the terminal, showing Node was installed and working.
 
 8. Now that you’re done creating your base image, you can remove that container:
 
-    ```console
-    $ docker rm -f base-container
-    ```
+   ```console
+   $ docker rm -f base-container
+   ```
 
 > **Base image definition**
 >
@@ -134,78 +133,76 @@ In this first step, you will create your own base image that you will then use f
 >
 > In this example, you probably won’t deploy this `node-base` image, as it doesn’t actually do anything yet. But it’s a base you can use for other builds.
 
-
 ### Build an app image
 
 Now that you have a base image, you can extend that image to build additional images.
 
 1. Start a new container using the newly created node-base image:
 
-    ```console
-    $ docker run --name=app-container -ti node-base
-    ```
+   ```console
+   $ docker run --name=app-container -ti node-base
+   ```
 
 2. Inside of this container, run the following command to create a Node program:
 
-    ```console
-    $ echo 'console.log("Hello from an app")' > app.js
-    ```
+   ```console
+   $ echo 'console.log("Hello from an app")' > app.js
+   ```
 
-    To run this Node program, you can use the following command and see the message printed on the screen:
+   To run this Node program, you can use the following command and see the message printed on the screen:
 
-    ```console
-    $ node app.js
-    ```
+   ```console
+   $ node app.js
+   ```
 
 3. In another terminal, run the following command to save this container’s changes as a new image:
 
-    ```console
-    $ docker container commit -c "CMD node app.js" -m "Add app" app-container sample-app
-    ```
+   ```console
+   $ docker container commit -c "CMD node app.js" -m "Add app" app-container sample-app
+   ```
 
-    This command not only creates a new image named `sample-app`, but also adds additional configuration to the image to set the default command when starting a container. In this case, you are setting it to automatically run `node app.js`.
+   This command not only creates a new image named `sample-app`, but also adds additional configuration to the image to set the default command when starting a container. In this case, you are setting it to automatically run `node app.js`.
 
 4. In a terminal outside of the container, run the following command to view the updated layers:
 
-    ```console
-    $ docker image history sample-app
-    ```
+   ```console
+   $ docker image history sample-app
+   ```
 
-    You’ll then see output that looks like the following. Note the top layer comment has “Add app” and the next layer has “Add node”:
+   You’ll then see output that looks like the following. Note the top layer comment has “Add app” and the next layer has “Add node”:
 
-    ```console
-    IMAGE          CREATED              CREATED BY                                      SIZE      COMMENT
-    c1502e2ec875   About a minute ago   /bin/bash                                       33B       Add app
-    5310da79c50a   4 minutes ago        /bin/bash                                       126MB     Add node
-    2b7cc08dcdbb   5 weeks ago          /bin/sh -c #(nop)  CMD ["/bin/bash"]            0B
-    <missing>      5 weeks ago          /bin/sh -c #(nop) ADD file:07cdbabf782942af0…   69.2MB
-    <missing>      5 weeks ago          /bin/sh -c #(nop)  LABEL org.opencontainers.…   0B
-    <missing>      5 weeks ago          /bin/sh -c #(nop)  LABEL org.opencontainers.…   0B
-    <missing>      5 weeks ago          /bin/sh -c #(nop)  ARG LAUNCHPAD_BUILD_ARCH     0B
-    <missing>      5 weeks ago          /bin/sh -c #(nop)  ARG RELEASE                  0B
-    ```
+   ```console
+   IMAGE          CREATED              CREATED BY                                      SIZE      COMMENT
+   c1502e2ec875   About a minute ago   /bin/bash                                       33B       Add app
+   5310da79c50a   4 minutes ago        /bin/bash                                       126MB     Add node
+   2b7cc08dcdbb   5 weeks ago          /bin/sh -c #(nop)  CMD ["/bin/bash"]            0B
+   <missing>      5 weeks ago          /bin/sh -c #(nop) ADD file:07cdbabf782942af0…   69.2MB
+   <missing>      5 weeks ago          /bin/sh -c #(nop)  LABEL org.opencontainers.…   0B
+   <missing>      5 weeks ago          /bin/sh -c #(nop)  LABEL org.opencontainers.…   0B
+   <missing>      5 weeks ago          /bin/sh -c #(nop)  ARG LAUNCHPAD_BUILD_ARCH     0B
+   <missing>      5 weeks ago          /bin/sh -c #(nop)  ARG RELEASE                  0B
+   ```
 
 5. Finally, start a new container using the brand new image. Since you specified the default command, you can use the following command:
 
-    ```console
-    $ docker run sample-app
-    ```
+   ```console
+   $ docker run sample-app
+   ```
 
-    You should see your greeting appear in the terminal, coming from your Node program.
+   You should see your greeting appear in the terminal, coming from your Node program.
 
 6. Now that you’re done with your containers, you can remove them using the following command:
 
-    ```console
-    $ docker rm -f app-container
-    ```
+   ```console
+   $ docker rm -f app-container
+   ```
 
 ## Additional resources
 
 If you’d like to dive deeper into the things you learned, check out the following resources:
 
-* [`docker image history`](/reference/cli/docker/image/history/)
-* [`docker container commit`](/reference/cli/docker/container/commit/)
-
+- [`docker image history`](/reference/cli/docker/image/history/)
+- [`docker container commit`](/reference/cli/docker/container/commit/)
 
 ## Next steps
 

--- a/content/get-started/docker-concepts/building-images/using-the-build-cache.md
+++ b/content/get-started/docker-concepts/building-images/using-the-build-cache.md
@@ -3,15 +3,15 @@ title: Using the build cache
 keywords: concepts, build, images, container, docker desktop
 description: This concept page will teach you about the build cache, what changes invalidate the cache and how to effectively use the build cache.
 summary: |
-  Using the build cache effectively allows you to achieve faster builds by
+  Using the build cache effectively lets you achieve faster builds by
   reusing results from previous builds and skipping unnecessary steps. To
   maximize cache usage and avoid resource-intensive and time-consuming
   rebuilds, it's crucial to understand how cache invalidation works. In this
   guide, you’ll learn how to use the Docker build cache efficiently for
   streamlined Docker image development and continuous integration workflows.
 weight: 4
-aliases: 
- - /guides/docker-concepts/building-images/using-the-build-cache/
+aliases:
+  - /guides/docker-concepts/building-images/using-the-build-cache/
 ---
 
 {{< youtube-embed Ri6jMknjprY >}}
@@ -19,7 +19,6 @@ aliases:
 ## Explanation
 
 Consider the following Dockerfile that you created for the [getting-started](./writing-a-dockerfile/) app.
-
 
 ```dockerfile
 FROM node:22-alpine
@@ -53,72 +52,67 @@ In this hands-on guide, you will learn how to use the Docker build cache effecti
 
 2. Open a terminal and [clone this sample application](https://github.com/dockersamples/todo-list-app).
 
-
-    ```console
-    $ git clone https://github.com/dockersamples/todo-list-app
-    ```
+   ```console
+   $ git clone https://github.com/dockersamples/todo-list-app
+   ```
 
 3. Navigate into the `todo-list-app` directory:
 
+   ```console
+   $ cd todo-list-app
+   ```
 
-    ```console
-    $ cd todo-list-app
-    ```
+   Inside this directory, you'll find a file named `Dockerfile` with the following content:
 
-    Inside this directory, you'll find a file named `Dockerfile` with the following content:
-
-
-    ```dockerfile
-    FROM node:22-alpine
-    WORKDIR /app
-    COPY . .
-    RUN yarn install --production
-    EXPOSE 3000
-    CMD ["node", "./src/index.js"]
-    ```
+   ```dockerfile
+   FROM node:22-alpine
+   WORKDIR /app
+   COPY . .
+   RUN yarn install --production
+   EXPOSE 3000
+   CMD ["node", "./src/index.js"]
+   ```
 
 4. Execute the following command to build the Docker image:
 
-    ```console
-    $ docker build .
-    ```
+   ```console
+   $ docker build .
+   ```
 
-    Here’s the result of the build process:
+   Here’s the result of the build process:
 
-    ```console
-    [+] Building 20.0s (10/10) FINISHED
-    ```
+   ```console
+   [+] Building 20.0s (10/10) FINISHED
+   ```
 
-    The first line indicates that the entire build process took *20.0 seconds*. The first build may take some time as it installs dependencies.
+   The first line indicates that the entire build process took _20.0 seconds_. The first build may take some time as it installs dependencies.
 
 5. Rebuild without making changes.
 
    Now, re-run the `docker build` command without making any change in the source code or Dockerfile as shown:
 
-    ```console
-    $ docker build .
-    ```
+   ```console
+   $ docker build .
+   ```
 
    Subsequent builds after the initial are faster due to the caching mechanism, as long as the commands and context remain unchanged. Docker caches the intermediate layers generated during the build process. When you rebuild the image without making any changes to the Dockerfile or the source code, Docker can reuse the cached layers, significantly speeding up the build process.
 
-    ```console
-    [+] Building 1.0s (9/9) FINISHED                                                                            docker:desktop-linux
-     => [internal] load build definition from Dockerfile                                                                        0.0s
-     => => transferring dockerfile: 187B                                                                                        0.0s
-     ...
-     => [internal] load build context                                                                                           0.0s
-     => => transferring context: 8.16kB                                                                                         0.0s
-     => CACHED [2/4] WORKDIR /app                                                                                               0.0s
-     => CACHED [3/4] COPY . .                                                                                                   0.0s
-     => CACHED [4/4] RUN yarn install --production                                                                              0.0s
-     => exporting to image                                                                                                      0.0s
-     => => exporting layers                                                                                                     0.0s
-     => => exporting manifest
+   ```console
+   [+] Building 1.0s (9/9) FINISHED                                                                            docker:desktop-linux
+    => [internal] load build definition from Dockerfile                                                                        0.0s
+    => => transferring dockerfile: 187B                                                                                        0.0s
+    ...
+    => [internal] load build context                                                                                           0.0s
+    => => transferring context: 8.16kB                                                                                         0.0s
+    => CACHED [2/4] WORKDIR /app                                                                                               0.0s
+    => CACHED [3/4] COPY . .                                                                                                   0.0s
+    => CACHED [4/4] RUN yarn install --production                                                                              0.0s
+    => exporting to image                                                                                                      0.0s
+    => => exporting layers                                                                                                     0.0s
+    => => exporting manifest
    ```
 
-
    The subsequent build was completed in just 1.0 second by leveraging the cached layers. No need to repeat time-consuming steps like installing dependencies.
-
 
     <table>
       <thead>
@@ -229,59 +223,58 @@ In this hands-on guide, you will learn how to use the Docker build cache effecti
      </tbody>
     </table>
 
+   Going back to the `docker image history` output, you see that each command in the Dockerfile becomes a new layer in the image. You might remember that when you made a change to the image, the `yarn` dependencies had to be reinstalled. Is there a way to fix this? It doesn't make much sense to reinstall the same dependencies every time you build, right?
 
-    Going back to the `docker image history` output, you see that each command in the Dockerfile becomes a new layer in the image. You might remember that when you made a change to the image, the `yarn` dependencies had to be reinstalled. Is there a way to fix this? It doesn't make much sense to reinstall the same dependencies every time you build, right?
-
-    To fix this, restructure your Dockerfile so that the dependency cache remains valid unless it really needs to be invalidated. For Node-based applications, dependencies are defined in the `package.json` file. You'll want to reinstall the dependencies if that file changes, but use cached dependencies if the file is unchanged. So, start by copying only that file first, then install the dependencies, and finally copy everything else. Then, you only need to recreate the yarn dependencies if there was a change to the `package.json` file.
+   To fix this, restructure your Dockerfile so that the dependency cache remains valid unless it really needs to be invalidated. For Node-based applications, dependencies are defined in the `package.json` file. You'll want to reinstall the dependencies if that file changes, but use cached dependencies if the file is unchanged. So, start by copying only that file first, then install the dependencies, and finally copy everything else. Then, you only need to recreate the yarn dependencies if there was a change to the `package.json` file.
 
 6. Update the Dockerfile to copy in the `package.json` file first, install dependencies, and then copy everything else in.
 
-     ```dockerfile
-     FROM node:22-alpine
-     WORKDIR /app
-     COPY package.json yarn.lock ./
-     RUN yarn install --production 
-     COPY . . 
-     EXPOSE 3000
-     CMD ["node", "src/index.js"]
-     ```
+   ```dockerfile
+   FROM node:22-alpine
+   WORKDIR /app
+   COPY package.json yarn.lock ./
+   RUN yarn install --production
+   COPY . .
+   EXPOSE 3000
+   CMD ["node", "src/index.js"]
+   ```
 
 7. Create a file named `.dockerignore` in the same folder as the Dockerfile with the following contents.
 
-     ```plaintext
-     node_modules
-     ```
+   ```plaintext
+   node_modules
+   ```
 
 8. Build the new image:
 
-    ```console
-    $ docker build .
-    ```
+   ```console
+   $ docker build .
+   ```
 
-    You'll then see output similar to the following:
+   You'll then see output similar to the following:
 
-    ```console
-    [+] Building 16.1s (10/10) FINISHED
-    => [internal] load build definition from Dockerfile                                               0.0s
-    => => transferring dockerfile: 175B                                                               0.0s
-    => [internal] load .dockerignore                                                                  0.0s
-    => => transferring context: 2B                                                                    0.0s
-    => [internal] load metadata for docker.io/library/node:22-alpine                                  0.0s
-    => [internal] load build context                                                                  0.8s
-    => => transferring context: 53.37MB                                                               0.8s
-    => [1/5] FROM docker.io/library/node:22-alpine                                                    0.0s
-    => CACHED [2/5] WORKDIR /app                                                                      0.0s
-    => [3/5] COPY package.json yarn.lock ./                                                           0.2s
-    => [4/5] RUN yarn install --production                                                           14.0s
-    => [5/5] COPY . .                                                                                 0.5s
-    => exporting to image                                                                             0.6s
-    => => exporting layers                                                                            0.6s
-    => => writing image     
-    sha256:d6f819013566c54c50124ed94d5e66c452325327217f4f04399b45f94e37d25        0.0s
-    => => naming to docker.io/library/node-app:2.0                                                 0.0s
-    ```
+   ```console
+   [+] Building 16.1s (10/10) FINISHED
+   => [internal] load build definition from Dockerfile                                               0.0s
+   => => transferring dockerfile: 175B                                                               0.0s
+   => [internal] load .dockerignore                                                                  0.0s
+   => => transferring context: 2B                                                                    0.0s
+   => [internal] load metadata for docker.io/library/node:22-alpine                                  0.0s
+   => [internal] load build context                                                                  0.8s
+   => => transferring context: 53.37MB                                                               0.8s
+   => [1/5] FROM docker.io/library/node:22-alpine                                                    0.0s
+   => CACHED [2/5] WORKDIR /app                                                                      0.0s
+   => [3/5] COPY package.json yarn.lock ./                                                           0.2s
+   => [4/5] RUN yarn install --production                                                           14.0s
+   => [5/5] COPY . .                                                                                 0.5s
+   => exporting to image                                                                             0.6s
+   => => exporting layers                                                                            0.6s
+   => => writing image
+   sha256:d6f819013566c54c50124ed94d5e66c452325327217f4f04399b45f94e37d25        0.0s
+   => => naming to docker.io/library/node-app:2.0                                                 0.0s
+   ```
 
-    You'll see that all layers were rebuilt. Perfectly fine since you changed the Dockerfile quite a bit.
+   You'll see that all layers were rebuilt. Perfectly fine since you changed the Dockerfile quite a bit.
 
 9. Now, make a change to the `src/static/index.html` file (like change the title to say "The Awesome Todo App").
 
@@ -294,22 +287,22 @@ In this hands-on guide, you will learn how to use the Docker build cache effecti
     You'll then see output similar to the following:
 
     ```console
-    [+] Building 1.2s (10/10) FINISHED 
+    [+] Building 1.2s (10/10) FINISHED
     => [internal] load build definition from Dockerfile                                               0.0s
     => => transferring dockerfile: 37B                                                                0.0s
     => [internal] load .dockerignore                                                                  0.0s
     => => transferring context: 2B                                                                    0.0s
-    => [internal] load metadata for docker.io/library/node:22-alpine                                  0.0s 
+    => [internal] load metadata for docker.io/library/node:22-alpine                                  0.0s
     => [internal] load build context                                                                  0.2s
     => => transferring context: 450.43kB                                                              0.2s
     => [1/5] FROM docker.io/library/node:22-alpine                                                    0.0s
     => CACHED [2/5] WORKDIR /app                                                                      0.0s
     => CACHED [3/5] COPY package.json yarn.lock ./                                                    0.0s
     => CACHED [4/5] RUN yarn install --production                                                     0.0s
-    => [5/5] COPY . .                                                                                 0.5s 
+    => [5/5] COPY . .                                                                                 0.5s
     => exporting to image                                                                             0.3s
     => => exporting layers                                                                            0.3s
-    => => writing image     
+    => => writing image
     sha256:91790c87bcb096a83c2bd4eb512bc8b134c757cda0bdee4038187f98148e2eda       0.0s
     => => naming to docker.io/library/node-app:3.0                                                 0.0s
     ```
@@ -320,10 +313,9 @@ By following these optimization techniques, you can make your Docker builds fast
 
 ## Additional resources
 
-* [Optimizing builds with cache management](/build/cache/)
-* [Cache Storage Backend](/build/cache/backends/)
-* [Build cache invalidation](/build/cache/invalidation/)
-
+- [Optimizing builds with cache management](/build/cache/)
+- [Cache Storage Backend](/build/cache/backends/)
+- [Build cache invalidation](/build/cache/invalidation/)
 
 ## Next steps
 

--- a/content/get-started/docker-concepts/the-basics/what-is-a-registry.md
+++ b/content/get-started/docker-concepts/the-basics/what-is-a-registry.md
@@ -4,20 +4,20 @@ weight: 30
 keywords: concepts, build, images, container, docker desktop
 description: What is a registry? This Docker Concept will explain what a registry is, explore their interoperability, and have you interact with registries.
 aliases:
-- /guides/walkthroughs/run-hub-images/
-- /guides/walkthroughs/publish-your-image/
-- /guides/docker-concepts/the-basics/what-is-a-registry/
+  - /guides/walkthroughs/run-hub-images/
+  - /guides/walkthroughs/publish-your-image/
+  - /guides/docker-concepts/the-basics/what-is-a-registry/
 ---
 
 {{< youtube-embed 2WDl10Wv5rs >}}
 
 ## Explanation
 
-Now that you know what a container image is and how it works, you might wonder - where do you store these images? 
+Now that you know what a container image is and how it works, you might wonder - where do you store these images?
 
 Well, you can store your container images on your computer system, but what if you want to share them with your friends or use them on another machine? That's where the image registry comes in.
 
-An image registry is a centralized location for storing and sharing your container images. It can be either public or private. [Docker Hub](https://hub.docker.com) is a public registry that anyone can use and is the default registry. 
+An image registry is a centralized location for storing and sharing your container images. It can be either public or private. [Docker Hub](https://hub.docker.com) is a public registry that anyone can use and is the default registry.
 
 While Docker Hub is a popular option, there are many other available container registries available today, including [Amazon Elastic Container Registry (ECR)](https://aws.amazon.com/ecr/), [Azure Container Registry (ACR)](https://azure.microsoft.com/en-in/products/container-registry), and [Google Container Registry (GCR)](https://cloud.google.com/artifact-registry). You can even run your private registry on your local system or inside your organization. For example, Harbor, JFrog Artifactory, GitLab Container registry etc.
 
@@ -54,7 +54,7 @@ The following diagram shows the relationship between a registry, repositories, a
 
 > [!TIP]
 >
->A Docker Personal plan gives you one private repository and unlimited public repositories. To get unlimited private repositories, upgrade to the [Docker Team plan](https://www.docker.com/pricing?ref=Docs&refAction=DocsConceptsRegistry).
+> A Docker Personal plan gives you one private repository and unlimited public repositories. To get unlimited private repositories, upgrade to the [Docker Team plan](https://www.docker.com/pricing?ref=Docs&refAction=DocsConceptsRegistry).
 
 ## Try it out
 
@@ -64,9 +64,9 @@ In this hands-on, you will learn how to build and push a Docker image to the Doc
 
 1. If you haven't created one yet, head over to the [Docker Hub](https://hub.docker.com) page to sign up for a new Docker account. Be sure to finish the verification steps sent to your email.
 
-    ![Screenshot of the official Docker Hub page showing the Sign up page](images/dockerhub-signup.webp?border)
+   ![Screenshot of the official Docker Hub page showing the Sign up page](images/dockerhub-signup.webp?border)
 
-    You can use your Google or GitHub account to authenticate.
+   You can use your Google or GitHub account to authenticate.
 
 ### Create your first repository
 
@@ -74,9 +74,9 @@ In this hands-on, you will learn how to build and push a Docker image to the Doc
 2. Select the **Create repository** button in the top-right corner.
 3. Select your namespace (most likely your username) and enter `docker-quickstart` as the repository name.
 
-    ![Screenshot of the Docker Hub page that shows how to create a public repository](images/create-hub-repository.webp?border)
+   ![Screenshot of the Docker Hub page that shows how to create a public repository](images/create-hub-repository.webp?border)
 
-4. Set the visibility to **Public**. 
+4. Set the visibility to **Public**.
 5. Select the **Create** button to create the repository.
 
 That's it. You've successfully created your first repository. 🎉
@@ -96,62 +96,62 @@ Don't worry about the specifics of the Dockerfile, as you'll learn about that in
 
 1. Clone the GitHub repository using the following command:
 
-    ```console
-    git clone https://github.com/dockersamples/helloworld-demo-node
-    ```
+   ```console
+   git clone https://github.com/dockersamples/helloworld-demo-node
+   ```
 
 2. Navigate into the newly created directory.
 
-    ```console
-    cd helloworld-demo-node
-    ```
+   ```console
+   cd helloworld-demo-node
+   ```
 
 3. Run the following command to build a Docker image, swapping out `YOUR_DOCKER_USERNAME` with your username.
 
-    ```console
-    docker build -t <YOUR_DOCKER_USERNAME>/docker-quickstart .
-    ```
+   ```console
+   docker build -t <YOUR_DOCKER_USERNAME>/docker-quickstart .
+   ```
 
-    > [!NOTE]
-    >
-    > Make sure you include the dot (.) at the end of the `docker build` command. This tells Docker where to find the Dockerfile.
+   > [!NOTE]
+   >
+   > Make sure you include the dot (.) at the end of the `docker build` command. This tells Docker where to find the Dockerfile.
 
 4. Run the following command to list the newly created Docker image:
 
-    ```console
-    docker images
-    ```
+   ```console
+   docker images
+   ```
 
-    You will see output like the following:
+   You will see output like the following:
 
-    ```console
-    REPOSITORY                                 TAG       IMAGE ID       CREATED         SIZE
-    <YOUR_DOCKER_USERNAME>/docker-quickstart   latest    476de364f70e   2 minutes ago   170MB
-    ```
+   ```console
+   REPOSITORY                                 TAG       IMAGE ID       CREATED         SIZE
+   <YOUR_DOCKER_USERNAME>/docker-quickstart   latest    476de364f70e   2 minutes ago   170MB
+   ```
 
 5. Start a container to test the image by running the following command (swap out the username with your own username):
 
-    ```console
-    docker run -d -p 8080:8080 <YOUR_DOCKER_USERNAME>/docker-quickstart 
-    ```
+   ```console
+   docker run -d -p 8080:8080 <YOUR_DOCKER_USERNAME>/docker-quickstart
+   ```
 
-    You can verify if the container is working by visiting [http://localhost:8080](http://localhost:8080) with your browser.
+   You can verify if the container is working by visiting [http://localhost:8080](http://localhost:8080) with your browser.
 
-6. Use the [`docker tag`](/reference/cli/docker/image/tag/) command to tag the Docker image. Docker tags allow you to label and version your images. 
+6. Use the [`docker tag`](/reference/cli/docker/image/tag/) command to tag the Docker image. Docker tags let you label and version your images.
 
-    ```console 
-    docker tag <YOUR_DOCKER_USERNAME>/docker-quickstart <YOUR_DOCKER_USERNAME>/docker-quickstart:1.0 
-    ```
+   ```console
+   docker tag <YOUR_DOCKER_USERNAME>/docker-quickstart <YOUR_DOCKER_USERNAME>/docker-quickstart:1.0
+   ```
 
 7. Finally, it's time to push the newly built image to your Docker Hub repository by using the [`docker push`](/reference/cli/docker/image/push/) command:
 
-    ```console 
-    docker push <YOUR_DOCKER_USERNAME>/docker-quickstart:1.0
-    ```
+   ```console
+   docker push <YOUR_DOCKER_USERNAME>/docker-quickstart:1.0
+   ```
 
 8. Open [Docker Hub](https://hub.docker.com) and navigate to your repository. Navigate to the **Tags** section and see your newly pushed image.
 
-    ![Screenshot of the Docker Hub page that displays the newly added image tag](images/dockerhub-tags.webp?border=true) 
+   ![Screenshot of the Docker Hub page that displays the newly added image tag](images/dockerhub-tags.webp?border=true)
 
 In this walkthrough, you signed up for a Docker account, created your first Docker Hub repository, and built, tagged, and pushed a container image to your Docker Hub repository.
 

--- a/content/get-started/docker-overview.md
+++ b/content/get-started/docker-overview.md
@@ -1,23 +1,25 @@
 ---
-description: Get an in-depth overview of the Docker platform including what it can
+description:
+  Get an in-depth overview of the Docker platform including what it can
   be used for, the architecture it employs, and its underlying technology.
-keywords: what is a docker, docker daemon, why use docker, docker architecture, what
+keywords:
+  what is a docker, docker daemon, why use docker, docker architecture, what
   to use docker for, docker client, what is docker for, why docker, uses for docker,
   what is docker container used for, what are docker containers used for
 title: What is Docker?
 weight: 20
 aliases:
- - /introduction/understanding-docker/
- - /engine/userguide/basics/
- - /engine/introduction/understanding-docker/
- - /engine/understanding-docker/
- - /engine/docker-overview/
- - /get-started/overview/
- - /guides/docker-overview/
+  - /introduction/understanding-docker/
+  - /engine/userguide/basics/
+  - /engine/introduction/understanding-docker/
+  - /engine/understanding-docker/
+  - /engine/docker-overview/
+  - /get-started/overview/
+  - /guides/docker-overview/
 ---
 
 Docker is an open platform for developing, shipping, and running applications.
-Docker enables you to separate your applications from your infrastructure so
+Docker lets you separate your applications from your infrastructure so
 you can deliver software quickly. With Docker, you can manage your infrastructure
 in the same ways you manage your applications. By taking advantage of Docker's
 methodologies for shipping, testing, and deploying code, you can
@@ -35,9 +37,9 @@ same way.
 
 Docker provides tooling and a platform to manage the lifecycle of your containers:
 
-* Develop your application and its supporting components using containers.
-* The container becomes the unit for distributing and testing your application.
-* When you're ready, deploy your application into your production environment,
+- Develop your application and its supporting components using containers.
+- The container becomes the unit for distributing and testing your application.
+- When you're ready, deploy your application into your production environment,
   as a container or an orchestrated service. This works the same whether your
   production environment is a local data center, a cloud provider, or a hybrid
   of the two.
@@ -107,7 +109,7 @@ Docker API. The Docker client can communicate with more than one daemon.
 
 ### Docker Desktop
 
-Docker Desktop is an easy-to-install application for your Mac, Windows, or Linux environment that enables you to build and share containerized applications and microservices. Docker Desktop includes the Docker daemon (`dockerd`), the Docker client (`docker`), Docker Compose, Docker Content Trust, Kubernetes, and Credential Helper. For more information, see [Docker Desktop](/manuals/desktop/_index.md).
+Docker Desktop is an easy-to-install application for your Mac, Windows, or Linux environment that lets you build and share containerized applications and microservices. Docker Desktop includes the Docker daemon (`dockerd`), the Docker client (`docker`), Docker Compose, Docker Content Trust, Kubernetes, and Credential Helper. For more information, see [Docker Desktop](/manuals/desktop/_index.md).
 
 ### Docker registries
 
@@ -128,7 +130,7 @@ of those objects.
 
 An image is a read-only template with instructions for creating a Docker
 container. Often, an image is based on another image, with some additional
-customization. For example, you may build an image that is based on the Ubuntu image 
+customization. For example, you may build an image that is based on the Ubuntu image
 but includes the Apache web server and your application, as well as the
 configuration details needed to make your application run.
 

--- a/content/get-started/get-docker.md
+++ b/content/get-started/get-docker.md
@@ -1,24 +1,26 @@
 ---
-description: Download and install Docker on the platform of your choice, including
+description:
+  Download and install Docker on the platform of your choice, including
   Mac, Linux, or Windows.
-keywords: install docker, docker download, download docker, docker installation, how
+keywords:
+  install docker, docker download, download docker, docker installation, how
   to install docker, get docker, docker locally
 title: Get Docker
 weight: 10
 aliases:
- - /install/
- - /install/overview/
- - /installation/
- - /get-docker/
- - /desktop/install/
- - /desktop/setup/install/
+  - /install/
+  - /install/overview/
+  - /installation/
+  - /get-docker/
+  - /desktop/install/
+  - /desktop/setup/install/
 ---
 
 Docker is an open platform for developing, shipping, and running applications.
 
-Docker allows you to separate your applications from your infrastructure so you
+Docker lets you separate your applications from your infrastructure so you
 can deliver software quickly. With Docker, you can manage your infrastructure in
-the same ways you manage your applications. 
+the same ways you manage your applications.
 
 By taking advantage of Docker’s
 methodologies for shipping, testing, and deploying code quickly, you can
@@ -51,6 +53,7 @@ section and choose the best installation path for you.
   description="A native Linux application that delivers all Docker tools to your Linux computer."
   link="/desktop/setup/install/linux/"
   icon="/icons/Linux.svg" >}}
+
 </div>
 
 > [!NOTE]

--- a/content/includes/install-script.md
+++ b/content/includes/install-script.md
@@ -18,7 +18,7 @@ of the convenience script:
 - The script requires `root` or `sudo` privileges to run.
 - The script attempts to detect your Linux distribution and version and
   configure your package management system for you.
-- The script doesn't allow you to customize most installation parameters.
+- The script doesn't let you customize most installation parameters.
 - The script installs dependencies and recommendations without asking for
   confirmation. This may install a large number of packages, depending on the
   current configuration of your host machine.


### PR DESCRIPTION
Replace Vale-flagged style violations in get-started and includes content.

## What

Replace "allows you to", "enables you to", and "allow you to" with "lets you" per the Docker docs style guide.

## Files changed

- `content/includes/install-script.md`
- `content/get-started/docker-overview.md`
- `content/get-started/get-docker.md`
- `content/get-started/docker-concepts/the-basics/what-is-a-registry.md`
- `content/get-started/docker-concepts/building-images/understanding-image-layers.md`
- `content/get-started/docker-concepts/building-images/using-the-build-cache.md`
- `content/get-started/docker-concepts/building-images/multi-stage-builds.md`