### PR TITLE
docs: document custom attribute log options for the local driver

### DIFF
--- a/content/manuals/engine/logging/drivers/local.md
+++ b/content/manuals/engine/logging/drivers/local.md
@@ -62,11 +62,16 @@ Note that `local` is a bash reserved keyword, so you may need to quote it in scr
 
 The `local` logging driver supports the following logging options:
 
-| Option     | Description                                                                                                                                                   | Example value              |
-| :--------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------ | :------------------------- |
-| `max-size` | The maximum size of the log before it's rolled. A positive integer plus a unit modifier (`k`, `m`, or `g`; case-insensitive). Defaults to 20m.      | `--log-opt max-size=10m`   |
-| `max-file` | The maximum number of log files that can be present. If rolling the logs creates excess files, the oldest file is removed. A positive integer. Defaults to 5. | `--log-opt max-file=3`     |
-| `compress` | Toggle compression of rotated log files. Enabled by default.                                                                                                  | `--log-opt compress=false` |
+| Option         | Description                                                                                                                                                                    | Example value                                      |
+| :------------- | :---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | :------------------------------------------------- |
+| `max-size`     | The maximum size of the log before it's rolled. A positive integer plus a unit modifier (`k`, `m`, or `g`; case-insensitive). Defaults to 20m.                                | `--log-opt max-size=10m`                           |
+| `max-file`     | The maximum number of log files that can be present. If rolling the logs creates excess files, the oldest file is removed. A positive integer. Defaults to 5.                | `--log-opt max-file=3`                             |
+| `compress`     | Toggle compression of rotated log files. Enabled by default.                                                                                                                   | `--log-opt compress=false`                         |
+| `labels`       | A comma-separated list of logging-related labels this daemon accepts. Used for advanced [log tag options](log_tags.md).                                                        | `--log-opt labels=production_status,geo`           |
+| `labels-regex` | Similar to and compatible with `labels`. A regular expression to match logging-related labels. Used for advanced [log tag options](log_tags.md).                              | `--log-opt labels-regex=^(production_status\|geo)` |
+| `env`          | A comma-separated list of logging-related environment variables this daemon accepts. Used for advanced [log tag options](log_tags.md).                                        | `--log-opt env=os,customer`                        |
+| `env-regex`    | Similar to and compatible with `env`. A regular expression to match logging-related environment variables. Used for advanced [log tag options](log_tags.md).                 | `--log-opt env-regex=^(os\|customer)`              |
+| `tag`          | Specify a template to set the `tag` value in log messages. Refer to the [log tag option documentation](log_tags.md) to customize the log tag format.                          | `--log-opt tag={{.ImageName}}`                     |
 
 ### Examples
 


### PR DESCRIPTION
## Summary

Documents the custom attribute log options (`labels`, `labels-regex`, `env`, `env-regex`, `tag`) that were added to the `local` logging driver in Docker Engine 29.5.0.

## Problem

The `local` file logging driver reference page only listed `max-size`, `max-file`, and `compress` in its Options table. Docker Engine 29.5.0 (moby/moby#52348) added support for custom attributes to the `local` driver, bringing feature-parity with the `json-file` driver for the `labels`, `labels-regex`, `env`, `env-regex`, and `tag` log options. These options were missing from the reference page, so users had no way to discover that the `local` driver now accepts them.

## Fix

Added `labels`, `labels-regex`, `env`, `env-regex`, and `tag` rows to the Options table in `content/manuals/engine/logging/drivers/local.md`, matching the wording and style used by the `json-file` driver reference (`json-file.md`). Each option links to the existing `log_tags.md` page for the advanced tag templating details.

The option names, descriptions, and example values were verified against:
- The `LogOptKeys` map in `moby/moby` `daemon/logger/local/local.go` (which registers `labels`, `labels-regex`, `env`, `env-regex`, `tag` via the shared `logger.Attr*` constants).
- The release notes entry in `content/manuals/engine/release-notes/29.md` (29.5.0: "The `local` logging driver now has support for custom attributes...").

## Verification

- `git diff` confirms a minimal, single-file change (10 insertions, 5 deletions).
- The Options table markdown is well-formed and the `log_tags.md` relative link resolves to the existing file in the same directory.
- Option names match the actual CLI option strings accepted by the driver (e.g. `--log-opt labels=...`, not the singular `label=...`).
