### PR TITLE
Clarify Model Runner replica count behavior

### DIFF
--- a/content/manuals/compose/bridge/use-model-runner.md
+++ b/content/manuals/compose/bridge/use-model-runner.md
@@ -88,4 +88,4 @@ When `modelRunner.enabled` is `true`, Compose Bridge uses the generated manifest
 The `modelRunner.enabled` setting also determines the number of replicas for the `model-runner-deployment`:
 
 - When `true`, the deployment replica count is set to 1, and Docker Model Runner is deployed in the Kubernetes cluster.
-- When `false`, the replica count is 0, and no Docker Model Runner resources are deployed.
+- When `false`, the Kubernetes deployment replica count is 0, so no in-cluster Docker Model Runner is deployed. On Docker Desktop, Compose Bridge instead configures workloads to connect to the Docker Model Runner instance running on the host.


### PR DESCRIPTION
## Description

Clarifies the behavior of `modelRunner.enabled=false` by distinguishing
between the Kubernetes deployment and the Docker Desktop host instance.

Updates the replica count explanation to specify that no in-cluster Docker
Model Runner is deployed when the deployment replica count is `0`, while
Docker Desktop workloads continue to connect to the host Model Runner.

## Related issues or tickets

Fixes #25485

## Reviews

- [x] Technical review
- [ ] Editorial review
- [ ] Product review