### PR TITLE
docs: restore alias for Windows permission requirements URL

### DIFF
--- a/content/manuals/desktop/setup/install/windows-permission-requirements.md
+++ b/content/manuals/desktop/setup/install/windows-permission-requirements.md
@@ -4,6 +4,9 @@ keywords: Docker Desktop, Windows, security, install
 title: Understand permission requirements for Windows
 linkTitle: Windows permission requirements
 weight: 40
+aliases:
+  - /desktop/windows/permission-requirements/
+  - /desktop/windows/permission-requirements
 ---
 
 This page contains information about the permission requirements for running and installing Docker Desktop on Windows, the functionality of the privileged helper process `com.docker.service`, and the reasoning behind this approach.

--- a/content/manuals/desktop/setup/install/windows-permission-requirements.md
+++ b/content/manuals/desktop/setup/install/windows-permission-requirements.md
@@ -6,7 +6,6 @@ linkTitle: Windows permission requirements
 weight: 40
 aliases:
   - /desktop/windows/permission-requirements/
-  - /desktop/windows/permission-requirements
 ---
 
 This page contains information about the permission requirements for running and installing Docker Desktop on Windows, the functionality of the privileged helper process `com.docker.service`, and the reasoning behind this approach.


### PR DESCRIPTION
Desktop still opens `/desktop/windows/permission-requirements/` for the privileged helper warning, and that path 404s.

Added the old path as an alias on the current Windows permission requirements page.

Fixes #25549