### PR TITLE
docs: note that docker run -a stdin is not --interactive

### DIFF
--- a/data/cli/engine/docker_container_run.yaml
+++ b/data/cli/engine/docker_container_run.yaml
@@ -1954,6 +1954,11 @@ examples: |-
     and input as needed. You can specify to which of the three standard streams
     (`STDIN`, `STDOUT`, `STDERR`) you'd like to connect instead, as in:
 
+    Attaching `STDIN` is not the same as `--interactive`. Without `-i`, the
+    container's standard input is closed, so
+    `docker run -a stdin -a stdout -a stderr busybox cat < file` prints nothing.
+    Add `-i` when you want to send input.
+
     ```console
     $ docker run -a stdin -a stdout -i -t ubuntu /bin/bash
     ```


### PR DESCRIPTION
`-a stdin` only binds the stream. without `-i` STDIN is still closed, so piping a file into `docker run -a stdin -a stdout -a stderr ...` prints nothing.

Fixes #14528