### PR TITLE
docs(exporters): document context on type=docker

### DIFF
--- a/content/manuals/build/exporters/oci-docker.md
+++ b/content/manuals/build/exporters/oci-docker.md
@@ -33,6 +33,7 @@ The following table describes the available parameters:
 | Parameter           | Type                                   | Default | Description                                                                                                                           |
 | ------------------- | -------------------------------------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------- |
 | `name`              | String                                 |         | Specify image name(s)                                                                                                                 |
+| `context`           | String                                 |         | Docker context to load the image into (`type=docker`). Empty uses the current CLI context.                                            |
 | `dest`              | String                                 |         | Path                                                                                                                                  |
 | `tar`               | `true`,`false`                         | `true`  | Bundle the output into a tarball layout                                                                                               |
 | `compression`       | `uncompressed`,`gzip`,`estargz`,`zstd` | `gzip`  | Compression type, see [compression][1]                                                                                                |


### PR DESCRIPTION
the table was missing `context` — that's which Docker context the image gets loaded into.

see docker/buildx#1486