### PR TITLE
docs: note ARG defaults override automatic TARGETPLATFORM

### DIFF
--- a/content/manuals/build/building/multi-platform.md
+++ b/content/manuals/build/building/multi-platform.md
@@ -226,6 +226,18 @@ FROM alpine
 COPY --from=build /log /log
 ```
 
+Declare these automatic arguments with no default. A default such as
+`ARG TARGETPLATFORM=linux/amd64` is treated as a user-set value, so it wins
+over `--platform`. If you need a fallback for builders that do not set the
+automatic arguments, apply it later:
+
+```dockerfile
+ARG TARGETPLATFORM
+ENV TARGETPLATFORM=${TARGETPLATFORM:-linux/amd64}
+```
+
+The same applies to `TARGETOS`, `TARGETARCH`, and `TARGETVARIANT`.
+
 ## Examples
 
 Here are some examples of multi-platform builds:


### PR DESCRIPTION
`ARG TARGETPLATFORM=linux/amd64` (same for TARGETOS/TARGETARCH) is treated as a user-set value, so `--platform` never overrides it.

Declare the ARG with no default and apply a fallback later if you still need one.

Related to docker/buildx#510.