### PR TITLE
guides: replace "allows/enables you to" with "lets you"

### DIFF
--- a/content/guides/angular/deploy.md
+++ b/content/guides/angular/deploy.md
@@ -4,12 +4,12 @@ linkTitle: Test your deployment
 weight: 60
 keywords: deploy, kubernetes, angular
 description: Learn how to deploy locally to test and debug your Kubernetes deployment
-
 ---
 
 ## Prerequisites
 
 Before you begin, make sure you’ve completed the following:
+
 - Complete all the previous sections of this guide, starting with [Containerize Angular application](containerize.md).
 - [Enable Kubernetes](/manuals/desktop/use-desktop/kubernetes.md#enable-kubernetes) in Docker Desktop.
 
@@ -33,7 +33,6 @@ Follow these steps to define your deployment configuration:
 2. Open the file in your IDE or preferred text editor.
 
 3. Add the following configuration, and be sure to replace `{DOCKER_USERNAME}` and `{DOCKERHUB_PROJECT_NAME}` with your actual Docker Hub username and repository name from the previous [Automate your builds with GitHub Actions](configure-github-actions.md).
-
 
 ```yaml
 apiVersion: apps/v1
@@ -87,7 +86,7 @@ This manifest defines two key Kubernetes resources, separated by `---`:
   (refer to [Automate your builds with GitHub Actions](configure-github-actions.md)).  
   The container listens on port `8080`, which is typically used by [Nginx](https://nginx.org/en/docs/) to serve your production Angular app.
 
-- Service (NodePort) 
+- Service (NodePort)
   Exposes the deployed pod to your local machine.  
   It forwards traffic from port `30001` on your host to port `8080` inside the container.  
   This lets you access the application in your browser at [http://localhost:30001](http://localhost:30001).
@@ -115,13 +114,13 @@ If everything is configured properly, you’ll see confirmation that both the De
   deployment.apps/angular-sample created
   service/angular-sample-service created
 ```
-   
+
 This confirms that both the Deployment and the Service were successfully created and are now running inside your local cluster.
 
 ### Step 2. Check the Deployment status
 
 Run the following command to check the status of your deployment:
-   
+
 ```console
   $ kubectl get deployments
 ```
@@ -174,18 +173,18 @@ Expected output:
 ```
 
 This ensures your cluster stays clean and ready for the next deployment.
-   
+
 ---
 
 ## Summary
 
-In this section, you learned how to deploy your Angular application to a local Kubernetes cluster using Docker Desktop. This setup allows you to test and debug your containerized app in a production-like environment before deploying it to the cloud.
+In this section, you learned how to deploy your Angular application to a local Kubernetes cluster using Docker Desktop. This setup lets you test and debug your containerized app in a production-like environment before deploying it to the cloud.
 
 What you accomplished:
 
-- Created a Kubernetes Deployment and NodePort Service for your Angular app  
-- Used `kubectl apply` to deploy the application locally  
-- Verified the app was running and accessible at `http://localhost:30001`  
+- Created a Kubernetes Deployment and NodePort Service for your Angular app
+- Used `kubectl apply` to deploy the application locally
+- Verified the app was running and accessible at `http://localhost:30001`
 - Cleaned up your Kubernetes resources after testing
 
 ---
@@ -194,8 +193,8 @@ What you accomplished:
 
 Explore official references and best practices to sharpen your Kubernetes deployment workflow:
 
-- [Kubernetes documentation](https://kubernetes.io/docs/home/) – Learn about core concepts, workloads, services, and more.  
+- [Kubernetes documentation](https://kubernetes.io/docs/home/) – Learn about core concepts, workloads, services, and more.
 - [Deploy on Kubernetes with Docker Desktop](/manuals/desktop/use-desktop/kubernetes.md) – Use Docker Desktop’s built-in Kubernetes support for local testing and development.
-- [`kubectl` CLI reference](https://kubernetes.io/docs/reference/kubectl/) – Manage Kubernetes clusters from the command line.  
-- [Kubernetes Deployment resource](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/) – Understand how to manage and scale applications using Deployments.  
+- [`kubectl` CLI reference](https://kubernetes.io/docs/reference/kubectl/) – Manage Kubernetes clusters from the command line.
+- [Kubernetes Deployment resource](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/) – Understand how to manage and scale applications using Deployments.
 - [Kubernetes Service resource](https://kubernetes.io/docs/concepts/services-networking/service/) – Learn how to expose your application to internal and external traffic.

--- a/content/guides/angular/develop.md
+++ b/content/guides/angular/develop.md
@@ -4,7 +4,6 @@ linkTitle: Develop your app
 weight: 30
 keywords: angular, development, node
 description: Learn how to develop your Angular application locally using containers.
-
 ---
 
 ## Prerequisites
@@ -15,9 +14,10 @@ Complete [Containerize Angular application](containerize.md).
 
 ## Overview
 
-In this section, you'll learn how to set up both production and development environments for your containerized Angular application using Docker Compose. This setup allows you to serve a static production build via Nginx and to develop efficiently inside containers using a live-reloading dev server with Compose Watch.
+In this section, you'll learn how to set up both production and development environments for your containerized Angular application using Docker Compose. This setup lets you serve a static production build via Nginx and to develop efficiently inside containers using a live-reloading dev server with Compose Watch.
 
 You’ll learn how to:
+
 - Configure separate containers for production and development
 - Enable automatic file syncing using Compose Watch in development
 - Debug and live-preview your changes in real-time without manual rebuilds
@@ -68,7 +68,6 @@ CMD ["npm", "start", "--", "--host=0.0.0.0"]
 
 This file sets up a lightweight development environment for your Angular application using the dev server.
 
-
 ### Step 2: Update your `compose.yaml` file
 
 Open your `compose.yaml` file and define two services: one for production (`angular-prod`) and one for development (`angular-dev`).
@@ -97,6 +96,7 @@ services:
           path: .
           target: /app
 ```
+
 - The `angular-prod` service builds and serves your static production app using Nginx.
 - The `angular-dev` service runs your Angular development server with live reload and hot module replacement.
 - `watch` triggers file sync with Compose Watch.
@@ -132,15 +132,15 @@ To verify that Compose Watch is working correctly:
 
 2. Locate the following line:
 
-    ```html
-    <h1>Docker Angular Sample Application</h1>
-    ```
+   ```html
+   <h1>Docker Angular Sample Application</h1>
+   ```
 
 3. Change it to:
 
-    ```html
-    <h1>Hello from Docker Compose Watch</h1>
-    ```
+   ```html
+   <h1>Hello from Docker Compose Watch</h1>
+   ```
 
 4. Save the file.
 
@@ -155,9 +155,10 @@ You should see the updated text appear instantly, without needing to rebuild the
 In this section, you set up a complete development and production workflow for your Angular application using Docker and Docker Compose.
 
 Here’s what you accomplished:
-- Created a `Dockerfile.dev` to streamline local development with hot reloading  
-- Defined separate `angular-dev` and `angular-prod` services in your `compose.yaml` file  
-- Enabled real-time file syncing using Compose Watch for a smoother development experience  
+
+- Created a `Dockerfile.dev` to streamline local development with hot reloading
+- Defined separate `angular-dev` and `angular-prod` services in your `compose.yaml` file
+- Enabled real-time file syncing using Compose Watch for a smoother development experience
 - Verified that live updates work seamlessly by modifying and previewing a component
 
 With this setup, you're now equipped to build, run, and iterate on your Angular app entirely within containers—efficiently and consistently across environments.
@@ -168,11 +169,11 @@ With this setup, you're now equipped to build, run, and iterate on your Angular 
 
 Deepen your knowledge and improve your containerized development workflow with these guides:
 
-- [Using Compose Watch](/manuals/compose/how-tos/file-watch.md) – Automatically sync source changes during development  
-- [Multi-stage builds](/manuals/build/building/multi-stage.md) – Create efficient, production-ready Docker images  
+- [Using Compose Watch](/manuals/compose/how-tos/file-watch.md) – Automatically sync source changes during development
+- [Multi-stage builds](/manuals/build/building/multi-stage.md) – Create efficient, production-ready Docker images
 - [Dockerfile best practices](/build/building/best-practices/) – Write clean, secure, and optimized Dockerfiles.
 - [Compose file reference](/compose/compose-file/) – Learn the full syntax and options available for configuring services in `compose.yaml`.
-- [Docker volumes](/storage/volumes/) – Persist and manage data between container runs  
+- [Docker volumes](/storage/volumes/) – Persist and manage data between container runs
 
 ## Next steps
 

--- a/content/guides/angular/run-tests.md
+++ b/content/guides/angular/run-tests.md
@@ -4,7 +4,6 @@ linkTitle: Run your tests
 weight: 40
 keywords: angular, test, jasmine
 description: Learn how to run your Angular tests in a container.
-
 ---
 
 ## Prerequisites
@@ -18,7 +17,6 @@ Testing is a critical part of the development process. In this section, you'll l
 - Run Jasmine unit tests using the Angular CLI inside a Docker container.
 - Use Docker Compose to isolate your test environment.
 - Ensure consistency between local and container-based testing.
-
 
 The `docker-angular-sample` project comes pre-configured with Jasmine, so you can get started quickly without extra setup.
 
@@ -36,7 +34,7 @@ This test uses Jasmine to validate the AppComponent logic.
 
 ### Step 1: Update compose.yaml
 
-Add a new service named `angular-test` to your `compose.yaml` file. This service allows you to run your test suite in an isolated, containerized environment.
+Add a new service named `angular-test` to your `compose.yaml` file. This service lets you run your test suite in an isolated, containerized environment.
 
 ```yaml {hl_lines="22-26",linenos=true}
 services:
@@ -65,11 +63,9 @@ services:
       context: .
       dockerfile: Dockerfile.dev
     command: ["npm", "run", "test"]
-
 ```
 
 The angular-test service reuses the same `Dockerfile.dev` used for [development](develop.md) and overrides the default command to run tests with `npm run test`. This setup ensures a consistent test environment that matches your local development configuration.
-
 
 After completing the previous steps, your project directory should contain the following files:
 
@@ -92,6 +88,7 @@ $ docker compose run --rm angular-test
 ```
 
 This command will:
+
 - Start the `angular-test` service defined in your `compose.yaml` file.
 - Execute the `npm run test` script using the same environment as development.
 - Automatically removes the container after tests complete, using the [`docker compose run --rm`](/reference/cli/docker/compose/run/) command.
@@ -116,6 +113,7 @@ Time:        1.529 s
 In this section, you learned how to run unit tests for your Angular application inside a Docker container using Jasmine and Docker Compose.
 
 What you accomplished:
+
 - Created a `angular-test` service in `compose.yaml` to isolate test execution.
 - Reused the development `Dockerfile.dev` to ensure consistency between dev and test environments.
 - Ran tests inside the container using `docker compose run --rm angular-test`.
@@ -129,8 +127,9 @@ Explore official references and best practices to sharpen your Docker testing wo
 
 - [Dockerfile reference](/reference/dockerfile/) – Understand all Dockerfile instructions and syntax.
 - [Best practices for writing Dockerfiles](/develop/develop-images/dockerfile_best-practices/) – Write efficient, maintainable, and secure Dockerfiles.
-- [Compose file reference](/compose/compose-file/) – Learn the full syntax and options available for configuring services in `compose.yaml`.  
+- [Compose file reference](/compose/compose-file/) – Learn the full syntax and options available for configuring services in `compose.yaml`.
 - [`docker compose run` CLI reference](/reference/cli/docker/compose/run/) – Run one-off commands in a service container.
+
 ---
 
 ## Next steps

--- a/content/guides/bun/deploy.md
+++ b/content/guides/bun/deploy.md
@@ -5,7 +5,7 @@ weight: 50
 keywords: deploy, kubernetes, bun
 description: Learn how to develop locally using Kubernetes
 aliases:
-- /language/bun/deploy/
+  - /language/bun/deploy/
 ---
 
 ## Prerequisites
@@ -15,7 +15,7 @@ aliases:
 
 ## Overview
 
-In this section, you'll learn how to use Docker Desktop to deploy your application to a fully-featured Kubernetes environment on your development machine. This allows you to test and debug your workloads on Kubernetes locally before deploying.
+In this section, you'll learn how to use Docker Desktop to deploy your application to a fully-featured Kubernetes environment on your development machine. This lets you test and debug your workloads on Kubernetes locally before deploying.
 
 ## Create a Kubernetes YAML file
 
@@ -42,9 +42,9 @@ spec:
         app: bun-api
     spec:
       containers:
-       - name: bun-api
-         image: DOCKER_USERNAME/REPO_NAME
-         imagePullPolicy: Always
+        - name: bun-api
+          image: DOCKER_USERNAME/REPO_NAME
+          imagePullPolicy: Always
 ---
 apiVersion: v1
 kind: Service
@@ -56,21 +56,21 @@ spec:
   selector:
     app: bun-api
   ports:
-  - port: 3000
-    targetPort: 3000
-    nodePort: 30001
+    - port: 3000
+      targetPort: 3000
+      nodePort: 30001
 ```
 
 In this Kubernetes YAML file, there are two objects, separated by the `---`:
 
- - A Deployment, describing a scalable group of identical pods. In this case,
-   you'll get just one replica, or copy of your pod. That pod, which is
-   described under `template`, has just one container in it. The
-    container is created from the image built by GitHub Actions in [Configure CI/CD for
-    your Bun application](configure-ci-cd.md).
- - A NodePort service, which will route traffic from port 30001 on your host to
-   port 3000 inside the pods it routes to, allowing you to reach your app
-   from the network.
+- A Deployment, describing a scalable group of identical pods. In this case,
+  you'll get just one replica, or copy of your pod. That pod, which is
+  described under `template`, has just one container in it. The
+  container is created from the image built by GitHub Actions in [Configure CI/CD for
+  your Bun application](configure-ci-cd.md).
+- A NodePort service, which will route traffic from port 30001 on your host to
+  port 3000 inside the pods it routes to, allowing you to reach your app
+  from the network.
 
 To learn more about Kubernetes objects, see the [Kubernetes documentation](https://kubernetes.io/docs/home/).
 
@@ -133,9 +133,10 @@ To learn more about Kubernetes objects, see the [Kubernetes documentation](https
 
 ## Summary
 
-In this section, you learned how to use Docker Desktop to deploy your Bun application to a fully-featured Kubernetes environment on your development machine. 
+In this section, you learned how to use Docker Desktop to deploy your Bun application to a fully-featured Kubernetes environment on your development machine.
 
 Related information:
-   - [Kubernetes documentation](https://kubernetes.io/docs/home/)
-   - [Deploy on Kubernetes with Docker Desktop](/manuals/desktop/use-desktop/kubernetes.md)
-   - [Swarm mode overview](/manuals/engine/swarm/_index.md)
+
+- [Kubernetes documentation](https://kubernetes.io/docs/home/)
+- [Deploy on Kubernetes with Docker Desktop](/manuals/desktop/use-desktop/kubernetes.md)
+- [Swarm mode overview](/manuals/engine/swarm/_index.md)

--- a/content/guides/cpp/deploy.md
+++ b/content/guides/cpp/deploy.md
@@ -16,7 +16,7 @@ aliases:
 
 ## Overview
 
-In this section, you'll learn how to use Docker Desktop to deploy your application to a fully-featured Kubernetes environment on your development machine. This allows you to test and debug your workloads on Kubernetes locally before deploying.
+In this section, you'll learn how to use Docker Desktop to deploy your application to a fully-featured Kubernetes environment on your development machine. This lets you test and debug your workloads on Kubernetes locally before deploying.
 
 ## Create a Kubernetes YAML file
 

--- a/content/guides/cpp/multistage.md
+++ b/content/guides/cpp/multistage.md
@@ -5,8 +5,8 @@ weight: 5
 keywords: C++, containerize, multi-stage
 description: Learn how to create a multi-stage build for a C++ application.
 aliases:
-- /language/cpp/multistage/
-- /guides/language/cpp/multistage/
+  - /language/cpp/multistage/
+  - /guides/language/cpp/multistage/
 ---
 
 ## Prerequisites
@@ -16,7 +16,7 @@ aliases:
 ## Overview
 
 This section walks you through creating a multi-stage Docker build for a C++ application.
-A multi-stage build is a Docker feature that allows you to use different base images for different stages of the build process,
+A multi-stage build is a Docker feature that lets you use different base images for different stages of the build process,
 so you can optimize the size of your final image and separate build dependencies from runtime dependencies.
 
 The standard practice for compiled languages like C++ is to have a build stage that compiles the code and a runtime stage that runs the compiled binary,

--- a/content/guides/deno/deploy.md
+++ b/content/guides/deno/deploy.md
@@ -5,7 +5,7 @@ weight: 50
 keywords: deploy, kubernetes, deno
 description: Learn how to develop locally using Kubernetes
 aliases:
-- /language/deno/deploy/
+  - /language/deno/deploy/
 ---
 
 ## Prerequisites
@@ -15,7 +15,7 @@ aliases:
 
 ## Overview
 
-In this section, you'll learn how to use Docker Desktop to deploy your application to a fully-featured Kubernetes environment on your development machine. This allows you to test and debug your workloads on Kubernetes locally before deploying.
+In this section, you'll learn how to use Docker Desktop to deploy your application to a fully-featured Kubernetes environment on your development machine. This lets you test and debug your workloads on Kubernetes locally before deploying.
 
 ## Create a Kubernetes YAML file
 
@@ -42,9 +42,9 @@ spec:
         app: deno-api
     spec:
       containers:
-       - name: deno-api
-         image: DOCKER_USERNAME/REPO_NAME
-         imagePullPolicy: Always
+        - name: deno-api
+          image: DOCKER_USERNAME/REPO_NAME
+          imagePullPolicy: Always
 ---
 apiVersion: v1
 kind: Service
@@ -56,21 +56,21 @@ spec:
   selector:
     app: deno-api
   ports:
-  - port: 8000
-    targetPort: 8000
-    nodePort: 30001
+    - port: 8000
+      targetPort: 8000
+      nodePort: 30001
 ```
 
 In this Kubernetes YAML file, there are two objects, separated by the `---`:
 
- - A Deployment, describing a scalable group of identical pods. In this case,
-   you'll get just one replica, or copy of your pod. That pod, which is
-   described under `template`, has just one container in it. The
-    container is created from the image built by GitHub Actions in [Configure CI/CD for
-    your Deno application](configure-ci-cd.md).
- - A NodePort service, which will route traffic from port 30001 on your host to
-   port 8000 inside the pods it routes to, allowing you to reach your app
-   from the network.
+- A Deployment, describing a scalable group of identical pods. In this case,
+  you'll get just one replica, or copy of your pod. That pod, which is
+  described under `template`, has just one container in it. The
+  container is created from the image built by GitHub Actions in [Configure CI/CD for
+  your Deno application](configure-ci-cd.md).
+- A NodePort service, which will route traffic from port 30001 on your host to
+  port 8000 inside the pods it routes to, allowing you to reach your app
+  from the network.
 
 To learn more about Kubernetes objects, see the [Kubernetes documentation](https://kubernetes.io/docs/home/).
 
@@ -133,9 +133,10 @@ To learn more about Kubernetes objects, see the [Kubernetes documentation](https
 
 ## Summary
 
-In this section, you learned how to use Docker Desktop to deploy your Deno application to a fully-featured Kubernetes environment on your development machine. 
+In this section, you learned how to use Docker Desktop to deploy your Deno application to a fully-featured Kubernetes environment on your development machine.
 
 Related information:
-   - [Kubernetes documentation](https://kubernetes.io/docs/home/)
-   - [Deploy on Kubernetes with Docker Desktop](/manuals/desktop/use-desktop/kubernetes.md)
-   - [Swarm mode overview](/manuals/engine/swarm/_index.md)
+
+- [Kubernetes documentation](https://kubernetes.io/docs/home/)
+- [Deploy on Kubernetes with Docker Desktop](/manuals/desktop/use-desktop/kubernetes.md)
+- [Swarm mode overview](/manuals/engine/swarm/_index.md)

--- a/content/guides/dotnet/deploy.md
+++ b/content/guides/dotnet/deploy.md
@@ -20,7 +20,7 @@ aliases:
 
 In this section, you'll learn how to use Docker Desktop to deploy your
 application to a fully-featured Kubernetes environment on your development
-machine. This allows you to test and debug your workloads on Kubernetes locally
+machine. This lets you test and debug your workloads on Kubernetes locally
 before deploying.
 
 ## Create a Kubernetes YAML file

--- a/content/guides/frameworks/laravel/prerequisites.md
+++ b/content/guides/frameworks/laravel/prerequisites.md
@@ -8,7 +8,7 @@ Before you begin setting up Laravel with Docker Compose, make sure you meet the 
 
 ## Docker and Docker Compose
 
-You need Docker and Docker Compose installed on your system. Docker allows you to containerize applications, and Docker Compose helps you manage multi-container applications.
+You need Docker and Docker Compose installed on your system. Docker lets you containerize applications, and Docker Compose helps you manage multi-container applications.
 
 - Docker: Make sure Docker is installed and running on your machine. Refer to the [Docker installation guide](/get-docker/) to install Docker.
 - Docker Compose: Docker Compose is included with Docker Desktop, but you can also follow the [Docker Compose installation guide](/compose/install/) if needed.

--- a/content/guides/genai-leveraging-rag/index.md
+++ b/content/guides/genai-leveraging-rag/index.md
@@ -1,7 +1,7 @@
 ---
 title: Leveraging RAG in GenAI to teach new information
 linkTitle: Leveraging RAG in GenAI
-description:  This guide walks through the process of setting up and utilizing a GenAI stack with Retrieval-Augmented Generation (RAG) systems and graph databases. Learn how to integrate graph databases like Neo4j with AI models for more accurate, contextually-aware responses.
+description: This guide walks through the process of setting up and utilizing a GenAI stack with Retrieval-Augmented Generation (RAG) systems and graph databases. Learn how to integrate graph databases like Neo4j with AI models for more accurate, contextually-aware responses.
 keywords: Docker, GenAI, Retrieval-Augmented Generation, RAG, Graph Databases, Neo4j, AI, LLM
 summary: |
   This guide explains setting up a GenAI stack with Retrieval-Augmented Generation (RAG) and Neo4j, covering key concepts, deployment steps, and a case study. It also includes troubleshooting tips for optimizing AI performance with real-time data.
@@ -16,9 +16,9 @@ Retrieval-Augmented Generation (RAG) is a powerful framework that enhances large
 
 In this guide, you will:
 
-* Explore the advantages of integrating graph databases into a RAG framework.
-* Configure a GenAI stack with Docker, incorporating Neo4j and an AI model.
-* Analyze a real-world case study that highlights the effectiveness of this approach for handling specialized queries.
+- Explore the advantages of integrating graph databases into a RAG framework.
+- Configure a GenAI stack with Docker, incorporating Neo4j and an AI model.
+- Analyze a real-world case study that highlights the effectiveness of this approach for handling specialized queries.
 
 ## Understanding RAG
 
@@ -31,6 +31,7 @@ RAG is a hybrid framework that enhances the capabilities of large language model
 In a RAG system, vector embeddings are used to represent the semantic meaning of text in a way that a machine can understand and process. For instance, the words "dog" and "puppy" will have similar embeddings because they share similar meanings. By integrating these embeddings into the RAG framework, the system can combine the generative power of large language models with the ability to pull in highly relevant, contextually-aware data from external sources.
 
 The system operates as follows:
+
 1. Questions get turned into mathematical patterns that capture their meaning
 2. These patterns help find matching information in a database
 3. The LLM generates responses that blend the model's inherent knowledge with the this extra information.
@@ -56,6 +57,7 @@ To illustrate the power of RAG systems in practice, let's examine a real-world i
 Apache NiFi serves as an excellent example of the limitations of traditional LLMs and how RAG can overcome them. As a relatively recent technology, many LLMs have limited or outdated knowledge about it, making it a perfect candidate for demonstrating RAG's capabilities.
 
 Without RAG, the LLM may provide broad responses or acknowledge its limited knowledge when asked about information that is beyond its cutoff date. The following example demonstrates this.
+
 ```text
 Question: What important events happened in 2024?
 RAG: Disabled
@@ -74,14 +76,15 @@ docker compose --profile linux-gpu up -d
 mv env.example .env
 nano .env
 ```
+
 In the `.env` file, make sure following lines are commented out. Set your own credentials for security
 
-  ```txt
-    NEO4J_URI=neo4j://database:7687
-    NEO4J_USERNAME=neo4j
-    NEO4J_PASSWORD=password
-    OLLAMA_BASE_URL=http://llm-gpu:11434
-  ```
+```txt
+  NEO4J_URI=neo4j://database:7687
+  NEO4J_USERNAME=neo4j
+  NEO4J_PASSWORD=password
+  OLLAMA_BASE_URL=http://llm-gpu:11434
+```
 
 ### CPU powered
 
@@ -91,14 +94,15 @@ docker compose --profile linux up -d
 mv env.example .env
 nano .env
 ```
+
 In the `.env` file, make sure following lines are commented out. Set your own credentials for security
 
-  ```txt
-    NEO4J_URI=neo4j://database:7687
-    NEO4J_USERNAME=neo4j
-    NEO4J_PASSWORD=password
-    OLLAMA_BASE_URL=http://llm:11434
-  ```
+```txt
+  NEO4J_URI=neo4j://database:7687
+  NEO4J_USERNAME=neo4j
+  NEO4J_PASSWORD=password
+  OLLAMA_BASE_URL=http://llm:11434
+```
 
 ### Setting up on other platforms
 
@@ -118,13 +122,13 @@ docker compose logs
 
 Wait for specific lines in the logs indicating that the download is complete and the stack is ready. These lines typically confirm successful setup and initialization.
 
-  ```text
-    pull-model-1 exited with code 0
-    database-1    | 2024-12-29 09:35:53.269+0000 INFO  Started.
-    pdf_bot-1     |   You can now view your Streamlit app in your browser.
-    loader-1      |   You can now view your Streamlit app in your browser.
-    bot-1         |   You can now view your Streamlit app in your browser.
-  ```
+```text
+  pull-model-1 exited with code 0
+  database-1    | 2024-12-29 09:35:53.269+0000 INFO  Started.
+  pdf_bot-1     |   You can now view your Streamlit app in your browser.
+  loader-1      |   You can now view your Streamlit app in your browser.
+  bot-1         |   You can now view your Streamlit app in your browser.
+```
 
 You can now access the interface at [http://localhost:8501/](http://localhost:8501/) to ask questions. For example, you can try the sample question:
 
@@ -181,12 +185,13 @@ Now, we are ready to enable our LLM to use this information. Go back to [http://
 ![alt text](image-3.png)
 
 The system delivers comprehensive, accurate information by pulling from current technical documentation.
+
 ```text
 Question: What is Apache Nifi?
 RAG: Enabled
 
 Answer:
-Apache NiFi is an open-source, distributed data processing system that allows you to collect, transform, and transport data across various sources and sinks. It provides a graphical user interface for designing and managing data flows, as well as a set of APIs for integrating with other systems.
+Apache NiFi is an open-source, distributed data processing system that lets you collect, transform, and transport data across various sources and sinks. It provides a graphical user interface for designing and managing data flows, as well as a set of APIs for integrating with other systems.
 According to this Stack Overflow question, the free Neo4J JDBC driver doesn't understand SQL, only Cypher, so you would need to use a non-free BI Connector to connect to Neo4j from Apache Drill.
 Additionally, this Stack Overflow question suggests that Apache POI does work in a Neo4j User Defined Function. However, there may be an unknown glitch in the standalone UDF mentioned in the initial question.
 To export data from Neo4j to Excel using APOC Extended procedures, you can use apoc.export.xls.query which takes a Cypher query and exports the results to an Excel file.
@@ -215,9 +220,9 @@ Retrieval-Augmented Generation (RAG) is particularly effective in scenarios wher
 
 LLMs are trained on a fixed dataset up until a certain point in time. This means they lack access to:
 
-* Real-time information: LLMs do not continuously update their knowledge, so they may not be aware of recent events, newly released research, or emerging technologies.
-* Specialized knowledge: Many niche subjects, proprietary frameworks, or industry-specific best practices may not be well-documented in the model’s training corpus.
-* Accurate contextual understanding: LLMs can struggle with nuances or evolving terminologies that frequently change within dynamic fields like finance, cybersecurity, or medical research.
+- Real-time information: LLMs do not continuously update their knowledge, so they may not be aware of recent events, newly released research, or emerging technologies.
+- Specialized knowledge: Many niche subjects, proprietary frameworks, or industry-specific best practices may not be well-documented in the model’s training corpus.
+- Accurate contextual understanding: LLMs can struggle with nuances or evolving terminologies that frequently change within dynamic fields like finance, cybersecurity, or medical research.
 
 By incorporating RAG with a graph database such as Neo4j, AI models can access and retrieve the latest, relevant, and highly connected data before generating a response. This ensures that answers are up-to-date and grounded in factual information rather than inferred approximations.
 
@@ -225,9 +230,9 @@ By incorporating RAG with a graph database such as Neo4j, AI models can access a
 
 Organizations in industries like healthcare, legal services, and financial analysis require their AI-driven solutions to be:
 
-* Accurate: Businesses need AI-generated content that is factual and relevant to their specific domain.
-* Compliant: Many industries must adhere to strict regulations regarding data usage and security.
-* Traceable: Enterprises often require AI responses to be auditable, meaning they need to reference source material.
+- Accurate: Businesses need AI-generated content that is factual and relevant to their specific domain.
+- Compliant: Many industries must adhere to strict regulations regarding data usage and security.
+- Traceable: Enterprises often require AI responses to be auditable, meaning they need to reference source material.
 
 By using RAG, AI-generated answers can be sourced from trusted databases, ensuring higher accuracy and compliance with industry standards. This mitigates risks such as misinformation or regulatory violations.
 
@@ -235,8 +240,8 @@ By using RAG, AI-generated answers can be sourced from trusted databases, ensuri
 
 Training and fine-tuning large AI models can be computationally expensive and time-consuming. However, integrating RAG provides:
 
-* Reduced fine-tuning needs: Instead of retraining an AI model every time new data emerges, RAG allows the model to fetch and incorporate updated information dynamically.
-* Better performance with smaller models: With the right retrieval techniques, even compact AI models can perform well by leveraging external knowledge efficiently.
-* Lower operational costs: Instead of investing in expensive infrastructure to support large-scale retraining, businesses can optimize resources by utilizing RAG’s real-time retrieval capabilities.
+- Reduced fine-tuning needs: Instead of retraining an AI model every time new data emerges, RAG allows the model to fetch and incorporate updated information dynamically.
+- Better performance with smaller models: With the right retrieval techniques, even compact AI models can perform well by leveraging external knowledge efficiently.
+- Lower operational costs: Instead of investing in expensive infrastructure to support large-scale retraining, businesses can optimize resources by utilizing RAG’s real-time retrieval capabilities.
 
 By following this guide, you now have the foundational knowledge to implement RAG with Neo4j, enabling your AI system to deliver more accurate, relevant, and insightful responses. The next step is experimentation—choose a dataset, configure your stack, and start enhancing your AI with the power of retrieval-augmented generation.

--- a/content/guides/go-prometheus-monitoring/_index.md
+++ b/content/guides/go-prometheus-monitoring/_index.md
@@ -10,7 +10,7 @@ params:
   time: 45 minutes
 ---
 
-The guide teaches you how to containerize a Golang application and monitor it with Prometheus and Grafana. 
+The guide teaches you how to containerize a Golang application and monitor it with Prometheus and Grafana.
 
 > **Acknowledgment**
 >
@@ -18,16 +18,16 @@ The guide teaches you how to containerize a Golang application and monitor it wi
 
 ## Overview
 
-To make sure your application is working as intended, monitoring is important. One of the most popular monitoring tools is Prometheus. Prometheus is an open-source monitoring and alerting toolkit that is designed for reliability and scalability. It collects metrics from monitored targets by scraping metrics HTTP endpoints on these targets. To visualize the metrics, you can use Grafana. Grafana is an open-source platform for monitoring and observability that allows you to query, visualize, alert on, and understand your metrics no matter where they are stored.
+To make sure your application is working as intended, monitoring is important. One of the most popular monitoring tools is Prometheus. Prometheus is an open-source monitoring and alerting toolkit that is designed for reliability and scalability. It collects metrics from monitored targets by scraping metrics HTTP endpoints on these targets. To visualize the metrics, you can use Grafana. Grafana is an open-source platform for monitoring and observability that lets you query, visualize, alert on, and understand your metrics no matter where they are stored.
 
 In this guide, you will be creating a Golang server with some endpoints to simulate a real-world application. Then you will expose metrics from the server using Prometheus. Finally, you will visualize the metrics using Grafana. You will containerize the Golang application, and using the Docker Compose file, you will connect all the services: Golang, Prometheus, and Grafana.
 
 ## What will you learn?
 
-* Create a Golang application with custom Prometheus metrics.
-* Containerize a Golang application.
-* Use Docker Compose to run multiple services and connect them together to monitor a Golang application with Prometheus and Grafana.
-* Visualize the metrics using Grafana dashboards.
+- Create a Golang application with custom Prometheus metrics.
+- Containerize a Golang application.
+- Use Docker Compose to run multiple services and connect them together to monitor a Golang application with Prometheus and Grafana.
+- Visualize the metrics using Grafana dashboards.
 
 ## Prerequisites
 

--- a/content/guides/golang/deploy.md
+++ b/content/guides/golang/deploy.md
@@ -20,7 +20,7 @@ aliases:
 
 In this section, you'll learn how to use Docker Desktop to deploy your
 application to a fully-featured Kubernetes environment on your development
-machine. This allows you to test and debug your workloads on Kubernetes locally
+machine. This lets you test and debug your workloads on Kubernetes locally
 before deploying.
 
 ## Create a Kubernetes YAML file

--- a/content/guides/localstack.md
+++ b/content/guides/localstack.md
@@ -12,7 +12,7 @@ params:
   time: 20 minutes
 ---
 
-In modern application development, testing cloud applications locally before deploying them to a live environment helps you ship faster and with more confidence. This approach involves simulating services locally, identifying and fixing issues early, and iterating quickly without incurring costs or facing the complexities of a full cloud environment. Tools like [LocalStack](https://www.localstack.cloud/) have become invaluable in this process, enabling you to emulate AWS services and containerize applications for consistent, isolated testing environments. 
+In modern application development, testing cloud applications locally before deploying them to a live environment helps you ship faster and with more confidence. This approach involves simulating services locally, identifying and fixing issues early, and iterating quickly without incurring costs or facing the complexities of a full cloud environment. Tools like [LocalStack](https://www.localstack.cloud/) have become invaluable in this process, enabling you to emulate AWS services and containerize applications for consistent, isolated testing environments.
 
 In this guide, you'll learn how to:
 
@@ -22,11 +22,11 @@ In this guide, you'll learn how to:
 
 ## What is LocalStack?
 
-LocalStack is a cloud service emulator that runs in a single container on your laptop. It provides a powerful, flexible, and cost-effective way to test and develop AWS-based applications locally. 
+LocalStack is a cloud service emulator that runs in a single container on your laptop. It provides a powerful, flexible, and cost-effective way to test and develop AWS-based applications locally.
 
 ## Why use LocalStack?
 
-Simulating AWS services locally allows you to test how your app interacts with services like S3, Lambda, and DynamoDB without needing to connect to the real AWS cloud. You can quickly iterate on your development, avoiding the cost and complexity of deploying to the cloud during this phase.
+Simulating AWS services locally lets you test how your app interacts with services like S3, Lambda, and DynamoDB without needing to connect to the real AWS cloud. You can quickly iterate on your development, avoiding the cost and complexity of deploying to the cloud during this phase.
 
 By mimicking the behavior of these services locally, LocalStack enables faster feedback loops. Your app can interact with external APIs, but everything runs locally, removing the need to deal with cloud provisioning or network latency.
 
@@ -40,7 +40,7 @@ The [official Docker image for LocalStack](https://hub.docker.com/r/localstack/l
 
 The following prerequisites are required to follow along with this how-to guide:
 
-- [Docker Desktop](https://www.docker.com/products/docker-desktop/) 
+- [Docker Desktop](https://www.docker.com/products/docker-desktop/)
 - [Node.js](https://nodejs.org/en/download/package-manager)
 - [Python and pip](https://www.python.org/downloads/)
 - Basic knowledge of Docker
@@ -58,7 +58,7 @@ Launch a quick demo of LocalStack by using the following steps:
 
 2. Bring up LocalStack
 
-   Run the following command to bring up LocalStack.   
+   Run the following command to bring up LocalStack.
 
    ```console
    $ docker compose -f compose-native.yml up -d
@@ -78,21 +78,21 @@ Launch a quick demo of LocalStack by using the following steps:
 
    To create Local Amazon S3 bucket, install the [`awscli-local` CLI](https://github.com/localstack/awscli-local) on your system. The `awslocal` command is a thin wrapper around the AWS command line interface for use with LocalStack. It lets you to test and develop against a simulated environment on your local machine without needing to access the real AWS services.
 
-    ```console
-    $ pip install awscli-local
-    ```
+   ```console
+   $ pip install awscli-local
+   ```
 
-    Create a new S3 bucket within the LocalStack environment with the following command:
+   Create a new S3 bucket within the LocalStack environment with the following command:
 
-    ```console
-    $ awslocal s3 mb s3://mysamplebucket
-    ```
+   ```console
+   $ awslocal s3 mb s3://mysamplebucket
+   ```
 
-    The command `s3 mb s3://mysamplebucket` tells the AWS CLI to create a new S3 bucket (mb stands for `make bucket`) named `mysamplebucket`.
+   The command `s3 mb s3://mysamplebucket` tells the AWS CLI to create a new S3 bucket (mb stands for `make bucket`) named `mysamplebucket`.
 
-    You can verify if the S3 bucket gets created or not by selecting the LocalStack container on the Docker Desktop Dashboard and viewing the logs. The logs indicates that your LocalStack environment is configured correctly and you can now use the `mysamplebucket` for storing and retrieving objects.
+   You can verify if the S3 bucket gets created or not by selecting the LocalStack container on the Docker Desktop Dashboard and viewing the logs. The logs indicates that your LocalStack environment is configured correctly and you can now use the `mysamplebucket` for storing and retrieving objects.
 
-    ![Diagram showing the logs of LocalStack that highlights the S3 bucket being created successfully ](./images/localstack-s3put.webp)
+   ![Diagram showing the logs of LocalStack that highlights the S3 bucket being created successfully ](./images/localstack-s3put.webp)
 
 ## Using LocalStack in development
 
@@ -104,7 +104,6 @@ Now that you've familiarized yourself with LocalStack, it's time to see it in ac
 - LocalStack: Emulates the Amazon S3 service and stores and retrieve images.
 
 ![Diagram showing the tech stack of the sample todo-list application that includes LocalStack, frontend and backend services ](images/localstack-arch.webp)
-
 
 ## Connecting to LocalStack from a non-containerized app
 
@@ -125,19 +124,18 @@ Let’s see it in action. Start by launching the Node.js backend service.
    ```
 
 2. Install the required dependencies:
-  
+
    ```console
    $ npm install
    ```
 
 3. Setting up AWS environment variables
 
-
    The `.env` file located in the backend/ directory already contains placeholder credentials and configuration values that LocalStack uses to emulate AWS services. The `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` are placeholder credentials, while `S3_BUCKET_NAME` and `S3_ENDPOINT_URL` are configuration settings. No changes are needed as these values are already correctly set for LocalStack.
 
    > [!TIP]
    >
-   > Given that you’re running Mongo in a Docker container and the backend Node app is running natively on your host, ensure that  `MONGODB_URI=mongodb://localhost:27017/todos` is set in your `.env` file.
+   > Given that you’re running Mongo in a Docker container and the backend Node app is running natively on your host, ensure that `MONGODB_URI=mongodb://localhost:27017/todos` is set in your `.env` file.
 
    ```plaintext
    MONGODB_URI=mongodb://localhost:27017/todos
@@ -148,14 +146,15 @@ Let’s see it in action. Start by launching the Node.js backend service.
    AWS_REGION=us-east-1
    ```
 
-   While the AWS SDK might typically use environment variables starting with `AWS_`, this specific application directly references the following `S3_*` variables in the index.js file (under the `backend/` directory) to configure the S3Client. 
+   While the AWS SDK might typically use environment variables starting with `AWS_`, this specific application directly references the following `S3_*` variables in the index.js file (under the `backend/` directory) to configure the S3Client.
 
    ```js
    const s3 = new S3Client({
      endpoint: process.env.S3_ENDPOINT_URL, // Use the provided endpoint or fallback to defaults
      credentials: {
-       accessKeyId: process.env.AWS_ACCESS_KEY_ID || 'default_access_key', // Default values for development
-       secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY || 'default_secret_key',  
+       accessKeyId: process.env.AWS_ACCESS_KEY_ID || "default_access_key", // Default values for development
+       secretAccessKey:
+         process.env.AWS_SECRET_ACCESS_KEY || "default_secret_key",
      },
    });
    ```
@@ -166,7 +165,7 @@ Let’s see it in action. Start by launching the Node.js backend service.
    $ node index.js
    ```
 
-    You will see the message that the backend service has successfully started at port 5000.
+   You will see the message that the backend service has successfully started at port 5000.
 
 ## Start the frontend service
 
@@ -179,7 +178,7 @@ To start the frontend service, open a new terminal and follow these steps:
    ```
 
 2. Install the required dependencies
-  
+
    ```console
    $ npm install
    ```
@@ -189,7 +188,7 @@ To start the frontend service, open a new terminal and follow these steps:
    ```console
    $ npm run dev
    ```
-   
+
    By now, you should see the following message:
 
    ```console
@@ -207,8 +206,7 @@ To start the frontend service, open a new terminal and follow these steps:
 
    ![Diagram showing the logs of the LocalStack that highlights image uploaded to the emulated S3 bucket](images/localstack-todolist-s3put.webp)
 
-   The `200` status code signifies that the `putObject` operation, which involves uploading an object to the S3 bucket, was executed successfully within the LocalStack environment. LocalStack logs this entry to provide visibility into the operations being performed. It helps debug and confirm that your application is interacting correctly with the emulated AWS services. 
-
+   The `200` status code signifies that the `putObject` operation, which involves uploading an object to the S3 bucket, was executed successfully within the LocalStack environment. LocalStack logs this entry to provide visibility into the operations being performed. It helps debug and confirm that your application is interacting correctly with the emulated AWS services.
 
    Since LocalStack is designed to simulate AWS services locally, this log entry shows that your application is functioning as expected when performing cloud operations in a local sandbox environment.
 
@@ -216,7 +214,7 @@ To start the frontend service, open a new terminal and follow these steps:
 
 Now that you have learnt how to connect a non-containerized Node.js application to LocalStack, it's time to explore the necessary changes to run the complete application stack in a containerized environment. To achieve this, you will create a Compose file specifying all required services - frontend, backend, database, and LocalStack.
 
-1. Examine the Docker Compose file. 
+1. Examine the Docker Compose file.
 
    The following Docker Compose file defines four services: `backend`, `frontend`, `mongodb`, and `localstack`. The `backend` and `frontend` services are your Node.js applications, while `mongodb` provides a database and `localstack` simulates AWS services like S3.
 
@@ -274,7 +272,7 @@ Now that you have learnt how to connect a non-containerized Node.js application 
 
    > [!TIP]
    > Given the previous Compose file, the app would connect to LocalStack using the hostname `localstack` while Mongo would connect using the hostname `mongodb`.
- 
+
    ```plaintext
    MONGODB_URI=mongodb://mongodb:27017/todos
    AWS_ACCESS_KEY_ID=test
@@ -286,8 +284,7 @@ Now that you have learnt how to connect a non-containerized Node.js application 
 
 3. Stop the running services
 
-   Ensure that you stop the Node frontend and backend service from the previous step by pressing “Ctrl+C” in the terminal. Also, you'll need to stop the LocalStack and Mongo containers by selecting them in the Docker Desktop Dashboard and selecting the "Delete" button. 
-
+   Ensure that you stop the Node frontend and backend service from the previous step by pressing “Ctrl+C” in the terminal. Also, you'll need to stop the LocalStack and Mongo containers by selecting them in the Docker Desktop Dashboard and selecting the "Delete" button.
 
 4. Start the application stack by executing the following command at the root of your cloned project directory:
 
@@ -301,18 +298,16 @@ Now that you have learnt how to connect a non-containerized Node.js application 
 
    The AWS S3 bucket is not created beforehand by the Compose file. Run the following command to create a new bucket within the LocalStack environment:
 
-
    ```console
    $ awslocal s3 mb s3://mysamplebucket
    ```
 
    The command creates an S3 bucket named `mysamplebucket`.
 
-   Open [http://localhost:5173](http://localhost:5173) to access the complete to-do list application and start uploading images to the Amazon S3 bucket. 
+   Open [http://localhost:5173](http://localhost:5173) to access the complete to-do list application and start uploading images to the Amazon S3 bucket.
 
    > [!TIP]
    > To optimize performance and reduce upload times during development, consider uploading smaller image files. Larger images may take longer to process and could impact the overall responsiveness of the application.
-
 
 ## Recap
 

--- a/content/guides/nextjs/deploy.md
+++ b/content/guides/nextjs/deploy.md
@@ -4,12 +4,12 @@ linkTitle: Test your deployment
 weight: 70
 keywords: deploy, kubernetes, next.js
 description: Learn how to deploy locally to test and debug your Kubernetes deployment
-
 ---
 
 ## Prerequisites
 
 Before you begin, make sure you've completed the following:
+
 - Complete all the previous sections of this guide, starting with [Containerize Next.js application](containerize.md).
 - [Enable Kubernetes](/manuals/desktop/use-desktop/kubernetes.md#enable-kubernetes) in Docker Desktop.
 
@@ -20,7 +20,7 @@ Before you begin, make sure you've completed the following:
 
 ## Overview
 
-This section guides you through deploying your containerized Next.js application locally using [Docker Desktop's built-in Kubernetes](/desktop/kubernetes/). Running your app in a local Kubernetes cluster allows you to closely simulate a real production environment, enabling you to test, validate, and debug your workloads with confidence before promoting them to staging or production.
+This section guides you through deploying your containerized Next.js application locally using [Docker Desktop's built-in Kubernetes](/desktop/kubernetes/). Running your app in a local Kubernetes cluster lets you closely simulate a real production environment, letting you test, validate, and debug your workloads with confidence before promoting them to staging or production.
 
 ---
 
@@ -33,7 +33,6 @@ Follow these steps to define your deployment configuration:
 2. Open the file in your IDE or preferred text editor.
 
 3. Add the following configuration, and be sure to replace `{DOCKER_USERNAME}` and `{DOCKERHUB_PROJECT_NAME}` with your actual Docker Hub username and repository name from the previous [Automate your builds with GitHub Actions](configure-github-actions.md).
-
 
 ```yaml
 apiVersion: apps/v1
@@ -85,7 +84,7 @@ This manifest defines two key Kubernetes resources, separated by `---`:
   (refer to [Automate your builds with GitHub Actions](configure-github-actions.md)).  
   The container listens on port `3000`, which is the default port for Next.js applications.
 
-- Service (NodePort) 
+- Service (NodePort)
   Exposes the deployed pod to your local machine.  
   It forwards traffic from port `30001` on your host to port `3000` inside the container.  
   This lets you access the application in your browser at [http://localhost:30001](http://localhost:30001).
@@ -113,13 +112,13 @@ If everything is configured properly, you'll see confirmation that both the Depl
   deployment.apps/nextjs-sample created
   service/nextjs-sample-service created
 ```
-   
+
 This output means that both the Deployment and the Service were successfully created and are now running inside your local cluster.
 
 ### Step 2. Check the Deployment status
 
 Run the following command to check the status of your deployment:
-   
+
 ```console
   $ kubectl get deployments
 ```
@@ -172,18 +171,18 @@ Expected output:
 ```
 
 This ensures your cluster stays clean and ready for the next deployment.
-   
+
 ---
 
 ## Summary
 
-In this section, you learned how to deploy your Next.js application to a local Kubernetes cluster using Docker Desktop. This setup allows you to test and debug your containerized app in a production-like environment before deploying it to the cloud.
+In this section, you learned how to deploy your Next.js application to a local Kubernetes cluster using Docker Desktop. This setup lets you test and debug your containerized app in a production-like environment before deploying it to the cloud.
 
 What you accomplished:
 
-- Created a Kubernetes Deployment and NodePort Service for your Next.js app  
-- Used `kubectl apply` to deploy the application locally  
-- Verified the app was running and accessible at `http://localhost:30001`  
+- Created a Kubernetes Deployment and NodePort Service for your Next.js app
+- Used `kubectl apply` to deploy the application locally
+- Verified the app was running and accessible at `http://localhost:30001`
 - Cleaned up your Kubernetes resources after testing
 
 ---
@@ -192,8 +191,8 @@ What you accomplished:
 
 Explore official references and best practices to sharpen your Kubernetes deployment workflow:
 
-- [Kubernetes documentation](https://kubernetes.io/docs/home/) – Learn about core concepts, workloads, services, and more.  
+- [Kubernetes documentation](https://kubernetes.io/docs/home/) – Learn about core concepts, workloads, services, and more.
 - [Deploy on Kubernetes with Docker Desktop](/manuals/desktop/use-desktop/kubernetes.md) – Use Docker Desktop's built-in Kubernetes support for local testing and development.
-- [`kubectl` CLI reference](https://kubernetes.io/docs/reference/kubectl/) – Manage Kubernetes clusters from the command line.  
-- [Kubernetes Deployment resource](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/) – Understand how to manage and scale applications using Deployments.  
+- [`kubectl` CLI reference](https://kubernetes.io/docs/reference/kubectl/) – Manage Kubernetes clusters from the command line.
+- [Kubernetes Deployment resource](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/) – Understand how to manage and scale applications using Deployments.
 - [Kubernetes Service resource](https://kubernetes.io/docs/concepts/services-networking/service/) – Learn how to expose your application to internal and external traffic.

--- a/content/guides/nextjs/develop.md
+++ b/content/guides/nextjs/develop.md
@@ -4,7 +4,6 @@ linkTitle: Develop your app
 weight: 30
 keywords: next.js, development, node
 description: Learn how to develop your Next.js application locally using containers.
-
 ---
 
 ## Prerequisites
@@ -15,9 +14,10 @@ Complete [Containerize Next.js application](containerize.md).
 
 ## Overview
 
-In this section, you'll learn how to set up both production and development environments for your containerized Next.js application using Docker Compose. This setup allows you to run a production build using the standalone server and to develop efficiently inside containers using Next.js's built-in hot reloading with Compose Watch.
+In this section, you'll learn how to set up both production and development environments for your containerized Next.js application using Docker Compose. This setup lets you run a production build using the standalone server and to develop efficiently inside containers using Next.js's built-in hot reloading with Compose Watch.
 
 You'll learn how to:
+
 - Configure separate containers for production and development
 - Enable automatic file syncing using Compose Watch in development
 - Debug and live-preview your changes in real-time without manual rebuilds
@@ -73,7 +73,6 @@ CMD ["sh", "-c", "if [ -f package-lock.json ]; then npm run dev; elif [ -f yarn.
 ```
 
 This file sets up a development environment for your Next.js app with hot module replacement and supports npm, yarn, and pnpm.
-
 
 ### Step 2: Update your `compose.yaml` file
 
@@ -131,12 +130,12 @@ The `next.config.ts` file you created during containerization already includes t
 
 > [!NOTE]
 > The Next.js development server automatically:
+>
 > - Enables Hot Module Replacement (HMR) for instant updates
 > - Watches for file changes and recompiles automatically
 > - Provides detailed error messages in the browser
 >
 > The `WATCHPACK_POLLING=true` environment variable in the compose file ensures file watching works correctly inside Docker containers.
-
 
 After completing the previous steps, your project directory should now contain the following files:
 
@@ -168,9 +167,9 @@ To verify that Compose Watch is working correctly:
 
 3. Make a visible change, for example, update a heading:
 
-    ```tsx
-    <h1>Hello from Docker Compose Watch!</h1>
-    ```
+   ```tsx
+   <h1>Hello from Docker Compose Watch!</h1>
+   ```
 
 4. Save the file.
 
@@ -185,9 +184,10 @@ You should see the updated text appear instantly, without needing to rebuild the
 In this section, you set up a complete development and production workflow for your Next.js application using Docker and Docker Compose.
 
 Here's what you achieved:
-- Created a `Dockerfile.dev` to streamline local development with hot reloading  
-- Defined separate `nextjs-dev` and `nextjs-prod-standalone` services in your `compose.yaml` file  
-- Enabled real-time file syncing using Compose Watch for a smoother development experience  
+
+- Created a `Dockerfile.dev` to streamline local development with hot reloading
+- Defined separate `nextjs-dev` and `nextjs-prod-standalone` services in your `compose.yaml` file
+- Enabled real-time file syncing using Compose Watch for a smoother development experience
 - Verified that live updates work seamlessly by modifying and previewing a component
 
 With this setup, you can build, run, and iterate on your Next.js app
@@ -199,11 +199,11 @@ entirely within containers across environments.
 
 Deepen your knowledge and improve your containerized development workflow with these guides:
 
-- [Using Compose Watch](/manuals/compose/how-tos/file-watch.md) – Automatically sync source changes during development  
-- [Multi-stage builds](/manuals/build/building/multi-stage.md) – Create efficient, production-ready Docker images  
+- [Using Compose Watch](/manuals/compose/how-tos/file-watch.md) – Automatically sync source changes during development
+- [Multi-stage builds](/manuals/build/building/multi-stage.md) – Create efficient, production-ready Docker images
 - [Dockerfile best practices](/build/building/best-practices/) – Write clean, secure, and optimized Dockerfiles.
 - [Compose file reference](/compose/compose-file/) – Learn the full syntax and options available for configuring services in `compose.yaml`.
-- [Docker volumes](/storage/volumes/) – Persist and manage data between container runs  
+- [Docker volumes](/storage/volumes/) – Persist and manage data between container runs
 
 ## Next steps
 

--- a/content/guides/php/deploy.md
+++ b/content/guides/php/deploy.md
@@ -20,7 +20,7 @@ aliases:
 
 In this section, you'll learn how to use Docker Desktop to deploy your
 application to a fully-featured Kubernetes environment on your development
-machine. This allows you to test and debug your workloads on Kubernetes locally
+machine. This lets you test and debug your workloads on Kubernetes locally
 before deploying.
 
 ## Create a Kubernetes YAML file

--- a/content/guides/postgresql/companions-for-postgresql.md
+++ b/content/guides/postgresql/companions-for-postgresql.md
@@ -9,7 +9,6 @@ keywords:
 weight: 40
 ---
 
-
 ## PostgreSQL Ecosystem companions: pgAdmin, PgBouncer, and Performance Testing
 
 Running a standalone PostgreSQL container is often just the beginning. What happens when thousands of connections arrive, or when you need a visual interface to manage your database?
@@ -63,11 +62,11 @@ PgBouncer is a lightweight proxy that pools connections, allowing thousands of a
 
 PgBouncer offers three distinct pooling modes:
 
-| Mode | Description | Use case |
-|------|-------------|----------|
-| **Session** | Connection assigned for entire session duration | Long-lived connections, session variables |
-| **Transaction** | Connection returned after each transaction ends | Web applications, microservices (most common) |
-| **Statement** | Connection returned after every SQL statement | Simple queries, no multi-statement transactions |
+| Mode            | Description                                     | Use case                                        |
+| --------------- | ----------------------------------------------- | ----------------------------------------------- |
+| **Session**     | Connection assigned for entire session duration | Long-lived connections, session variables       |
+| **Transaction** | Connection returned after each transaction ends | Web applications, microservices (most common)   |
+| **Statement**   | Connection returned after every SQL statement   | Simple queries, no multi-statement transactions |
 
 ### When to use PgBouncer
 
@@ -166,12 +165,9 @@ Key configuration notes:
 >
 > The `Percona PgBouncer` entrypoint script processes the configuration files on startup. Mount them without the read-only flag to avoid permission errors.
 
-
-
-
 ## `pgbench`: Performance benchmarking
 
-`pgbench` is a benchmarking utility included with the official PostgreSQL image. It allows you to simulate heavy workloads and verify how your Docker configuration performs under pressure.
+`pgbench` is a benchmarking utility included with the official PostgreSQL image. It lets you simulate heavy workloads and verify how your Docker configuration performs under pressure.
 
 ### Initialize benchmark tables
 
@@ -224,8 +220,8 @@ Try increasing the client count (`-c` parameter) gradually: 50, 100, 150, 200. A
 #### 3. Throughput varies by environment
 
 On some systems, direct connections show higher transactions per second (TPS) at low concurrency. On others, PgBouncer wins even with few clients. The difference depends on:
+
 - CPU and memory available
 - Docker networking overhead
 - Disk I/O speed
 - Whether connections are being rapidly opened and closed
-

--- a/content/guides/python/configure-github-actions.md
+++ b/content/guides/python/configure-github-actions.md
@@ -27,7 +27,7 @@ If you didn't create a [GitHub repository](https://github.com/new) for your proj
 
 ## Overview
 
-GitHub Actions is a CI/CD (Continuous Integration and Continuous Deployment) automation tool built into GitHub. It allows you to define custom workflows for building, testing, and deploying your code when specific events occur (e.g., pushing code, creating a pull request, etc.). A workflow is a YAML-based automation script that defines a sequence of steps to be executed when triggered. Workflows are stored in the `.github/workflows/` directory of a repository.
+GitHub Actions is a CI/CD (Continuous Integration and Continuous Deployment) automation tool built into GitHub. It lets you define custom workflows for building, testing, and deploying your code when specific events occur (e.g., pushing code, creating a pull request, etc.). A workflow is a YAML-based automation script that defines a sequence of steps to be executed when triggered. Workflows are stored in the `.github/workflows/` directory of a repository.
 
 In this section, you'll learn how to set up and use GitHub Actions to build your Docker image as well as push it to Docker Hub. You will complete the following steps:
 
@@ -64,11 +64,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@{{% param "checkout_action_version" %}}
-      
+
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: '3.14'
+          python-version: "3.14"
 
       - name: Install dependencies
         run: |
@@ -133,4 +133,3 @@ Related information:
 ## Next steps
 
 In the next section, you'll learn how you can develop locally using kubernetes.
-

--- a/content/guides/python/deploy.md
+++ b/content/guides/python/deploy.md
@@ -16,7 +16,7 @@ aliases:
 
 ## Overview
 
-In this section, you'll learn how to use Docker Desktop to deploy your application to a fully-featured Kubernetes environment on your development machine. This allows you to test and debug your workloads on Kubernetes locally before deploying.
+In this section, you'll learn how to use Docker Desktop to deploy your application to a fully-featured Kubernetes environment on your development machine. This lets you test and debug your workloads on Kubernetes locally before deploying.
 
 ## Create a Kubernetes YAML file
 

--- a/content/guides/r/deploy.md
+++ b/content/guides/r/deploy.md
@@ -16,7 +16,7 @@ aliases:
 
 ## Overview
 
-In this section, you'll learn how to use Docker Desktop to deploy your application to a fully-featured Kubernetes environment on your development machine. This allows you to test and debug your workloads on Kubernetes locally before deploying.
+In this section, you'll learn how to use Docker Desktop to deploy your application to a fully-featured Kubernetes environment on your development machine. This lets you test and debug your workloads on Kubernetes locally before deploying.
 
 ## Create a Kubernetes YAML file
 

--- a/content/guides/rag-ollama/containerize.md
+++ b/content/guides/rag-ollama/containerize.md
@@ -52,7 +52,7 @@ Containerizing an application involves packaging it along with its dependencies 
 
 1. Dockerfile: A Dockerfile that contains instructions on how to build a Docker image for your application. It specifies the base image, dependencies, configuration files, and the command to run your application.
 
-2. Docker Compose File: Docker Compose is a tool for defining and running multi-container Docker applications. A Compose file allows you to configure your application's services, networks, and volumes in a single file.
+2. Docker Compose File: Docker Compose is a tool for defining and running multi-container Docker applications. A Compose file lets you configure your application's services, networks, and volumes in a single file.
 
 ## Run the application
 
@@ -105,4 +105,3 @@ application using Docker.
 ## Next steps
 
 In the next section, you'll learn how to properly configure the application with your preferred LLM model, completely locally, using Docker.
-

--- a/content/guides/reactjs/deploy.md
+++ b/content/guides/reactjs/deploy.md
@@ -4,12 +4,12 @@ linkTitle: Test your deployment
 weight: 60
 keywords: deploy, kubernetes, react, react.js
 description: Learn how to deploy locally to test and debug your Kubernetes deployment
-
 ---
 
 ## Prerequisites
 
 Before you begin, make sure you’ve completed the following:
+
 - Complete all the previous sections of this guide, starting with [Containerize React.js application](containerize.md).
 - [Enable Kubernetes](/manuals/desktop/use-desktop/kubernetes.md#enable-kubernetes) in Docker Desktop.
 
@@ -20,7 +20,7 @@ Before you begin, make sure you’ve completed the following:
 
 ## Overview
 
-This section guides you through deploying your containerized React.js application locally using [Docker Desktop’s built-in Kubernetes](/desktop/kubernetes/). Running your app in a local Kubernetes cluster allows you to closely simulate a real production environment, enabling you to test, validate, and debug your workloads with confidence before promoting them to staging or production.
+This section guides you through deploying your containerized React.js application locally using [Docker Desktop’s built-in Kubernetes](/desktop/kubernetes/). Running your app in a local Kubernetes cluster lets you closely simulate a real production environment, letting you test, validate, and debug your workloads with confidence before promoting them to staging or production.
 
 ---
 
@@ -33,7 +33,6 @@ Follow these steps to define your deployment configuration:
 2. Open the file in your IDE or preferred text editor.
 
 3. Add the following configuration, and be sure to replace `{DOCKER_USERNAME}` and `{DOCKERHUB_PROJECT_NAME}` with your actual Docker Hub username and repository name from the previous [Automate your builds with GitHub Actions](configure-github-actions.md).
-
 
 ```yaml
 apiVersion: apps/v1
@@ -80,7 +79,7 @@ This manifest defines two key Kubernetes resources, separated by `---`:
   (refer to [Automate your builds with GitHub Actions](configure-github-actions.md)).  
   The container listens on port `8080`, which is typically used by [Nginx](https://nginx.org/en/docs/) to serve your production React app.
 
-- Service (NodePort) 
+- Service (NodePort)
   Exposes the deployed pod to your local machine.  
   It forwards traffic from port `30001` on your host to port `8080` inside the container.  
   This lets you access the application in your browser at [http://localhost:30001](http://localhost:30001).
@@ -108,13 +107,13 @@ If everything is configured properly, you’ll see confirmation that both the De
   deployment.apps/reactjs-sample created
   service/reactjs-sample-service created
 ```
-   
+
 This output means that both the Deployment and the Service were successfully created and are now running inside your local cluster.
 
 ### Step 2. Check the Deployment status
 
 Run the following command to check the status of your deployment:
-   
+
 ```console
   $ kubectl get deployments
 ```
@@ -167,18 +166,18 @@ Expected output:
 ```
 
 This ensures your cluster stays clean and ready for the next deployment.
-   
+
 ---
 
 ## Summary
 
-In this section, you learned how to deploy your React.js application to a local Kubernetes cluster using Docker Desktop. This setup allows you to test and debug your containerized app in a production-like environment before deploying it to the cloud.
+In this section, you learned how to deploy your React.js application to a local Kubernetes cluster using Docker Desktop. This setup lets you test and debug your containerized app in a production-like environment before deploying it to the cloud.
 
 What you accomplished:
 
-- Created a Kubernetes Deployment and NodePort Service for your React.js app  
-- Used `kubectl apply` to deploy the application locally  
-- Verified the app was running and accessible at `http://localhost:30001`  
+- Created a Kubernetes Deployment and NodePort Service for your React.js app
+- Used `kubectl apply` to deploy the application locally
+- Verified the app was running and accessible at `http://localhost:30001`
 - Cleaned up your Kubernetes resources after testing
 
 ---
@@ -187,8 +186,8 @@ What you accomplished:
 
 Explore official references and best practices to sharpen your Kubernetes deployment workflow:
 
-- [Kubernetes documentation](https://kubernetes.io/docs/home/) – Learn about core concepts, workloads, services, and more.  
+- [Kubernetes documentation](https://kubernetes.io/docs/home/) – Learn about core concepts, workloads, services, and more.
 - [Deploy on Kubernetes with Docker Desktop](/manuals/desktop/use-desktop/kubernetes.md) – Use Docker Desktop’s built-in Kubernetes support for local testing and development.
-- [`kubectl` CLI reference](https://kubernetes.io/docs/reference/kubectl/) – Manage Kubernetes clusters from the command line.  
-- [Kubernetes Deployment resource](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/) – Understand how to manage and scale applications using Deployments.  
+- [`kubectl` CLI reference](https://kubernetes.io/docs/reference/kubectl/) – Manage Kubernetes clusters from the command line.
+- [Kubernetes Deployment resource](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/) – Understand how to manage and scale applications using Deployments.
 - [Kubernetes Service resource](https://kubernetes.io/docs/concepts/services-networking/service/) – Learn how to expose your application to internal and external traffic.

--- a/content/guides/reactjs/develop.md
+++ b/content/guides/reactjs/develop.md
@@ -4,7 +4,6 @@ linkTitle: Develop your app
 weight: 30
 keywords: react.js, development, node
 description: Learn how to develop your React.js application locally using containers.
-
 ---
 
 ## Prerequisites
@@ -15,9 +14,10 @@ Complete [Containerize React.js application](containerize.md).
 
 ## Overview
 
-In this section, you'll learn how to set up both production and development environments for your containerized React.js application using Docker Compose. This setup allows you to serve a static production build via Nginx and to develop efficiently inside containers using a live-reloading dev server with Compose Watch.
+In this section, you'll learn how to set up both production and development environments for your containerized React.js application using Docker Compose. This setup lets you serve a static production build via Nginx and to develop efficiently inside containers using a live-reloading dev server with Compose Watch.
 
 You’ll learn how to:
+
 - Configure separate containers for production and development
 - Enable automatic file syncing using Compose Watch in development
 - Debug and live-preview your changes in real-time without manual rebuilds
@@ -62,7 +62,6 @@ CMD ["npm", "run", "dev"]
 
 This file sets up a lightweight development environment for your React app using the dev server.
 
-
 ### Step 2: Update your `compose.yaml` file
 
 Open your `compose.yaml` file and define two services: one for production (`react-prod`) and one for development (`react-dev`).
@@ -90,8 +89,8 @@ services:
         - action: sync
           path: .
           target: /app
-
 ```
+
 - The `react-prod` service builds and serves your static production app using Nginx.
 - The `react-dev` service runs your React development server with live reload and hot module replacement.
 - `watch` triggers file sync with Compose Watch.
@@ -124,12 +123,12 @@ export default defineConfig({
 
 > [!NOTE]
 > The `server` options in `vite.config.ts` are essential for running Vite inside Docker:
+>
 > - `host: true` allows the dev server to be accessible from outside the container.
 > - `port: 5173` sets a consistent development port (must match the one exposed in Docker).
 > - `strictPort: true` ensures Vite fails clearly if the port is unavailable, rather than switching silently.
-> 
+>
 > For full details, refer to the [Vite server configuration docs](https://vitejs.dev/config/server-options.html).
-
 
 After completing the previous steps, your project directory should now contain the following files:
 
@@ -159,15 +158,15 @@ To verify that Compose Watch is working correctly:
 
 2. Locate the following line:
 
-    ```html
-    <h1>Vite + React</h1>
-    ```
+   ```html
+   <h1>Vite + React</h1>
+   ```
 
 3. Change it to:
 
-    ```html
-    <h1>Hello from Docker Compose Watch</h1>
-    ```
+   ```html
+   <h1>Hello from Docker Compose Watch</h1>
+   ```
 
 4. Save the file.
 
@@ -182,9 +181,10 @@ You should see the updated text appear instantly, without needing to rebuild the
 In this section, you set up a complete development and production workflow for your React.js application using Docker and Docker Compose.
 
 Here's what you achieved:
-- Created a `Dockerfile.dev` to streamline local development with hot reloading  
-- Defined separate `react-dev` and `react-prod` services in your `compose.yaml` file  
-- Enabled real-time file syncing using Compose Watch for a smoother development experience  
+
+- Created a `Dockerfile.dev` to streamline local development with hot reloading
+- Defined separate `react-dev` and `react-prod` services in your `compose.yaml` file
+- Enabled real-time file syncing using Compose Watch for a smoother development experience
 - Verified that live updates work seamlessly by modifying and previewing a component
 
 With this setup, you're now equipped to build, run, and iterate on your React.js app entirely within containers—efficiently and consistently across environments.
@@ -195,11 +195,11 @@ With this setup, you're now equipped to build, run, and iterate on your React.js
 
 Deepen your knowledge and improve your containerized development workflow with these guides:
 
-- [Using Compose Watch](/manuals/compose/how-tos/file-watch.md) – Automatically sync source changes during development  
-- [Multi-stage builds](/manuals/build/building/multi-stage.md) – Create efficient, production-ready Docker images  
+- [Using Compose Watch](/manuals/compose/how-tos/file-watch.md) – Automatically sync source changes during development
+- [Multi-stage builds](/manuals/build/building/multi-stage.md) – Create efficient, production-ready Docker images
 - [Dockerfile best practices](/build/building/best-practices/) – Write clean, secure, and optimized Dockerfiles.
 - [Compose file reference](/compose/compose-file/) – Learn the full syntax and options available for configuring services in `compose.yaml`.
-- [Docker volumes](/storage/volumes/) – Persist and manage data between container runs  
+- [Docker volumes](/storage/volumes/) – Persist and manage data between container runs
 
 ## Next steps
 

--- a/content/guides/reactjs/run-tests.md
+++ b/content/guides/reactjs/run-tests.md
@@ -4,7 +4,6 @@ linkTitle: Run your tests
 weight: 40
 keywords: react.js, react, test, vitest
 description: Learn how to run your React.js tests in a container.
-
 ---
 
 ## Prerequisites
@@ -78,15 +77,16 @@ export default defineConfig({
 
 > [!NOTE]
 > The `test` options in `vitest.config.ts` are essential for reliable testing inside Docker:
-> - `environment: "jsdom"` simulates a browser-like environment for rendering and DOM interactions.  
-> - `setupFiles: "./src/setupTests.ts"` loads global configuration or mocks before each test file (optional but recommended).  
+>
+> - `environment: "jsdom"` simulates a browser-like environment for rendering and DOM interactions.
+> - `setupFiles: "./src/setupTests.ts"` loads global configuration or mocks before each test file (optional but recommended).
 > - `globals: true` enables global test functions like `describe`, `it`, and `expect` without importing them.
 >
 > For more details, see the official [Vitest configuration docs](https://vitest.dev/config/).
 
 ### Step 3: Update compose.yaml
 
-Add a new service named `react-test` to your `compose.yaml` file. This service allows you to run your test suite in an isolated containerized environment.
+Add a new service named `react-test` to your `compose.yaml` file. This service lets you run your test suite in an isolated containerized environment.
 
 ```yaml {hl_lines="22-26",linenos=true}
 services:
@@ -115,11 +115,9 @@ services:
       context: .
       dockerfile: Dockerfile.dev
     command: ["npm", "run", "test"]
-
 ```
 
 The react-test service reuses the same `Dockerfile.dev` used for [development](develop.md) and overrides the default command to run tests with `npm run test`. This setup ensures a consistent test environment that matches your local development configuration.
-
 
 After completing the previous steps, your project directory should contain the following files:
 
@@ -142,6 +140,7 @@ $ docker compose run --rm react-test
 ```
 
 This command will:
+
 - Start the `react-test` service defined in your `compose.yaml` file.
 - Execute the `npm run test` script using the same environment as development.
 - Automatically remove the container after the tests complete [`docker compose run --rm`](/reference/cli/docker/compose/run/) command.
@@ -157,6 +156,7 @@ This command will:
 In this section, you learned how to run unit tests for your React.js application inside a Docker container using Vitest and Docker Compose.
 
 What you accomplished:
+
 - Installed and configured Vitest and React Testing Library for testing React components.
 - Created a `react-test` service in `compose.yaml` to isolate test execution.
 - Reused the development `Dockerfile.dev` to ensure consistency between dev and test environments.
@@ -171,8 +171,9 @@ Explore official references and best practices to sharpen your Docker testing wo
 
 - [Dockerfile reference](/reference/dockerfile/) – Understand all Dockerfile instructions and syntax.
 - [Best practices for writing Dockerfiles](/develop/develop-images/dockerfile_best-practices/) – Write efficient, maintainable, and secure Dockerfiles.
-- [Compose file reference](/compose/compose-file/) – Learn the full syntax and options available for configuring services in `compose.yaml`.  
+- [Compose file reference](/compose/compose-file/) – Learn the full syntax and options available for configuring services in `compose.yaml`.
 - [`docker compose run` CLI reference](/reference/cli/docker/compose/run/) – Run one-off commands in a service container.
+
 ---
 
 ## Next steps

--- a/content/guides/ros2/turtlesim-example.md
+++ b/content/guides/ros2/turtlesim-example.md
@@ -94,7 +94,7 @@ A window should appear on your desktop showing a turtle in a grid.
    $ ros2 run turtlesim turtle_teleop_key
    ```
 
-   This node allows you to control the turtle using your keyboard. Use the arrow keys to move the turtle forward, backward, left, and right. Press `Ctrl+C` to stop the teleop node.
+   This node lets you control the turtle using your keyboard. Use the arrow keys to move the turtle forward, backward, left, and right. Press `Ctrl+C` to stop the teleop node.
 
 2. Move the turtle around the window. You should see it draw a path as it moves.
 

--- a/content/guides/ruby/configure-github-actions.md
+++ b/content/guides/ruby/configure-github-actions.md
@@ -27,7 +27,7 @@ If you didn't create a [GitHub repository](https://github.com/new) for your proj
 
 ## Overview
 
-GitHub Actions is a CI/CD (Continuous Integration and Continuous Deployment) automation tool built into GitHub. It allows you to define custom workflows for building, testing, and deploying your code when specific events occur (e.g., pushing code, creating a pull request, etc.). A workflow is a YAML-based automation script that defines a sequence of steps to be executed when triggered. Workflows are stored in the `.github/workflows/` directory of a repository.
+GitHub Actions is a CI/CD (Continuous Integration and Continuous Deployment) automation tool built into GitHub. It lets you define custom workflows for building, testing, and deploying your code when specific events occur (e.g., pushing code, creating a pull request, etc.). A workflow is a YAML-based automation script that defines a sequence of steps to be executed when triggered. Workflows are stored in the `.github/workflows/` directory of a repository.
 
 In this section, you'll learn how to set up and use GitHub Actions to build your Docker image as well as push it to Docker Hub. You will complete the following steps:
 
@@ -108,4 +108,3 @@ Related information:
 ## Next steps
 
 In the next section, you'll learn how you can develop your application using containers.
-

--- a/content/guides/tensorflowjs.md
+++ b/content/guides/tensorflowjs.md
@@ -37,7 +37,7 @@ perform face detection. In this guide, you'll explore how to:
 ## What is TensorFlow.js?
 
 [TensorFlow.js](https://www.tensorflow.org/js) is an open-source JavaScript
-library for machine learning that enables you to train and deploy ML models in
+library for machine learning that lets you train and deploy ML models in
 the browser or on Node.js. It supports creating new models from scratch or using
 pre-trained models, facilitating a wide range of ML applications directly in web
 environments. TensorFlow.js offers efficient computation, making sophisticated

--- a/content/guides/vuejs/deploy.md
+++ b/content/guides/vuejs/deploy.md
@@ -4,12 +4,12 @@ linkTitle: Test your deployment
 weight: 60
 keywords: deploy, kubernetes, vue, vue.js
 description: Learn how to deploy locally to test and debug your Kubernetes deployment
-
 ---
 
 ## Prerequisites
 
 Before you begin, make sure you’ve completed the following:
+
 - Complete all the previous sections of this guide, starting with [Containerize Vue.js application](containerize.md).
 - [Enable Kubernetes](/manuals/desktop/use-desktop/kubernetes.md#enable-kubernetes) in Docker Desktop.
 
@@ -33,7 +33,6 @@ Follow these steps to define your deployment configuration:
 2. Open the file in your IDE or preferred text editor.
 
 3. Add the following configuration, and be sure to replace `{DOCKER_USERNAME}` and `{DOCKERHUB_PROJECT_NAME}` with your actual Docker Hub username and repository name from the previous [Automate your builds with GitHub Actions](configure-github-actions.md).
-
 
 ```yaml
 apiVersion: apps/v1
@@ -87,7 +86,7 @@ This manifest defines two key Kubernetes resources, separated by `---`:
   (refer to [Automate your builds with GitHub Actions](configure-github-actions.md)).  
   The container listens on port `8080`, which is typically used by [Nginx](https://nginx.org/en/docs/) to serve your production Vue.js app.
 
-- Service (NodePort) 
+- Service (NodePort)
   Exposes the deployed pod to your local machine.  
   It forwards traffic from port `30001` on your host to port `8080` inside the container.  
   This lets you access the application in your browser at [http://localhost:30001](http://localhost:30001).
@@ -115,13 +114,13 @@ If everything is configured properly, you’ll see confirmation that both the De
   deployment.apps/vuejs-sample created
   service/vuejs-sample-service created
 ```
-   
+
 This confirms that both the Deployment and the Service were successfully created and are now running inside your local cluster.
 
 ### Step 2. Check the Deployment status
 
 Run the following command to check the status of your deployment:
-   
+
 ```console
   $ kubectl get deployments
 ```
@@ -174,18 +173,18 @@ Expected output:
 ```
 
 This ensures your cluster stays clean and ready for the next deployment.
-   
+
 ---
 
 ## Summary
 
-In this section, you learned how to deploy your Vue.js application to a local Kubernetes cluster using Docker Desktop. This setup allows you to test and debug your containerized app in a production-like environment before deploying it to the cloud.
+In this section, you learned how to deploy your Vue.js application to a local Kubernetes cluster using Docker Desktop. This setup lets you test and debug your containerized app in a production-like environment before deploying it to the cloud.
 
 What you accomplished:
 
-- Created a Kubernetes Deployment and NodePort Service for your Vue.js app  
-- Used `kubectl apply` to deploy the application locally  
-- Verified the app was running and accessible at `http://localhost:30001`  
+- Created a Kubernetes Deployment and NodePort Service for your Vue.js app
+- Used `kubectl apply` to deploy the application locally
+- Verified the app was running and accessible at `http://localhost:30001`
 - Cleaned up your Kubernetes resources after testing
 
 ---
@@ -194,8 +193,8 @@ What you accomplished:
 
 Explore official references and best practices to sharpen your Kubernetes deployment workflow:
 
-- [Kubernetes documentation](https://kubernetes.io/docs/home/) – Learn about core concepts, workloads, services, and more.  
+- [Kubernetes documentation](https://kubernetes.io/docs/home/) – Learn about core concepts, workloads, services, and more.
 - [Deploy on Kubernetes with Docker Desktop](/manuals) – Use Docker Desktop’s built-in Kubernetes support for local testing and development.
-- [`kubectl` CLI reference](https://kubernetes.io/docs/reference/kubectl/) – Manage Kubernetes clusters from the command line.  
-- [Kubernetes Deployment resource](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/) – Understand how to manage and scale applications using Deployments.  
+- [`kubectl` CLI reference](https://kubernetes.io/docs/reference/kubectl/) – Manage Kubernetes clusters from the command line.
+- [Kubernetes Deployment resource](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/) – Understand how to manage and scale applications using Deployments.
 - [Kubernetes Service resource](https://kubernetes.io/docs/concepts/services-networking/service/) – Learn how to expose your application to internal and external traffic.

--- a/content/guides/vuejs/run-tests.md
+++ b/content/guides/vuejs/run-tests.md
@@ -4,7 +4,6 @@ linkTitle: Run your tests
 weight: 40
 keywords: vue.js, vue, test, vitest
 description: Learn how to run your vue.js tests in a container.
-
 ---
 
 ## Prerequisites
@@ -38,7 +37,7 @@ This test uses Vitest and Vue Test Utils to verify the behavior of the HelloWorl
 
 ### Step 1: Update compose.yaml
 
-Add a new service named `vuejs-test` to your `compose.yaml` file. This service allows you to run your test suite in an isolated containerized environment.
+Add a new service named `vuejs-test` to your `compose.yaml` file. This service lets you run your test suite in an isolated containerized environment.
 
 ```yaml {hl_lines="22-26",linenos=true}
 services:
@@ -61,7 +60,7 @@ services:
         - action: sync
           path: .
           target: /app
-          
+
   vuejs-test:
     build:
       context: .
@@ -70,7 +69,6 @@ services:
 ```
 
 The vuejs-test service reuses the same `Dockerfile.dev` used for [development](develop.md) and overrides the default command to run tests with `npm run test`. This setup ensures a consistent test environment that matches your local development configuration.
-
 
 After completing the previous steps, your project directory should contain the following files:
 
@@ -93,6 +91,7 @@ $ docker compose run --rm vuejs-test
 ```
 
 This command will:
+
 - Start the `vuejs-test` service defined in your `compose.yaml` file.
 - Execute the `npm run test` script using the same environment as development.
 - Automatically remove the container after the tests complete [`docker compose run --rm`](/reference/cli/docker/compose/run/) command.
@@ -117,6 +116,7 @@ Duration:   718ms
 In this section, you learned how to run unit tests for your Vue.js application inside a Docker container using Vitest and Docker Compose.
 
 What you accomplished:
+
 - Created a `vuejs-test` service in `compose.yaml` to isolate test execution.
 - Reused the development `Dockerfile.dev` to ensure consistency between dev and test environments.
 - Ran tests inside the container using `docker compose run --rm vuejs-test`.
@@ -130,8 +130,9 @@ Explore official references and best practices to sharpen your Docker testing wo
 
 - [Dockerfile reference](/reference/dockerfile/) – Understand all Dockerfile instructions and syntax.
 - [Best practices for writing Dockerfiles](/develop/develop-images/dockerfile_best-practices/) – Write efficient, maintainable, and secure Dockerfiles.
-- [Compose file reference](/compose/compose-file/) – Learn the full syntax and options available for configuring services in `compose.yaml`.  
+- [Compose file reference](/compose/compose-file/) – Learn the full syntax and options available for configuring services in `compose.yaml`.
 - [`docker compose run` CLI reference](/reference/cli/docker/compose/run/) – Run one-off commands in a service container.
+
 ---
 
 ## Next steps


### PR DESCRIPTION
Replace "allows you to" and "enables you to" with "lets you" across guides per Vale `Docker.AllowsYouTo` style rule.

Affects 29 files across multiple guide directories: angular, bun, cpp, deno, dotnet, frameworks/laravel, genai-leveraging-rag, go-prometheus-monitoring, golang, localstack, nextjs, php, postgresql, python, r, rag-ollama, reactjs, ros2, ruby, tensorflowjs, and vuejs.