### PR TITLE
Sandboxes: published ports now default to IPv4

### DIFF
--- a/content/manuals/ai/sandboxes/customize/kit-reference.md
+++ b/content/manuals/ai/sandboxes/customize/kit-reference.md
@@ -402,18 +402,21 @@ Use `ports` to expose sandbox services to the host:
 ```yaml
 ports:
   - container: 8080
-    protocol: tcp
     name: web
 ```
 
 | Field       | Description                                                         |
 | ----------- | ------------------------------------------------------------------- |
 | `container` | Container port, 1 to 65535.                                         |
-| `protocol`  | `tcp` or `udp`. Empty means `tcp`.                                  |
+| `protocol`  | `tcp` or `udp`. Empty publishes one family; see below.              |
 | `name`      | Optional label surfaced by tools that list published port bindings. |
 
-Host ports are allocated ephemerally on `127.0.0.1`. Users can pin host ports
-with `sbx ports --publish <host>:<container>`.
+Host ports are allocated ephemerally. Leave `protocol` empty unless the service
+listens on IPv6: an empty value publishes IPv4 only (`127.0.0.1`), which is what
+a service bound to `0.0.0.0` needs, while `tcp` publishes both `127.0.0.1` and
+`::1` — and a client arriving over `::1` is accepted and then reset if nothing
+in the sandbox is listening there. Users can pin host ports with
+`sbx ports --publish <host>:<container>`.
 
 ## Environment
 

--- a/content/manuals/ai/sandboxes/usage.md
+++ b/content/manuals/ai/sandboxes/usage.md
@@ -341,7 +341,8 @@ $ sbx run --publish 8080:3000 --name my-sandbox claude
 ```
 
 For an existing sandbox, use [`sbx ports`](/reference/cli/sbx/ports/) to
-forward traffic from your host:
+forward traffic from your host. Publishing a port on a stopped local sandbox
+starts it first:
 
 ```console
 $ sbx ports my-sandbox --publish 8080:3000

--- a/content/manuals/ai/sandboxes/usage.md
+++ b/content/manuals/ai/sandboxes/usage.md
@@ -363,7 +363,7 @@ them in detail.
 ```console
 $ sbx ls
 SANDBOX         AGENT   STATUS   PORTS                    WORKSPACE
-my-sandbox      claude  running  127.0.0.1:8080->3000/tcp /home/user/proj
+my-sandbox      claude  running  127.0.0.1:8080->3000/tcp4 /home/user/proj
 ```
 
 To stop forwarding a port:

--- a/content/manuals/ai/sandboxes/workflows/development.md
+++ b/content/manuals/ai/sandboxes/workflows/development.md
@@ -70,7 +70,7 @@ lists them in detail:
 ```console
 $ sbx ls
 SANDBOX         AGENT   STATUS   PORTS                    WORKSPACE
-my-sandbox      claude  running  127.0.0.1:8080->3000/tcp /home/user/proj
+my-sandbox      claude  running  127.0.0.1:8080->3000/tcp4 /home/user/proj
 ```
 
 To stop forwarding a port:
@@ -82,12 +82,14 @@ $ sbx ports my-sandbox --unpublish 8080:3000
 For a service to be reachable, it must listen on all interfaces inside the
 sandbox, not only `127.0.0.1`. Bind it to `0.0.0.0` for IPv4 or `[::]` for both
 IPv4 and IPv6. Most dev servers need a flag like `--host 0.0.0.0` to do this.
-On the host, `--publish` listens on both `127.0.0.1` and `::1`, so a client
-resolving `localhost` might pick IPv6 and fail with "connection reset by peer"
-if the sandboxed service only listens on IPv4, even when
-`http://127.0.0.1:<port>/` works. To fix that, bind the service to `[::]`, or
-pin the published port to one family with `--publish 8080:3000/tcp4` or
-`/tcp6`.
+
+On the host, a published port binds IPv4 (`127.0.0.1`) unless you name another
+protocol, so `http://localhost:<port>/` reaches a service listening on IPv4
+whichever address your resolver picks for `localhost`. To publish on both
+families use `--publish 8080:3000/tcp`, and for IPv6 alone `/tcp6`. Both of
+those require the sandboxed service to listen on IPv6 as well — bind it to
+`[::]` — or a client arriving over `::1` has its connection accepted and then
+reset.
 
 Published ports survive restarts: `sbx` re-publishes them when the sandbox or
 the daemon restarts. Explicit host ports are reused, while a port published with

--- a/content/manuals/ai/sandboxes/workflows/development.md
+++ b/content/manuals/ai/sandboxes/workflows/development.md
@@ -45,7 +45,8 @@ $ sbx run --publish 8080:3000 --name my-sandbox claude
 ```
 
 For an existing sandbox, use [`sbx ports`](/reference/cli/sbx/ports/) to
-forward traffic from your host.
+forward traffic from your host. Publishing a port on a stopped local sandbox
+starts it first.
 
 The common case: an agent has started a dev server or API, and you want to open
 it in your browser or run tests against it.
@@ -85,8 +86,10 @@ IPv4 and IPv6. Most dev servers need a flag like `--host 0.0.0.0` to do this.
 
 On the host, a published port binds IPv4 (`127.0.0.1`) unless you name another
 protocol, so `http://localhost:<port>/` reaches a service listening on IPv4
-whichever address your resolver picks for `localhost`. To publish on both
-families use `--publish 8080:3000/tcp`, and for IPv6 alone `/tcp6`. Both of
+whichever address your resolver picks for `localhost`. Naming an explicit IPv6
+host address, such as `--publish [::1]:8080:3000`, defaults the protocol to
+`tcp6` instead. To publish on both families use `--publish 8080:3000/tcp`, and
+for IPv6 alone `/tcp6`. Both of
 those require the sandboxed service to listen on IPv6 as well — bind it to
 `[::]` — or a client arriving over `::1` has its connection accepted and then
 reset.


### PR DESCRIPTION
<!-- Delete the sections that don't apply -->

## Description

Docker Sandboxes 0.42 publishes a port on IPv4 only when no protocol is named, where it previously bound both address families (docker/sandboxes#4994, reported as docker/sbx-releases#342). Three pages still describe the old behaviour, and one of them recommends a pattern that now works against the fix.

**`customize/kit-reference.md`** said an empty `protocol` means `tcp`, and its example spelled out `protocol: tcp`. Both are now misleading: omitting the field publishes IPv4 only, which is what a service bound to `0.0.0.0` needs, while `tcp` publishes both families and needs the service listening on IPv6 too. A kit copying the old example opts itself out of the new default — that is exactly what happened to the `code-server` kit (docker/sbx-kits-contrib#208). The field table now points at prose that explains both choices, and the example omits the field.

**`workflows/development.md`** (formerly `workflows.md`) told readers to work around dual-stack publishing themselves ("pin the published port to one family with `--publish 8080:3000/tcp4`"). The default now does that for them, so the paragraph explains what the default gives you and what naming `tcp` or `/tcp6` requires instead. It also now notes that naming an explicit IPv6 host address defaults the protocol to `tcp6`, and that publishing a port on a stopped local sandbox starts it first.

**`workflows/development.md` and `usage.md`** both showed `sbx ls` reporting `127.0.0.1:8080->3000/tcp` for a defaulted publish. It now reports `/tcp4`. `usage.md` also picks up the stopped-sandbox auto-start note.

The CLI reference at `data/sbx_cli/sbx_ports.yaml` is generated from the sandboxes repo and already carries the new help text, so it needs a sync rather than an edit here. `ai/sandboxes/release-notes.md` is generated too, and picks the change up from the release's own notes.

## Related issues or tickets

- docker/sandboxes#4994 (merged) — the behaviour change
- docker/sbx-releases#342 — the original report
- docker/sbx-kits-contrib#208 — the `code-server` kit, which pinned `protocol: tcp` and so kept the old dead end

## Reviews

- [x] Technical review
- [ ] Editorial review
- [ ] Product review

<sub>🤖 Raised by Claude Code on behalf of @robmry.</sub>
