### PR TITLE
docs(sbx) clarify sbx env command

### DIFF
--- a/content/manuals/ai/sandboxes/security/isolation.md
+++ b/content/manuals/ai/sandboxes/security/isolation.md
@@ -123,6 +123,7 @@ including:
 - CI configuration (`.github/workflows/`, `.gitlab-ci.yml`)
 - IDE configuration (`.vscode/tasks.json`, `.idea/` run configurations)
 - AI project configuration and settings (`.claude/`, `.codex/`, `.gemini/`)
+- Sandbox environment files (`.sbxenv.yaml`)
 - Hidden files, shell scripts, and executables
 
 Some of these files execute code when you trigger normal development
@@ -141,6 +142,12 @@ Review them after any agent session before performing those actions:
 - AI project configuration and settings (`.claude/settings.json`, `.codex/config.toml`,
   `.gemini/settings.json`) can define hooks and startup commands that
   execute automatically.
+- Sandbox environment files (`.sbxenv.yaml`) can declare `secrets` and
+  `registries` whose values come from a `command`. Those commands run on
+  the host, as you, the next time you run `sbx env create` or
+  `sbx env run` in that directory — before the sandbox exists. Because the
+  file sits in the workspace, an agent in direct mount can add or change
+  one.
 
 > [!WARNING]
 > Treat sandbox-modified workspace files the same way you would treat a pull


### PR DESCRIPTION
## Description

The sbxenv docs [document](https://docs.docker.com/ai/sandboxes/sandbox-environments/#workspace) the direct mount risks, mirroring them here for completeness.
## Related issues or tickets


## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Technical review
- [x] Editorial review
- [x] Product review