### PR TITLE
docs: say the host, not the host container, has swap

### DIFF
--- a/content/manuals/engine/containers/resource_constraints.md
+++ b/content/manuals/engine/containers/resource_constraints.md
@@ -115,7 +115,7 @@ Its setting can have complicated effects:
   [Prevent a container from using swap](#prevent-a-container-from-using-swap).
 
 - If `--memory-swap` is unset, and `--memory` is set, the container can use
-  as much swap as the `--memory` setting, if the host container has swap
+  as much swap as the `--memory` setting, if the host has swap
   memory configured. For instance, if `--memory="300m"` and `--memory-swap` is
   not set, the container can use 600m in total of memory and swap.
 

--- a/content/reference/compose-file/services.md
+++ b/content/reference/compose-file/services.md
@@ -1294,7 +1294,7 @@ There is a performance penalty for applications that swap memory to disk often.
 - If `memswap_limit` is set to a positive integer, then both `memory` and `memswap_limit` must be set. `memswap_limit` represents the total amount of memory and swap that can be used, and `memory` controls the amount used by non-swap memory. So if `memory`="300m" and `memswap_limit`="1g", the container can use 300m of memory and 700m (1g - 300m) swap.
 - If `memswap_limit` is set to 0, the setting is ignored, and the value is treated as unset.
 - If `memswap_limit` is set to the same value as `memory`, and `memory` is set to a positive integer, the container does not have access to swap.
-- If `memswap_limit` is unset, and `memory` is set, the container can use as much swap as the `memory` setting, if the host container has swap memory configured. For instance, if `memory`="300m" and `memswap_limit` is not set, the container can use 600m in total of memory and swap.
+- If `memswap_limit` is unset, and `memory` is set, the container can use as much swap as the `memory` setting, if the host has swap memory configured. For instance, if `memory`="300m" and `memswap_limit` is not set, the container can use 600m in total of memory and swap.
 - If `memswap_limit` is explicitly set to -1, the container is allowed to use unlimited swap, up to the amount available on the host system.
 
 ### `models`


### PR DESCRIPTION
The memory-swap fallback is about whether the Docker host has swap. \"Host container\" was leftover wording on the resource-constraints page and the Compose memswap_limit note.

@netlify /engine/containers/resource_constraints/