### PR TITLE
docs: remove linked containers restart policy note

### DIFF
--- a/content/manuals/engine/containers/start-containers-automatically.md
+++ b/content/manuals/engine/containers/start-containers-automatically.md
@@ -12,7 +12,7 @@ aliases:
 
 Docker provides [restart policies](/reference/cli/docker/container/run/#restart)
 to control whether your containers start automatically when they exit, or when
-Docker restarts. Restart policies start linked containers in the correct order.
+Docker restarts.
 Docker recommends that you use restart policies, and avoid using process
 managers to start containers.
 


### PR DESCRIPTION
## Description

Remove a misleading sentence from the restart policy documentation that says restart policies start linked containers in the correct order.

Restart policies are container-level behavior, and the phrase "linked containers" can be confused with the legacy `--link` feature.

## Related issues or tickets

Closes #25684

## Reviews

- [ ] Technical review
- [ ] Editorial review
- [ ] Product review