### PR TITLE
docs(fluentd): document fluentd-request-ack logging driver option

### DIFF
--- a/content/manuals/engine/logging/drivers/fluentd.md
+++ b/content/manuals/engine/logging/drivers/fluentd.md
@@ -132,7 +132,7 @@ up to this number. If the buffer is full, the call to record logs will fail.
 The default is 1048576.
 (https://github.com/fluent/fluent-logger-golang/tree/master#bufferlimit)
 
-### fluentd-request-ack
+### `fluentd-request-ack`
 
 Require the Fluentd daemon to acknowledge received log messages.
 When enabled, each message is sent with a unique chunk ID and Docker waits

--- a/content/manuals/engine/logging/drivers/fluentd.md
+++ b/content/manuals/engine/logging/drivers/fluentd.md
@@ -132,6 +132,13 @@ up to this number. If the buffer is full, the call to record logs will fail.
 The default is 1048576.
 (https://github.com/fluent/fluent-logger-golang/tree/master#bufferlimit)
 
+### fluentd-request-ack
+
+Require the Fluentd daemon to acknowledge received log messages.
+When enabled, each message is sent with a unique chunk ID and Docker waits
+for an acknowledgement from the server. This improves the reliability of
+message transmission at the cost of increased latency. Defaults to `false`.
+
 ### fluentd-retry-wait
 
 How long to wait between retries. Defaults to 1 second.


### PR DESCRIPTION
## Problem

The `fluentd-request-ack` logging driver option is accepted by Docker Engine
(since v20.10, added in [moby/moby#39086](https://github.com/moby/moby/pull/39086))
but is not documented in the Fluentd logging driver reference page. All other
`fluentd-*` options have documentation sections.

## Verification

- Option is defined in Moby source:
  [`daemon/logger/fluentd/fluentd.go`](https://github.com/moby/moby/blob/main/daemon/logger/fluentd/fluentd.go)
  (`requestAckKey = "fluentd-request-ack"`, parsed as bool, default `false`)
- Option is listed in Docker 20.10 release notes alongside `fluentd-async`
- The underlying [fluent-logger-golang](https://github.com/fluent/fluent-logger-golang)
  library documents the behavior: *"sends the chunk option with a unique ID.
  The server will respond with an acknowledgement. This option improves the
  reliability of the message transmission."*

## Fix

Add a `fluentd-request-ack` section to the options documentation, following the
same format as existing options (description, default value).

Closes #25823 (partial — this PR documents `fluentd-request-ack`; `fluentd-read-timeout`
is covered separately in PR #25823)