### PR TITLE
docs: document kit setup order

### DIFF
--- a/content/manuals/ai/sandboxes/customize/kit-reference.md
+++ b/content/manuals/ai/sandboxes/customize/kit-reference.md
@@ -400,7 +400,7 @@ When a sandbox is created, kit content is applied in this order:
 2. Static files under `files/home/`.
 3. `setup.install` commands, in declaration order.
 4. `setup.files` entries.
-5. `setup.startup` commands are registered for each container start.
+5. `setup.startup` commands are registered for each sandbox start.
 6. Static files under `files/workspace/`, after the workspace is ready. With
    `--clone`, this means after the repository has been cloned.
 

--- a/content/manuals/ai/sandboxes/customize/kit-reference.md
+++ b/content/manuals/ai/sandboxes/customize/kit-reference.md
@@ -392,9 +392,31 @@ setup:
       description: <text>
 ```
 
+### Execution order
+
+When a sandbox is created, kit content is applied in this order:
+
+1. Network permissions and environment variables.
+2. Static files under `files/home/`.
+3. `setup.install` commands, in declaration order.
+4. `setup.files` entries.
+5. `setup.startup` commands are registered for each container start.
+6. Static files under `files/workspace/`, after the workspace is ready. With
+   `--clone`, this means after the repository has been cloned.
+
+For stacked kits, entries in each stage are applied in `--kit` order. An install
+command can consume a bundled file from `files/home/`, but not one from
+`files/workspace/` or `setup.files`, because those files land later.
+
+Runtime injection with `sbx kit add` uses a different order: install commands
+run before static files are copied into the existing container. If an install
+command depends on a bundled file, apply the kit when you create the sandbox or
+have the install command create or download its input.
+
 ### install
 
-Runs once during sandbox creation. Shell strings passed to `sh -c`.
+Runs synchronously when a kit is applied, either during sandbox creation or
+through `sbx kit add`. Shell strings are passed to `sh -c`.
 
 | Field         | Default | Description                   |
 | ------------- | ------- | ----------------------------- |

--- a/content/manuals/ai/sandboxes/customize/kit-reference.md
+++ b/content/manuals/ai/sandboxes/customize/kit-reference.md
@@ -408,8 +408,8 @@ For stacked kits, entries in each stage are applied in `--kit` order. An install
 command can consume a bundled file from `files/home/`, but not one from
 `files/workspace/` or `setup.files`, because those files land later.
 
-`sbx kit add` recreates the sandbox's container instead of injecting the kit
-into the running container. It supports mixin kits limited to
+`sbx kit add` recreates the sandbox rather than modifying it in place. It
+supports mixin kits limited to
 `environment.variables`, `setup.install`, and `permissions.network.allow`,
 which follow the same order as sandbox creation. It rejects a kit that declares
 static files, `setup.startup`, or `setup.files`. To use those fields, recreate

--- a/content/manuals/ai/sandboxes/customize/kit-reference.md
+++ b/content/manuals/ai/sandboxes/customize/kit-reference.md
@@ -408,10 +408,12 @@ For stacked kits, entries in each stage are applied in `--kit` order. An install
 command can consume a bundled file from `files/home/`, but not one from
 `files/workspace/` or `setup.files`, because those files land later.
 
-Runtime injection with `sbx kit add` uses a different order: install commands
-run before static files are copied into the existing container. If an install
-command depends on a bundled file, apply the kit when you create the sandbox or
-have the install command create or download its input.
+`sbx kit add` recreates the sandbox's container instead of injecting the kit
+into the running container. It supports mixin kits limited to
+`environment.variables`, `setup.install`, and `permissions.network.allow`,
+which follow the same order as sandbox creation. It rejects a kit that declares
+static files, `setup.startup`, or `setup.files`. To use those fields, recreate
+the sandbox with the kit.
 
 ### install
 

--- a/content/manuals/ai/sandboxes/customize/kits.md
+++ b/content/manuals/ai/sandboxes/customize/kits.md
@@ -315,6 +315,12 @@ To start a new sandbox with this mixin:
 $ sbx run claude --kit /path/to/ruff-lint/
 ```
 
+To apply the mixin to a sandbox that's already running, use
+[`sbx kit add`](#local) instead. The `--kit` flag only takes effect when a
+sandbox is created. `sbx kit add` restarts the sandbox to apply the kit, but VM
+state — installed packages, Docker images, volumes, and agent history — is
+preserved.
+
 ## Sandbox kits
 
 A sandbox kit defines a full agent from scratch — image, entrypoint, and

--- a/content/manuals/ai/sandboxes/customize/kits.md
+++ b/content/manuals/ai/sandboxes/customize/kits.md
@@ -315,12 +315,6 @@ To start a new sandbox with this mixin:
 $ sbx run claude --kit /path/to/ruff-lint/
 ```
 
-To apply the mixin to a sandbox that's already running, use
-[`sbx kit add`](#local) instead. The `--kit` flag only takes effect when a
-sandbox is created. `sbx kit add` restarts the sandbox to apply the kit, but VM
-state — installed packages, Docker images, volumes, and agent history — is
-preserved.
-
 ## Sandbox kits
 
 A sandbox kit defines a full agent from scratch — image, entrypoint, and
@@ -390,13 +384,15 @@ repository, or an OCI registry. Pass `--kit` more than once to stack
 several kits on the same sandbox.
 
 > [!IMPORTANT]
-> `--kit` only takes effect when a sandbox is created. Passing it
-> against an existing sandbox name fails with
-> `--kit can only be used when creating a new sandbox`. To extend a
-> running sandbox with a kit, use [`sbx kit add`](#local) instead.
+> `--kit` only takes effect when a sandbox is created. Passing it against an
+> existing sandbox name fails with
+> `--kit can only be used when creating a new sandbox`. To add a supported
+> mixin kit to a running sandbox, use [`sbx kit add`](#local) instead.
 > `sbx kit add` restarts the sandbox to apply the updated kit set.
 > VM state — installed packages, Docker images, volumes, and agent history
-> — is preserved across the restart.
+> — is preserved across the restart. It supports mixin kits limited to
+> `environment.variables`, `setup.install`, and `permissions.network.allow`.
+> To use other fields, recreate the sandbox with `--kit`.
 
 ### Local
 
@@ -407,7 +403,8 @@ $ sbx run claude --kit ./my-kit/
 $ sbx run claude --kit ./my-kit-1.0.zip
 ```
 
-While iterating on a kit, apply changes to a running sandbox with `sbx kit add`:
+While iterating on a supported mixin kit, apply changes to a running sandbox
+with `sbx kit add`:
 
 ```console
 $ sbx kit add my-sandbox ./my-kit/
@@ -415,9 +412,8 @@ $ sbx kit add my-sandbox ./my-kit/
 
 `sbx kit add` restarts the sandbox to apply the updated kit set.
 VM state — installed packages, Docker images, volumes, and agent history — is
-preserved across the restart. The kit's network allow/deny rules take effect
-immediately. Kits can't be removed from a running sandbox — remove and recreate
-it to start clean.
+preserved across the restart. Kits can't be removed from a running sandbox —
+remove and recreate it to start clean.
 
 ### Git repository
 


### PR DESCRIPTION
## Summary

Document when network settings, environment variables, static files, generated files, and setup commands are applied during sandbox creation. Clarify that `sbx kit add` recreates the sandbox, follows creation order for supported fields, and rejects file and startup fields.

@netlify /ai/sandboxes/customize/kit-reference/

[Preview the kit spec reference](https://deploy-preview-25746--docsdocker.netlify.app/ai/sandboxes/customize/kit-reference/)

Closes docker/sbx-releases#134

Generated by Codex