### PR TITLE
docs: say swarm drain does not wait for replacement tasks

### DIFF
--- a/content/manuals/engine/swarm/swarm-tutorial/drain-node.md
+++ b/content/manuals/engine/swarm/swarm-tutorial/drain-node.md
@@ -21,6 +21,11 @@ node and launches replica tasks on a node with `Active` availability.
 > such as those created with `docker run`, `docker compose up`, or the Docker Engine
 > API. A node's status, including `Drain`, only affects the node's ability to schedule
 > swarm service workloads.
+>
+> Drain also does not wait for replacement tasks to be running on another node
+> before it stops the tasks on the drained node. The service can drop below its
+> replica count while the new tasks start. If you drain the last worker that
+> still has replicas, those tasks stop together.
 
 1.  If you haven't already, open a terminal and ssh into the machine where you
     run your manager node. For example, the tutorial uses a machine named


### PR DESCRIPTION
The drain tutorial says the manager stops tasks on the node and launches replicas on an active node. That's true, but it doesn't wait for those replacements to be running first — so you can dip under `--replicas`, and draining the last worker takes everything down at once.

Added that to the existing note.

@netlify /engine/swarm/swarm-tutorial/drain-node/

Fixes #9917