### PR TITLE
docs: remove obsolete Docker Desktop product name

### DIFF
--- a/content/manuals/desktop/enterprise/_index.md
+++ b/content/manuals/desktop/enterprise/_index.md
@@ -9,7 +9,7 @@ aliases:
 - /desktop/enterprise/admin/configure/windows-admin/
 ---
 
-Docker Desktop Enterprise (DDE) has been deprecated and is no longer in active development. Use [Docker Desktop](../_index.md) instead.
+Docker Desktop Enterprise (DDE) has been deprecated and is no longer in active development. Use [Docker Desktop](/manuals/enterprise/enterprise-deployment/_index.md) instead.
 
 If you are an existing DDE customer, use the [Support form](https://hub.docker.com/support/desktop/) to request a transition to one of the new [subscriptions](https://www.docker.com/pricing?ref=Docs&refAction=DocsDesktopEnterprise).
 

--- a/content/manuals/desktop/enterprise/_index.md
+++ b/content/manuals/desktop/enterprise/_index.md
@@ -9,7 +9,7 @@ aliases:
 - /desktop/enterprise/admin/configure/windows-admin/
 ---
 
-Docker Desktop Enterprise (DDE) has been deprecated and is no longer in active development. Please use [Docker Desktop](../_index.md) Community instead.
+Docker Desktop Enterprise (DDE) has been deprecated and is no longer in active development. Please use [Docker Desktop](../_index.md) instead.
 
 If you are an existing DDE customer, use the [Support form](https://hub.docker.com/support/desktop/) to request a transition to one of the new [subscriptions](https://www.docker.com/pricing?ref=Docs&refAction=DocsDesktopEnterprise).
 

--- a/content/manuals/desktop/enterprise/_index.md
+++ b/content/manuals/desktop/enterprise/_index.md
@@ -9,7 +9,7 @@ aliases:
 - /desktop/enterprise/admin/configure/windows-admin/
 ---
 
-Docker Desktop Enterprise (DDE) has been deprecated and is no longer in active development. Please use [Docker Desktop](../_index.md) instead.
+Docker Desktop Enterprise (DDE) has been deprecated and is no longer in active development. Use [Docker Desktop](../_index.md) instead.
 
 If you are an existing DDE customer, use the [Support form](https://hub.docker.com/support/desktop/) to request a transition to one of the new [subscriptions](https://www.docker.com/pricing?ref=Docs&refAction=DocsDesktopEnterprise).
 


### PR DESCRIPTION
Fixes #25691

The Docker Desktop Enterprise deprecation notice called the current product “Docker Desktop Community.” Update the sentence to use the current product name, Docker Desktop. This keeps the notice aligned with the product terminology used throughout the docs and pricing pages.

Validation:
- `scripts/lint.sh content/manuals/desktop/enterprise/_index.md` (markdownlint passes; Vale unavailable locally)