### PR TITLE
docs: add fluentd-read-timeout logging driver option

### DIFF
--- a/content/manuals/engine/logging/drivers/fluentd.md
+++ b/content/manuals/engine/logging/drivers/fluentd.md
@@ -149,7 +149,7 @@ Generates event logs in nanosecond resolution. Defaults to `false`.
 Sets the timeout for the write call to the `fluentd` daemon. By default,
 writes have no timeout and will block indefinitely.
 
-### fluentd-read-timeout
+### Fluentd-read-timeout
 
 Sets the timeout for reading acknowledgements (ACKs) from the `fluentd`
 daemon. By default, reads have no timeout and will block indefinitely.

--- a/content/manuals/engine/logging/drivers/fluentd.md
+++ b/content/manuals/engine/logging/drivers/fluentd.md
@@ -149,6 +149,11 @@ Generates event logs in nanosecond resolution. Defaults to `false`.
 Sets the timeout for the write call to the `fluentd` daemon. By default,
 writes have no timeout and will block indefinitely.
 
+### fluentd-read-timeout
+
+Sets the timeout for reading acknowledgements (ACKs) from the `fluentd`
+daemon. By default, reads have no timeout and will block indefinitely.
+
 ## Fluentd daemon management with Docker
 
 About `Fluentd` itself, see [the project webpage](https://www.fluentd.org)


### PR DESCRIPTION
## Problem

Docker Engine 29.0.0 added the `fluentd-read-timeout` log option ([moby/moby#50249](https://github.com/moby/moby/pull/50249)) for configuring the read timeout when waiting for acknowledgements from the Fluentd daemon. The [fluentd logging driver docs](https://docs.docker.com/engine/logging/drivers/fluentd/) page documents `fluentd-write-timeout` (added in Engine 28.0.0) but does not mention the new read-timeout counterpart.

## Fix

Added a `fluentd-read-timeout` section to the fluentd driver docs, placed directly after `fluentd-write-timeout` to match the existing section style and ordering.

## Verification

- Docker Engine 29.0.0 release notes confirm the option exists: `Add a new log option for fluentd log driver (fluentd-read-timeout)`
- Grep of the docs tree confirmed no prior mention of `fluentd-read-timeout` outside the release notes
- Duplicate check: no open or closed PR on this topic