### PR TITLE
docs: document Claude Code remote control in sandboxes

### DIFF
--- a/content/manuals/ai/sandboxes/agents/claude-code.md
+++ b/content/manuals/ai/sandboxes/agents/claude-code.md
@@ -49,6 +49,15 @@ available inside the sandbox. See
 [Why doesn't the sandbox use my user-level agent configuration?](../faq.md#why-doesnt-the-sandbox-use-my-user-level-agent-configuration)
 for workarounds.
 
+### Remote control
+
+To use Claude Code's `/remote-control` command inside a sandbox, turn on remote
+control:
+
+```console
+$ sbx settings set claude.remoteControl true
+```
+
 ### Default startup command
 
 Without extra args, the sandbox runs:


### PR DESCRIPTION
## Summary

Document how to turn on Claude Code remote control inside Docker Sandboxes.

@netlify /ai/sandboxes/agents/claude-code/

Preview: https://deploy-preview-25789--docsdocker.netlify.app/ai/sandboxes/agents/claude-code/

Generated by Codex