### PR TITLE
docs(sandboxes): correct the on-disk secret store's protection claim

### DIFF
--- a/content/manuals/ai/sandboxes/faq.md
+++ b/content/manuals/ai/sandboxes/faq.md
@@ -225,18 +225,20 @@ $ sbx settings set clipboard.imagePaste false
 
 Yes. On Linux, `sbx` stores secrets in the Secret Service exposed by your
 desktop keyring, such as GNOME Keyring or KDE Wallet. Headless servers and some
-WSL setups have no running Secret Service, so `sbx` falls back to an encrypted
-file under `$XDG_CONFIG_HOME/com.docker.sandboxes`, which defaults to
+WSL setups have no running Secret Service, so `sbx` falls back to a file under
+`$XDG_CONFIG_HOME/com.docker.sandboxes`, which defaults to
 `~/.config/com.docker.sandboxes` when `$XDG_CONFIG_HOME` is unset. No setup is
 required. When you store a secret on such a host, `sbx` prints a notice:
 
 ```text
-No keychain detected - this secret will be stored in an encrypted file on disk
+No keychain detected - this secret will be stored on disk, protected by file permissions rather than a password
 ```
 
-The file is encrypted at rest and protected by `0700` directory permissions,
-the same posture as `~/.docker/config.json`. It's weaker than an OS keychain,
-which also mediates access per application.
+`sbx` stores the file in a directory with `0700` permissions, the same
+file-permission model used for `~/.docker/config.json`. Any user or process that
+can read the file can retrieve the stored credentials, so treat the directory as
+sensitive. Where available, prefer a keychain, which mediates access per
+application.
 
 To keep secrets in a keyring instead, run a Secret Service on the host before
 storing them: install `gnome-keyring` and start `dbus-run-session`, or run the

--- a/content/manuals/ai/sandboxes/security/credentials.md
+++ b/content/manuals/ai/sandboxes/security/credentials.md
@@ -59,22 +59,25 @@ The store backing `sbx secret set` depends on your operating system:
 The Ubuntu package depends on GNOME Keyring, so a standard desktop install
 needs no extra setup.
 
-On Linux hosts without a running Secret Service — headless servers and some
-WSL setups — `sbx` falls back to an encrypted file under your user config
-directory `$XDG_CONFIG_HOME/com.docker.sandboxes`, which defaults to
+On Linux hosts without a running Secret Service — headless servers and some WSL
+setups — `sbx` falls back to a file under your user config directory
+`$XDG_CONFIG_HOME/com.docker.sandboxes`, which defaults to
 `~/.config/com.docker.sandboxes` when `$XDG_CONFIG_HOME` is unset. The fallback
 is automatic and needs no configuration. When you store a secret this way,
 `sbx` prints a notice:
 
 ```text
-No keychain detected - this secret will be stored in an encrypted file on disk
+No keychain detected - this secret will be stored on disk, protected by file permissions rather than a password
 ```
 
-The file is encrypted at rest and protected by `0700` directory permissions,
-the same posture as `~/.docker/config.json`. This is weaker than an OS
-keychain, which also mediates access per application. If you start a Secret
-Service on the host later, `sbx` stores new secrets in the keychain again. For
-more on running sandboxes without a desktop keyring, see
+`sbx` stores the file in a directory with `0700` permissions, the same
+file-permission model used for `~/.docker/config.json`. Any user or process that
+can read the file can retrieve the stored credentials, so treat the directory as
+sensitive. Where available, prefer a keychain, which mediates access per
+application.
+
+If you start a Secret Service on the host later, `sbx` stores new secrets in the
+keychain again. For more on running sandboxes without a desktop keyring, see
 [Can I use Docker Sandboxes on headless Linux?](../faq.md#can-i-use-docker-sandboxes-on-headless-linux)
 
 ### Store a secret
@@ -445,9 +448,10 @@ $ sbx secret rm --sandbox my-sandbox --registry ghcr.io -f
 
 ## Best practices
 
-- Use [stored secrets](#stored-secrets) to provide credentials. They are
-  encrypted at rest in the OS keychain (or an encrypted file on Linux hosts
-  without a keychain). See [Where secrets are stored](#where-secrets-are-stored).
+- Use [stored secrets](#stored-secrets) to provide credentials. The OS keychain
+  protects them at rest; on Linux hosts without a keychain they are held in a
+  permission-protected file instead. See
+  [Where secrets are stored](#where-secrets-are-stored).
 - Don't set API keys manually inside the sandbox. Sandbox agents are
   pre-configured to use proxy-managed credentials.
 - Registry credentials stay on the host and are injected by the proxy when a


### PR DESCRIPTION
## Description

The Sandboxes credential pages describe the keychain-less Linux fallback as "an encrypted file" and quote a CLI notice that no longer exists. They also frame the fallback as weaker than an OS keychain only because a keychain "mediates access per application".

Both understate it. The file is encrypted with a key compiled into `sbx`, not a secret the user holds, so anyone who can read the file can decrypt it. What actually protects it is the `0700` directory mode — which the pages already mention, so this mostly moves the emphasis onto the claim that holds.

`sbx` now prints:

```text
No keychain detected - this secret will be stored on disk, protected by file permissions rather than a password
```

replacing the previous "…stored in an encrypted file on disk". The quoted strings here are byte-matched against the constant in the CLI.

Four passages change:

- `security/credentials.md` — the fallback description, the quoted notice, and the protection claim
- `security/credentials.md` — the **Best practices** list, which repeated "encrypted at rest in the OS keychain (or an encrypted file on Linux hosts without a keychain)"
- `faq.md` — the headless-Linux entry, which carried the same notice and claim

No behaviour or feature is being documented here — only the accuracy of an existing description.

## Related issues or tickets

The CLI-side change is in `docker/sandboxes` and ships in the next release. Worth holding this until that release is out: until then the page would quote a notice users don't see yet.

## Reviews

- [ ] Technical review
- [ ] Editorial review
- [ ] Product review

Two things a reviewer may want to weigh in on:

- **Tone.** The intent is to be accurate without being alarming: it states what protects the file and what the encryption does and does not give you, rather than editorialising about weakness. Happy to soften or sharpen.
- **Adjacent advice, unchanged here.** The FAQ paragraph immediately below the edited text tells headless users to install `gnome-keyring` and start `dbus-run-session`. A *locked* Secret Service collection is known to make `sbx` commands hang rather than fall back, and on a key-only SSH host locked is the default state after the keyring daemon restarts — so that advice can land users somewhere worse than the fallback. It is left alone because the underlying issue is being worked separately, but it may deserve a caveat once that is resolved.

<sub>Investigated, authored and posted by Claude Code on behalf of @robmry.</sub>
