### PR TITLE
docs: list Docker.app damaged issue for all Macs

### DIFF
--- a/content/manuals/desktop/troubleshoot-and-support/troubleshoot/known-issues.md
+++ b/content/manuals/desktop/troubleshoot-and-support/troubleshoot/known-issues.md
@@ -8,11 +8,11 @@ aliases:
  - /desktop/troubleshoot/known-issues/
 ---
 
+On Mac (Intel and Apple silicon), if you see a **"Docker.app is damaged"** dialog during install or update, see [Fix "Docker.app is damaged" on macOS](mac-damaged-dialog.md).
+
 {{< tabs >}}
 {{< tab name="For Mac with Intel chip" >}}
 - The Mac Activity Monitor reports that Docker is using twice the amount of memory it's actually using. This is due to a [bug in macOS](https://docs.google.com/document/d/17ZiQC1Tp9iH320K-uqVLyiJmk4DHJ3c4zgQetJiKYQM/edit?usp=sharing).
-
-- **"Docker.app is damaged" dialog**: If you see a "Docker.app is damaged and can't be opened" dialog during installation or updates, this is typically caused by non-atomic copy operations when other applications are using the Docker CLI. See [Fix "Docker.app is damaged" on macOS](mac-damaged-dialog.md) for resolution steps.
 
 - Force-ejecting the `.dmg` after running `Docker.app` from it can cause the
   whale icon to become unresponsive, Docker tasks to show as not responding in the Activity Monitor, and for some processes to consume a large amount of CPU resources. Reboot and restart Docker to resolve these issues.


### PR DESCRIPTION
The damaged-app known issue only showed under the Intel tab. Same Gatekeeper/copy problem can hit Apple silicon too.

Moved the note above the architecture tabs and linked the existing fix page.

Fixes #25739