### PR TITLE
docs: say build.network is a mode, not a Compose network

### DIFF
--- a/content/reference/compose-file/build.md
+++ b/content/reference/compose-file/build.md
@@ -348,7 +348,11 @@ build:
 
 ### `network`
 
-Set the network containers connect to for the `RUN` instructions during build.
+Set the networking mode for `RUN` instructions during the build. This is
+the same as [`docker build --network`](/reference/cli/docker/buildx/build/#network).
+It is not a Compose network from the top-level [`networks`](networks.md) key.
+
+The value is a mode (`default`, `none`, or `host`), not a network name:
 
 ```yaml
 build:
@@ -356,13 +360,7 @@ build:
   network: host
 ```
 
-```yaml
-build:
-  context: .
-  network: custom_network_1
-```
-
-Use `none` to disable networking during build:
+Use `none` to disable networking during the build:
 
 ```yaml
 build:


### PR DESCRIPTION
build.network was showing `custom_network_1`, which looks like a user-defined Compose network. it's the RUN networking mode (`default` / `none` / `host`), same as `docker build --network`.

@netlify /reference/compose-file/build/

Fixes #21982