### PR TITLE
docs: say -p on the links page is not --link

### DIFF
--- a/content/manuals/engine/network/links.md
+++ b/content/manuals/engine/network/links.md
@@ -38,6 +38,10 @@ detail on container linking in default `bridge` network.
 
 ## Connect using network port mapping
 
+Publishing a port with `-p` or `-P` is not container linking. It exposes a
+container port on the host. For the current reference, see
+[Published ports](port-publishing.md).
+
 Let's say you used this command to run a simple Python Flask application:
 
 ```console


### PR DESCRIPTION
The legacy links page still walks through `-p`/`-P` before it gets to `--link`. That's host port publishing, not linking. Pointed that section at the published-ports page so people don't mix them up.

Fixes #17081