### PR TITLE
ci: deduplicate automated PR reviews

### DIFF
--- a/.github/workflows/pr-review-trigger.yml
+++ b/.github/workflows/pr-review-trigger.yml
@@ -1,7 +1,7 @@
 name: PR Review - Trigger
 on:
   pull_request:
-    types: [ready_for_review, opened, review_requested]
+    types: [opened, review_requested]
   pull_request_review_comment:
     types: [created]
 
@@ -9,18 +9,26 @@ permissions: {}
 
 jobs:
   save-context:
+    if: >
+      github.event_name != 'pull_request' ||
+      github.event.action != 'review_requested' ||
+      github.event.requested_reviewer.login == 'docker-agent'
     runs-on: ubuntu-latest
     steps:
       - name: Save event context
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
           PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          REQUESTED_REVIEWER: ${{ github.event.requested_reviewer.login }}
           COMMENT_JSON: ${{ toJSON(github.event.comment) }}
         run: |
           mkdir -p context
           printf '%s' "${{ github.event_name }}" > context/event_name.txt
           printf '%s' "$PR_NUMBER" > context/pr_number.txt
           printf '%s' "$PR_HEAD_SHA" > context/pr_head_sha.txt
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            printf '%s' "$REQUESTED_REVIEWER" > context/requested_reviewer.txt
+          fi
           if [ "${{ github.event_name }}" = "pull_request_review_comment" ]; then
             printf '%s' "$COMMENT_JSON" > context/comment.json
           fi

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   review:
-    uses: docker/docker-agent-action/.github/workflows/review-pr.yml@e96a4bb40cac114f64358621e1d08346c8eadc8c # v2.0.1
+    uses: docker/docker-agent-action/.github/workflows/review-pr.yml@baf90543d81f5de59751dfd10e6cf45e21a5a982 # v2.0.3
     # Scoped to the job so other jobs in this workflow aren't over-permissioned
     permissions:
       contents: read # Read repository files and PR diffs


### PR DESCRIPTION
## Summary

Review PRs once when opened, including drafts, and retrigger only when `docker-agent` is explicitly requested. Upgrade `docker-agent-action` to v2.0.3 so the reusable workflow filters unrelated human and team review requests.

Generated by Codex