### PR TITLE
docs: say contrib/apparmor is the CLI profile

### DIFF
--- a/content/manuals/engine/security/apparmor.md
+++ b/content/manuals/engine/security/apparmor.md
@@ -215,7 +215,7 @@ looks like the following:
 ```
 
 In the above example, you can see `profile=/usr/bin/docker`. This means the
-user has the `docker-engine` (Docker Engine daemon) profile loaded.
+user has the Docker CLI profile loaded.
 
 Look at another log line:
 
@@ -267,7 +267,7 @@ container PIDs is in `enforce` mode. This means AppArmor is actively blocking
 and auditing in `dmesg` anything outside the bounds of the `docker-default`
 profile.
 
-The output above also shows the `/usr/bin/docker` (Docker Engine daemon) profile
+The output above also shows the `/usr/bin/docker` (Docker CLI) profile
 is running in `complain` mode. This means AppArmor only logs to `dmesg`
 activity outside the bounds of the profile. (Except in the case of Ubuntu
 Trusty, where some interesting behaviors are enforced.)
@@ -275,7 +275,7 @@ Trusty, where some interesting behaviors are enforced.)
 ## Contribute to Docker's AppArmor code
 
 Advanced users and package managers can find a profile for `/usr/bin/docker`
-(Docker Engine daemon) underneath
+(the Docker CLI) underneath
 [contrib/apparmor](https://github.com/moby/moby/tree/master/contrib/apparmor)
 in the Docker Engine source repository.
 

--- a/content/manuals/engine/security/apparmor.md
+++ b/content/manuals/engine/security/apparmor.md
@@ -17,11 +17,11 @@ loads it into the kernel.
 >
 > This profile is used on containers, not on the Docker daemon.
 
-A profile for the Docker Engine daemon exists but it is not currently installed
-with the `deb` packages. If you are interested in the source for the daemon
-profile, it is located in
+No AppArmor profile for `dockerd` is shipped with the `deb` packages. The
+files under
 [contrib/apparmor](https://github.com/moby/moby/tree/master/contrib/apparmor)
-in the Docker Engine source repository.
+in the Moby repository are a profile for the `/usr/bin/docker` CLI, not for
+the daemon.
 
 ## Understand the policies
 


### PR DESCRIPTION
The contrib/apparmor template is `profile /usr/bin/docker`, not dockerd. The old wording made it look like a daemon profile.

Fixes #12675