### PR TITLE
docs: note Windows path for registry client certificates

### DIFF
--- a/content/manuals/engine/security/certificates.md
+++ b/content/manuals/engine/security/certificates.md
@@ -21,9 +21,25 @@ for the registry and how to set the client TLS certificate for verification.
 
 ## Understand the configuration
 
-A custom certificate is configured by creating a directory under
-`/etc/docker/certs.d` using the same name as the registry's hostname, such as
+A custom certificate is configured by creating a directory under the daemon's
+certificate root using the same name as the registry's hostname, such as
 `localhost`. All `*.crt` files are added to this directory as CA roots.
+
+Where that certificate root lives depends on the platform:
+
+- Native Linux Engine: `/etc/docker/certs.d/`
+- Rootless Linux: `$XDG_CONFIG_HOME/docker/certs.d` (defaults to
+  `~/.config/docker/certs.d`), not `/etc/docker/certs.d`
+- Native Windows Engine (Windows containers):
+  `%PROGRAMDATA%\docker\certs.d` (normally `C:\ProgramData\docker\certs.d`).
+  If the registry address includes a port, strip the colon from the directory
+  name because Windows filenames cannot contain `:`. For example,
+  `registry.example.com:5000` becomes `registry.example.com5000`.
+- Docker Desktop with Linux containers: put client certificates in
+  `~/.docker/certs.d` on the host. Docker Desktop copies them into the VM;
+  don't configure `/etc/docker/certs.d` inside the VM yourself. Trusted CAs
+  can also come from the host certificate store (on Windows, the Windows
+  certificate store).
 
 > [!NOTE]
 >


### PR DESCRIPTION
The certs page only showed `/etc/docker/certs.d`. Windows Server / Windows containers use `C:\ProgramData\docker\certs.d` instead; Desktop with Linux containers still uses the Linux path inside the engine.

Fixes #5798