### PR TITLE
docs: note ** exception patterns in .dockerignore are unreliable

### DIFF
--- a/content/manuals/build/concepts/context.md
+++ b/content/manuals/build/concepts/context.md
@@ -615,6 +615,11 @@ README-secret.md
 All of the README files are included. The middle line has no effect because
 `!README*.md` matches `README-secret.md` and comes last.
 
+Exception patterns that use `**` to pull files back out of an excluded
+directory (for example `!vendor/**/*.go` after a `vendor` exclude) are not
+reliably supported. Prefer a tighter exclude, or list the paths you want to
+keep.
+
 ## Named contexts
 
 In addition to the default build context (the positional argument to the


### PR DESCRIPTION
The exception examples with `!README.md` are fine. What still bites people is `!dir/**/*.go` after excluding a directory — that never really worked and isn't planned.

Fixes #13343