### PR TITLE
docs: clarify Sandboxes Linux support

### DIFF
--- a/content/manuals/ai/sandboxes/install.md
+++ b/content/manuals/ai/sandboxes/install.md
@@ -74,7 +74,13 @@ Install `sbx` using Windows Package Manager:
 winget install -h Docker.sbx
 ```
 
-## Install on Linux
+## Install on Ubuntu
+
+> [!NOTE]
+>
+> Docker does not test or support Docker Sandboxes on Ubuntu derivatives, such
+> as Linux Mint and Pop!_OS. The convenience script can configure an incorrect
+> package repository on these distributions.
 
 You can install `sbx` with Docker Engine or install only the `sbx` package.
 
@@ -94,13 +100,15 @@ repository and install the `docker-sbx` package:
 
 ```console
 $ curl -fsSL https://get.docker.com | sudo REPO_ONLY=1 sh
-$ sudo apt-get install docker-sbx
+$ sudo apt install docker-sbx
 ```
 
-## Install manually
+## Install from release artifacts
 
-To install `sbx` without a package manager, download a binary from the
-[sbx-releases repository](https://github.com/docker/sbx-releases/releases).
+To install `sbx` from a package or archive, follow the
+[manual installation instructions](https://github.com/docker/sbx-releases#manual-install-from-release-artifacts).
+The availability of a Linux release artifact does not indicate that Docker
+tests or supports the corresponding distribution.
 
 ## Sign in
 


### PR DESCRIPTION
## Summary

Clarify that Ubuntu is the supported Linux installation path and that Ubuntu derivatives are not tested or supported. Link to the manual release-artifact instructions without implying support, and use `apt` for the interactive installation command.

This takes a different approach from #25872 by documenting the support boundary instead of a Pop!_OS-specific workaround.

@netlify /ai/sandboxes/install/

[Preview the updated install page](https://deploy-preview-25883--docsdocker.netlify.app/ai/sandboxes/install/)

Closes #25867

Generated by Codex