### PR TITLE
docs: clarify what replaces the deprecated self-diagnose tool

### DIFF
--- a/content/manuals/desktop/troubleshoot-and-support/troubleshoot/_index.md
+++ b/content/manuals/desktop/troubleshoot-and-support/troubleshoot/_index.md
@@ -194,7 +194,9 @@ If you don't have a paid Docker subscription, create an issue on [GitHub](https:
 
 > [!IMPORTANT]
 >
-> This tool has been deprecated.
+> This tool has been deprecated. Use the diagnostic methods in
+> [Diagnose](#diagnose) above, including the [`docker desktop diagnose`
+> command](/manuals/desktop/features/desktop-cli.md), instead.
 
 ## Check the logs
 


### PR DESCRIPTION
## Summary
- explain that the deprecated Self-diagnose tool is replaced by the current Diagnose workflows
- point readers to the existing `docker desktop diagnose` command instead of leaving the section as a dead-end

## Testing
- git diff --check

Fixes #25740