### PR TITLE
docs: say nginx, not Redis, in the shared PID namespace example

### DIFF
--- a/data/cli/engine/docker_container_run.yaml
+++ b/data/cli/engine/docker_container_run.yaml
@@ -1216,7 +1216,7 @@ examples: |-
     Joining another container's PID namespace can be useful for debugging that
     container.
 
-    1. Start a container running a Redis server:
+    1. Start a container running nginx:
 
        ```console
        $ docker run --rm --name my-nginx -d nginx:alpine


### PR DESCRIPTION
The \`--pid\` example heading still said Redis after the commands were switched to \`nginx:alpine\`.

@netlify /reference/cli/docker/container/run/

Fixes #25857