### PR TITLE
fix(docs): add missing leading slash to build_path for v4.87.0

### DIFF
--- a/content/manuals/desktop/release-notes.md
+++ b/content/manuals/desktop/release-notes.md
@@ -28,7 +28,7 @@ For more frequently asked questions, see the [FAQs](/manuals/desktop/troubleshoo
 
 {{< release-date date="2026-08-17" >}}
 
-{{< desktop-install-v2 all=true win_arm_release="Early Access" version="4.87.0" build_path="236836/" >}}
+{{< desktop-install-v2 all=true win_arm_release="Early Access" version="4.87.0" build_path="/236836/" >}}
 
 ### Updates
 


### PR DESCRIPTION
## Description

This PR fixes a broken download link for the Linux package and affects other platforms generated by the shortcode on the Release Notes page for version `4.87.0`.

The `build_path` parameter was missing a leading forward slash (`build_path="236836/"`). This caused the shortcode string concatenation to output an invalid S3 bucket path (`amd64236836`), resulting in a `403 Forbidden (AccessDenied)` error from Amazon S3.

* **Malformed URL (Current):** `https://desktop.docker.com/linux/main/amd64236836/docker-desktop-amd64.deb`
* **Corrected URL (Expected):** `https://desktop.docker.com/linux/main/amd64/236836/docker-desktop-amd64.deb`

**Changes Made:**
* Added the missing leading slash to the `build_path` parameter: `build_path="/236836/"`.

## Related issues or tickets

None / Discovered during documentation manual update check.

## Reviews

* [x] Technical review
* [ ] Editorial review
* [ ] Product review
