### PR TITLE
docs: note insecure registries with containerd image store

### DIFF
--- a/content/manuals/engine/storage/containerd.md
+++ b/content/manuals/engine/storage/containerd.md
@@ -113,6 +113,23 @@ Docker Engine uses the `overlayfs` containerd snapshotter by default.
 > image store, push them to a registry first, or use `docker save` to export
 > them.
 
+## Private and insecure registries
+
+Registry settings such as `insecure-registries` and custom CAs under
+`/etc/docker/certs.d/` apply through the daemon configuration, but they are
+implemented on a different code path than the legacy graph-driver image store.
+
+After changing those settings, restart Docker and confirm a real
+`docker pull` / `docker push` against the registry. `docker info` may still
+list an insecure registry even when a TLS handshake fails for
+containerd-backed pulls.
+
+If an insecure or custom-CA registry works only after setting
+`"containerd-snapshotter": false`, upgrade Docker Engine to a recent 29.x
+release (auth/TLS handling for the containerd path has received fixes such as
+[moby#52600](https://github.com/moby/moby/pull/52600)) and re-test with the
+containerd image store enabled.
+
 ## Experimental automatic migration
 
 Docker Engine includes an experimental feature that can automatically switch to


### PR DESCRIPTION
With the containerd image store (default on fresh Engine 29 installs), people hit cases where `insecure-registries` / certs.d look configured in `docker info` but pull/push still fail TLS.

Adds a short section on the containerd image store page: restart, verify with a real pull/push, and point at recent 29.x TLS fixes if it only works after turning snapshotter off.

Related to docker/cli#6748