### PR TITLE
docs: say Raspberry Pi OS 32-bit ends at Engine v28

### DIFF
--- a/content/manuals/engine/install/_index.md
+++ b/content/manuals/engine/install/_index.md
@@ -62,7 +62,7 @@ Click on a platform's link to view the relevant installation procedure.
 | [CentOS](centos.md)                            |       ✅       |       ✅        |              |   ✅    |       |
 | [Debian](debian.md)                            |       ✅       |       ✅        |      ✅      |   ✅    |       |
 | [Fedora](fedora.md)                            |       ✅       |       ✅        |              |   ✅    |       |
-| [Raspberry Pi OS (32-bit)](raspberry-pi-os.md) |                |                 |      ⚠️      |         |       |
+| [Raspberry Pi OS (32-bit)](raspberry-pi-os.md) |                |                 |   last: v28  |         |       |
 | [RHEL](rhel.md)                                |       ✅       |       ✅        |              |         |  ✅   |
 | [Ubuntu](ubuntu.md)                            |       ✅       |       ✅        |      ✅      |   ✅    |  ✅   |
 | [Binaries](binaries.md)                        |       ✅       |       ✅        |      ✅      |         |       |

--- a/content/manuals/engine/install/_index.md
+++ b/content/manuals/engine/install/_index.md
@@ -67,6 +67,13 @@ Click on a platform's link to view the relevant installation procedure.
 | [Ubuntu](ubuntu.md)                            |       ✅       |       ✅        |      ✅      |   ✅    |  ✅   |
 | [Binaries](binaries.md)                        |       ✅       |       ✅        |      ✅      |         |       |
 
+> [!WARNING]
+>
+> Docker Engine v28 is the last major version that provides packages for
+> [Raspberry Pi OS 32-bit (armhf)](raspberry-pi-os.md). Starting with v29,
+> use the [Debian `arm64`](debian.md) packages, or Debian `armhf` on 32-bit
+> ARMv7.
+
 ### Other Linux distributions
 
 > [!NOTE]


### PR DESCRIPTION
the install index only had a ⚠️ on Raspberry Pi OS 32-bit, which reads like "limited" rather than "v28 is the last release." spelled the cutoff out under the table.

@netlify /engine/install/

Fixes #25879