### PR TITLE
docs: point Notary production section at upstream deploy docs

### DIFF
--- a/content/manuals/engine/security/trust/deploying_notary.md
+++ b/content/manuals/engine/security/trust/deploying_notary.md
@@ -27,6 +27,7 @@ for [Notary](https://github.com/docker/notary#using-notary) depending on which o
 
 ## If you want to use Notary in production
 
-Check back here for instructions after Notary Server has an official
-stable release. To get a head start on deploying Notary in production, see
-[the Notary repository](https://github.com/theupdateframework/notary).
+The Compose sample on this page is for local testing and uses sample
+certificates. For a production deployment, follow the upstream
+[instructions to run a Notary service](https://github.com/theupdateframework/notary/blob/master/docs/running_a_service.md)
+and the rest of [the Notary repository](https://github.com/theupdateframework/notary).


### PR DESCRIPTION
the production section still said to wait for a Notary stable release, while the steps above already link the upstream service guide. pointed both at the same place.

Fixes #25145