### PR TITLE
docs: fix persistent environment file owner

### DIFF
--- a/content/manuals/ai/sandboxes/customize/kit-examples.md
+++ b/content/manuals/ai/sandboxes/customize/kit-examples.md
@@ -142,15 +142,15 @@ setup:
         unset NPM_CONFIG_PREFIX
         [ -s "$NVM_DIR/nvm.sh" ] && source "$NVM_DIR/nvm.sh"
         EOF
+      user: "1000"
       description: Source nvm for every shell
 ```
 
-The install step runs as `user: "1000"` so the tool lands under
-`/home/agent/`. The append step runs as root (the default), since
-`/etc/sandbox-persistent.sh` is a system file. The `$HOME` in the
-appended lines resolves per user at source time, so the agent user finds
-its own install. Append to the file rather than overwriting it — the
-sandbox relies on its existing contents.
+Both install steps run as `user: "1000"`. This installs the tool under
+`/home/agent/` and can update `/etc/sandbox-persistent.sh`, which the agent user
+owns. The `$HOME` in the appended lines resolves per user at source time, so the
+agent user finds its own install. Append to the file rather than overwriting it
+— the sandbox relies on its existing contents.
 
 The base image ships its own Node and sets `NPM_CONFIG_PREFIX`, which
 nvm won't activate alongside. `unset NPM_CONFIG_PREFIX` before sourcing


### PR DESCRIPTION
## Summary

Correct the nvm kit example to update /etc/sandbox-persistent.sh as the agent user, matching the file ownership in sandbox images.

@netlify /ai/sandboxes/customize/kit-examples/

[Preview the kit examples](https://deploy-preview-25747--docsdocker.netlify.app/ai/sandboxes/customize/kit-examples/)

Closes docker/sbx-releases#313

Generated by Codex