### PR TITLE
docs: alias old synchronized-file-sharing Desktop URL

### DIFF
--- a/content/manuals/desktop/features/synchronized-file-sharing.md
+++ b/content/manuals/desktop/features/synchronized-file-sharing.md
@@ -3,6 +3,8 @@ title: Synchronized file shares
 weight: 70
 description: Get started with Synchronized file shares on Docker Desktop.
 keyword: mutagen, file sharing, docker desktop, bind mounts
+aliases:
+  - /desktop/synchronized-file-sharing/
 ---
 
 {{< summary-bar feature_name="Synchronized file sharing" >}}


### PR DESCRIPTION
`/desktop/synchronized-file-sharing/` 404s; the page lives under features now.

Added the old path as an alias.

Fixes #25646