### PR TITLE
docs: update sandbox local model provider syntax

### DIFF
--- a/content/manuals/ai/sandboxes/agents/claude-code.md
+++ b/content/manuals/ai/sandboxes/agents/claude-code.md
@@ -137,11 +137,10 @@ $ sbx run --model gemma4 claude
 On first use, `sbx` starts `llmman`, pulls the model, and leaves the server
 running on your host. Later sandboxes reuse the server and its model store.
 
-To use an existing Ollama installation instead, prefix the model name with
-`ollama/`:
+To use an existing Ollama installation instead, set the provider to `ollama`:
 
 ```console
-$ sbx run --model ollama/gemma4 claude
+$ sbx run --model gemma4 --provider ollama claude
 ```
 
 Ollama must already be installed and running. `sbx` connects to it but doesn't


### PR DESCRIPTION
## Summary

Update the experimental Claude Code local-model instructions for [docker/sandboxes#4856](https://github.com/docker/sandboxes/pull/4856). The Ollama example uses the new explicit `--provider ollama` flag instead of the removed `ollama/` model-name prefix.

@netlify /ai/sandboxes/agents/claude-code/

[Preview the Claude Code sandbox page](https://deploy-preview-25787--docsdocker.netlify.app/ai/sandboxes/agents/claude-code/)

Generated by Codex