### PR TITLE
docs: HTTPS wording and --tls CA file on protect-access

### DIFF
--- a/content/manuals/engine/security/protect-access.md
+++ b/content/manuals/engine/security/protect-access.md
@@ -77,7 +77,7 @@ ControlPersist    yes
 
 ## Use TLS (HTTPS) to protect the Docker daemon socket
 
-If you need Docker to be reachable through HTTP rather than SSH in a safe manner,
+If you need Docker to be reachable through HTTPS rather than SSH,
 you can enable TLS (HTTPS) by specifying the `tlsverify` flag and pointing Docker's
 `tlscacert` flag to a trusted CA certificate.
 

--- a/content/manuals/engine/security/protect-access.md
+++ b/content/manuals/engine/security/protect-access.md
@@ -315,12 +315,17 @@ Docker in various other modes by mixing the flags.
 
 #### Client modes
 
- - `tls`: Authenticate server based on public/default CA pool
- - `tlsverify`, `tlscacert`: Authenticate server based on given CA
- - `tls`, `tlscert`, `tlskey`: Authenticate with client certificate, do not
-   authenticate server based on given CA
- - `tlsverify`, `tlscacert`, `tlscert`, `tlskey`: Authenticate with client
-   certificate and authenticate server based on given CA
+- `tls`: Enable TLS. The client still loads `--tlscacert` (default
+  `~/.docker/ca.pem`) and fails if that file is missing. It does not use
+  the system CA pool. Without `--tlsverify`, the daemon certificate is
+  not verified.
+- `tlsverify`, `tlscacert`: Enable TLS and verify the daemon against the
+  given CA
+- `tls`, `tlscert`, `tlskey`: Present a client certificate. Still loads
+  `--tlscacert` as above. The daemon certificate is not verified unless
+  `--tlsverify` is also set
+- `tlsverify`, `tlscacert`, `tlscert`, `tlskey`: Present a client
+  certificate and verify the daemon against the given CA
 
 If found, the client sends its client certificate, so you just need
 to drop your keys into `~/.docker/{ca,cert,key}.pem`. Alternatively,


### PR DESCRIPTION
The TLS section said you could reach the daemon "through HTTP rather than SSH in a safe manner". That's HTTPS.

Also fixed the client-modes list: `--tls` does not use the system CA pool. The CLI still loads `--tlscacert` (default `~/.docker/ca.pem`) and errors if that file is missing.

@netlify /engine/security/protect-access/