### PR TITLE
docs: drop outdated Desktop Community product name

### DIFF
--- a/content/manuals/desktop/enterprise/_index.md
+++ b/content/manuals/desktop/enterprise/_index.md
@@ -9,7 +9,7 @@ aliases:
 - /desktop/enterprise/admin/configure/windows-admin/
 ---
 
-Docker Desktop Enterprise (DDE) has been deprecated and is no longer in active development. Please use [Docker Desktop](../_index.md) Community instead.
+Docker Desktop Enterprise (DDE) has been deprecated and is no longer in active development. Use [Docker Desktop](../_index.md) instead.
 
 If you are an existing DDE customer, use the [Support form](https://hub.docker.com/support/desktop/) to request a transition to one of the new [subscriptions](https://www.docker.com/pricing?ref=Docs&refAction=DocsDesktopEnterprise).
 


### PR DESCRIPTION
The DDE deprecation note still said \"Docker Desktop Community\", which isn't a current product name.

Fixes #25691