### PR TITLE
docs: clarify single-engine note for NVIDIA GPUs

### DIFF
--- a/content/manuals/engine/containers/gpu.md
+++ b/content/manuals/engine/containers/gpu.md
@@ -88,7 +88,10 @@ This exposes the GPUs at index `0` and `2` — the first and third GPUs listed i
 
 > [!NOTE]
 >
-> NVIDIA GPUs can only be accessed by systems running a single engine.
+> The `--gpus` flag works with a single Docker Engine on one host. It does not
+> schedule GPUs across multiple Swarm nodes. Multiple containers on the same
+> engine can share or request GPUs; for Swarm services, advertise GPUs as
+> [generic resources](/engine/swarm/services/#control-service-placement) instead.
 
 ### Set NVIDIA capabilities
 


### PR DESCRIPTION
The GPU page said "systems running a single engine" without explaining what that means.

Reworded it: `--gpus` is for one Docker Engine on a host (not multi-node Swarm scheduling), and multiple containers on that engine can still use GPUs. Pointed Swarm users at generic resources for service placement.

Fixes #25685