### PR TITLE
docs: note MCP secrets engine and 401 when running agentic sample

### DIFF
--- a/content/guides/agentic-ai.md
+++ b/content/guides/agentic-ai.md
@@ -116,6 +116,14 @@ To run the application locally, follow these steps:
 
    ![Screenshot of the application](./images/agentic-ai-app.png)
 
+   > [!NOTE]
+   >
+   > If the MCP gateway logs `secrets engine is not available`, Docker Desktop's
+   > secrets engine for MCP isn't running. The DuckDuckGo sample usually still
+   > works without it. If queries return HTTP 401 from the app or gateway, check
+   > that Model Runner is enabled, the model finished pulling, and the gateway
+   > finished listing tools before you submit a prompt.
+
 3. Press ctrl-c in the terminal to stop the application when you're done.
 
 ## Step 3: Review the application environment


### PR DESCRIPTION
People following the agentic AI Compose guide hit MCP gateway warnings about the secrets engine and occasional 401s on localhost:8080.

Added a short note after the first `docker compose up` steps: secrets-engine warning is often non-fatal for the DuckDuckGo sample, and what to check if queries return 401.

Fixes #25620