### PR TITLE
docs: document sbx mount/umount for running sandboxes

### DIFF
--- a/content/manuals/ai/sandboxes/usage.md
+++ b/content/manuals/ai/sandboxes/usage.md
@@ -228,8 +228,9 @@ $ sbx rm <sandbox-name>       # when finished
 
 Extra workspaces passed to `sbx run` are fixed at create time. To expose an
 additional host path to a sandbox that's already running — without stopping or
-recreating it — use `sbx mount`. The mount spec follows the same
-`HOST[:CONTAINER_TARGET[:ro|rw]]` form as `docker run -v`:
+recreating it — use `sbx mount`. The mount spec takes a shape similar to
+Docker's `-v` flag, `HOST[:PATH[:ro|rw]]`, where `PATH` is a location inside
+the sandbox:
 
 ```console
 $ sbx mount my-sandbox /Users/me/extra-data
@@ -239,8 +240,8 @@ With a host path alone, the directory becomes visible inside the sandbox under
 `/mnt/host/`, mirroring the host path — in this example,
 `/mnt/host/Users/me/extra-data`.
 
-To bind the host path to a specific location inside the sandbox, append a
-container target. The target must be an absolute path:
+To bind the host path to a specific location inside the sandbox, append that
+path. It must be absolute:
 
 ```console
 $ sbx mount my-sandbox /Users/me/extra-data:/workspace/data
@@ -259,8 +260,8 @@ re-running the same command is a no-op. The same
 [filesystem rules](governance/concepts.md#filesystem-rules) that govern
 create-time mounts are enforced here, so a path your policy denies is rejected.
 
-To revoke a path, use `sbx umount`. If you bound the path to a container target,
-pass the same target back to also remove the bind mount inside the sandbox:
+To revoke a path, use `sbx umount`. If you bound the path to a location inside
+the sandbox, pass that same path back to also remove the bind mount:
 
 ```console
 $ sbx umount my-sandbox /Users/me/extra-data                 # drop the host path

--- a/content/manuals/ai/sandboxes/usage.md
+++ b/content/manuals/ai/sandboxes/usage.md
@@ -224,6 +224,54 @@ $ sbx run claude ~/project-b
 $ sbx rm <sandbox-name>       # when finished
 ```
 
+## Mounting host paths into a running sandbox
+
+Extra workspaces passed to `sbx run` are fixed at create time. To expose an
+additional host path to a sandbox that's already running — without stopping or
+recreating it — use `sbx mount`. The mount spec follows the same
+`HOST[:CONTAINER_TARGET[:ro|rw]]` form as `docker run -v`:
+
+```console
+$ sbx mount my-sandbox /Users/me/extra-data
+```
+
+With a host path alone, the directory becomes visible inside the sandbox under
+`/mnt/host/`, mirroring the host path — in this example,
+`/mnt/host/Users/me/extra-data`.
+
+To bind the host path to a specific location inside the sandbox, append a
+container target. The target must be an absolute path:
+
+```console
+$ sbx mount my-sandbox /Users/me/extra-data:/workspace/data
+```
+
+Mounts are read-write by default. Append `:ro` to mount read-only — writes from
+inside the sandbox then fail with a "read-only file system" error:
+
+```console
+$ sbx mount my-sandbox /Users/me/extra-data:/workspace/data:ro
+```
+
+The host path must exist. Relative host paths are resolved against your current
+directory before being sent to the sandbox. Mount operations are idempotent, so
+re-running the same command is a no-op. The same
+[filesystem rules](governance/concepts.md#filesystem-rules) that govern
+create-time mounts are enforced here, so a path your policy denies is rejected.
+
+To revoke a path, use `sbx umount`. If you bound the path to a container target,
+pass the same target back to also remove the bind mount inside the sandbox:
+
+```console
+$ sbx umount my-sandbox /Users/me/extra-data                 # drop the host path
+$ sbx umount my-sandbox /Users/me/extra-data:/workspace/data # also remove the bind mount
+```
+
+A host path with no target revokes only the exposed path. Like `sbx mount`,
+`sbx umount` is idempotent — revoking a path that was never mounted succeeds
+without error. Both commands operate on the live container, so the sandbox must
+be running.
+
 ## Copying files between host and sandbox
 
 Use [`sbx cp`](/reference/cli/sbx/cp/) to copy files or directories between

--- a/content/manuals/ai/sandboxes/usage.md
+++ b/content/manuals/ai/sandboxes/usage.md
@@ -229,8 +229,8 @@ $ sbx rm <sandbox-name>       # when finished
 Extra workspaces passed to `sbx run` are fixed at create time. To expose an
 additional host path to a sandbox that's already running — without stopping or
 recreating it — use `sbx mount`. The mount spec takes a shape similar to
-Docker's `-v` flag, `HOST[:PATH[:ro|rw]]`, where `PATH` is a location inside
-the sandbox:
+Docker's `-v` flag, `HOST_PATH[:PATH[:ro|rw]]`, where `HOST_PATH` is the path
+on your machine and `PATH` is a location inside the sandbox:
 
 ```console
 $ sbx mount my-sandbox /Users/me/extra-data


### PR DESCRIPTION
Documents `sbx mount` / `sbx umount`, which expose host paths into an
already-running sandbox at runtime — without stopping or recreating it — using
a `docker run -v`-style spec (`HOST[:CONTAINER_TARGET[:ro|rw]]`).

Upstream change: [docker/sandboxes#3542](https://github.com/docker/sandboxes/pull/3542)

## What's added

A new **Mounting host paths into a running sandbox** section in
`content/manuals/ai/sandboxes/usage.md` covering:

- Allowlist-only mounts (`HOST`), visible under `/mnt/host/`
- Bind mounts at an absolute container target (`HOST:CONTAINER_TARGET`)
- Read-only mounts (`:ro`, enforced at the kernel mount layer)
- Idempotency, the host-path-must-exist rule, and relative-path resolution
- Filesystem policy enforcement, cross-linked to the governance concepts page
- Revoking paths with `sbx umount` (and passing the target back to unbind)

## Notes

- The `sbx mount` / `sbx umount` CLI reference pages
  (`/reference/cli/sbx/mount/`, `.../umount/`) are generated from the vendored
  `data/sbx_cli/` YAML, which is synced from `docker/sandboxes` at release time.
  They'll appear automatically once the release that ships these commands is
  vendored, so this PR intentionally doesn't hand-add those files or link to
  the not-yet-generated pages.
- Opened as a **draft** to land alongside the release that ships the feature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
