### PR TITLE
compose: note that secrets require Linux containers

### DIFF
--- a/content/manuals/compose/how-tos/use-secrets.md
+++ b/content/manuals/compose/how-tos/use-secrets.md
@@ -21,7 +21,7 @@ Secrets are mounted as a file in `/run/secrets/<secret_name>` inside the contain
 
 > [!NOTE]
 >
-> Secrets are supported on Linux containers only. Compose delivers each secret by bind-mounting a single file into the container, and Windows containers support bind-mounting directories only. For Windows containers, bind-mount a directory containing the secret file instead.
+> Secrets are supported on Linux containers only. Compose delivers each secret by bind-mounting a single file into the container, and Windows containers support bind-mounting directories only.
 
 Getting a secret into a container is a two-step process. First, define the secret using the [top-level secrets element in your Compose file](/reference/compose-file/secrets.md). Next, update your service definitions to reference the secrets they require with the [secrets attribute](/reference/compose-file/services.md#secrets). Compose grants access to secrets on a per-service basis.
 

--- a/content/manuals/compose/how-tos/use-secrets.md
+++ b/content/manuals/compose/how-tos/use-secrets.md
@@ -19,6 +19,10 @@ Environment variables are often available to all processes, and it can be diffic
 
 Secrets are mounted as a file in `/run/secrets/<secret_name>` inside the container.
 
+> [!NOTE]
+>
+> Secrets are supported on Linux containers only. Compose delivers each secret by bind-mounting a single file into the container, and Windows containers support bind-mounting directories only. For Windows containers, bind-mount a directory containing the secret file instead.
+
 Getting a secret into a container is a two-step process. First, define the secret using the [top-level secrets element in your Compose file](/reference/compose-file/secrets.md). Next, update your service definitions to reference the secrets they require with the [secrets attribute](/reference/compose-file/services.md#secrets). Compose grants access to secrets on a per-service basis.
 
 Unlike the other methods, this permits granular access control within a service container via standard filesystem permissions.


### PR DESCRIPTION
### Description

Adds a NOTE callout to the Compose secrets guide stating that secrets are supported on Linux containers only, with the reason.

The page states secrets are delivered as a bind mount at `/run/secrets/<secret_name>`, with no platform caveat. On Windows containers this fails at container creation:

```
invalid mount config for type "bind": source path must be a directory
```

Windows containers can't bind-mount a single file, only directories — a platform limitation confirmed by maintainers in moby/moby#37120 and docker/cli#2055. Because Compose secrets are single-file bind mounts, they can't work on Windows containers.

Tested on a Windows Server 2025 container (`mcr.microsoft.com/windows/server:ltsc2025`), Hyper-V isolation, Docker 29.6.1, Compose v2.

Fixes #25540

### Related issues or tickets

- #25540
- moby/moby#37120
- docker/cli#2055

### Reviews

- [ ] Technical review
- [ ] Editorial review
