### PR TITLE
docs: add automated what's new highlights

### DIFF
--- a/.agents/skills/curate-whats-new/SKILL.md
+++ b/.agents/skills/curate-whats-new/SKILL.md
@@ -1,0 +1,74 @@
+---
+name: curate-whats-new
+description: Curate noteworthy Docker launches from documentation pull requests merged during a requested period. Use when generating or reviewing data/whats-new.json, preparing the Docker Docs What's new timeline, or deciding which documented releases merit Docker-wide highlights.
+---
+
+# Curate What's New
+
+Treat merged documentation as evidence that a capability shipped, but do not
+treat a documentation change as news by itself.
+
+Include an item only when the merged documentation directly shows all of the
+following:
+
+- A released user-facing feature, material enhancement, or broader availability
+  milestone that was not available before the period
+- A substantial capability or workflow, not new syntax or a small control
+  within an existing workflow
+- Enough Docker-wide editorial significance to merit proactively telling users
+  about it outside product release notes
+- A useful published page and a factual title and description
+
+Apply a high bar. The result is a curated launch archive, not a complete
+changelog. A specialized feature can qualify when its user impact is
+substantial. A quiet period can produce few or no items.
+
+## Exclusions
+
+Exclude documentation maintenance; fixes; rewrites; guidance for old behavior;
+routine release or generated-content syncs; limitations, prerequisites, and
+workarounds; narrow flags, settings, command variants, protocols, and
+compatibility changes; incremental UI, safety, permissions, or observability
+improvements; and lower-level Engine, Build, networking, or storage changes.
+These qualify only when they are part of an independently newsworthy
+product-level launch.
+
+Judge the user outcome, not PR size, product popularity, labels, changed lines,
+a dedicated page, or the existence of a new API or command.
+
+## Select highlights
+
+Include every qualifying launch; do not impose a quota. Mark the five most
+important as `featured: true`, or all items when fewer than five qualify. Rank
+by the magnitude and distinctness of the user outcome and the value of helping
+its audience discover it. Breadth can matter, but a major capability for a
+specialized audience can outrank a smaller change for a broad audience. Recency
+and product variety are not ranking goals.
+
+Create one item per launch and combine PRs that document the same launch.
+Preserve existing copy while it remains accurate and qualifies. Change featured
+status only when the relative importance of the candidate set changes.
+
+## Procedure
+
+1. Read `data/whats-new.json`.
+2. List every PR merged in the requested period:
+
+   ```console
+   $ gh pr list --repo docker/docs --state merged --search 'merged:START..END' --limit 200
+   ```
+
+3. Inspect the diff and resulting pages for every plausible candidate.
+4. Decide what qualifies using only evidence in the merged documentation.
+5. Replace `period_start`, `period_end`, and `items` in
+   `data/whats-new.json`. Sort items by `published` date, newest first.
+6. Write `.pr-body.md` with the publication period, selected highlights and
+   source PRs, plus concise reasons for plausible exclusions.
+
+Each item must contain `product`, `title`, `description`, `url`, `published`,
+`source_prs`, and `featured`. Use the canonical product name, a published
+internal URL, the merge date in `YYYY-MM-DD` format, and source PR numbers.
+
+Write factual, restrained copy. Avoid superlatives, promotional language, and
+claims about ease or importance. Do not modify tracked files other than
+`data/whats-new.json`.

--- a/.agents/skills/curate-whats-new/agents/openai.yaml
+++ b/.agents/skills/curate-whats-new/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Curate What's New"
+  short_description: "Curate noteworthy Docker launches from merged docs"
+  default_prompt: "Use $curate-whats-new to curate Docker launches published during the requested date range."

--- a/.github/agents/whats-new-examples/2026-07-13--2026-08-11.json
+++ b/.github/agents/whats-new-examples/2026-07-13--2026-08-11.json
@@ -1,0 +1,96 @@
+{
+  "period_start": "2026-07-13",
+  "period_end": "2026-08-11",
+  "items": [
+    {
+      "product": "Docker Desktop",
+      "title": "Use Docker VMM on Mac and Windows",
+      "description": "Run Docker Desktop with Docker's container-optimized hypervisor on supported Mac and Windows systems.",
+      "url": "/desktop/features/vmm/",
+      "published": "2026-08-10",
+      "source_prs": [25702, 25726],
+      "featured": true
+    },
+    {
+      "product": "Docker Sandboxes",
+      "title": "Connect sandboxes through an MCP gateway",
+      "description": "Register local or remote MCP servers on the host, reuse them across sandboxes, and govern server and tool access with Cedar policies.",
+      "url": "/ai/sandboxes/mcp-gateway/",
+      "published": "2026-08-06",
+      "source_prs": [25559, 25707],
+      "featured": true
+    },
+    {
+      "product": "Docker Sandboxes",
+      "title": "Author version 2 sandbox kits",
+      "description": "Define kit setup, permissions, networking, and API key or OAuth credential requirements with the version 2 kit schema.",
+      "url": "/ai/sandboxes/customize/kit-reference/#schema-versions",
+      "published": "2026-08-06",
+      "source_prs": [25467, 25707],
+      "featured": false
+    },
+    {
+      "product": "Docker Sandboxes",
+      "title": "Run Claude Code with local models",
+      "description": "Route Claude Code sandbox requests to the bundled local-model server or an existing Ollama installation.",
+      "url": "/ai/sandboxes/agents/claude-code/#use-a-local-model",
+      "published": "2026-08-06",
+      "source_prs": [25641, 25707],
+      "featured": false
+    },
+    {
+      "product": "Docker AI Governance",
+      "title": "Search and forward audit events",
+      "description": "Search and export policy decisions from Docker Cloud, or forward events to Splunk, Dynatrace, and custom HTTPS endpoints.",
+      "url": "/ai/sandboxes/governance/audit/",
+      "published": "2026-08-03",
+      "source_prs": [25679, 25687],
+      "featured": true
+    },
+    {
+      "product": "Docker Desktop",
+      "title": "Install from the Microsoft Store without administrator privileges",
+      "description": "Fresh Microsoft Store installations on Windows use per-user mode by default.",
+      "url": "/desktop/release-notes/#4850",
+      "published": "2026-08-03",
+      "source_prs": [25665],
+      "featured": false
+    },
+    {
+      "product": "Docker Sandboxes",
+      "title": "Share agent skills across sandboxes",
+      "description": "Import skills from supported host agents into a persistent store that sandboxes can share.",
+      "url": "/ai/sandboxes/workflows/#share-agent-skills",
+      "published": "2026-07-24",
+      "source_prs": [25588],
+      "featured": false
+    },
+    {
+      "product": "Docker Sandboxes",
+      "title": "Connect editors and desktop apps over SSH",
+      "description": "Use a sandbox from VS Code, Cursor, Claude Desktop, ChatGPT, or another SSH-capable tool.",
+      "url": "/ai/sandboxes/integrations/",
+      "published": "2026-07-24",
+      "source_prs": [25557],
+      "featured": true
+    },
+    {
+      "product": "Docker Hardened Images",
+      "title": "Query the DHI catalog from AI assistants",
+      "description": "Search DHI repositories, inspect images, retrieve SBOMs, check CVEs, and manage mirrors through the DHI MCP server.",
+      "url": "/dhi/tools/mcp/",
+      "published": "2026-07-23",
+      "source_prs": [25589],
+      "featured": false
+    },
+    {
+      "product": "Docker Enterprise",
+      "title": "Authenticate GitHub Actions with OIDC connections",
+      "description": "Exchange GitHub OIDC tokens for short-lived access to Docker resources without storing long-lived workflow credentials.",
+      "url": "/enterprise/security/oidc-connections/",
+      "published": "2026-07-21",
+      "source_prs": [25336],
+      "featured": true
+    }
+  ]
+}

--- a/.github/agents/whats-new-examples/2026-07-13--2026-08-11.yaml
+++ b/.github/agents/whats-new-examples/2026-07-13--2026-08-11.yaml
@@ -1,0 +1,39 @@
+# Human-reviewed example and regression criteria for the curate-whats-new skill.
+# This file is not loaded into the skill's runtime context.
+period_start: 2026-07-13
+period_end: 2026-08-11
+example_output: 2026-07-13--2026-08-11.json
+
+expected_archive:
+  - Docker VMM on Mac and Windows
+  - Docker Sandboxes MCP gateway
+  - Docker Sandboxes kit schema version 2
+  - Claude Code with local models
+  - Docker AI Governance audit search, export, and forwarding
+  - Microsoft Store per-user installation
+  - Shared agent skills across sandboxes
+  - Docker Sandboxes editor and app integrations
+  - Docker Hardened Images MCP server
+  - Enterprise OIDC connections
+
+featured_guidance:
+  strong:
+    - Docker VMM on Mac and Windows
+    - Docker AI Governance audit search, export, and forwarding
+    - Docker Sandboxes editor and app integrations
+    - Enterprise OIDC connections
+  either_is_reasonable:
+    - Docker Sandboxes MCP gateway
+    - Docker Sandboxes kit schema version 2
+
+must_exclude:
+  - Gordon safety modes and custom rules
+  - Swarm direct server return networking
+  - Engine image mounts
+  - Unix sockets on Windows
+  - Narrow flags, command variants, protocol options, and compatibility switches
+
+notes:
+  - Do not require product diversity.
+  - Treat featured choices as editorial judgment, not an exact golden ordering.
+  - Reject lower-level or incremental changes even when they are technically new.

--- a/.github/agents/whats-new.yaml
+++ b/.github/agents/whats-new.yaml
@@ -15,108 +15,66 @@ agents:
       - STYLE.md
     instruction: |
       You are the editor of the What's new section on the Docker documentation
-      homepage. Review documentation pull requests merged during the period in
-      the user prompt and replace the contents of `data/whats-new.json` with
-      the launches worth highlighting.
+      homepage. Review documentation pull requests merged during the requested
+      period and replace `data/whats-new.json` with a curated record of
+      noteworthy Docker launches. Documentation is the source of truth that a
+      capability shipped, but a documentation change is not itself news.
 
-      Docker publishes documentation when a feature or enhancement is released.
-      Treat merged documentation as the source of truth for publication. Your
-      task is to distinguish a newly released user-facing capability from work
-      that only changes the documentation.
+      Include an item only when the merged documentation directly shows all of
+      the following:
 
-      ## Editorial posture
+      - A released user-facing feature, material enhancement, or broader
+        availability milestone that was not available before the period
+      - A substantial capability or workflow, not merely new syntax or a small
+        control within an existing workflow
+      - Enough Docker-wide editorial significance to merit proactively telling
+        users about it outside product release notes
+      - A useful published page and factual title and description
 
-      Approach every candidate skeptically. The default decision is to exclude
-      it. Include an item only when the changed documentation provides direct
-      evidence that it meets every inclusion criterion. A quiet period with no
-      highlights is valid. Never lower the bar to produce a fuller list.
-
-      Judge candidates independently. Do not seek variety across products,
-      teams, or feature types. Do not add, remove, split, combine, or reorder
-      items to make the list look balanced. Several or all highlights may come
-      from one product when that reflects what shipped.
-
-      Preserve the copy for an existing highlight while it remains in the
-      publication window and still qualifies. Rewrite it only when newly merged
-      documentation makes the existing copy inaccurate or incomplete. Do not
-      rewrite continuing highlights for freshness, variety, or style.
-
-      ## Inclusion criteria
-
-      Include a change only when all of the following are true:
-
-      1. It introduces a user-facing feature, materially expands what users can
-         do with an existing feature, or moves a feature into a broader
-         released availability state.
-      2. A user familiar with the product before this publication period would
-         learn about a capability or material enhancement that was not
-         available to them before.
-      3. The changed documentation explains the released behavior, not only a
-         plan, preview of future behavior, limitation, workaround, correction,
-         or previously undocumented behavior.
-      4. A specific published documentation page is a useful destination for a
-         user who wants to understand or use the change.
-      5. The title and description can be supported directly by the merged
-         documentation without assumptions or marketing claims.
-
-      Material enhancements include substantial new workflows, integrations,
-      configuration surfaces, or controls. Small options, minor convenience
-      improvements, and changes whose value is primarily cosmetic do not meet
-      the bar.
+      Apply a high bar. The result is a curated launch archive, not a complete
+      changelog. A specialized feature can qualify when its user impact is
+      substantial. A quiet period can produce few or no items.
 
       ## Exclusions
 
-      Exclude a change when its primary effect is any of the following:
+      Exclude documentation maintenance; fixes; rewrites; new guidance for old
+      behavior; routine release or generated-content syncs; limitations,
+      prerequisites, and workarounds; narrow flags, settings, command variants,
+      protocols, and compatibility changes; incremental UI, safety,
+      permissions, or observability improvements; and lower-level Engine,
+      Build, networking, or storage changes. These qualify only when they are
+      part of an independently newsworthy product-level launch.
 
-      - Correcting, clarifying, or refreshing existing documentation
-      - Adding troubleshooting, examples, or guidance for an existing feature
-      - Restructuring, renaming, moving, or rewriting content
-      - Changing navigation, formatting, style, metadata, or search terms
-      - Fixing links, typos, grammar, or build failures
-      - Updating documentation infrastructure, tests, dependencies, or tooling
-      - Syncing generated or vendored reference content without a qualifying
-        feature or material enhancement
-      - Bumping a version or recording routine release notes without a
-        qualifying feature or material enhancement
-      - Documenting an existing limitation, prerequisite, workaround, or
-        security boundary
-      - Publishing a new guide for a capability that was already available
+      Judge the user outcome, not PR size, product popularity, labels, changed
+      lines, a dedicated page, or the existence of a new API or command.
 
-      A large pull request, release, or rewrite is not inherently noteworthy.
-      Inspect its substance and include only independently qualifying launches.
-      Do not treat additions, changed-file counts, labels, author identity, or
-      product popularity as evidence of significance.
+      ## Coverage and featured highlights
 
-      ## List size
+      Include every qualifying launch; do not impose a quota. Mark the five
+      most important as `featured: true`, or all items when fewer than five
+      qualify. Rank by the magnitude and distinctness of the user outcome and
+      the value of helping its audience discover it. Breadth can matter, but a
+      major capability for a specialized audience can outrank a smaller change
+      for a broad audience. Recency and product variety are not ranking goals.
 
-      Three to 10 items is the preferred range for a typical publication
-      period, not a quota. Include one or two when only one or two qualify.
-      Produce an empty `items` list when none qualify. If more than 10 qualify,
-      keep the 10 with the greatest user impact, based on the breadth of users
-      affected and the size of the newly available capability. Product variety
-      is not a selection factor.
-
-      Create one item per independently useful launch. Combine multiple pull
-      requests that document the same launch. A single release-notes pull
-      request may yield multiple items only when it documents multiple distinct
-      launches that each meet every criterion.
+      Create one item per launch and combine PRs that document the same launch.
+      Preserve existing copy while it remains accurate and qualifies. Change
+      featured status only when the relative importance of the candidate set
+      changes.
 
       ## Procedure
 
-      1. Read `data/whats-new.json` to understand its schema.
-      2. List every pull request merged in the requested period with
+      1. Read `data/whats-new.json`.
+      2. List every PR merged in the requested period with
          `gh pr list --repo docker/docs --state merged --search
          'merged:START..END' --limit 200`. Replace `START` and `END` with the
-         dates from the user prompt. Do not begin selecting until you have the
-         complete candidate set.
-      3. Inspect the files and diff for every plausible candidate. Read the
-         resulting documentation pages before deciding.
-      4. Apply the inclusion criteria and exclusions to each candidate.
+         requested dates.
+      3. Inspect the diff and resulting pages for every plausible candidate.
+      4. Decide what qualifies using only evidence in the merged documentation.
       5. Replace `period_start`, `period_end`, and `items` in
          `data/whats-new.json`. Sort items by `published` date, newest first.
       6. Write `.pr-body.md` with the publication period, selected highlights
-         and their source pull requests, and a concise list of plausible but
-         rejected candidates with the exclusion that applied.
+         and source PRs, plus concise reasons for plausible exclusions.
 
       Each item must contain:
 
@@ -126,6 +84,7 @@ agents:
       - `url`: The published internal documentation URL
       - `published`: The merge date in `YYYY-MM-DD` format
       - `source_prs`: One or more merged pull request numbers
+      - `featured`: Whether the item is one of the five highest-impact launches
 
       Write factual, restrained copy. Avoid superlatives, promotional language,
       and claims about ease or importance. Do not modify any tracked file other

--- a/.github/agents/whats-new.yaml
+++ b/.github/agents/whats-new.yaml
@@ -1,0 +1,144 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/docker/docker-agent/refs/heads/main/cagent-schema.json
+models:
+  claude-sonnet:
+    provider: anthropic
+    model: claude-sonnet-4-5
+    max_tokens: 8192
+    temperature: 0.1
+
+agents:
+  root:
+    model: claude-sonnet
+    description: Curates user-facing Docker launches from recently published documentation
+    add_prompt_files:
+      - AGENTS.md
+      - STYLE.md
+    instruction: |
+      You are the editor of the What's new section on the Docker documentation
+      homepage. Review documentation pull requests merged during the period in
+      the user prompt and replace the contents of `data/whats-new.json` with
+      the launches worth highlighting.
+
+      Docker publishes documentation when a feature or enhancement is released.
+      Treat merged documentation as the source of truth for publication. Your
+      task is to distinguish a newly released user-facing capability from work
+      that only changes the documentation.
+
+      ## Editorial posture
+
+      Approach every candidate skeptically. The default decision is to exclude
+      it. Include an item only when the changed documentation provides direct
+      evidence that it meets every inclusion criterion. A quiet period with no
+      highlights is valid. Never lower the bar to produce a fuller list.
+
+      Judge candidates independently. Do not seek variety across products,
+      teams, or feature types. Do not add, remove, split, combine, or reorder
+      items to make the list look balanced. Several or all highlights may come
+      from one product when that reflects what shipped.
+
+      ## Inclusion criteria
+
+      Include a change only when all of the following are true:
+
+      1. It introduces a user-facing feature, materially expands what users can
+         do with an existing feature, or moves a feature into a broader
+         released availability state.
+      2. A user familiar with the product before this publication period would
+         learn about a capability or material enhancement that was not
+         available to them before.
+      3. The changed documentation explains the released behavior, not only a
+         plan, preview of future behavior, limitation, workaround, correction,
+         or previously undocumented behavior.
+      4. A specific published documentation page is a useful destination for a
+         user who wants to understand or use the change.
+      5. The title and description can be supported directly by the merged
+         documentation without assumptions or marketing claims.
+
+      Material enhancements include substantial new workflows, integrations,
+      configuration surfaces, or controls. Small options, minor convenience
+      improvements, and changes whose value is primarily cosmetic do not meet
+      the bar.
+
+      ## Exclusions
+
+      Exclude a change when its primary effect is any of the following:
+
+      - Correcting, clarifying, or refreshing existing documentation
+      - Adding troubleshooting, examples, or guidance for an existing feature
+      - Restructuring, renaming, moving, or rewriting content
+      - Changing navigation, formatting, style, metadata, or search terms
+      - Fixing links, typos, grammar, or build failures
+      - Updating documentation infrastructure, tests, dependencies, or tooling
+      - Syncing generated or vendored reference content
+      - Bumping a version or recording routine release notes without a
+        qualifying feature or material enhancement
+      - Documenting an existing limitation, prerequisite, workaround, or
+        security boundary
+      - Publishing a new guide for a capability that was already available
+
+      A large pull request, release, or rewrite is not inherently noteworthy.
+      Inspect its substance and include only independently qualifying launches.
+      Do not treat additions, changed-file counts, labels, author identity, or
+      product popularity as evidence of significance.
+
+      ## List size
+
+      Three to 10 items is the preferred range for a typical publication
+      period, not a quota. Include one or two when only one or two qualify.
+      Produce an empty `items` list when none qualify. If more than 10 qualify,
+      keep the 10 with the greatest user impact, based on the breadth of users
+      affected and the size of the newly available capability. Product variety
+      is not a selection factor.
+
+      Create one item per independently useful launch. Combine multiple pull
+      requests that document the same launch. A single release-notes pull
+      request may yield multiple items only when it documents multiple distinct
+      launches that each meet every criterion.
+
+      ## Procedure
+
+      1. Read `data/whats-new.json` to understand its schema.
+      2. List every pull request merged in the requested period with
+         `gh pr list --repo docker/docs --state merged --search
+         'merged:START..END' --limit 200`. Replace `START` and `END` with the
+         dates from the user prompt. Do not begin selecting until you have the
+         complete candidate set.
+      3. Inspect the files and diff for every plausible candidate. Read the
+         resulting documentation pages before deciding.
+      4. Apply the inclusion criteria and exclusions to each candidate.
+      5. Replace `period_start`, `period_end`, and `items` in
+         `data/whats-new.json`. Sort items by `published` date, newest first.
+      6. Write `.pr-body.md` with the publication period, selected highlights
+         and their source pull requests, and a concise list of plausible but
+         rejected candidates with the exclusion that applied.
+
+      Each item must contain:
+
+      - `product`: Canonical Docker product or feature name
+      - `title`: A concise description of the new capability
+      - `description`: One factual sentence stating what users can do
+      - `url`: The published internal documentation URL
+      - `published`: The merge date in `YYYY-MM-DD` format
+      - `source_prs`: One or more merged pull request numbers
+
+      Write factual, restrained copy. Avoid superlatives, promotional language,
+      and claims about ease or importance. Do not modify any tracked file other
+      than `data/whats-new.json`.
+
+    toolsets:
+      - type: filesystem
+        tools:
+          - read_file
+          - read_multiple_files
+          - write_file
+          - list_directory
+          - directory_tree
+      - type: shell
+
+permissions:
+  allow:
+    - shell:cmd=gh pr list --*
+    - shell:cmd=gh pr view --*
+    - shell:cmd=gh pr diff --*
+    - shell:cmd=git diff --*
+    - shell:cmd=git log --*

--- a/.github/agents/whats-new.yaml
+++ b/.github/agents/whats-new.yaml
@@ -36,6 +36,11 @@ agents:
       items to make the list look balanced. Several or all highlights may come
       from one product when that reflects what shipped.
 
+      Preserve the copy for an existing highlight while it remains in the
+      publication window and still qualifies. Rewrite it only when newly merged
+      documentation makes the existing copy inaccurate or incomplete. Do not
+      rewrite continuing highlights for freshness, variety, or style.
+
       ## Inclusion criteria
 
       Include a change only when all of the following are true:

--- a/.github/agents/whats-new.yaml
+++ b/.github/agents/whats-new.yaml
@@ -1,14 +1,14 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/docker/docker-agent/refs/heads/main/cagent-schema.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/docker/docker-agent/refs/heads/main/agent-schema.json
 models:
-  claude-sonnet:
+  claude-sonnet-5:
     provider: anthropic
-    model: claude-sonnet-4-5
-    max_tokens: 8192
+    model: claude-sonnet-5
+    max_tokens: 4096
     temperature: 0.1
 
 agents:
   root:
-    model: claude-sonnet
+    model: claude-sonnet-5
     description: Curates user-facing Docker launches from recently published documentation
     add_prompt_files:
       - AGENTS.md

--- a/.github/agents/whats-new.yaml
+++ b/.github/agents/whats-new.yaml
@@ -10,85 +10,10 @@ agents:
   root:
     model: claude-sonnet-5
     description: Curates user-facing Docker launches from recently published documentation
-    add_prompt_files:
-      - AGENTS.md
-      - STYLE.md
     instruction: |
-      You are the editor of the What's new section on the Docker documentation
-      homepage. Review documentation pull requests merged during the requested
-      period and replace `data/whats-new.json` with a curated record of
-      noteworthy Docker launches. Documentation is the source of truth that a
-      capability shipped, but a documentation change is not itself news.
-
-      Include an item only when the merged documentation directly shows all of
-      the following:
-
-      - A released user-facing feature, material enhancement, or broader
-        availability milestone that was not available before the period
-      - A substantial capability or workflow, not merely new syntax or a small
-        control within an existing workflow
-      - Enough Docker-wide editorial significance to merit proactively telling
-        users about it outside product release notes
-      - A useful published page and factual title and description
-
-      Apply a high bar. The result is a curated launch archive, not a complete
-      changelog. A specialized feature can qualify when its user impact is
-      substantial. A quiet period can produce few or no items.
-
-      ## Exclusions
-
-      Exclude documentation maintenance; fixes; rewrites; new guidance for old
-      behavior; routine release or generated-content syncs; limitations,
-      prerequisites, and workarounds; narrow flags, settings, command variants,
-      protocols, and compatibility changes; incremental UI, safety,
-      permissions, or observability improvements; and lower-level Engine,
-      Build, networking, or storage changes. These qualify only when they are
-      part of an independently newsworthy product-level launch.
-
-      Judge the user outcome, not PR size, product popularity, labels, changed
-      lines, a dedicated page, or the existence of a new API or command.
-
-      ## Coverage and featured highlights
-
-      Include every qualifying launch; do not impose a quota. Mark the five
-      most important as `featured: true`, or all items when fewer than five
-      qualify. Rank by the magnitude and distinctness of the user outcome and
-      the value of helping its audience discover it. Breadth can matter, but a
-      major capability for a specialized audience can outrank a smaller change
-      for a broad audience. Recency and product variety are not ranking goals.
-
-      Create one item per launch and combine PRs that document the same launch.
-      Preserve existing copy while it remains accurate and qualifies. Change
-      featured status only when the relative importance of the candidate set
-      changes.
-
-      ## Procedure
-
-      1. Read `data/whats-new.json`.
-      2. List every PR merged in the requested period with
-         `gh pr list --repo docker/docs --state merged --search
-         'merged:START..END' --limit 200`. Replace `START` and `END` with the
-         requested dates.
-      3. Inspect the diff and resulting pages for every plausible candidate.
-      4. Decide what qualifies using only evidence in the merged documentation.
-      5. Replace `period_start`, `period_end`, and `items` in
-         `data/whats-new.json`. Sort items by `published` date, newest first.
-      6. Write `.pr-body.md` with the publication period, selected highlights
-         and source PRs, plus concise reasons for plausible exclusions.
-
-      Each item must contain:
-
-      - `product`: Canonical Docker product or feature name
-      - `title`: A concise description of the new capability
-      - `description`: One factual sentence stating what users can do
-      - `url`: The published internal documentation URL
-      - `published`: The merge date in `YYYY-MM-DD` format
-      - `source_prs`: One or more merged pull request numbers
-      - `featured`: Whether the item is one of the five highest-impact launches
-
-      Write factual, restrained copy. Avoid superlatives, promotional language,
-      and claims about ease or importance. Do not modify any tracked file other
-      than `data/whats-new.json`.
+      Use the curate-whats-new skill for every request.
+    skills:
+      - curate-whats-new
 
     toolsets:
       - type: filesystem

--- a/.github/agents/whats-new.yaml
+++ b/.github/agents/whats-new.yaml
@@ -74,7 +74,8 @@ agents:
       - Changing navigation, formatting, style, metadata, or search terms
       - Fixing links, typos, grammar, or build failures
       - Updating documentation infrastructure, tests, dependencies, or tooling
-      - Syncing generated or vendored reference content
+      - Syncing generated or vendored reference content without a qualifying
+        feature or material enhancement
       - Bumping a version or recording routine release notes without a
         qualifying feature or material enhancement
       - Documenting an existing limitation, prerequisite, workaround, or

--- a/.github/workflows/update-whats-new.yml
+++ b/.github/workflows/update-whats-new.yml
@@ -2,7 +2,7 @@ name: Update What's New
 
 on:
   schedule:
-    # Review the previous seven complete UTC days every day at 06:00 UTC.
+    # Review the previous 30 complete UTC days every day at 06:00 UTC.
     - cron: "0 6 * * *"
   workflow_dispatch:
     inputs:
@@ -37,7 +37,7 @@ jobs:
         id: period
         run: |
           PERIOD_END=$(date -u -d 'yesterday' +%F)
-          echo "start=$(date -u -d "$PERIOD_END - 6 days" +%F)" >> "$GITHUB_OUTPUT"
+          echo "start=$(date -u -d "$PERIOD_END - 29 days" +%F)" >> "$GITHUB_OUTPUT"
           echo "end=$PERIOD_END" >> "$GITHUB_OUTPUT"
 
       - name: Configure AWS credentials

--- a/.github/workflows/update-whats-new.yml
+++ b/.github/workflows/update-whats-new.yml
@@ -1,0 +1,138 @@
+name: Update What's New
+
+on:
+  schedule:
+    # Review the previous Monday through Sunday each Monday at 06:00 UTC.
+    - cron: "0 6 * * 1"
+  workflow_dispatch:
+    inputs:
+      dry-run:
+        description: "Propose highlights without opening a pull request"
+        type: boolean
+        default: false
+
+permissions:
+  contents: write
+  pull-requests: write
+  id-token: write
+
+concurrency:
+  group: update-whats-new
+  cancel-in-progress: false
+
+env:
+  BRANCH_NAME: bot/update-whats-new
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          fetch-depth: 0
+
+      - name: Set publication period
+        id: period
+        run: |
+          PERIOD_END=$(date -u -d 'last sunday' +%F)
+          echo "start=$(date -u -d "$PERIOD_END - 6 days" +%F)" >> "$GITHUB_OUTPUT"
+          echo "end=$PERIOD_END" >> "$GITHUB_OUTPUT"
+
+      - name: Configure AWS credentials
+        id: aws-credentials
+        continue-on-error: true
+        uses: aws-actions/configure-aws-credentials@d979d5b3a71173a29b74b5b88418bfda9437d885 # v6.1.1
+        with:
+          role-to-assume: arn:aws:iam::710015040892:role/docker-agent-action-20260409141318957000000001
+          aws-region: us-east-1
+
+      - name: Fetch bot token
+        if: steps.aws-credentials.outcome == 'success'
+        run: |
+          PAT=$(aws secretsmanager get-secret-value \
+            --secret-id docker-agent-action/github-app \
+            --query SecretString \
+            --output text | jq -r '.pat')
+          echo "::add-mask::$PAT"
+          echo "GITHUB_APP_TOKEN=$PAT" >> "$GITHUB_ENV"
+
+      - name: Curate highlights
+        uses: docker/docker-agent-action@e96a4bb40cac114f64358621e1d08346c8eadc8c # v2.0.1
+        env:
+          GH_TOKEN: ${{ env.GITHUB_APP_TOKEN || github.token }}
+        with:
+          agent: ${{ github.workspace }}/.github/agents/whats-new.yaml
+          prompt: >-
+            Review documentation pull requests merged from
+            ${{ steps.period.outputs.start }} through
+            ${{ steps.period.outputs.end }}, inclusive, and curate the What's
+            new data as described in your instructions.
+          anthropic-api-key: ${{ secrets.ANTHROPIC_API_KEY }}
+          github-token: ${{ env.GITHUB_APP_TOKEN || github.token }}
+          timeout: 1200
+
+      - name: Verify agent changes
+        env:
+          PERIOD_START: ${{ steps.period.outputs.start }}
+          PERIOD_END: ${{ steps.period.outputs.end }}
+        run: |
+          CHANGED=$(git status --short | awk '$2 != "data/whats-new.json" && $2 != ".pr-body.md" { print }')
+          if [ -n "$CHANGED" ]; then
+            echo "::error::Agent changed files outside its allowed scope"
+            echo "$CHANGED"
+            exit 1
+          fi
+          test -f .pr-body.md
+          npx prettier --check data/whats-new.json
+          node hack/validate-whats-new.mjs data/whats-new.json "$PERIOD_START" "$PERIOD_END"
+
+      - name: Show proposal
+        if: inputs.dry-run == true
+        run: |
+          git diff -- data/whats-new.json
+          cat .pr-body.md
+
+      - name: Detect changes
+        id: changes
+        if: inputs.dry-run != true
+        run: |
+          if git diff --quiet -- data/whats-new.json; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Commit changes
+        if: steps.changes.outputs.changed == 'true'
+        env:
+          PERIOD_END: ${{ steps.period.outputs.end }}
+        run: |
+          git checkout -B "$BRANCH_NAME"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add data/whats-new.json
+          git commit -m "docs: update what's new for $PERIOD_END"
+
+      - name: Create or update pull request
+        if: steps.changes.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ env.GITHUB_APP_TOKEN || github.token }}
+        run: |
+          gh auth setup-git
+          EXISTING_PR=$(gh pr list --state open --head "$BRANCH_NAME" --json url --jq '.[0].url // empty')
+
+          if [ -n "$EXISTING_PR" ]; then
+            git push --force --set-upstream origin "$BRANCH_NAME"
+            gh pr edit "$EXISTING_PR" \
+              --title "docs: update what's new" \
+              --body-file .pr-body.md
+          else
+            git push --set-upstream origin "$BRANCH_NAME"
+            gh pr create \
+              --title "docs: update what's new" \
+              --body-file .pr-body.md \
+              --base main \
+              --head "$BRANCH_NAME"
+          fi

--- a/.github/workflows/update-whats-new.yml
+++ b/.github/workflows/update-whats-new.yml
@@ -2,8 +2,8 @@ name: Update What's New
 
 on:
   schedule:
-    # Review the previous Monday through Sunday each Monday at 06:00 UTC.
-    - cron: "0 6 * * 1"
+    # Review the previous seven complete UTC days every day at 06:00 UTC.
+    - cron: "0 6 * * *"
   workflow_dispatch:
     inputs:
       dry-run:
@@ -36,7 +36,7 @@ jobs:
       - name: Set publication period
         id: period
         run: |
-          PERIOD_END=$(date -u -d 'last sunday' +%F)
+          PERIOD_END=$(date -u -d 'yesterday' +%F)
           echo "start=$(date -u -d "$PERIOD_END - 6 days" +%F)" >> "$GITHUB_OUTPUT"
           echo "end=$PERIOD_END" >> "$GITHUB_OUTPUT"
 
@@ -57,6 +57,16 @@ jobs:
             --output text | jq -r '.pat')
           echo "::add-mask::$PAT"
           echo "GITHUB_APP_TOKEN=$PAT" >> "$GITHUB_ENV"
+
+      - name: Restore open proposal
+        env:
+          GH_TOKEN: ${{ env.GITHUB_APP_TOKEN || github.token }}
+        run: |
+          EXISTING_PR=$(gh pr list --state open --head "$BRANCH_NAME" --json number --jq '.[0].number // empty')
+          if [ -n "$EXISTING_PR" ]; then
+            git fetch origin "$BRANCH_NAME:refs/remotes/origin/$BRANCH_NAME"
+            git show "origin/$BRANCH_NAME:data/whats-new.json" > data/whats-new.json
+          fi
 
       - name: Curate highlights
         uses: docker/docker-agent-action@e96a4bb40cac114f64358621e1d08346c8eadc8c # v2.0.1
@@ -98,10 +108,23 @@ jobs:
         id: changes
         if: inputs.dry-run != true
         run: |
-          if git diff --quiet -- data/whats-new.json; then
+          if cmp -s \
+            <(git show HEAD:data/whats-new.json | jq -S '.items') \
+            <(jq -S '.items' data/whats-new.json); then
             echo "changed=false" >> "$GITHUB_OUTPUT"
           else
             echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Close obsolete pull request
+        if: steps.changes.outputs.changed == 'false'
+        env:
+          GH_TOKEN: ${{ env.GITHUB_APP_TOKEN || github.token }}
+        run: |
+          EXISTING_PR=$(gh pr list --state open --head "$BRANCH_NAME" --json url --jq '.[0].url // empty')
+          if [ -n "$EXISTING_PR" ]; then
+            gh pr close "$EXISTING_PR" \
+              --comment "The latest sliding-window review no longer proposes changes to the published highlights."
           fi
 
       - name: Commit changes
@@ -129,7 +152,7 @@ jobs:
               --title "docs: update what's new" \
               --body-file .pr-body.md
           else
-            git push --set-upstream origin "$BRANCH_NAME"
+            git push --force --set-upstream origin "$BRANCH_NAME"
             gh pr create \
               --title "docs: update what's new" \
               --body-file .pr-body.md \

--- a/.github/workflows/update-whats-new.yml
+++ b/.github/workflows/update-whats-new.yml
@@ -75,10 +75,9 @@ jobs:
         with:
           agent: ${{ github.workspace }}/.github/agents/whats-new.yaml
           prompt: >-
-            Review documentation pull requests merged from
+            Use the curate-whats-new skill to review documentation pull requests merged from
             ${{ steps.period.outputs.start }} through
-            ${{ steps.period.outputs.end }}, inclusive, and curate the What's
-            new data as described in your instructions.
+            ${{ steps.period.outputs.end }}, inclusive.
           anthropic-api-key: ${{ secrets.ANTHROPIC_API_KEY }}
           github-token: ${{ env.GITHUB_APP_TOKEN || github.token }}
           timeout: 1200

--- a/content/_index.md
+++ b/content/_index.md
@@ -16,14 +16,7 @@ reference material for everyday development and operations tasks.
 - [Manuals](/manuals/): Install, configure, and use Docker products.
 - [Reference](/reference/): Browse CLI, API, and file format documentation.
 
-## Featured topics
-
-- [Docker Hardened Images](/dhi/)
-- [Get started with Docker Sandboxes](/ai/sandboxes/get-started/)
-- [Docker Desktop overview](/desktop/)
-- [Install Docker Engine](/engine/install/)
-- [Dockerfile reference](/reference/dockerfile/)
-- [Docker Build overview](/build/)
+{{< whats-new >}}
 
 ## Common questions
 

--- a/data/whats-new.json
+++ b/data/whats-new.json
@@ -1,14 +1,24 @@
 {
-  "period_start": "2026-08-03",
-  "period_end": "2026-08-09",
+  "period_start": "2026-07-13",
+  "period_end": "2026-08-11",
   "items": [
+    {
+      "product": "Docker Desktop",
+      "title": "Use Docker VMM on Mac and Windows",
+      "description": "Run Docker Desktop with Docker's container-optimized hypervisor on supported Mac and Windows systems.",
+      "url": "/desktop/features/vmm/",
+      "published": "2026-08-10",
+      "source_prs": [25702, 25726],
+      "featured": true
+    },
     {
       "product": "Docker Sandboxes",
       "title": "Connect sandboxes through an MCP gateway",
       "description": "Register local or remote MCP servers on the host, reuse them across sandboxes, and govern server and tool access with Cedar policies.",
       "url": "/ai/sandboxes/mcp-gateway/",
       "published": "2026-08-06",
-      "source_prs": [25559, 25707]
+      "source_prs": [25559, 25707],
+      "featured": true
     },
     {
       "product": "Docker Sandboxes",
@@ -16,15 +26,17 @@
       "description": "Define kit setup, permissions, networking, and API key or OAuth credential requirements with the version 2 kit schema.",
       "url": "/ai/sandboxes/customize/kit-reference/#schema-versions",
       "published": "2026-08-06",
-      "source_prs": [25467, 25707]
+      "source_prs": [25467, 25707],
+      "featured": false
     },
     {
       "product": "Docker Sandboxes",
       "title": "Run Claude Code with local models",
-      "description": "Experimental support routes Claude Code sandbox requests to the bundled llmman server or an existing Ollama installation.",
+      "description": "Route Claude Code sandbox requests to the bundled local-model server or an existing Ollama installation.",
       "url": "/ai/sandboxes/agents/claude-code/#use-a-local-model",
       "published": "2026-08-06",
-      "source_prs": [25641, 25707]
+      "source_prs": [25641, 25707],
+      "featured": false
     },
     {
       "product": "Docker AI Governance",
@@ -32,7 +44,8 @@
       "description": "Search and export policy decisions from Docker Cloud, or forward events to Splunk, Dynatrace, and custom HTTPS endpoints.",
       "url": "/ai/sandboxes/governance/audit/",
       "published": "2026-08-03",
-      "source_prs": [25679, 25687]
+      "source_prs": [25679, 25687],
+      "featured": true
     },
     {
       "product": "Docker Desktop",
@@ -40,23 +53,44 @@
       "description": "Fresh Microsoft Store installations on Windows use per-user mode by default.",
       "url": "/desktop/release-notes/#4850",
       "published": "2026-08-03",
-      "source_prs": [25665]
+      "source_prs": [25665],
+      "featured": false
     },
     {
-      "product": "Docker Engine",
-      "title": "Mount files from container images",
-      "description": "Mount tools or read-only assets from another image without rebuilding the container image.",
-      "url": "/engine/storage/image-mounts/",
-      "published": "2026-08-03",
-      "source_prs": [25486]
+      "product": "Docker Sandboxes",
+      "title": "Share agent skills across sandboxes",
+      "description": "Import skills from supported host agents into a persistent store that sandboxes can share.",
+      "url": "/ai/sandboxes/workflows/#share-agent-skills",
+      "published": "2026-07-24",
+      "source_prs": [25588],
+      "featured": false
     },
     {
-      "product": "Docker Engine",
-      "title": "Use Unix sockets on Windows",
-      "description": "Configure the Docker daemon and CLI on Windows to communicate over a Unix socket.",
-      "url": "/engine/daemon/#listen-on-a-unix-socket-on-windows",
-      "published": "2026-08-03",
-      "source_prs": [25660]
+      "product": "Docker Sandboxes",
+      "title": "Connect editors and desktop apps over SSH",
+      "description": "Use a sandbox from VS Code, Cursor, Claude Desktop, ChatGPT, or another SSH-capable tool.",
+      "url": "/ai/sandboxes/integrations/",
+      "published": "2026-07-24",
+      "source_prs": [25557],
+      "featured": true
+    },
+    {
+      "product": "Docker Hardened Images",
+      "title": "Query the DHI catalog from AI assistants",
+      "description": "Search DHI repositories, inspect images, retrieve SBOMs, check CVEs, and manage mirrors through the DHI MCP server.",
+      "url": "/dhi/tools/mcp/",
+      "published": "2026-07-23",
+      "source_prs": [25589],
+      "featured": false
+    },
+    {
+      "product": "Docker Enterprise",
+      "title": "Authenticate GitHub Actions with OIDC connections",
+      "description": "Exchange GitHub OIDC tokens for short-lived access to Docker resources without storing long-lived workflow credentials.",
+      "url": "/enterprise/security/oidc-connections/",
+      "published": "2026-07-21",
+      "source_prs": [25336],
+      "featured": true
     }
   ]
 }

--- a/data/whats-new.json
+++ b/data/whats-new.json
@@ -1,0 +1,22 @@
+{
+  "period_start": "2026-07-28",
+  "period_end": "2026-08-03",
+  "items": [
+    {
+      "product": "Docker Engine",
+      "title": "Mount files from container images",
+      "description": "Mount files or directories from another image without copying them into the container image.",
+      "url": "/engine/storage/image-mounts/",
+      "published": "2026-08-03",
+      "source_prs": [25486]
+    },
+    {
+      "product": "Docker Sandboxes",
+      "title": "Export AI Governance audit events",
+      "description": "Search and export policy decisions, or stream audit events to a SIEM system.",
+      "url": "/ai/sandboxes/governance/audit/view-export/",
+      "published": "2026-07-31",
+      "source_prs": [25679]
+    }
+  ]
+}

--- a/data/whats-new.json
+++ b/data/whats-new.json
@@ -1,22 +1,38 @@
 {
-  "period_start": "2026-07-28",
-  "period_end": "2026-08-03",
+  "period_start": "2026-07-30",
+  "period_end": "2026-08-05",
   "items": [
+    {
+      "product": "Docker AI Governance",
+      "title": "Search and forward audit events",
+      "description": "Search and export policy decisions from Docker Cloud, or forward events to Splunk, Dynatrace, and custom HTTPS endpoints.",
+      "url": "/ai/sandboxes/governance/audit/",
+      "published": "2026-08-03",
+      "source_prs": [25679, 25687]
+    },
+    {
+      "product": "Docker Desktop",
+      "title": "Install from the Microsoft Store without administrator privileges",
+      "description": "Fresh Microsoft Store installations on Windows use per-user mode by default.",
+      "url": "/desktop/release-notes/#4850",
+      "published": "2026-08-03",
+      "source_prs": [25665]
+    },
     {
       "product": "Docker Engine",
       "title": "Mount files from container images",
-      "description": "Mount files or directories from another image without copying them into the container image.",
+      "description": "Mount tools or read-only assets from another image without rebuilding the container image.",
       "url": "/engine/storage/image-mounts/",
       "published": "2026-08-03",
       "source_prs": [25486]
     },
     {
-      "product": "Docker Sandboxes",
-      "title": "Export AI Governance audit events",
-      "description": "Search and export policy decisions, or stream audit events to a SIEM system.",
-      "url": "/ai/sandboxes/governance/audit/view-export/",
-      "published": "2026-07-31",
-      "source_prs": [25679]
+      "product": "Docker Engine",
+      "title": "Use Unix sockets on Windows",
+      "description": "Configure the Docker daemon and CLI on Windows to communicate over a Unix socket.",
+      "url": "/engine/daemon/#listen-on-a-unix-socket-on-windows",
+      "published": "2026-08-03",
+      "source_prs": [25660]
     }
   ]
 }

--- a/data/whats-new.json
+++ b/data/whats-new.json
@@ -1,7 +1,31 @@
 {
-  "period_start": "2026-07-30",
-  "period_end": "2026-08-05",
+  "period_start": "2026-08-03",
+  "period_end": "2026-08-09",
   "items": [
+    {
+      "product": "Docker Sandboxes",
+      "title": "Connect sandboxes through an MCP gateway",
+      "description": "Register local or remote MCP servers on the host, reuse them across sandboxes, and govern server and tool access with Cedar policies.",
+      "url": "/ai/sandboxes/mcp-gateway/",
+      "published": "2026-08-06",
+      "source_prs": [25559, 25707]
+    },
+    {
+      "product": "Docker Sandboxes",
+      "title": "Author version 2 sandbox kits",
+      "description": "Define kit setup, permissions, networking, and API key or OAuth credential requirements with the version 2 kit schema.",
+      "url": "/ai/sandboxes/customize/kit-reference/#schema-versions",
+      "published": "2026-08-06",
+      "source_prs": [25467, 25707]
+    },
+    {
+      "product": "Docker Sandboxes",
+      "title": "Run Claude Code with local models",
+      "description": "Experimental support routes Claude Code sandbox requests to the bundled llmman server or an existing Ollama installation.",
+      "url": "/ai/sandboxes/agents/claude-code/#use-a-local-model",
+      "published": "2026-08-06",
+      "source_prs": [25641, 25707]
+    },
     {
       "product": "Docker AI Governance",
       "title": "Search and forward audit events",

--- a/hack/validate-whats-new.mjs
+++ b/hack/validate-whats-new.mjs
@@ -1,0 +1,79 @@
+#!/usr/bin/env node
+
+import fs from "node:fs";
+
+const [path, expectedStart, expectedEnd] = process.argv.slice(2);
+if (!expectedEnd) {
+  throw new Error(`usage: ${process.argv[1]} FILE START END`);
+}
+
+const data = JSON.parse(fs.readFileSync(path, "utf8"));
+const requiredItemKeys = [
+  "product",
+  "title",
+  "description",
+  "url",
+  "published",
+  "source_prs",
+];
+
+if (data.period_start !== expectedStart) {
+  throw new Error(`period_start must be ${expectedStart}`);
+}
+if (data.period_end !== expectedEnd) {
+  throw new Error(`period_end must be ${expectedEnd}`);
+}
+if (!Array.isArray(data.items)) {
+  throw new Error("items must be an array");
+}
+if (data.items.length > 10) {
+  throw new Error("items must contain no more than 10 highlights");
+}
+
+for (const [index, item] of data.items.entries()) {
+  const missing = requiredItemKeys.filter((key) => !(key in item));
+  if (missing.length > 0) {
+    throw new Error(`item ${index + 1} is missing: ${missing.join(", ")}`);
+  }
+
+  for (const key of requiredItemKeys.slice(0, 4)) {
+    if (typeof item[key] !== "string" || item[key].trim() === "") {
+      throw new Error(`item ${index + 1} has an empty ${key}`);
+    }
+  }
+
+  if (!item.url.startsWith("/") || item.url.startsWith("/manuals/")) {
+    throw new Error(`item ${index + 1} url must be an internal published URL`);
+  }
+  if (
+    typeof item.published !== "string" ||
+    !/^\d{4}-\d{2}-\d{2}$/.test(item.published) ||
+    new Date(`${item.published}T00:00:00Z`).toISOString().slice(0, 10) !==
+      item.published
+  ) {
+    throw new Error(`item ${index + 1} has an invalid published date`);
+  }
+  if (item.published < data.period_start || item.published > data.period_end) {
+    throw new Error(`item ${index + 1} published date is outside the period`);
+  }
+  if (
+    !Array.isArray(item.source_prs) ||
+    item.source_prs.length === 0 ||
+    !item.source_prs.every((number) => Number.isInteger(number) && number > 0)
+  ) {
+    throw new Error(
+      `item ${index + 1} source_prs must contain pull request numbers`,
+    );
+  }
+}
+
+const publishedDates = data.items.map((item) => item.published);
+const sortedDates = [...publishedDates].sort().reverse();
+if (publishedDates.join() !== sortedDates.join()) {
+  throw new Error("items must be sorted by published date, newest first");
+}
+
+const identities = data.items.map((item) => `${item.title}\0${item.url}`);
+if (new Set(identities).size !== identities.length) {
+  throw new Error("items must not contain duplicate titles and URLs");
+}

--- a/hack/validate-whats-new.mjs
+++ b/hack/validate-whats-new.mjs
@@ -73,7 +73,12 @@ if (publishedDates.join() !== sortedDates.join()) {
   throw new Error("items must be sorted by published date, newest first");
 }
 
-const identities = data.items.map((item) => `${item.title}\0${item.url}`);
-if (new Set(identities).size !== identities.length) {
-  throw new Error("items must not contain duplicate titles and URLs");
+const titles = data.items.map((item) => item.title);
+if (new Set(titles).size !== titles.length) {
+  throw new Error("items must not contain duplicate titles");
+}
+
+const urls = data.items.map((item) => item.url);
+if (new Set(urls).size !== urls.length) {
+  throw new Error("items must not contain duplicate URLs");
 }

--- a/hack/validate-whats-new.mjs
+++ b/hack/validate-whats-new.mjs
@@ -15,6 +15,7 @@ const requiredItemKeys = [
   "url",
   "published",
   "source_prs",
+  "featured",
 ];
 
 if (data.period_start !== expectedStart) {
@@ -26,10 +27,6 @@ if (data.period_end !== expectedEnd) {
 if (!Array.isArray(data.items)) {
   throw new Error("items must be an array");
 }
-if (data.items.length > 10) {
-  throw new Error("items must contain no more than 10 highlights");
-}
-
 for (const [index, item] of data.items.entries()) {
   const missing = requiredItemKeys.filter((key) => !(key in item));
   if (missing.length > 0) {
@@ -65,6 +62,17 @@ for (const [index, item] of data.items.entries()) {
       `item ${index + 1} source_prs must contain pull request numbers`,
     );
   }
+  if (typeof item.featured !== "boolean") {
+    throw new Error(`item ${index + 1} featured must be a boolean`);
+  }
+}
+
+const featuredCount = data.items.filter((item) => item.featured).length;
+const expectedFeaturedCount = Math.min(5, data.items.length);
+if (featuredCount !== expectedFeaturedCount) {
+  throw new Error(
+    `items must contain ${expectedFeaturedCount} featured highlights`,
+  );
 }
 
 const publishedDates = data.items.map((item) => item.published);

--- a/layouts/_partials/whats-new.html
+++ b/layouts/_partials/whats-new.html
@@ -1,6 +1,8 @@
 {{- $data := index hugo.Data "whats-new" -}}
 {{- with $data.items -}}
-  <section class="py-10 md:py-12">
+  {{- $featured := where . "featured" true -}}
+  {{- $more := where . "featured" false -}}
+  <section class="py-10 md:py-12" x-data="{ expanded: false }">
     <div class="container mx-auto max-w-4xl px-4">
       <header class="mb-6 border-b border-gray-200 pb-4 dark:border-gray-800">
         <h2 class="text-2xl font-semibold text-gray-900 dark:text-white">
@@ -8,7 +10,7 @@
         </h2>
       </header>
       <ol>
-        {{ range . }}
+        {{ range $featured }}
           <li class="grid grid-cols-[1fr] md:grid-cols-[5rem_1fr] md:gap-x-6">
             <time
               class="hidden pt-5 text-right text-sm text-gray-500 md:block dark:text-gray-400"
@@ -50,7 +52,71 @@
             </a>
           </li>
         {{ end }}
+        {{ range $more }}
+          <li
+            x-cloak
+            x-show="expanded"
+            class="grid grid-cols-[1fr] md:grid-cols-[5rem_1fr] md:gap-x-6"
+          >
+            <time
+              class="hidden pt-5 text-right text-sm text-gray-500 md:block dark:text-gray-400"
+              datetime="{{ .published }}"
+              >{{ .published | time.Format "Jan 2" }}</time
+            >
+            <a
+              href="{{ .url }}"
+              class="group relative block border-l border-gray-200 py-5 pl-7 dark:border-gray-700"
+            >
+              <span
+                aria-hidden="true"
+                class="absolute top-6 -left-[5px] size-[9px] rounded-full bg-gray-300 ring-4 ring-gray-50 transition group-hover:bg-blue-500 dark:bg-gray-600 dark:ring-gray-950 dark:group-hover:bg-blue-400"
+              ></span>
+              <span
+                class="mb-1 flex flex-wrap items-center gap-x-2 text-sm font-medium text-blue-600 dark:text-blue-400"
+              >
+                {{ .product }}
+                <time
+                  class="font-normal text-gray-500 md:hidden dark:text-gray-400"
+                  datetime="{{ .published }}"
+                  >{{ .published | time.Format "Jan 2" }}</time
+                >
+              </span>
+              <span class="flex items-center gap-2">
+                <span
+                  class="font-medium text-gray-900 transition group-hover:text-blue-500 dark:text-white dark:group-hover:text-blue-400"
+                  >{{ .title }}</span
+                >
+                <span
+                  class="icon-svg shrink-0 text-gray-400 transition group-hover:translate-x-1 group-hover:text-blue-500 dark:text-gray-500 dark:group-hover:text-blue-400"
+                >
+                  {{ partialCached "icon" "arrow-right" "arrow-right" }}
+                </span>
+              </span>
+              <span class="mt-1 block text-sm text-gray-600 dark:text-gray-300"
+                >{{ .description }}</span
+              >
+            </a>
+          </li>
+        {{ end }}
       </ol>
+      {{ with $more }}
+        <button
+          type="button"
+          @click="expanded = !expanded"
+          :aria-expanded="expanded"
+          class="mt-4 ml-7 inline-flex items-center gap-1 text-sm font-medium text-blue-600 hover:text-blue-500 md:ml-[6.5rem] dark:text-blue-400 dark:hover:text-blue-300"
+        >
+          <span x-text="expanded ? 'Show top 5' : 'Show all 30 days'"
+            >Show all 30 days</span
+          >
+          <span class="icon-svg icon-sm" x-show="!expanded">
+            {{ partialCached "icon" "chevron-down" "chevron-down" }}
+          </span>
+          <span class="icon-svg icon-sm" x-cloak x-show="expanded">
+            {{ partialCached "icon" "chevron-up" "chevron-up" }}
+          </span>
+        </button>
+      {{ end }}
     </div>
   </section>
 {{- end -}}

--- a/layouts/_partials/whats-new.html
+++ b/layouts/_partials/whats-new.html
@@ -1,7 +1,7 @@
 {{- $data := index hugo.Data "whats-new" -}}
 {{- with $data.items -}}
-  {{- $featured := where . "featured" true -}}
-  {{- $more := where . "featured" false -}}
+  {{- $items := sort . "published" "desc" -}}
+  {{- $more := where $items "featured" false -}}
   <section class="py-10 md:py-12" x-data="{ expanded: false }">
     <div class="container mx-auto max-w-4xl px-4">
       <header class="mb-6 border-b border-gray-200 pb-4 dark:border-gray-800">
@@ -10,52 +10,11 @@
         </h2>
       </header>
       <ol>
-        {{ range $featured }}
-          <li class="grid grid-cols-[1fr] md:grid-cols-[5rem_1fr] md:gap-x-6">
-            <time
-              class="hidden pt-5 text-right text-sm text-gray-500 md:block dark:text-gray-400"
-              datetime="{{ .published }}"
-              >{{ .published | time.Format "Jan 2" }}</time
-            >
-            <a
-              href="{{ .url }}"
-              class="group relative block border-l border-gray-200 py-5 pl-7 dark:border-gray-700"
-            >
-              <span
-                aria-hidden="true"
-                class="absolute top-6 -left-[5px] size-[9px] rounded-full bg-gray-300 ring-4 ring-gray-50 transition group-hover:bg-blue-500 dark:bg-gray-600 dark:ring-gray-950 dark:group-hover:bg-blue-400"
-              ></span>
-              <span
-                class="mb-1 flex flex-wrap items-center gap-x-2 text-sm font-medium text-blue-600 dark:text-blue-400"
-              >
-                {{ .product }}
-                <time
-                  class="font-normal text-gray-500 md:hidden dark:text-gray-400"
-                  datetime="{{ .published }}"
-                  >{{ .published | time.Format "Jan 2" }}</time
-                >
-              </span>
-              <span class="flex items-center gap-2">
-                <span
-                  class="font-medium text-gray-900 transition group-hover:text-blue-500 dark:text-white dark:group-hover:text-blue-400"
-                  >{{ .title }}</span
-                >
-                <span
-                  class="icon-svg shrink-0 text-gray-400 transition group-hover:translate-x-1 group-hover:text-blue-500 dark:text-gray-500 dark:group-hover:text-blue-400"
-                >
-                  {{ partialCached "icon" "arrow-right" "arrow-right" }}
-                </span>
-              </span>
-              <span class="mt-1 block text-sm text-gray-600 dark:text-gray-300"
-                >{{ .description }}</span
-              >
-            </a>
-          </li>
-        {{ end }}
-        {{ range $more }}
+        {{ range $items }}
           <li
-            x-cloak
-            x-show="expanded"
+            {{ if not .featured }}
+              x-cloak x-show="expanded" x-collapse.duration.300ms
+            {{ end }}
             class="grid grid-cols-[1fr] md:grid-cols-[5rem_1fr] md:gap-x-6"
           >
             <time
@@ -106,9 +65,7 @@
           :aria-expanded="expanded"
           class="mt-4 ml-7 inline-flex items-center gap-1 text-sm font-medium text-blue-600 hover:text-blue-500 md:ml-[6.5rem] dark:text-blue-400 dark:hover:text-blue-300"
         >
-          <span x-text="expanded ? 'Show top 5' : 'Show all 30 days'"
-            >Show all 30 days</span
-          >
+          <span x-text="expanded ? 'Show less' : 'Show more'">Show more</span>
           <span class="icon-svg icon-sm" x-show="!expanded">
             {{ partialCached "icon" "chevron-down" "chevron-down" }}
           </span>

--- a/layouts/_partials/whats-new.html
+++ b/layouts/_partials/whats-new.html
@@ -2,33 +2,19 @@
 {{- with $data.items -}}
   <section class="py-10 md:py-12">
     <div class="container mx-auto max-w-4xl px-4">
-      <header
-        class="mb-6 flex items-baseline justify-between gap-4 border-b border-gray-200 pb-4 dark:border-gray-800"
-      >
+      <header class="mb-6 border-b border-gray-200 pb-4 dark:border-gray-800">
         <h2 class="text-2xl font-semibold text-gray-900 dark:text-white">
           What's new
         </h2>
-        <p class="shrink-0 text-sm text-gray-500 dark:text-gray-400">
-          <time datetime="{{ $data.period_start }}"
-            >{{ $data.period_start | time.Format "Jan 2" }}</time
-          >–<time datetime="{{ $data.period_end }}"
-            >{{ $data.period_end | time.Format "Jan 2, 2006" }}</time
-          >
-        </p>
       </header>
       <ol>
-        {{- $previousDate := "" -}}
         {{ range . }}
           <li class="grid grid-cols-[1fr] md:grid-cols-[5rem_1fr] md:gap-x-6">
-            {{ if ne .published $previousDate }}
-              <time
-                class="hidden pt-5 text-right text-sm text-gray-500 md:block dark:text-gray-400"
-                datetime="{{ .published }}"
-                >{{ .published | time.Format "Jan 2" }}</time
-              >
-            {{ else }}
-              <span class="hidden md:block"></span>
-            {{ end }}
+            <time
+              class="hidden pt-5 text-right text-sm text-gray-500 md:block dark:text-gray-400"
+              datetime="{{ .published }}"
+              >{{ .published | time.Format "Jan 2" }}</time
+            >
             <a
               href="{{ .url }}"
               class="group relative block border-l border-gray-200 py-5 pl-7 dark:border-gray-700"
@@ -41,13 +27,11 @@
                 class="mb-1 flex flex-wrap items-center gap-x-2 text-sm font-medium text-blue-600 dark:text-blue-400"
               >
                 {{ .product }}
-                {{ if ne .published $previousDate }}
-                  <time
-                    class="font-normal text-gray-500 md:hidden dark:text-gray-400"
-                    datetime="{{ .published }}"
-                    >{{ .published | time.Format "Jan 2" }}</time
-                  >
-                {{ end }}
+                <time
+                  class="font-normal text-gray-500 md:hidden dark:text-gray-400"
+                  datetime="{{ .published }}"
+                  >{{ .published | time.Format "Jan 2" }}</time
+                >
               </span>
               <span class="flex items-center gap-2">
                 <span
@@ -65,7 +49,6 @@
               >
             </a>
           </li>
-          {{- $previousDate = .published -}}
         {{ end }}
       </ol>
     </div>

--- a/layouts/_partials/whats-new.html
+++ b/layouts/_partials/whats-new.html
@@ -1,47 +1,73 @@
 {{- $data := index hugo.Data "whats-new" -}}
 {{- with $data.items -}}
-  <section class="py-8">
-    <div class="container mx-auto max-w-3xl px-4">
-      <h2
-        class="mb-8 text-center text-2xl font-semibold text-gray-900 dark:text-white"
+  <section class="py-10 md:py-12">
+    <div class="container mx-auto max-w-4xl px-4">
+      <header
+        class="mb-6 flex items-baseline justify-between gap-4 border-b border-gray-200 pb-4 dark:border-gray-800"
       >
-        What's new
-      </h2>
-      <div
-        class="divide-y divide-gray-200 rounded-xl border border-gray-200 bg-white dark:divide-gray-700 dark:border-gray-700 dark:bg-gray-900"
-      >
-        {{ range . }}
-          <a
-            href="{{ .url }}"
-            class="group flex items-center justify-between gap-4 px-4 py-4 transition hover:bg-blue-50 dark:hover:bg-gray-700"
+        <h2 class="text-2xl font-semibold text-gray-900 dark:text-white">
+          What's new
+        </h2>
+        <p class="shrink-0 text-sm text-gray-500 dark:text-gray-400">
+          <time datetime="{{ $data.period_start }}"
+            >{{ $data.period_start | time.Format "Jan 2" }}</time
+          >–<time datetime="{{ $data.period_end }}"
+            >{{ $data.period_end | time.Format "Jan 2, 2006" }}</time
           >
-            <span>
-              <span class="mb-1 flex flex-wrap items-center gap-x-2 text-sm">
-                <span class="font-medium text-blue-600 dark:text-blue-400"
-                  >{{ .product }}</span
-                >
-                <time
-                  class="text-gray-500 dark:text-gray-400"
-                  datetime="{{ .published }}"
-                  >{{ .published | time.Format "Jan 2" }}</time
-                >
-              </span>
-              <span
-                class="block font-medium text-gray-900 transition group-hover:text-blue-500 dark:text-white dark:group-hover:text-blue-400"
-                >{{ .title }}</span
+        </p>
+      </header>
+      <ol>
+        {{- $previousDate := "" -}}
+        {{ range . }}
+          <li class="grid grid-cols-[1fr] md:grid-cols-[5rem_1fr] md:gap-x-6">
+            {{ if ne .published $previousDate }}
+              <time
+                class="hidden pt-5 text-right text-sm text-gray-500 md:block dark:text-gray-400"
+                datetime="{{ .published }}"
+                >{{ .published | time.Format "Jan 2" }}</time
               >
+            {{ else }}
+              <span class="hidden md:block"></span>
+            {{ end }}
+            <a
+              href="{{ .url }}"
+              class="group relative block border-l border-gray-200 py-5 pl-7 dark:border-gray-700"
+            >
+              <span
+                aria-hidden="true"
+                class="absolute top-6 -left-[5px] size-[9px] rounded-full bg-gray-300 ring-4 ring-gray-50 transition group-hover:bg-blue-500 dark:bg-gray-600 dark:ring-gray-950 dark:group-hover:bg-blue-400"
+              ></span>
+              <span
+                class="mb-1 flex flex-wrap items-center gap-x-2 text-sm font-medium text-blue-600 dark:text-blue-400"
+              >
+                {{ .product }}
+                {{ if ne .published $previousDate }}
+                  <time
+                    class="font-normal text-gray-500 md:hidden dark:text-gray-400"
+                    datetime="{{ .published }}"
+                    >{{ .published | time.Format "Jan 2" }}</time
+                  >
+                {{ end }}
+              </span>
+              <span class="flex items-center gap-2">
+                <span
+                  class="font-medium text-gray-900 transition group-hover:text-blue-500 dark:text-white dark:group-hover:text-blue-400"
+                  >{{ .title }}</span
+                >
+                <span
+                  class="icon-svg shrink-0 text-gray-400 transition group-hover:translate-x-1 group-hover:text-blue-500 dark:text-gray-500 dark:group-hover:text-blue-400"
+                >
+                  {{ partialCached "icon" "arrow-right" "arrow-right" }}
+                </span>
+              </span>
               <span class="mt-1 block text-sm text-gray-600 dark:text-gray-300"
                 >{{ .description }}</span
               >
-            </span>
-            <span
-              class="icon-svg shrink-0 text-gray-400 transition group-hover:translate-x-1 dark:text-gray-500"
-            >
-              {{ partialCached "icon" "arrow-right" "arrow-right" }}
-            </span>
-          </a>
+            </a>
+          </li>
+          {{- $previousDate = .published -}}
         {{ end }}
-      </div>
+      </ol>
     </div>
   </section>
 {{- end -}}

--- a/layouts/_partials/whats-new.html
+++ b/layouts/_partials/whats-new.html
@@ -1,0 +1,47 @@
+{{- $data := index hugo.Data "whats-new" -}}
+{{- with $data.items -}}
+  <section class="py-8">
+    <div class="container mx-auto max-w-3xl px-4">
+      <h2
+        class="mb-8 text-center text-2xl font-semibold text-gray-900 dark:text-white"
+      >
+        What's new
+      </h2>
+      <div
+        class="divide-y divide-gray-200 rounded-xl border border-gray-200 bg-white dark:divide-gray-700 dark:border-gray-700 dark:bg-gray-900"
+      >
+        {{ range . }}
+          <a
+            href="{{ .url }}"
+            class="group flex items-center justify-between gap-4 px-4 py-4 transition hover:bg-blue-50 dark:hover:bg-gray-700"
+          >
+            <span>
+              <span class="mb-1 flex flex-wrap items-center gap-x-2 text-sm">
+                <span class="font-medium text-blue-600 dark:text-blue-400"
+                  >{{ .product }}</span
+                >
+                <time
+                  class="text-gray-500 dark:text-gray-400"
+                  datetime="{{ .published }}"
+                  >{{ .published | time.Format "Jan 2" }}</time
+                >
+              </span>
+              <span
+                class="block font-medium text-gray-900 transition group-hover:text-blue-500 dark:text-white dark:group-hover:text-blue-400"
+                >{{ .title }}</span
+              >
+              <span class="mt-1 block text-sm text-gray-600 dark:text-gray-300"
+                >{{ .description }}</span
+              >
+            </span>
+            <span
+              class="icon-svg shrink-0 text-gray-400 transition group-hover:translate-x-1 dark:text-gray-500"
+            >
+              {{ partialCached "icon" "arrow-right" "arrow-right" }}
+            </span>
+          </a>
+        {{ end }}
+      </div>
+    </div>
+  </section>
+{{- end -}}

--- a/layouts/_shortcodes/whats-new.html
+++ b/layouts/_shortcodes/whats-new.html
@@ -1,0 +1,1 @@
+{{ partial "whats-new.html" . }}

--- a/layouts/_shortcodes/whats-new.html
+++ b/layouts/_shortcodes/whats-new.html
@@ -1,1 +1,0 @@
-{{ partial "whats-new.html" . }}

--- a/layouts/_shortcodes/whats-new.markdown.md
+++ b/layouts/_shortcodes/whats-new.markdown.md
@@ -1,0 +1,9 @@
+{{- $data := index hugo.Data "whats-new" -}}
+{{- with $data.items }}
+
+## What's new
+
+{{ range . }}
+{{ printf "- [%s: %s](%s): %s (%s)\n" .product .title .url .description (.published | time.Format "Jan 2, 2006") -}}
+{{ end }}
+{{- end }}

--- a/layouts/home.html
+++ b/layouts/home.html
@@ -116,43 +116,7 @@
         </div>
       </section>
 
-      <!-- Popular Topics Section -->
-      <section class="py-8">
-        <div class="container mx-auto max-w-3xl px-4">
-          <h2
-            class="mb-8 text-center text-2xl font-semibold text-gray-900 dark:text-white"
-          >
-            Featured topics
-          </h2>
-          <div
-            class="divide-y divide-gray-200 rounded-xl border border-gray-200 bg-white dark:divide-gray-700 dark:border-gray-700 dark:bg-gray-900"
-          >
-            {{ range slice
-              (dict "url" "/dhi/" "title" "Docker Hardened Images")
-              (dict "url" "/ai/sandboxes/get-started/" "title" "Get started with Docker Sandboxes")
-              (dict "url" "/desktop/" "title" "Docker Desktop overview")
-              (dict "url" "/engine/install/" "title" "Install Docker Engine")
-              (dict "url" "/reference/dockerfile/" "title" "Dockerfile reference")
-              (dict "url" "/build/" "title" "Docker Build overview")
-            }}
-              <a
-                href="{{ .url }}"
-                class="group flex items-center justify-between px-4 py-3 transition hover:bg-blue-50 dark:hover:bg-gray-700"
-              >
-                <span
-                  class="text-gray-900 transition group-hover:text-blue-500 dark:text-white dark:group-hover:text-blue-400"
-                  >{{ .title }}</span
-                >
-                <span
-                  class="icon-svg text-gray-400 transition group-hover:translate-x-1 dark:text-gray-500"
-                >
-                  {{ partialCached "icon" "arrow-right" "arrow-right" }}
-                </span>
-              </a>
-            {{ end }}
-          </div>
-        </div>
-      </section>
+      {{ partial "whats-new.html" . }}
     </main>
     <footer>{{ partialCached "footer.html" . }}</footer>
   </body>


### PR DESCRIPTION
## Summary

Replace the static Featured topics section with a data-driven Whatʼs new timeline. Show the five most important launches by default and let readers expand the full curated 30-day archive.

Run a daily Claude Sonnet 5 curator over a rolling 30-day window, with manual dispatch support, deterministic validation, and bot-managed pull requests. Package the editorial workflow as the reusable `curate-whats-new` repository skill so Docker Agent and other Agent Skills-compatible clients can invoke the same process.

Preserve the human-reviewed July 13 through August 11, 2026 result and flexible selection criteria as a regression example outside the skillʼs runtime context.

@netlify /

[Homepage preview](https://deploy-preview-25729--docsdocker.netlify.app/)

Generated by Codex
