### PR TITLE
docs: remove hedge words from dhi, offload, and extensions docs

### DIFF
--- a/content/manuals/dhi/_index.md
+++ b/content/manuals/dhi/_index.md
@@ -42,27 +42,27 @@ params:
 Docker Hardened Images (DHI) provide minimal, secure, and production-ready
 container images, Helm charts, and system packages maintained by Docker.
 Designed to reduce vulnerabilities and simplify compliance, DHI integrates
-easily into your existing Docker-based workflows with little to no retooling
+into your existing Docker-based workflows with little to no retooling
 required.
 
 DHI is available in the following three subscriptions.
 
-| Feature | Community | Select | Enterprise |
-|---|---|---|---|
-| Hardened, minimal images | ✅ | ✅ | ✅ |
-| Near-zero CVEs | ✅ | ✅ | ✅ |
-| Verifiable SBOMs & SLSA Build L3 provenance | ✅ | ✅ | ✅ |
-| Full, unsuppressed CVE visibility | ✅ | ✅ | ✅ |
-| Drop-in adoption, no workflow changes | ✅ | ✅ | ✅ |
-| Full catalog of open source images under Apache 2.0 | ✅ | ✅ | ✅ |
-| Built with Docker Hardened System Packages | ✅ | ✅ | ✅ |
-| Upstream cadence for Docker-released patches | ✅ | ✅ | ✅ |
-| FIPS/STIG variants | ❌ | ✅ | ✅ |
-| Critical CVE fixes < 7 days with SLA-backed continuous patching | ❌ | ✅ | ✅ |
-| Customizations | ❌ | Up to 5 | Unlimited |
-| Access to Hardened System Packages repository | ❌ | ❌ | ✅ |
-| Full catalog access available | ❌ | ❌ | ✅ |
-| Extended Lifecycle Support add-on available | ❌ | ❌ | ✅<br><br>Includes:<br>✅ +5 years of hardened updates<br>✅ Maintains security updates after upstream EOL<br>✅ SBOMs & provenance<br>✅ Protects long-lived workloads |
+| Feature                                                         | Community | Select  | Enterprise                                                                                                                                                              |
+| --------------------------------------------------------------- | --------- | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Hardened, minimal images                                        | ✅        | ✅      | ✅                                                                                                                                                                      |
+| Near-zero CVEs                                                  | ✅        | ✅      | ✅                                                                                                                                                                      |
+| Verifiable SBOMs & SLSA Build L3 provenance                     | ✅        | ✅      | ✅                                                                                                                                                                      |
+| Full, unsuppressed CVE visibility                               | ✅        | ✅      | ✅                                                                                                                                                                      |
+| Drop-in adoption, no workflow changes                           | ✅        | ✅      | ✅                                                                                                                                                                      |
+| Full catalog of open source images under Apache 2.0             | ✅        | ✅      | ✅                                                                                                                                                                      |
+| Built with Docker Hardened System Packages                      | ✅        | ✅      | ✅                                                                                                                                                                      |
+| Upstream cadence for Docker-released patches                    | ✅        | ✅      | ✅                                                                                                                                                                      |
+| FIPS/STIG variants                                              | ❌        | ✅      | ✅                                                                                                                                                                      |
+| Critical CVE fixes < 7 days with SLA-backed continuous patching | ❌        | ✅      | ✅                                                                                                                                                                      |
+| Customizations                                                  | ❌        | Up to 5 | Unlimited                                                                                                                                                               |
+| Access to Hardened System Packages repository                   | ❌        | ❌      | ✅                                                                                                                                                                      |
+| Full catalog access available                                   | ❌        | ❌      | ✅                                                                                                                                                                      |
+| Extended Lifecycle Support add-on available                     | ❌        | ❌      | ✅<br><br>Includes:<br>✅ +5 years of hardened updates<br>✅ Maintains security updates after upstream EOL<br>✅ SBOMs & provenance<br>✅ Protects long-lived workloads |
 
 For pricing and more details, see the [Docker Hardened Images subscription
 comparison](https://www.docker.com/products/hardened-images/#compare).
@@ -71,5 +71,6 @@ Explore the sections below to get started with Docker Hardened Images, integrate
 them into your workflow, and learn what makes them secure and enterprise-ready.
 
 {{< grid
-  items="grid_sections"
->}}
+items="grid_sections"
+
+> }}

--- a/content/manuals/dhi/explore/_index.md
+++ b/content/manuals/dhi/explore/_index.md
@@ -43,7 +43,7 @@ aliases:
 
 Docker Hardened Images (DHI) are minimal, secure, and production-ready container
 base and application images maintained by Docker. Designed to reduce
-vulnerabilities and simplify compliance, DHI integrates easily into your
+vulnerabilities and simplify compliance, DHI integrates into your
 existing Docker-based workflows with little to no retooling required.
 
 This section helps you understand what Docker Hardened Images are, how they're
@@ -54,5 +54,6 @@ capabilities, see [Features](/dhi/features/).
 ## Learn more about Docker Hardened Images
 
 {{< grid
-  items="grid_about"
->}}
+items="grid_about"
+
+> }}

--- a/content/manuals/dhi/explore/available.md
+++ b/content/manuals/dhi/explore/available.md
@@ -19,7 +19,7 @@ available images, tags, and metadata from the command line.
 
 DHI includes a selection of popular frameworks and application images, each
 hardened and maintained to ensure security and compliance. These images
-integrate seamlessly into existing workflows, allowing developers to focus on
+integrate into existing workflows, allowing developers to focus on
 building applications without compromising on security.
 
 For example, you might find repositories like the following in the DHI catalog:
@@ -63,13 +63,13 @@ To accommodate different stages of the application lifecycle, DHI offers all
 language framework images and select application images in two variants:
 
 - Development (dev) images: Equipped with necessary development tools and
-libraries, these images facilitate the building and testing of applications in a
-secure environment. They include a shell, package manager, a root user, and
-other tools needed for development.
+  libraries, these images facilitate the building and testing of applications in a
+  secure environment. They include a shell, package manager, a root user, and
+  other tools needed for development.
 
 - Runtime images: Stripped of development tools, these images contain only the
-essential components needed to run applications, ensuring a minimal attack
-surface in production.
+  essential components needed to run applications, ensuring a minimal attack
+  surface in production.
 
 This separation supports multi-stage builds, enabling developers to compile code
 in a secure build environment and deploy it using a lean runtime image.
@@ -95,6 +95,7 @@ environments.
 You can recognize FIPS variants by their tag that includes `-fips`.
 
 For example:
+
 - `3.13-fips`: FIPS variant of the Python 3.13 image
 - `3.9.23-debian12-fips`: FIPS variant of the Debian-based Python 3.9.23 image
 

--- a/content/manuals/dhi/explore/scanner-integrations.md
+++ b/content/manuals/dhi/explore/scanner-integrations.md
@@ -118,7 +118,7 @@ significant limitations:
   CVEs; scanners must implement proprietary feeds rather than using open
   standards that work with all images
 - No transparency: Proprietary feeds act as "black boxes" - vulnerabilities
-  simply disappear from vendor tools with no explanation
+  disappear from vendor tools with no explanation
 - Limited verifiability: Security teams have no way to independently verify
   why vulnerabilities are excluded or whether the reasoning is sound
 - Maintenance challenges: If you scan older image versions with standard
@@ -171,4 +171,3 @@ exceptions. This requires:
 
 Learn how to [scan Docker Hardened Images](/manuals/dhi/how-to/scan.md) with
 VEX-compliant scanners.
-

--- a/content/manuals/dhi/explore/test.md
+++ b/content/manuals/dhi/explore/test.md
@@ -37,7 +37,7 @@ Each DHI undergoes rigorous checks to meet the following standards:
   ensure they are free from known Common Vulnerabilities and Exposures (CVEs).
 - Multi-architecture support: DHIs are built for multiple architectures
   (`linux/amd64` and `linux/arm64`) to ensure broad compatibility.
-- Kubernetes compatibility: Images are tested to run seamlessly within
+- Kubernetes compatibility: Images are tested to run within
   Kubernetes clusters, ensuring they meet the requirements for container
   orchestration environments.
 
@@ -101,23 +101,23 @@ You can view and verify this attestation using the Docker Scout CLI.
 
    Example output:
 
-    ```console
-        v SBOM obtained from attestation, 101 packages found
-        v Provenance obtained from attestation
-        {
-          "reportFormat": "CTRF",
-          "results": {
-            "summary": {
-              "failed": 0,
-              "passed": 1,
-              "skipped": 0,
-              "start": 1749216533,
-              "stop": 1749216574,
-              "tests": 1
-            },
-            "tests": [
-              {
-                ...
+   ```console
+       v SBOM obtained from attestation, 101 packages found
+       v Provenance obtained from attestation
+       {
+         "reportFormat": "CTRF",
+         "results": {
+           "summary": {
+             "failed": 0,
+             "passed": 1,
+             "skipped": 0,
+             "start": 1749216533,
+             "stop": 1749216574,
+             "tests": 1
+           },
+           "tests": [
+             {
+               ...
    ```
 
 2. Verify the test attestation signature. To ensure the attestation is authentic
@@ -131,7 +131,7 @@ You can view and verify this attestation using the Docker Scout CLI.
    ```
 
    Example output:
-   
+
    ```console
     v SBOM obtained from attestation, 101 packages found
     v Provenance obtained from attestation
@@ -146,7 +146,7 @@ You can view and verify this attestation using the Docker Scout CLI.
 
     i Signature payload
     ...
-    ```
+   ```
 
 If the attestation is valid, Docker Scout will confirm the signature and show
 the matching `cosign verify` command.

--- a/content/manuals/dhi/features.md
+++ b/content/manuals/dhi/features.md
@@ -14,7 +14,7 @@ aliases:
 
 Docker Hardened Images (DHI) are minimal, secure, and production-ready container
 base and application images maintained by Docker. Designed to reduce
-vulnerabilities and simplify compliance, DHI integrates easily into your
+vulnerabilities and simplify compliance, DHI integrates into your
 existing Docker-based workflows with little to no retooling required.
 
 DHI provides security for everyone:
@@ -70,7 +70,7 @@ Every image includes complete, verifiable security metadata:
 - Familiar foundations: Built on Alpine and Debian, requiring minimal changes to adopt
 - glibc and musl support: Available in both variants for broad application compatibility
 - Development and runtime variants: Use dev images for building, minimal runtime images for production
-- Drop-in compatibility: Works seamlessly with existing Docker workflows, CI/CD pipelines, and tools
+- Drop-in compatibility: Works with existing Docker workflows, CI/CD pipelines, and tools
 
 ### Continuous maintenance
 

--- a/content/manuals/extensions/extensions-sdk/design/design-guidelines.md
+++ b/content/manuals/extensions/extensions-sdk/design/design-guidelines.md
@@ -3,18 +3,18 @@ title: Design guidelines for Docker extensions
 linkTitle: Guidelines
 description: Docker extension design
 keywords: Docker, extensions, design
-aliases: 
- - /desktop/extensions-sdk/design/design-guidelines/
+aliases:
+  - /desktop/extensions-sdk/design/design-guidelines/
 weight: 10
 ---
 
 At Docker, we aim to build tools that integrate into a user's existing workflows rather than requiring them to adopt new ones. We strongly recommend that you follow these guidelines when creating extensions. We review and approve your Marketplace publication based on these requirements.
 
 Here is a simple checklist to go through when creating your extension:
+
 - Is it easy to get started?
 - Is it easy to use?
 - Is it easy to get help when needed?
-
 
 ## Create a consistent experience with Docker Desktop
 
@@ -32,7 +32,7 @@ Use the [Docker Material UI Theme](https://www.npmjs.com/package/@docker/docker-
 
   ![Header that sets the context](images/header.webp)
 
-- Avoid embedding terminal windows. The advantage we have with Docker Desktop over the CLI is that we have the opportunity to provide rich information to users. Make use of this interface as much as possible. 
+- Avoid embedding terminal windows. The advantage we have with Docker Desktop over the CLI is that we have the opportunity to provide rich information to users. Make use of this interface as much as possible.
 
   ![Terminal window used incorrectly](images/terminal_window_dont.webp)
 
@@ -58,10 +58,10 @@ Use the [Docker Material UI Theme](https://www.npmjs.com/package/@docker/docker-
 
 ## Onboarding new users
 
-When creating your extension, ensure that first time users of the extension and your product can understand its value-add and adopt it easily. Ensure you include contextual help within the extension.
+When creating your extension, ensure that first time users of the extension and your product can understand its value-add and adopt it. Ensure you include contextual help within the extension.
 
 - Ensure that all necessary information is added to the extensions Marketplace as well as the extensions detail page. This should include:
-  - Screenshots of the extension. Note that the recommended size for screenshots is 2400x1600 pixels. 
+  - Screenshots of the extension. Note that the recommended size for screenshots is 2400x1600 pixels.
   - A detailed description that covers what the purpose of the extension is, who would find it useful and how it works.
   - Link to necessary resources such as documentation.
 - If your extension has particularly complex functionality, add a demo or video to the start page. This helps onboard a first time user quickly.

--- a/content/manuals/offload/about.md
+++ b/content/manuals/offload/about.md
@@ -58,7 +58,7 @@ using environments such as virtual desktops, cloud-hosted development machines,
 or older hardware.
 
 Despite running remotely, features like bind mounts and port forwarding continue
-to work seamlessly, providing a local-like experience from within Docker Desktop
+to work, providing a local-like experience from within Docker Desktop
 and the CLI.
 
 ### Cloud resources


### PR DESCRIPTION
Remove Vale-flagged hedge words (`simply`, `easily`, `seamlessly`) across 8 files in dhi/, offload/, and extensions/ manuals.

## Changes

- `dhi/features.md`: "integrates easily into your" → "integrates into your"; "Works seamlessly with" → "Works with"
- `dhi/_index.md`: "integrates easily into your" → "integrates into your"
- `dhi/explore/_index.md`: "integrates easily into your" → "integrates into your"
- `dhi/explore/test.md`: "tested to run seamlessly within" → "tested to run within"
- `dhi/explore/available.md`: "integrate seamlessly into existing workflows" → "integrate into existing workflows"
- `dhi/explore/scanner-integrations.md`: "simply disappear from vendor tools" → "disappear from vendor tools"
- `offload/about.md`: "continue to work seamlessly, providing" → "continue to work, providing"
- `extensions/extensions-sdk/design/design-guidelines.md`: "adopt it easily" → "adopt it"

These words are flagged by Vale's `Docker.Hedge` rule. No semantic content was changed.