### PR TITLE
docs: fix broken privileged helper link in release notes

### DIFF
--- a/content/manuals/desktop/release-notes.md
+++ b/content/manuals/desktop/release-notes.md
@@ -2583,7 +2583,7 @@ For more information, see [microsoft/WSL#11794](https://github.com/microsoft/WSL
 #### For Windows
 
 - Fixed an issue on the WSL 2 engine where Docker Desktop would not detect the existence of the `docker-desktop-data` distribution if it had been manually moved by the user.
-- The Windows on ARM installer and the [privileged service](/manuals/desktop/setup/install/windows-permission-requirements.md#privileged-helper) are now built for ARM64.
+- The Windows on ARM installer and the [privileged service](/desktop/setup/install/windows-install/#privileged-helper) are now built for ARM64.
 
 #### For Mac
 


### PR DESCRIPTION
## Summary

Fixes a broken documentation link in the Docker Desktop release notes.

The previous link pointed to an outdated internal path:

`/manuals/desktop/setup/install/windows-permission-requirements.md#privileged-helper`

which resulted in a 404 on the published docs site.

It has been updated to:

`/desktop/setup/install/windows-install/#privileged-helper`

which points to the current **Privileged helper** section in the Windows installation documentation.
