### PR TITLE
docs: say unless-stopped still restarts after a daemon reboot

### DIFF
--- a/content/manuals/engine/containers/start-containers-automatically.md
+++ b/content/manuals/engine/containers/start-containers-automatically.md
@@ -17,7 +17,7 @@ Docker recommends that you use restart policies, and avoid using process
 managers to start containers.
 
 Restart policies are different from the `--live-restore` flag of the `dockerd`
-command. Using `--live-restore` lets you to keep your containers running during
+command. Using `--live-restore` lets you keep your containers running during
 a Docker upgrade, though networking and user input are interrupted.
 
 ## Use a restart policy

--- a/content/manuals/engine/containers/start-containers-automatically.md
+++ b/content/manuals/engine/containers/start-containers-automatically.md
@@ -33,8 +33,9 @@ any of the following:
 | `always`                   | Always restart the container if it stops. If it's manually stopped, it's restarted only when Docker daemon restarts or the container itself is manually restarted. (See the second bullet listed in [restart policy details](#restart-policy-details))                                                                                                                |
 | `unless-stopped`           | Similar to `always`, except that when the container is stopped (manually or otherwise), it isn't restarted even after Docker daemon restarts.                                                                                                                                                                                                                         |
 
-The following command starts a Redis container and configures it to always
-restart, unless the container is explicitly stopped, or the daemon restarts.
+The following command starts a Redis container with the `unless-stopped`
+restart policy. Docker restarts the container if it exits or if the daemon
+restarts, but not if you stopped the container yourself.
 
 ```console
 $ docker run -d --name redis --restart unless-stopped redis


### PR DESCRIPTION
The Redis example already used `--restart unless-stopped`, but the sentence above it made it sound like the container would stay down when dockerd came back. That's `on-failure`, not `unless-stopped`.

@netlify /engine/containers/start-containers-automatically/