### PR TITLE
docs: remove hedge words from build, desktop, scout, and docker-hub docs

### DIFF
--- a/content/manuals/build/_index.md
+++ b/content/manuals/build/_index.md
@@ -7,44 +7,46 @@ params:
   sidebar:
     group: Open source
 grid:
-- title: Packaging your software
-  description: 'Build and package your application to run it anywhere: locally or
-    in the cloud.'
-  icon: inventory_2
-  link: /build/concepts/overview/
-- title: Multi-stage builds
-  description: Keep your images small and secure with minimal dependencies.
-  icon: stairs
-  link: /build/building/multi-stage/
-- title: Multi-platform images
-  description: Build, push, pull, and run images seamlessly on different computer
-    architectures.
-  icon: content_copy
-  link: /build/building/multi-platform/
-- title: BuildKit
-  description: Explore BuildKit, the open source build engine.
-  icon: construction
-  link: /build/buildkit/
-- title: Build drivers
-  description: Configure where and how you run your builds.
-  icon: engineering
-  link: /build/builders/drivers/
-- title: Exporters
-  description: Export any artifact you like, not just Docker images.
-  icon: output
-  link: /build/exporters/
-- title: Build caching
-  description: Avoid unnecessary repetitions of costly operations, such as package
-    installs.
-  icon: cycle
-  link: /build/cache/
-- title: Bake
-  description: Orchestrate your builds with Bake.
-  icon: cake
-  link: /build/bake/
+  - title: Packaging your software
+    description:
+      "Build and package your application to run it anywhere: locally or
+      in the cloud."
+    icon: inventory_2
+    link: /build/concepts/overview/
+  - title: Multi-stage builds
+    description: Keep your images small and secure with minimal dependencies.
+    icon: stairs
+    link: /build/building/multi-stage/
+  - title: Multi-platform images
+    description: Build, push, pull, and run images on different computer
+      architectures.
+    icon: content_copy
+    link: /build/building/multi-platform/
+  - title: BuildKit
+    description: Explore BuildKit, the open source build engine.
+    icon: construction
+    link: /build/buildkit/
+  - title: Build drivers
+    description: Configure where and how you run your builds.
+    icon: engineering
+    link: /build/builders/drivers/
+  - title: Exporters
+    description: Export any artifact you like, not just Docker images.
+    icon: output
+    link: /build/exporters/
+  - title: Build caching
+    description:
+      Avoid unnecessary repetitions of costly operations, such as package
+      installs.
+    icon: cycle
+    link: /build/cache/
+  - title: Bake
+    description: Orchestrate your builds with Bake.
+    icon: cake
+    link: /build/bake/
 aliases:
-- /buildx/working-with-buildx/
-- /develop/develop-images/build_enhancements/
+  - /buildx/working-with-buildx/
+  - /develop/develop-images/build_enhancements/
 ---
 
 Docker Build is one of Docker Engine's most used features. Whenever you are

--- a/content/manuals/build/bake/contexts.md
+++ b/content/manuals/build/bake/contexts.md
@@ -89,4 +89,4 @@ target "app" {
 
 In most cases you should just use a single multi-stage Dockerfile with multiple
 targets for similar behavior. This case is only recommended when you have
-multiple Dockerfiles that can't be easily merged into one.
+multiple Dockerfiles that can't be merged into one.

--- a/content/manuals/build/bake/introduction.md
+++ b/content/manuals/build/bake/introduction.md
@@ -6,8 +6,7 @@ description: Get started with using Bake to build your project
 keywords: bake, quickstart, build, project, introduction, getting started
 ---
 
-Bake is an abstraction for the `docker build` command that lets you more easily
-manage your build configuration (CLI flags, environment variables, etc.) in a
+Bake is an abstraction for the `docker build` command that lets you manage your build configuration (CLI flags, environment variables, etc.) in a
 consistent way for everyone on your team.
 
 Bake is a command built into the Buildx CLI, so as long as you have Buildx

--- a/content/manuals/build/building/best-practices.md
+++ b/content/manuals/build/building/best-practices.md
@@ -729,7 +729,7 @@ CMD ["postgres"]
 
 This script lets you interact with Postgres in several ways.
 
-It can simply start Postgres:
+It can start Postgres:
 
 ```console
 $ docker run postgres

--- a/content/manuals/build/buildkit/frontend.md
+++ b/content/manuals/build/buildkit/frontend.md
@@ -34,7 +34,7 @@ $ docker build --build-arg BUILDKIT_SYNTAX=docker/dockerfile:1 .
 ```
 
 This defines the location of the Dockerfile syntax that is used to build the
-Dockerfile. The BuildKit backend allows seamlessly using external
+Dockerfile. The BuildKit backend allows using external
 implementations that are distributed as Docker images and execute inside a
 container sandbox environment.
 

--- a/content/manuals/build/cache/garbage-collection.md
+++ b/content/manuals/build/cache/garbage-collection.md
@@ -52,7 +52,7 @@ remainder of 6GB, meaning the 2nd policy does not need to clear any more cache.
 
 The default GC policies are (approximately):
 
-1. Remove cache that can be easily regenerated, such as build contexts from
+1. Remove cache that can be regenerated, such as build contexts from
    local directories or remote Git repositories, and cache mounts, if hasn't
    been used for more than 48 hours.
 2. Remove cache that hasn't been used in a build for more than 60 days.
@@ -171,7 +171,7 @@ following policies:
 > `==`:
 >
 > | `daemon.json`       | `buildkitd.toml`     |
-> |---------------------|----------------------|
+> | ------------------- | -------------------- |
 > | `type=source.local` | `type==source.local` |
 > | `private=true`      | `private==true`      |
 > | `shared=true`       | `shared==true`       |

--- a/content/manuals/desktop/setup/vm-vdi.md
+++ b/content/manuals/desktop/setup/vm-vdi.md
@@ -32,7 +32,7 @@ allowing the Docker CLI and Docker Desktop Dashboard to interact with
 cloud-based resources as if they were local. When you run a container, Docker
 provisions a secure, isolated, and ephemeral cloud environment connected to
 Docker Desktop via an SSH tunnel. Despite running remotely, features like bind
-mounts and port forwarding continue to work seamlessly, providing a local-like
+mounts and port forwarding continue to work, providing a local-like
 experience. To use Docker Offload:
 
 For more information, see the [Docker Offload product

--- a/content/manuals/docker-hub/_index.md
+++ b/content/manuals/docker-hub/_index.md
@@ -7,53 +7,54 @@ params:
   sidebar:
     group: Products
 grid:
-- title: Quickstart
-  description: Step-by-step instructions on getting started on Docker Hub.
-  icon: explore
-  link: /docker-hub/quickstart
-- title: Library
-  description: Explore the content library, featuring millions of images for operating systems, frameworks, databases, and more.
-  icon: book
-  link: /docker-hub/image-library/
-- title: Repositories
-  description: Create a repository to share your images with your team, customers,
-    or the Docker community.
-  icon: inbox
-  link: /docker-hub/repos
-- title: Settings
-  description: Learn about settings in Docker Hub.
-  icon: settings
-  link: /docker-hub/settings
-- title: Organizations
-  description: Learn about organization administration.
-  icon: store
-  link: /admin/
-- title: Usage and limits
-  description: Explore usage limits and how to better utilize Docker Hub.
-  icon: leaderboard
-  link: /docker-hub/usage/
-- title: Release notes
-  description: Find out about new features, improvements, and bug fixes.
-  icon: note_add
-  link: /docker-hub/release-notes
+  - title: Quickstart
+    description: Step-by-step instructions on getting started on Docker Hub.
+    icon: explore
+    link: /docker-hub/quickstart
+  - title: Library
+    description: Explore the content library, featuring millions of images for operating systems, frameworks, databases, and more.
+    icon: book
+    link: /docker-hub/image-library/
+  - title: Repositories
+    description:
+      Create a repository to share your images with your team, customers,
+      or the Docker community.
+    icon: inbox
+    link: /docker-hub/repos
+  - title: Settings
+    description: Learn about settings in Docker Hub.
+    icon: settings
+    link: /docker-hub/settings
+  - title: Organizations
+    description: Learn about organization administration.
+    icon: store
+    link: /admin/
+  - title: Usage and limits
+    description: Explore usage limits and how to better utilize Docker Hub.
+    icon: leaderboard
+    link: /docker-hub/usage/
+  - title: Release notes
+    description: Find out about new features, improvements, and bug fixes.
+    icon: note_add
+    link: /docker-hub/release-notes
 aliases:
   - /docker-hub/overview/
 ---
 
 Docker Hub simplifies development with the world's largest container registry
-for storing, managing, and sharing Docker images. By integrating seamlessly with
+for storing, managing, and sharing Docker images. By integrating with
 your tools, it enhances productivity and ensures reliable deployment,
 distribution, and access to containerized applications. It also provides
 developers with pre-built images and assets to speed up development workflows.
 
 Key features of Docker Hub:
 
-* Unlimited public repositories
-* Private repositories
-* Webhooks to automate workflows
-* GitHub and Bitbucket integrations
-* Concurrent and automated builds
-* Trusted content featuring high-quality, secure images
+- Unlimited public repositories
+- Private repositories
+- Webhooks to automate workflows
+- GitHub and Bitbucket integrations
+- Concurrent and automated builds
+- Trusted content featuring high-quality, secure images
 
 In addition to the graphical interface, you can interact with Docker Hub using
 the [Docker Hub API](../../reference/api/hub/latest.md) or experimental [Docker

--- a/content/manuals/docker-hub/image-library/mirror.md
+++ b/content/manuals/docker-hub/image-library/mirror.md
@@ -1,14 +1,15 @@
 ---
 description: Setting-up a local mirror for Docker Hub images
-keywords: registry, on-prem, images, tags, repository, distribution, mirror, Hub,
+keywords:
+  registry, on-prem, images, tags, repository, distribution, mirror, Hub,
   recipe, advanced
 title: Mirror the Docker Hub library
 linkTitle: Mirror
 weight: 80
 aliases:
-- /engine/admin/registry_mirror/
-- /registry/recipes/mirror/
-- /docker-hub/mirror/
+  - /engine/admin/registry_mirror/
+  - /registry/recipes/mirror/
+  - /docker-hub/mirror/
 ---
 
 ## Use-case
@@ -26,7 +27,7 @@ there, to avoid this extra internet traffic.
 ### Alternatives
 
 Alternatively, if the set of images you are using is well delimited, you can
-simply pull them manually and push them to a simple, local, private registry.
+pull them manually and push them to a simple, local, private registry.
 
 Furthermore, if your images are all built in-house, not using the Hub at all and
 relying entirely on your local registry is the simplest scenario.
@@ -50,11 +51,13 @@ responds to all normal docker pull requests but stores all content locally.
 If Docker Hub access is restricted via your Registry Access Management (RAM) configuration, you will not be able to pull images originating from Docker Hub even if the images are available in your registry mirror.
 
 You will encounter the following error:
+
 ```console
 Error response from daemon: Access to docker.io has been restricted by your administrators.
 ```
 
 If you are unable to allow access to Docker Hub, you can manually pull from your registry mirror and optionally, retag the image. For example:
+
 ```console
 docker pull <your-registry-mirror>[:<port>]/library/busybox
 docker tag <your-registry-mirror>[:<port>]/library/busybox:latest busybox:latest

--- a/content/manuals/docker-hub/image-library/search.md
+++ b/content/manuals/docker-hub/image-library/search.md
@@ -121,8 +121,7 @@ environments. These containerized AI models provide:
 - Pre-trained models: Access ready-to-use machine learning models for common
   tasks such as image recognition, natural language processing, and predictive
   analytics.
-- Model serving: Deploy models as containerized services that can be easily
-  integrated into applications and scaled as needed.
+- Model serving: Deploy models as containerized services that can be integrated into applications and scaled as needed.
 - Reproducible environments: Package models with their dependencies, ensuring
   consistent behavior across development and production environments.
 - Framework support: Find models built with popular frameworks like TensorFlow,
@@ -151,7 +150,6 @@ and workflows.
 
 To learn more about plugins, see [Docker Engine managed plugin
 system](/manuals/engine/extend/_index.md).
-
 
 ### Trusted content
 

--- a/content/manuals/docker-hub/quickstart.md
+++ b/content/manuals/docker-hub/quickstart.md
@@ -74,7 +74,7 @@ To search or browse for content on Docker Hub:
    > [!TIP]
    >
    > The Docker Desktop Dashboard contains a built-in terminal. At the bottom of
-   > the Dashboard, select **>_ Terminal** to open it.
+   > the Dashboard, select **>\_ Terminal** to open it.
 
 2. In the terminal, run the following command.
 
@@ -120,7 +120,6 @@ You can run images from Docker Hub using the CLI or Docker Desktop Dashboard.
 6. In the Docker Desktop Dashboard, select the **Stop** button to stop the
    container.
 
-
 {{< /tab >}}
 {{< tab name="CLI" >}}
 
@@ -129,7 +128,7 @@ You can run images from Docker Hub using the CLI or Docker Desktop Dashboard.
    > [!TIP]
    >
    > The Docker Desktop Dashboard contains a built-in terminal. At the bottom of
-   > the Dashboard, select **>_ Terminal** to open it.
+   > the Dashboard, select **>\_ Terminal** to open it.
 
 2. In your terminal, run the following command to pull and run the Nginx image.
 
@@ -193,7 +192,6 @@ existing software.
 You can also extend images from Docker Hub, letting you quickly build and
 customize your own images to suit specific needs.
 
-
 ## Step 3: Build and push an image to Docker Hub
 
 1. Create a [Dockerfile](/reference/dockerfile.md) to specify your application:
@@ -204,7 +202,7 @@ customize your own images to suit specific needs.
    ```
 
    This Dockerfile extends the Nginx image from Docker Hub to create a
-   simple website. With just a few lines, you can easily set up, customize, and
+   simple website. With just a few lines, you can set up, customize, and
    share a static website using Docker.
 
 2. Run the following command to build your image. Replace `<YOUR-USERNAME>` with your Docker ID.
@@ -255,9 +253,9 @@ customize your own images to suit specific needs.
    $ docker push <YOUR-USERNAME>/nginx-custom
    ```
 
-    > [!NOTE]
-    >
-    > You must be signed in to Docker Hub through Docker Desktop or the command line, and you must also name your images correctly, as per the above steps.
+   > [!NOTE]
+   >
+   > You must be signed in to Docker Hub through Docker Desktop or the command line, and you must also name your images correctly, as per the above steps.
 
    The command pushes the image to Docker Hub and automatically
    creates the repository if it doesn't exist. To learn more about the command,
@@ -279,8 +277,8 @@ customize your own images to suit specific needs.
    latest: digest: sha256:7f5223ae866e725a7f86b856c30edd3b86f60d76694df81d90b08918d8de1e3f size: 1985
    ```
 
-  Now that you've created a repository and pushed your image, it's time to view
-  your repository and explore its options.
+Now that you've created a repository and pushed your image, it's time to view
+your repository and explore its options.
 
 ## Step 4: View your repository on Docker Hub and explore options
 

--- a/content/manuals/docker-hub/repos/manage/information.md
+++ b/content/manuals/docker-hub/repos/manage/information.md
@@ -5,7 +5,7 @@ title: Repository information
 toc_max: 3
 weight: 40
 aliases:
-- /docker-hub/repos/categories/
+  - /docker-hub/repos/categories/
 ---
 
 Each repository can include a description, an overview, and categories to help
@@ -107,7 +107,7 @@ Consider the following repository overview best practices.
 ## Repository categories
 
 You can tag Docker Hub repositories with categories, representing the primary
-intended use cases for your images. This lets users more easily find and
+intended use cases for your images. This lets users find and
 explore content for the problem domain that they're interested in.
 
 ### Available categories

--- a/content/manuals/docker-hub/repos/manage/trusted-content/dvp-program.md
+++ b/content/manuals/docker-hub/repos/manage/trusted-content/dvp-program.md
@@ -2,18 +2,18 @@
 description: Learn what the Docker Verified Publisher Program is and how it works
 title: Docker Verified Publisher Program
 aliases:
-- /docker-hub/publish/publish/
-- /docker-hub/publish/customer_faq/
-- /docker-hub/publish/publisher_faq/
-- /docker-hub/publish/certify-images/
-- /docker-hub/publish/certify-plugins-logging/
-- /docker-hub/publish/trustchain/
-- /docker-hub/publish/byol/
-- /docker-hub/publish/publisher-center-migration/
-- /docker-hub/publish/
-- /docker-hub/publish/repository-logos/
-- /docker-hub/dvp-program/
-- /trusted-content/dvp-program/
+  - /docker-hub/publish/publish/
+  - /docker-hub/publish/customer_faq/
+  - /docker-hub/publish/publisher_faq/
+  - /docker-hub/publish/certify-images/
+  - /docker-hub/publish/certify-plugins-logging/
+  - /docker-hub/publish/trustchain/
+  - /docker-hub/publish/byol/
+  - /docker-hub/publish/publisher-center-migration/
+  - /docker-hub/publish/
+  - /docker-hub/publish/repository-logos/
+  - /docker-hub/dvp-program/
+  - /trusted-content/dvp-program/
 toc_max: 2
 ---
 
@@ -74,7 +74,7 @@ benefits from:
 - Durability: Docker maintains a documented backup policy and performs full
   daily backups of production data.
 
-You simply push your images to Docker Hub as usual, and Docker takes care of the
+Push your images to Docker Hub as usual, and Docker takes care of the
 rest, serving your image to millions of developers worldwide.
 
 ![DVP flow in Docker Hub](./images/dvp-hub-flow.svg)
@@ -152,8 +152,8 @@ Only a user with an owner or editor role for the organization can change the rep
 1. Sign in to [Docker Hub](https://hub.docker.com).
 2. Go to the page of the repository that you want to change the logo for.
 3. Select the upload logo button, represented by a camera icon ({{< inline-image
-   src="../../../images/upload_logo_sm.png" alt="camera icon" >}}) overlaying the
-current repository logo.
+      src="../../../images/upload_logo_sm.png" alt="camera icon" >}}) overlaying the
+   current repository logo.
 4. In the dialog that opens, select the PNG image that you want to upload to
    set it as the logo for the repository.
 

--- a/content/manuals/scout/policy/_index.md
+++ b/content/manuals/scout/policy/_index.md
@@ -37,8 +37,7 @@ In Docker Scout, policies are designed to help you ratchet forward your
 security and supply chain stature. Where other tools focus on providing a pass
 or fail status, Docker Scout policies visualizes how small, incremental changes
 affect policy status, even when your artifacts don't meet the policy
-requirements (yet). By tracking how the fail gap changes over time, you more
-easily see whether your artifact is improving or deteriorating relative to
+requirements (yet). By tracking how the fail gap changes over time, you can see whether your artifact is improving or deteriorating relative to
 policy.
 
 Policies don't necessarily have to be related to application security and
@@ -48,7 +47,7 @@ image up-to-dateness.
 
 ## Policy types
 
-In Docker Scout, a *policy* is derived from a *policy type*. Policy types are
+In Docker Scout, a _policy_ is derived from a _policy type_. Policy types are
 templates that define the core parameters of a policy. You can compare policy
 types to classes in object-oriented programming, with each policy acting as an
 instance created from its corresponding policy type.
@@ -104,6 +103,7 @@ The following policy parameters are configurable in a custom version:
   fail until you've had a chance to address them.
 
 <!-- vale Vale.Spelling = NO -->
+
 - **Severities**: Severity levels to consider (default: `Critical, High`)
 <!-- vale Vale.Spelling = YES -->
 
@@ -184,7 +184,7 @@ The **Supply Chain Attestations** policy type checks whether your images have
 [provenance](/manuals/build/metadata/attestations/slsa-provenance.md) attestations.
 
 Images are considered non-compliant if they lack either an SBOM attestation or
-a provenance attestation with *max mode* provenance. To ensure compliance,
+a provenance attestation with _max mode_ provenance. To ensure compliance,
 update your build command to attach these attestations at build-time:
 
 ```console


### PR DESCRIPTION
Remove Vale-flagged hedge words (`simply`, `easily`, `seamlessly`) across 14 files in build/, desktop/, scout/, and docker-hub/ manuals.

## Changes

- `build/_index.md`: "seamlessly on different computer architectures" → removed "seamlessly"
- `build/bake/introduction.md`: "more easily manage" → "manage"
- `build/bake/contexts.md`: "can't be easily merged" → "can't be merged"
- `build/building/best-practices.md`: "It can simply start Postgres" → "It can start Postgres"
- `build/buildkit/frontend.md`: "allows seamlessly using external" → "allows using external"
- `build/cache/garbage-collection.md`: "can be easily regenerated" → "can be regenerated"
- `desktop/setup/vm-vdi.md`: "continue to work seamlessly" → "continue to work"
- `scout/policy/_index.md`: "you more easily see whether" → "you can see whether"
- `docker-hub/_index.md`: "By integrating seamlessly with" → "By integrating with"
- `docker-hub/image-library/mirror.md`: "you can simply pull them manually" → "you can pull them manually"
- `docker-hub/image-library/search.md`: "can be easily integrated" → "can be integrated"
- `docker-hub/repos/manage/information.md`: "more easily find and explore" → "find and explore"
- `docker-hub/repos/manage/trusted-content/dvp-program.md`: "You simply push your images" → "Push your images"
- `docker-hub/quickstart.md`: "you can easily set up" → "you can set up"

These words are flagged by Vale's `Docker.Hedge` rule. No semantic content was changed.