### PR TITLE
docs(rootless): setuptool needs a pam_systemd session

### DIFF
--- a/content/manuals/engine/security/rootless/_index.md
+++ b/content/manuals/engine/security/rootless/_index.md
@@ -91,6 +91,12 @@ export PATH=/usr/bin:$PATH
 export DOCKER_HOST=unix:///run/user/1000/docker.sock
 ```
 
+Run the installer from a real login session (`ssh` as yourself, or
+`machinectl shell $USER@`). `$XDG_RUNTIME_DIR` must be `/run/user/$(id -u)`.
+If it is empty or something like `~/.docker/run`, the script cannot see
+systemd and tells you to start `dockerd-rootless.sh` by hand. See
+[Troubleshooting](./troubleshoot.md#unable-to-install-with-systemd-when-systemd-is-present-on-the-system).
+
 If `dockerd-rootless-setuptool.sh` is not present, you may need to install the `docker-ce-rootless-extras` package manually, e.g.,
 
 ```console

--- a/content/manuals/engine/security/rootless/troubleshoot.md
+++ b/content/manuals/engine/security/rootless/troubleshoot.md
@@ -110,6 +110,19 @@ $ sudo machinectl shell myuser@
 ```
 Where `myuser@` is your desired username and @ signifies this machine.
 
+The same "systemd not detected" message appears when `$XDG_RUNTIME_DIR` is
+missing or is a fallback such as `~/.docker/run`. On a systemd host it must
+be `/run/user/$(id -u)` so `systemctl --user` can reach the session bus.
+Setting `XDG_RUNTIME_DIR` to the path printed by a failed install does not
+fix that. Log in with `pam_systemd` first (`ssh`, graphical console, or
+`machinectl shell`), then check:
+
+```console
+$ echo $XDG_RUNTIME_DIR
+/run/user/1000
+$ systemctl --user status
+```
+
 ### Errors when starting the Docker daemon
 
 **\[rootlesskit:parent\] error: failed to start the child: fork/exec /proc/self/exe: operation not permitted**


### PR DESCRIPTION
If you `sudo su` in and `$XDG_RUNTIME_DIR` is empty (or the `~/.docker/run` fallback the script prints), it says systemd isn't there even on a systemd box. `systemctl --user` needs `/run/user/$UID`.

Called that out on the install page and in the existing troubleshoot section.

@netlify /engine/security/rootless/

Fixes #14491