### PR TITLE
docs: system prune default keeps unused tagged images

### DIFF
--- a/content/manuals/engine/manage-resources/pruning.md
+++ b/content/manuals/engine/manage-resources/pruning.md
@@ -202,9 +202,10 @@ Are you sure you want to continue? [y/N] y
 By default, you're prompted to continue. To bypass the prompt, use the `-f` or
 `--force` flag.
 
-By default, all unused containers, networks, and images are removed. You can
-limit the scope using the `--filter` flag. For instance, the following command
-removes items older than 24 hours:
+By default, unused containers and networks are removed, along with dangling
+images. Unused tagged images are kept unless you also pass `-a` / `--all`.
+You can further limit the scope with the `--filter` flag. For instance, the
+following command removes items older than 24 hours:
 
 ```console
 $ docker system prune --filter "until=24h"


### PR DESCRIPTION
## Summary

The "Prune everything" section said that by default `docker system prune` removes all unused images. On Docker 29.1.3 the default confirmation only lists dangling images; unused tagged images stay unless you pass `-a` / `--all`.

Corrected that sentence. Did not change the example command to include `-a` (that was the stale approach in closed #17488).

@netlify /engine/manage-resources/pruning/

Generated by Grok.
