### PR TITLE
docs: clarify persisted env vars reach the agent process

### DIFF
--- a/content/manuals/ai/sandboxes/faq.md
+++ b/content/manuals/ai/sandboxes/faq.md
@@ -112,17 +112,15 @@ sandbox instead of on your host.
 > credentials where proxy-based injection isn't available.
 
 Variables in `/etc/sandbox-persistent.sh` are sourced automatically for
-interactive sessions and for agents started with `sbx run` — including
-agent-specific variables such as API keys. The agent process itself sees
-these variables, not just an interactive shell you open separately.
+interactive sessions and for agents started with `sbx run`.
 
 A variable only takes effect for sessions and agents started *after* it's
 added. If an agent is already running when you append to the file, restart
 it (or stop and start the sandbox) to pick up the new value.
 
-If you run a command directly with `sbx exec <name> <command>`, the command
-runs without a shell, so the persistent environment file is not sourced.
-Wrap the command in `bash -c` to load the environment:
+Running commands directly with `sbx exec <name> <command>` does not invoke
+a shell, so the persistent environment file is not sourced. Wrap the
+command in `bash -c` to load the environment:
 
 ```console
 $ sbx exec <sandbox-name> bash -c "your-command"

--- a/content/manuals/ai/sandboxes/faq.md
+++ b/content/manuals/ai/sandboxes/faq.md
@@ -111,12 +111,18 @@ sandbox instead of on your host.
 > the sandbox. The agent process can read it directly. Only use this for
 > credentials where proxy-based injection isn't available.
 
-Variables in `/etc/sandbox-persistent.sh` are sourced automatically when
-bash runs inside the sandbox, including interactive sessions and agents
-started with `sbx run`. If you run a command directly with
-`sbx exec <name> <command>`, the command runs without a shell, so the
-persistent environment file is not sourced. Wrap the command in `bash -c`
-to load the environment:
+Variables in `/etc/sandbox-persistent.sh` are sourced automatically for
+interactive sessions and for agents started with `sbx run` — including
+agent-specific variables such as API keys. The agent process itself sees
+these variables, not just an interactive shell you open separately.
+
+A variable only takes effect for sessions and agents started *after* it's
+added. If an agent is already running when you append to the file, restart
+it (or stop and start the sandbox) to pick up the new value.
+
+If you run a command directly with `sbx exec <name> <command>`, the command
+runs without a shell, so the persistent environment file is not sourced.
+Wrap the command in `bash -c` to load the environment:
 
 ```console
 $ sbx exec <sandbox-name> bash -c "your-command"


### PR DESCRIPTION
## Summary
- Clarifies that variables set in `/etc/sandbox-persistent.sh` are visible to the agent process itself (not just an interactive shell), including API keys.
- Notes that a variable only takes effect for sessions/agents started after it's added — a running agent needs a restart to pick it up.

## Why
Prompted by confusion in https://github.com/docker/sbx-releases/issues/252, where users assumed variables set this way wouldn't reach `sbx run` agent sessions, or weren't sure how a new value propagates to an already-running agent.

## Test plan
- [ ] Docs site build/preview renders the FAQ section correctly