### PR TITLE
docs: use --data-path-port for the overlay VXLAN port

### DIFF
--- a/content/manuals/engine/network/drivers/overlay.md
+++ b/content/manuals/engine/network/drivers/overlay.md
@@ -41,7 +41,7 @@ participating hosts:
 | Ports                  | Description                                                                                                                                             |
 | :--------------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | `2377/tcp`             | The default Swarm control plane port, is configurable with [`docker swarm join --listen-addr`](/reference/cli/docker/swarm/join/#listen-addr) |
-| `4789/udp`             | The default overlay traffic port, configurable with [`docker swarm init --data-path-addr`](/reference/cli/docker/swarm/init/#data-path-port)          |
+| `4789/udp`             | The default overlay traffic port, configurable with [`docker swarm init --data-path-port`](/reference/cli/docker/swarm/init/#data-path-port)          |
 | `7946/tcp`, `7946/udp` | Used for communication among nodes, not configurable                                                                                                    |
 
 ## Create an overlay network


### PR DESCRIPTION
The overlay requirements table pointed at the data-path-port docs but labeled the flag \`--data-path-addr\`. That's the address. 4789/udp is \`--data-path-port\`.

@netlify /engine/network/drivers/overlay/