### PR TITLE
docs: note COPY *.go does not include Go packages in subdirs

### DIFF
--- a/content/guides/golang.md
+++ b/content/guides/golang.md
@@ -242,6 +242,11 @@ This `COPY` command uses a wildcard to copy all files with `.go` extension
 located in the current directory on the host (the directory where the `Dockerfile`
 is located) into the current directory inside the image.
 
+`COPY *.go ./` does not recurse. Packages under `pkg/` or other
+subdirectories are left out, so `go build` then fails to find them. For a
+multi-package module, copy the module root instead (`COPY . .`) and use a
+`.dockerignore` file to keep the context small.
+
 Now, to compile your application, use the familiar `RUN` command:
 
 ```dockerfile

--- a/content/guides/golang.md
+++ b/content/guides/golang.md
@@ -242,10 +242,11 @@ This `COPY` command uses a wildcard to copy all files with `.go` extension
 located in the current directory on the host (the directory where the `Dockerfile`
 is located) into the current directory inside the image.
 
-`COPY *.go ./` does not recurse. Packages under `pkg/` or other
-subdirectories are left out, so `go build` then fails to find them. For a
-multi-package module, copy the module root instead (`COPY . .`) and use a
-`.dockerignore` file to keep the context small.
+`COPY *.go ./` only matches `.go` files in that one directory. Packages
+under `pkg/` or other subdirectories are left out, so `go build` then
+fails to find them. For a multi-package module, copy the module root
+instead (`COPY . .`) and use a `.dockerignore` file to keep the context
+small.
 
 Now, to compile your application, use the familiar `RUN` command:
 


### PR DESCRIPTION
The Go guide's `COPY *.go ./` only picks up files in the Dockerfile directory. A module with `pkg/` then fails at `go build` for a reason that looks like a missing dependency.

Left the sample Dockerfile as-is (it's a single-directory app) and called out `COPY . .` for multi-package trees.

Fixes #14609