### PR TITLE
docs(scout): clarify PR-only compare workflow

### DIFF
--- a/content/manuals/scout/integrations/ci/gha.md
+++ b/content/manuals/scout/integrations/ci/gha.md
@@ -109,7 +109,11 @@ This creates workflow steps to:
 > evaluate the image locally, you must ensure that the image is loaded the
 > local image store of your runner.
 >
-> This comparison doesn't work if you push the image to a registry, or if you
+> In this example, the comparison step runs only for `pull_request` events. On
+> other events, the workflow pushes the image and enables SBOM and provenance
+> attestations instead of loading the image locally.
+>
+> The comparison doesn't work if you push the image to a registry, or if you
 > build an image that can't be loaded to the runner's local image store. For
 > example, multi-platform images or images with SBOM or provenance attestation
 > can't be loaded to the local image store.


### PR DESCRIPTION
## Summary
- clarify that the local Docker Scout compare step in the GitHub Actions example runs only on `pull_request` events
- explain that non-PR events push the image and enable SBOM/provenance instead of loading the image locally
- align the explanatory note with the workflow conditions already shown in the example

Fixes #25851.

## Validation
- `git diff --check`
- `npx --yes markdownlint-cli2 content/manuals/scout/integrations/ci/gha.md` *(fails on a pre-existing line-length violation at line 68, outside this change)*