### PR TITLE
docs: mention EXPOSE can take a port range

### DIFF
--- a/content/get-started/docker-concepts/building-images/writing-a-dockerfile.md
+++ b/content/get-started/docker-concepts/building-images/writing-a-dockerfile.md
@@ -49,7 +49,7 @@ Some of the most common instructions in a `Dockerfile` include:
 - `COPY <host-path> <image-path>` - this instruction tells the builder to copy files from the host and put them into the container image.
 - `RUN <command>` - this instruction tells the builder to run the specified command.
 - `ENV <name> <value>` - this instruction sets an environment variable that a running container will use.
-- `EXPOSE <port-number>` - this instruction sets configuration on the image that indicates a port the image would like to expose.
+- `EXPOSE <port-number>` - this instruction sets configuration on the image that indicates a port the image would like to expose. You can also give a range, for example `EXPOSE 3000-3005`.
 - `USER <user-or-uid>` - this instruction sets the default user for all subsequent instructions.
 - `CMD ["<command>", "<arg1>"]` - this instruction sets the default command a container using this image will run.
 

--- a/content/manuals/build/building/best-practices.md
+++ b/content/manuals/build/building/best-practices.md
@@ -526,7 +526,7 @@ The `EXPOSE` instruction indicates the ports on which a container listens
 for connections. Consequently, you should use the common, traditional port for
 your application. For example, an image containing the Apache web server would
 use `EXPOSE 80`, while an image containing MongoDB would use `EXPOSE 27017` and
-so on.
+so on. A range is valid too (`EXPOSE 3000-3005`).
 
 For external access, your users can execute `docker run` with a flag indicating
 how to map the specified port to the port of their choice.


### PR DESCRIPTION
getting-started and best-practices only showed a single port. `EXPOSE 3000-3005` already works.

see also docker/cli#1562