### PR TITLE
docs: clarify kit startup command use

### DIFF
--- a/content/manuals/ai/sandboxes/customize/kit-reference.md
+++ b/content/manuals/ai/sandboxes/customize/kit-reference.md
@@ -450,8 +450,8 @@ don't gate the agent's entrypoint: the agent launches once startup
 commands have been dispatched, regardless of `background`. A value of
 `false` waits within the startup dispatcher before it runs the next command;
 it doesn't delay the agent entrypoint. Use startup commands
-for non-interactive prep, such as launching daemons and warming caches. Use
-`setup.files` for any value that needs to land on disk before the agent runs.
+for work that can run alongside the agent. Use `setup.files` for any value that
+needs to land on disk before the agent runs.
 
 Startup commands must be idempotent. They run on every sandbox start
 and replay on container restarts, so a command that fails or

--- a/content/manuals/ai/sandboxes/customize/kit-reference.md
+++ b/content/manuals/ai/sandboxes/customize/kit-reference.md
@@ -450,9 +450,8 @@ don't gate the agent's entrypoint: the agent launches once startup
 commands have been dispatched, regardless of `background`. A value of
 `false` waits within the startup dispatcher before it runs the next command;
 it doesn't delay the agent entrypoint. Use startup commands
-for non-interactive prep — launching daemons, warming caches,
-refreshing config — and use `setup.files` for any value that
-needs to land on disk before the agent runs.
+for non-interactive prep, such as launching daemons and warming caches. Use
+`setup.files` for any value that needs to land on disk before the agent runs.
 
 Startup commands must be idempotent. They run on every sandbox start
 and replay on container restarts, so a command that fails or

--- a/content/manuals/ai/sandboxes/customize/kits.md
+++ b/content/manuals/ai/sandboxes/customize/kits.md
@@ -53,9 +53,9 @@ setup:
     - command: "apt-get update && apt-get install -y jq"
 ```
 
-Startup commands cover things like launching background services,
-warming caches, or refreshing config on each start. They must be
-idempotent — see the [`startup`](kit-reference.md#startup) spec reference:
+Startup commands cover things like launching background services or warming
+caches on each start. They must be idempotent — see the
+[`startup`](kit-reference.md#startup) spec reference:
 
 ```yaml
 setup:

--- a/content/manuals/ai/sandboxes/customize/kits.md
+++ b/content/manuals/ai/sandboxes/customize/kits.md
@@ -53,8 +53,8 @@ setup:
     - command: "apt-get update && apt-get install -y jq"
 ```
 
-Startup commands cover things like launching background services or warming
-caches on each start. They must be idempotent — see the
+Startup commands are for work that can run alongside the agent, such as a
+background service. They must be idempotent — see the
 [`startup`](kit-reference.md#startup) spec reference:
 
 ```yaml


### PR DESCRIPTION
## Summary

Replace ambiguous startup-command examples with direct guidance that startup work can run alongside the agent. This makes clear why startup commands aren't suitable for configuration the agent must read during initialization.

Follow-up to docker/docs#25749 and docker/sbx-releases#408.

Generated by Codex