### PR TITLE
docs: say what PATH, URL, and - mean on docker build

### DIFF
--- a/data/cli/engine/docker_build.yaml
+++ b/data/cli/engine/docker_build.yaml
@@ -1,7 +1,12 @@
 command: docker build
 aliases: docker image build, docker build, docker builder build
 short: Build an image from a Dockerfile
-long: Build an image from a Dockerfile
+long: |-
+    Build an image from a Dockerfile.
+
+    `PATH` is a local directory used as the [build context](/manuals/build/concepts/context.md)
+    (commonly `.`). `URL` is a remote Git repository or tarball. `-` reads a
+    Dockerfile or tarball from standard input.
 usage: docker build [OPTIONS] PATH | URL | -
 pname: docker
 plink: docker.yaml


### PR DESCRIPTION
the usage line was just `PATH | URL | -` with no explanation on the CLI page. one sentence each, plus a link to the build context doc.

Fixes #13148