### PR TITLE
docs: align Desktop Linux support wording with package pages

### DIFF
--- a/content/manuals/desktop/setup/install/linux/_index.md
+++ b/content/manuals/desktop/setup/install/linux/_index.md
@@ -129,7 +129,7 @@ and architectures:
 
 An experimental package is available for [Arch](archlinux.md)-based distributions. Docker has not tested or verified the installation.
 
-Docker supports Docker Desktop on the current and previous LTS releases of the aforementioned distributions, as well as the most recent version.
+Docker publishes Docker Desktop packages for the Linux distributions listed above. The exact releases packages are built for are listed on each distro-specific install page (for example, [Debian](debian.md)).
 
 ## General system requirements
 

--- a/content/manuals/desktop/setup/install/linux/debian.md
+++ b/content/manuals/desktop/setup/install/linux/debian.md
@@ -24,7 +24,7 @@ This page contains information on how to install, launch, and upgrade Docker Des
 To install Docker Desktop successfully, you must:
 
 - Meet the [general system requirements](_index.md#general-system-requirements).
-- Have a 64-bit version of Debian 12.
+- Have a 64-bit version of Debian 12 (Bookworm). Packages are currently built for this release.
 - For a Gnome Desktop environment, you must also install AppIndicator and KStatusNotifierItem [Gnome extensions](https://extensions.gnome.org/extension/615/appindicator-support/).
 - If you're not using GNOME, you must install `gnome-terminal` to enable terminal access from Docker Desktop:
 


### PR DESCRIPTION
The overview said “current and previous LTS” for every listed distro, while the Debian page only documents Debian 12.

Pointed the overview at the per-distro install pages for the exact releases, and clarified that Debian packages currently target 12.

Fixes #25700