### PR TITLE
docs: point self-diagnose deprecation at Diagnose section

### DIFF
--- a/content/manuals/desktop/troubleshoot-and-support/troubleshoot/_index.md
+++ b/content/manuals/desktop/troubleshoot-and-support/troubleshoot/_index.md
@@ -194,7 +194,8 @@ If you don't have a paid Docker subscription, create an issue on [GitHub](https:
 
 > [!IMPORTANT]
 >
-> This tool has been deprecated.
+> This tool has been deprecated. Use the diagnostic methods in
+> [Diagnose](#diagnose) instead (from the app, an error message, or the terminal).
 
 ## Check the logs
 


### PR DESCRIPTION
The self-diagnose section only said the tool was deprecated.

Added a pointer to the Diagnose section (app / error dialog / terminal) so people know what to use instead.

Fixes #25740