### PR TITLE
docs: remove extended-agent OAuth workaround

### DIFF
--- a/content/manuals/ai/sandboxes/configuration/credentials.md
+++ b/content/manuals/ai/sandboxes/configuration/credentials.md
@@ -425,13 +425,6 @@ If a third-party kit declares the same service itself, that service also
 requires approval. Kits on `schemaVersion: "1"` inject their declared
 credentials without a binding.
 
-> [!WARNING]
-> Proxy-managed OAuth isn't supported for third-party sandbox agents, including
-> kits that extend a built-in agent. Repeating the parent's OAuth declaration in
-> the child kit doesn't activate OAuth interception. Use a stored API key when
-> the service supports one. Otherwise, an OAuth login performed inside the
-> sandbox stores the real token there.
-
 ## Registry credentials
 
 Registry credentials authenticate to private OCI registries when pulling

--- a/content/manuals/ai/sandboxes/customize/kit-examples.md
+++ b/content/manuals/ai/sandboxes/customize/kit-examples.md
@@ -365,25 +365,10 @@ passing the child kit directory in place of a built-in agent name:
 $ sbx run ./claude-sonnet
 ```
 
-Proxy-managed OAuth isn't supported for a third-party kit that extends the
-built-in `claude` agent. Store an Anthropic API key on the host before the first
-launch:
-
-```console
-$ sbx secret set anthropic
-```
-
 When you launch the kit for the first time, `sbx` prompts you to approve its
 inherited Anthropic credentials. Because this is a third-party schema v2 kit,
 `sbx` records your approval as a
-[credential binding](../configuration/credentials.md#credential-bindings). The
-sandbox receives a sentinel value, and the proxy injects the real API key into
-requests to the domains declared by the kit.
-
-> [!WARNING]
-> The approval prompt also lists OAuth, but OAuth doesn't work for the extended
-> agent. If you use Claude Code's `/login` command, Claude Code stores the real
-> OAuth tokens inside the sandbox.
+[credential binding](../configuration/credentials.md#credential-bindings).
 
 OpenCode supports an additional config file through `OPENCODE_CONFIG`. Keep the
 kit's config separate from the sandbox-managed
@@ -453,9 +438,7 @@ sandbox:
 The child inherits the built-in image, credentials, network permissions,
 persistent volumes, settings, MCP integration, agent instructions, setup
 entries, and environment variables. Its `sandbox.entrypoint` replaces the
-inherited entrypoint. Proxy-managed OAuth
-isn't supported for the extended agent, so follow the
-[Anthropic API-key setup](#customize-agent-settings) before launching it.
+inherited entrypoint.
 
 Launch by passing the sandbox kit in place of a built-in agent name:
 


### PR DESCRIPTION
## Summary

Remove the temporary extended-agent OAuth limitation and required API-key workaround added in #25810, while retaining its credential-binding approval clarifications.

OAuth policy resolution for extended third-party kits is fixed in the public [Docker Sandboxes v0.42.0-rc1 release](https://github.com/docker/sbx-releases/releases/tag/v0.42.0-rc1).

@netlify /ai/sandboxes/customize/kit-examples/

- [Preview the kit examples](https://deploy-preview-25833--docsdocker.netlify.app/ai/sandboxes/customize/kit-examples/)
- [Preview the credentials page](https://deploy-preview-25833--docsdocker.netlify.app/ai/sandboxes/configuration/credentials/)

Generated by Codex
