### PR TITLE
docs: document credentialFile.structure support

### DIFF
--- a/content/manuals/ai/sandboxes/customize/kit-reference.md
+++ b/content/manuals/ai/sandboxes/customize/kit-reference.md
@@ -296,16 +296,14 @@ the real token response into the sandbox.
 | `sentinels.accessToken` / `refreshToken` | Sentinel values written into the container in place of the real tokens.                                                                                                                           |
 | `credentialFile.path`                    | Where to write the credential file inside the container (`~` expands).                                                                                                                            |
 | `credentialFile.structure`               | Declarative JSON shape. Supports `{{.AccessToken}}`, `{{.RefreshToken}}`, `{{.ExpiresAt}}`, and `{{.Scopes}}`.                                                                                   |
-| `credentialFile.template`                | Free-form Go template. Supports `{{.AccessToken}}`, `{{.RefreshToken}}`, `{{.ExpiresAt}}`, `{{.Scopes}}`, and `{{.ScopesJSON}}`. Use `{{.ScopesJSON}}` for a JSON array.                           |
+| `credentialFile.template`                | Go template. Supports `{{.AccessToken}}`, `{{.RefreshToken}}`, `{{.ExpiresAt}}`, `{{.Scopes}}`, and `{{.ScopesJSON}}`.                                                                          |
 | `resourceHosts`                          | API hosts where the proxy attaches the token on outbound requests, distinct from the token endpoint host.                                                                                         |
 | `skipIfEnv`                              | Accepted for compatibility, but ignored for schema v2. A v2 binding is authoritative instead of host environment variables.                                                                       |
 | `responseFields`                         | Overrides the default field names the proxy reads from the token response.                                                                                                                        |
 | `passthrough`                            | If `true`, the proxy passes the token response through unchanged instead of replacing the tokens with sentinels.                                                                                  |
 
 `credentialFile.structure` provides a declarative alternative to
-`credentialFile.template`. The engine substitutes the declared placeholders
-and then encodes the structure as JSON, which preserves the numeric type of
-`ExpiresAt`, the array type of `Scopes`, and produces well-formed JSON. If both
+`credentialFile.template`. The engine renders it as well-formed JSON. If both
 fields are set, `structure` takes precedence.
 
 ## Network

--- a/content/manuals/ai/sandboxes/customize/kit-reference.md
+++ b/content/manuals/ai/sandboxes/customize/kit-reference.md
@@ -247,15 +247,12 @@ credentials:
         refreshToken: <sentinel>
       credentialFile:
         path: <path>
-        template: |
-          {
-            "<key>": {
-              "accessToken": "{{.AccessToken}}",
-              "refreshToken": "{{.RefreshToken}}",
-              "expiresAt": {{.ExpiresAt}},
-              "scopes": {{.ScopesJSON}}
-            }
-          }
+        structure:
+          <key>:
+            accessToken: "{{.AccessToken}}"
+            refreshToken: "{{.RefreshToken}}"
+            expiresAt: "{{.ExpiresAt}}"
+            scopes: "{{.Scopes}}"
 ```
 
 `credentials` is a list; each entry names a `service` and configures one or more
@@ -298,12 +295,18 @@ the real token response into the sandbox.
 | `tokenEndpoint.host` / `path`            | The OAuth token endpoint the proxy intercepts.                                                                                                                                                    |
 | `sentinels.accessToken` / `refreshToken` | Sentinel values written into the container in place of the real tokens.                                                                                                                           |
 | `credentialFile.path`                    | Where to write the credential file inside the container (`~` expands).                                                                                                                            |
-| `credentialFile.template`                | Go template used to render the credential file. Supports `{{.AccessToken}}`, `{{.RefreshToken}}`, `{{.ExpiresAt}}`, `{{.Scopes}}`, and `{{.ScopesJSON}}`. Use `{{.ScopesJSON}}` for a JSON array. |
-| `credentialFile.structure`               | Declarative JSON shape defined by schema v2 but not supported by the `sbx` engine. A structure-only kit fails validation. Use `credentialFile.template`.                                          |
+| `credentialFile.structure`               | Declarative JSON shape. Supports `{{.AccessToken}}`, `{{.RefreshToken}}`, `{{.ExpiresAt}}`, and `{{.Scopes}}`.                                                                                   |
+| `credentialFile.template`                | Free-form Go template. Supports `{{.AccessToken}}`, `{{.RefreshToken}}`, `{{.ExpiresAt}}`, `{{.Scopes}}`, and `{{.ScopesJSON}}`. Use `{{.ScopesJSON}}` for a JSON array.                           |
 | `resourceHosts`                          | API hosts where the proxy attaches the token on outbound requests, distinct from the token endpoint host.                                                                                         |
 | `skipIfEnv`                              | Accepted for compatibility, but ignored for schema v2. A v2 binding is authoritative instead of host environment variables.                                                                       |
 | `responseFields`                         | Overrides the default field names the proxy reads from the token response.                                                                                                                        |
 | `passthrough`                            | If `true`, the proxy passes the token response through unchanged instead of replacing the tokens with sentinels.                                                                                  |
+
+`credentialFile.structure` provides a declarative alternative to
+`credentialFile.template`. The engine substitutes the declared placeholders
+and then encodes the structure as JSON, which preserves the numeric type of
+`ExpiresAt`, the array type of `Scopes`, and produces well-formed JSON. If both
+fields are set, `structure` takes precedence.
 
 ## Network
 


### PR DESCRIPTION
## Summary

Update the kit spec reference for Docker Sandboxes v0.39.0 to document `credentialFile.structure` alongside `credentialFile.template`. Show the declarative structure form in the OAuth example and document its supported placeholders, typed JSON output, and precedence when both fields are set, as implemented by [docker/sandboxes#4830](https://github.com/docker/sandboxes/pull/4830).

@netlify /ai/sandboxes/customize/kit-reference/

[Preview the updated kit spec reference](https://deploy-preview-25786--docsdocker.netlify.app/ai/sandboxes/customize/kit-reference/)

Generated by Codex