### PR TITLE
docs: drop doubled 'logging driver' in the json-file tip

### DIFF
--- a/content/manuals/engine/logging/configure.md
+++ b/content/manuals/engine/logging/configure.md
@@ -26,7 +26,7 @@ included with Docker, you can also implement and use [logging driver plugins](pl
 > [!TIP]
 >
 > Use the `local` logging driver to prevent disk-exhaustion. By default, no log-rotation is performed. As a result, log-files stored by the
-> default [`json-file` logging driver](drivers/json-file.md) logging driver can cause
+> default [`json-file` logging driver](drivers/json-file.md) can cause
 > a significant amount of disk space to be used for containers that generate much
 > output, which can lead to disk space exhaustion.
 >


### PR DESCRIPTION
The tip already links \"json-file logging driver\", then said \"logging driver\" again.

@netlify /engine/logging/configure/