### PR TITLE
docs: show network=host for the docker-container builder

### DIFF
--- a/content/manuals/build/builders/drivers/docker-container.md
+++ b/content/manuals/build/builders/drivers/docker-container.md
@@ -165,6 +165,20 @@ $ docker inspect buildx_buildkit_mybuilder0 --format={{.NetworkSettings.Networks
 map[foonet:0xc00018c0c0]
 ```
 
+To reach a service on the host (for example a local registry or a
+development database), put the builder on the host network instead:
+
+```console
+$ docker buildx create --use --bootstrap \
+  --driver docker-container \
+  --name mybuilder \
+  --driver-opt network=host
+```
+
+The default `docker` driver cannot see Docker overlay networks. Use a
+`docker-container` builder with `network=host` (or a user-defined
+network, as above) when the build needs that connectivity.
+
 ## Further reading
 
 For more information on the Docker container driver, see the


### PR DESCRIPTION
The docker-container driver page showed a user-defined overlay, but not the host-network case. That's the usual way to reach something on the host (local registry, etc.) when the default docker driver cannot see overlay networks.

@netlify /build/builders/drivers/docker-container/

Closes docker/buildx#1437