### PR TITLE
docs: say why GHA Scout compare disables SBOM on PRs

### DIFF
--- a/content/manuals/scout/integrations/ci/gha.md
+++ b/content/manuals/scout/integrations/ci/gha.md
@@ -110,7 +110,7 @@ This creates workflow steps to:
 > and leave `sbom` / `provenance` off so the image can land in the runner's
 > local store.
 >
-> On push events the same job turns SBOM and provenance on and `push`es to
+> On push events the same job turns SBOM and provenance on and pushes to
 > the registry. Don't enable those attestations (or a multi-platform build)
 > on the PR path — those images can't be loaded locally, and compare would
 > have nothing to inspect.

--- a/content/manuals/scout/integrations/ci/gha.md
+++ b/content/manuals/scout/integrations/ci/gha.md
@@ -105,14 +105,15 @@ This creates workflow steps to:
 
 > [!NOTE]
 >
-> This CI workflow runs a local analysis and evaluation of your image. To
-> evaluate the image locally, you must ensure that the image is loaded the
-> local image store of your runner.
+> The Scout compare step only runs on pull requests
+> (`if: github.event_name == 'pull_request'`). Those builds set `load: true`
+> and leave `sbom` / `provenance` off so the image can land in the runner's
+> local store.
 >
-> This comparison doesn't work if you push the image to a registry, or if you
-> build an image that can't be loaded to the runner's local image store. For
-> example, multi-platform images or images with SBOM or provenance attestation
-> can't be loaded to the local image store.
+> On push events the same job turns SBOM and provenance on and `push`es to
+> the registry. Don't enable those attestations (or a multi-platform build)
+> on the PR path — those images can't be loaded locally, and compare would
+> have nothing to inspect.
 
 With this setup out of the way, you can add the following steps to run the
 image comparison:


### PR DESCRIPTION
The workflow turns SBOM/provenance on for pushes and off for PRs, then the next note said those attestations break local compare. That's the same split: compare only runs on PRs, where the image is loaded without attestations.

Fixes #25851