### PR TITLE
docs(compose): note file secrets don't work on Windows containers

### DIFF
--- a/content/manuals/compose/how-tos/use-secrets.md
+++ b/content/manuals/compose/how-tos/use-secrets.md
@@ -19,6 +19,15 @@ Environment variables are often available to all processes, and it can be diffic
 
 Secrets are mounted as a file in `/run/secrets/<secret_name>` inside the container.
 
+> [!NOTE]
+>
+> File-based secrets rely on bind-mounting a single file. Windows containers
+> only support bind-mounting directories, so `file:` secrets fail on Windows
+> containers (for example, "source path must be a directory"). Use Linux
+> containers, or another secret mechanism that doesn't require a file mount,
+> when you target Windows containers.
+
+
 Getting a secret into a container is a two-step process. First, define the secret using the [top-level secrets element in your Compose file](/reference/compose-file/secrets.md). Next, update your service definitions to reference the secrets they require with the [secrets attribute](/reference/compose-file/services.md#secrets). Compose grants access to secrets on a per-service basis.
 
 Unlike the other methods, this permits granular access control within a service container via standard filesystem permissions.


### PR DESCRIPTION
File-based Compose secrets mount a single file under `/run/secrets`. Windows containers can't bind-mount individual files (only directories), so those examples fail there.

Added a short note on the secrets how-to page.

Fixes #25540