### PR TITLE
docs: document sbx prune cleanup

### DIFF
--- a/content/manuals/ai/sandboxes/usage.md
+++ b/content/manuals/ai/sandboxes/usage.md
@@ -48,6 +48,17 @@ $ sbx rm my-sandbox
 $ sbx run claude
 ```
 
+To remove all stopped local sandboxes, use `sbx prune`. Running sandboxes are
+never removed. Preview the sandboxes that would be removed, or filter out
+sandboxes stopped within the last week:
+
+```console
+$ sbx prune --dry-run
+$ sbx prune --filter since=168h
+```
+
+Run `sbx prune` without flags to confirm and remove all stopped sandboxes.
+
 ## Reconnect and name sandboxes
 
 Sandboxes persist after the agent exits. Running the same workspace path again


### PR DESCRIPTION
## Summary

Document routine cleanup of stopped local sandboxes with `sbx prune`, including dry-run and stop-age filter examples.

@netlify /ai/sandboxes/usage/

Preview: https://deploy-preview-25788--docsdocker.netlify.app/ai/sandboxes/usage/

Generated by Codex