### PR TITLE
docs: make rootless cgroup delegate.conf copy-pasteable

### DIFF
--- a/content/manuals/engine/security/rootless/tips.md
+++ b/content/manuals/engine/security/rootless/tips.md
@@ -152,15 +152,23 @@ $ cat /sys/fs/cgroup/user.slice/user-$(id -u).slice/user@$(id -u).service/cgroup
 memory pids
 ```
 
-To allow delegation of all controllers, you need to change the systemd configuration as follows:
+To allow delegation of all controllers, change the systemd configuration:
 
 ```console
-# mkdir -p /etc/systemd/system/user@.service.d
-# cat > /etc/systemd/system/user@.service.d/delegate.conf << EOF
+$ sudo mkdir -p /etc/systemd/system/user@.service.d
+```
+
+Create `/etc/systemd/system/user@.service.d/delegate.conf`:
+
+```ini
 [Service]
 Delegate=cpu cpuset io memory pids
-EOF
-# systemctl daemon-reload
+```
+
+Then reload systemd:
+
+```console
+$ sudo systemctl daemon-reload
 ```
 
 > [!NOTE]


### PR DESCRIPTION
the heredoc body was getting dropped when you copy the console block. split the unit file out so you can grab the `[Service]` lines.

Fixes #14490