### PR TITLE
build: document driver and image store support for attestations

### DIFF
--- a/content/manuals/build/metadata/attestations/_index.md
+++ b/content/manuals/build/metadata/attestations/_index.md
@@ -65,6 +65,39 @@ You can also disable default provenance attestations by setting the
 environment variable. See [Provenance attestation](./slsa-provenance.md) for
 more details about provenance modes and options.
 
+### Driver and image store support
+
+Attestations attach to an image index. The classic image store doesn't support
+image indices, so it can't hold an image with attestations.
+
+The default `docker` driver builds with the BuildKit library bundled into the
+Docker daemon, and writes the result to the daemon's image store. If the daemon
+still uses the classic image store, the build fails:
+
+```text
+ERROR: failed to build: Attestation is not supported for the docker driver.
+Switch to a different driver, or turn on the containerd image store, and try again.
+```
+
+To build attestations with the `docker` driver, turn on the containerd image
+store. See [containerd image store with Docker Desktop](/manuals/desktop/features/containerd.md)
+or [containerd image store with Docker Engine](/manuals/engine/storage/containerd.md).
+
+| Driver                    | Attestation support                 |
+| :------------------------ | :---------------------------------- |
+| `docker`                  | Requires the containerd image store |
+| `docker-container`        | Supported                           |
+| `kubernetes` and `remote` | Supported                           |
+
+The `docker-container`, `kubernetes`, and `remote` drivers run BuildKit outside
+the Docker daemon, so they build attestations regardless of which image store
+the daemon uses. Pushing the result to a registry with `--push` keeps the
+attestations. If you load the result into the daemon with `--load` instead, the
+same image store requirement applies.
+
+If you don't want to switch image stores or drivers, opt out of attestations
+with `--provenance=false --sbom=false`.
+
 ## Storage
 
 BuildKit produces attestations in the [in-toto format](https://github.com/in-toto/attestation),


### PR DESCRIPTION
## Description

The build attestations page states that "All BuildKit exporters support attestations", but never mentions that the default `docker` driver rejects attestations while the daemon still uses the classic image store. That combination is what Docker Engine 29 errors on, and the error's `Learn more` link (`/go/attestations/`, mapped to `/build/attestations/` in `data/redirects.yml:222-223`) lands on exactly this page, which today has no answer.

This adds a `Driver and image store support` subsection under `Creating attestations` in `content/manuals/build/metadata/attestations/_index.md`:

- Attestations attach to an image index, and the classic image store doesn't support image indices, so it can't hold an image with attestations.
- With the default `docker` driver on the classic image store, the build fails; the exact engine error string is quoted.
- How to fix it: turn on the containerd image store, with links to `/manuals/desktop/features/containerd.md` and `/manuals/engine/storage/containerd.md`.
- A compact 3-row driver support table (`docker`, `docker-container`, `kubernetes` and `remote`).
- A note that `docker-container`, `kubernetes`, and `remote` run BuildKit outside the daemon, that `--push` keeps attestations, and that `--load` runs into the same image store requirement.
- An opt-out line (`--provenance=false --sbom=false`).

The `local`/`tar` exporter behavior is already covered under `Storage`, so that section is untouched. One file changed, 33 insertions, no deletions.

## Sources

Both claims are already documented elsewhere in this repository and are reused verbatim rather than invented:

- `content/manuals/desktop/features/containerd.md` (Classic image store): "It doesn't support image indices or manifest lists, so you can't load multi-platform images locally or build images with attestations."
- `content/manuals/dhi/how-to/scan.md:225`: "Without the containerd image store, Docker Engine rejects the build with: `Attestation is not supported for the docker driver. Switch to a different driver, or turn on the containerd image store, and try again.`" — the error text in the new section is copied from this in-repo string, matching the one in the issue report.
- Driver descriptions match `content/manuals/build/builders/drivers/_index.md` ("`docker`: uses the BuildKit library bundled into the Docker daemon").

## Validation

- `markdownlint-cli@0.45.0` (the version pinned in the repo `Dockerfile` lint stage) on the changed file: 0 issues.
- `vale` 3.16.0 with the repo's `.vale.ini` and `_vale/` styles on the changed file: 0 errors, 0 warnings, 0 suggestions.
- `prettier@3.8.1` (repo-pinned version) check on the changed file: passes, formatting unchanged elsewhere in the file.
- Both new link targets exist in the tree: `content/manuals/desktop/features/containerd.md`, `content/manuals/engine/storage/containerd.md`.
- htmltest and the Hugo build were not run locally (they require the Docker-based bake targets, and no daemon was available in this environment).

## Related issues or tickets

Fixes #25599

## Reviews

- [ ] Technical review
- [ ] Editorial review
- [ ] Product review

