### PR TITLE
docs: prefer ip addr over ifconfig in the swarm tutorial

### DIFF
--- a/content/manuals/engine/swarm/swarm-tutorial/_index.md
+++ b/content/manuals/engine/swarm/swarm-tutorial/_index.md
@@ -59,7 +59,7 @@ the IP address.
 Because other nodes contact the manager node on its IP address, you should use a
 fixed IP address.
 
-You can run `ifconfig` on Linux or macOS to see a list of the
+You can run `ip addr` on Linux, or `ifconfig` on macOS, to see a list of the
 available network interfaces.
 
 The tutorial uses `manager1` : `192.168.99.100`.


### PR DESCRIPTION
The swarm tutorial told people to run \`ifconfig\` on Linux. That's often not installed anymore. \`ip addr\` on Linux, \`ifconfig\` still on macOS.

@netlify /engine/swarm/swarm-tutorial/