### PR TITLE
docs: point host-network port mapping at the publish page

### DIFF
--- a/content/manuals/engine/network/drivers/host.md
+++ b/content/manuals/engine/network/drivers/host.md
@@ -18,7 +18,7 @@ address.
 > [!NOTE]
 >
 > Given that the container does not have its own IP-address when using
-> `host` mode networking, [port-mapping](overlay.md#publish-ports) doesn't
+> `host` mode networking, [port mapping](../port-publishing.md) doesn't
 > take effect, and the `-p`, `--publish`, `-P`, and `--publish-all` option are
 > ignored, producing a warning instead:
 >

--- a/content/manuals/engine/network/drivers/host.md
+++ b/content/manuals/engine/network/drivers/host.md
@@ -19,7 +19,7 @@ address.
 >
 > Given that the container does not have its own IP-address when using
 > `host` mode networking, [port mapping](../port-publishing.md) doesn't
-> take effect, and the `-p`, `--publish`, `-P`, and `--publish-all` option are
+> take effect, and the `-p`, `--publish`, `-P`, and `--publish-all` options are
 > ignored, producing a warning instead:
 >
 > ```console


### PR DESCRIPTION
The host-network note linked overlay.md#publish-ports, which isn't a heading. Host mode just ignores \`-p\`, so point at the published-ports page.

@netlify /engine/network/drivers/host/