### PR TITLE
docs: alias retired /ai/sandboxes/sandbox-environments/ URL

### DIFF
--- a/content/manuals/ai/sandboxes/_index.md
+++ b/content/manuals/ai/sandboxes/_index.md
@@ -3,6 +3,8 @@ title: Docker Sandboxes
 description: Run AI coding agents in isolated environments
 keywords: docker sandboxes, sbx, ai agents, sandboxed agents, microVM
 weight: 10
+aliases:
+  - /ai/sandboxes/sandbox-environments/
 params:
   sidebar:
     group: AI and agents


### PR DESCRIPTION
old sbx-releases notes still send people to `/ai/sandboxes/sandbox-environments/`, which 404s. added an alias so that path lands on the sandboxes page.

Closes #25843

@netlify /ai/sandboxes/