### PR TITLE
docs: explain NAME[:TAG] namespace on docker push

### DIFF
--- a/data/cli/engine/docker_image_push.yaml
+++ b/data/cli/engine/docker_image_push.yaml
@@ -8,6 +8,15 @@ long: |-
     Refer to the [`docker image tag`](/reference/cli/docker/image/tag/) reference for more information
     about valid image and tag names.
 
+    `NAME[:TAG]` is the repository to push. The name can include a registry host
+    and a namespace (usually your username or organization):
+
+    `[HOST[:PORT]/][NAMESPACE/]REPOSITORY[:TAG]`
+
+    For Docker Hub, omit `HOST` and use your Docker ID as the namespace. For a
+    private registry, include `HOST[:PORT]`. In the examples below, `myadmin`
+    and `myname` are that namespace — not a special Docker flag.
+
     Killing the `docker image push` process, for example by pressing `CTRL-c` while it is
     running in a terminal, terminates the push operation.
 
@@ -95,10 +104,9 @@ examples: |-
     $ docker container commit c16378f943fe rhel-httpd:latest
     ```
 
-    Now, push the image to the registry using the image ID. In this example the
-    registry is on host named `registry-host` and listening on port `5000`. To do
-    this, tag the image with the host name or IP address, and the port of the
-    registry:
+    Now, push the image to the registry. In this example the registry is
+    `registry-host:5000` and `myadmin` is the repository namespace (your
+    username or org on that registry):
 
     ```console
     $ docker image tag rhel-httpd:latest registry-host:5000/myadmin/rhel-httpd:latest

--- a/data/cli/engine/docker_push.yaml
+++ b/data/cli/engine/docker_push.yaml
@@ -1,7 +1,12 @@
 command: docker push
 aliases: docker image push, docker push
 short: Upload an image to a registry
-long: Upload an image to a registry
+long: |-
+    Upload an image to a registry.
+
+    `NAME[:TAG]` is `[HOST[:PORT]/][NAMESPACE/]REPOSITORY[:TAG]`. `NAMESPACE` is
+    usually your username or organization (for example `myadmin` in the
+    [image push](/reference/cli/docker/image/push/) examples).
 usage: docker push [OPTIONS] NAME[:TAG]
 pname: docker
 plink: docker.yaml


### PR DESCRIPTION
the push examples use `registry-host:5000/myadmin/...` without saying what `myadmin` is. spelled out the host/namespace/repo form and that the middle bit is just your username or org.

Fixes #16891