### PR TITLE
docs: document SSH agent forwarding settings

### DIFF
--- a/content/manuals/ai/sandboxes/configuration/credentials.md
+++ b/content/manuals/ai/sandboxes/configuration/credentials.md
@@ -279,28 +279,18 @@ Docker Sandboxes uses the value from the client that creates, starts, or joins
 each sandbox. It forwards that agent into the sandbox and sets `SSH_AUTH_SOCK`
 there.
 
-If your agent uses a custom socket path, such as the 1Password SSH agent,
-configure a fixed path:
+Run `sbx setup` to configure forwarding and choose which socket to use:
 
 ```console
-$ sbx settings set ssh.agentSocketPath /path/to/agent.sock
+$ sbx setup
 ```
 
-An empty `ssh.agentSocketPath`, which is the default, uses each client's
-current `SSH_AUTH_SOCK` instead. A non-empty value overrides client sockets
-with the fixed path.
+From the SSH agent row, you can disable forwarding, use each client's current
+`SSH_AUTH_SOCK`, or set a fixed socket path for every sandbox. A fixed path is
+useful for agents that use a custom socket, such as the 1Password SSH agent.
 
-To prevent sandboxes from using your SSH agent, turn off forwarding:
-
-```console
-$ sbx settings set ssh.agentForwardingEnabled false
-```
-
-You can also configure forwarding and choose between the current client socket
-and a fixed path by running `sbx setup`.
-
-Restart the daemon after changing either setting to replace forwarders for
-existing sandboxes:
+Restart the daemon after changing forwarding or the socket mode to replace
+forwarders for existing sandboxes:
 
 ```console
 $ sbx daemon restart

--- a/content/manuals/ai/sandboxes/configuration/credentials.md
+++ b/content/manuals/ai/sandboxes/configuration/credentials.md
@@ -274,11 +274,37 @@ interact with GitHub APIs on your behalf.
 
 ### SSH agent
 
-If your host has an SSH agent and `SSH_AUTH_SOCK` is set, Docker Sandboxes
-forwards the agent into the sandbox and sets `SSH_AUTH_SOCK` there. The
-private keys stay on your host. Processes inside the sandbox can request
-signatures from the forwarded agent, but they can't read or copy the private
-key.
+SSH agent forwarding is off by default. To use your host SSH agent for Git
+authentication or commit signing inside a sandbox, turn it on:
+
+```console
+$ sbx settings set ssh.agentForwardingEnabled true
+```
+
+When forwarding is enabled, Docker Sandboxes uses the `SSH_AUTH_SOCK` value
+from the client that creates, starts, or joins each sandbox. It forwards that
+agent into the sandbox and sets `SSH_AUTH_SOCK` there.
+
+If your agent uses a custom socket path, such as the 1Password SSH agent,
+configure a fixed path:
+
+```console
+$ sbx settings set ssh.agentSocketPath /path/to/agent.sock
+```
+
+An empty `ssh.agentSocketPath` uses each client's current `SSH_AUTH_SOCK`
+instead. You can also configure forwarding and choose between the current
+client socket and a fixed path by running `sbx setup`.
+
+Restart the daemon after changing either setting to replace forwarders for
+existing sandboxes:
+
+```console
+$ sbx daemon restart
+```
+
+The private keys stay on your host. Processes inside the sandbox can request
+signatures from the forwarded agent, but they can't read or copy a private key.
 
 Use SSH agent forwarding for Git operations over SSH and SSH-based commit
 signing. The signing key must be loaded in the host SSH agent for sandboxed

--- a/content/manuals/ai/sandboxes/configuration/credentials.md
+++ b/content/manuals/ai/sandboxes/configuration/credentials.md
@@ -285,12 +285,12 @@ Run `sbx setup` to configure forwarding and choose which socket to use:
 $ sbx setup
 ```
 
-From the SSH agent row, you can disable forwarding, use each client's current
+In the SSH agent step, you can disable forwarding, use each client's current
 `SSH_AUTH_SOCK`, or set a fixed socket path for every sandbox. A fixed path is
 useful for agents that use a custom socket, such as the 1Password SSH agent.
 
-Restart the daemon after changing forwarding or the socket mode to replace
-forwarders for existing sandboxes:
+After changing forwarding or the socket selection, restart the daemon so
+existing sandboxes use the new configuration:
 
 ```console
 $ sbx daemon restart

--- a/content/manuals/ai/sandboxes/configuration/credentials.md
+++ b/content/manuals/ai/sandboxes/configuration/credentials.md
@@ -274,16 +274,10 @@ interact with GitHub APIs on your behalf.
 
 ### SSH agent
 
-SSH agent forwarding is off by default. To use your host SSH agent for Git
-authentication or commit signing inside a sandbox, turn it on:
-
-```console
-$ sbx settings set ssh.agentForwardingEnabled true
-```
-
-When forwarding is enabled, Docker Sandboxes uses the `SSH_AUTH_SOCK` value
-from the client that creates, starts, or joins each sandbox. It forwards that
-agent into the sandbox and sets `SSH_AUTH_SOCK` there.
+SSH agent forwarding is enabled by default. When `SSH_AUTH_SOCK` is set,
+Docker Sandboxes uses the value from the client that creates, starts, or joins
+each sandbox. It forwards that agent into the sandbox and sets `SSH_AUTH_SOCK`
+there.
 
 If your agent uses a custom socket path, such as the 1Password SSH agent,
 configure a fixed path:
@@ -292,9 +286,18 @@ configure a fixed path:
 $ sbx settings set ssh.agentSocketPath /path/to/agent.sock
 ```
 
-An empty `ssh.agentSocketPath` uses each client's current `SSH_AUTH_SOCK`
-instead. You can also configure forwarding and choose between the current
-client socket and a fixed path by running `sbx setup`.
+An empty `ssh.agentSocketPath`, which is the default, uses each client's
+current `SSH_AUTH_SOCK` instead. A non-empty value overrides client sockets
+with the fixed path.
+
+To prevent sandboxes from using your SSH agent, turn off forwarding:
+
+```console
+$ sbx settings set ssh.agentForwardingEnabled false
+```
+
+You can also configure forwarding and choose between the current client socket
+and a fixed path by running `sbx setup`.
 
 Restart the daemon after changing either setting to replace forwarders for
 existing sandboxes:

--- a/content/manuals/ai/sandboxes/configuration/credentials.md
+++ b/content/manuals/ai/sandboxes/configuration/credentials.md
@@ -279,15 +279,16 @@ Docker Sandboxes uses the value from the client that creates, starts, or joins
 each sandbox. It forwards that agent into the sandbox and sets `SSH_AUTH_SOCK`
 there.
 
-Run `sbx setup` to configure forwarding and choose which socket to use:
+If your agent exposes a stable socket path, such as the 1Password SSH agent,
+configure that path for every sandbox:
 
 ```console
-$ sbx setup
+$ sbx settings set ssh.agentSocketPath "$SSH_AUTH_SOCK"
 ```
 
-In the SSH agent step, you can disable forwarding, use each client's current
-`SSH_AUTH_SOCK`, or set a fixed socket path for every sandbox. A fixed path is
-useful for agents that use a custom socket, such as the 1Password SSH agent.
+An empty `ssh.agentSocketPath`, which is the default, uses each client's
+current `SSH_AUTH_SOCK` instead. The `ssh.agentForwardingEnabled` setting is a
+boolean that turns forwarding on or off.
 
 After changing forwarding or the socket selection, restart the daemon so
 existing sandboxes use the new configuration:

--- a/content/manuals/ai/sandboxes/security/isolation.md
+++ b/content/manuals/ai/sandboxes/security/isolation.md
@@ -233,4 +233,11 @@ environment variables or files inside the sandbox unless you explicitly set
 them. This means a compromised sandbox cannot read API keys from the local
 environment.
 
+SSH agent forwarding is also off by default. When you opt in, private keys
+stay on the host, but any process inside the sandbox can ask the forwarded
+agent to authenticate or sign data. Docker Sandboxes validates the upstream
+socket as an SSH agent before forwarding requests. If forwarding is disabled,
+the settings can't be read, or no client socket is available, the sandbox
+doesn't receive access to an SSH agent.
+
 For how to store and manage credentials, see [Credentials](../configuration/credentials.md).

--- a/content/manuals/ai/sandboxes/security/isolation.md
+++ b/content/manuals/ai/sandboxes/security/isolation.md
@@ -233,11 +233,11 @@ environment variables or files inside the sandbox unless you explicitly set
 them. This means a compromised sandbox cannot read API keys from the local
 environment.
 
-SSH agent forwarding is also off by default. When you opt in, private keys
-stay on the host, but any process inside the sandbox can ask the forwarded
-agent to authenticate or sign data. Docker Sandboxes validates the upstream
-socket as an SSH agent before forwarding requests. If forwarding is disabled,
-the settings can't be read, or no client socket is available, the sandbox
-doesn't receive access to an SSH agent.
+SSH agent forwarding is enabled by default. Private keys stay on the host, but
+any process inside the sandbox can ask the forwarded agent to authenticate or
+sign data. Docker Sandboxes validates the upstream socket as an SSH agent
+before forwarding requests. If forwarding is disabled, the settings can't be
+read, or no usable fixed or client socket is available, the sandbox doesn't
+receive access to an SSH agent.
 
 For how to store and manage credentials, see [Credentials](../configuration/credentials.md).

--- a/content/manuals/ai/sandboxes/security/isolation.md
+++ b/content/manuals/ai/sandboxes/security/isolation.md
@@ -235,9 +235,8 @@ environment.
 
 SSH agent forwarding is enabled by default. Private keys stay on the host, but
 any process inside the sandbox can ask the forwarded agent to authenticate or
-sign data. Docker Sandboxes validates the upstream socket as an SSH agent
-before forwarding requests. If forwarding is disabled, the settings can't be
-read, or no usable fixed or client socket is available, the sandbox doesn't
-receive access to an SSH agent.
+sign data. Docker Sandboxes forwards only sockets it recognizes as SSH agents.
+A sandbox receives no SSH agent when forwarding is disabled, the configuration
+is unavailable, or the selected socket can't be used.
 
 For how to store and manage credentials, see [Credentials](../configuration/credentials.md).

--- a/content/manuals/ai/sandboxes/troubleshooting.md
+++ b/content/manuals/ai/sandboxes/troubleshooting.md
@@ -273,15 +273,16 @@ the command again:
 Docker Sandboxes can sign Git commits with SSH keys from your host agent.
 For setup steps, see [Commit signing](workflows/git.md#commit-signing).
 
-Forwarding is enabled by default. Confirm that it hasn't been disabled:
+Forwarding is enabled by default. Run `sbx setup` and confirm that forwarding
+is enabled and the SSH agent row shows the intended socket mode:
 
 ```console
-$ sbx settings get ssh.agentForwardingEnabled
+$ sbx setup
 ```
 
-If you configured `ssh.agentSocketPath`, confirm that it points to your active
-host agent socket. An empty value uses the `SSH_AUTH_SOCK` from the client that
-created, started, or joined the sandbox. After changing either setting, run
+In dynamic mode, reconnect from a shell where `SSH_AUTH_SOCK` points to the
+intended agent. In fixed mode, confirm that the configured path points to your
+active host agent socket. After changing forwarding or the socket mode, run
 `sbx daemon restart`.
 
 If `ssh-add -L` prints `The agent has no identities.`, the sandbox can reach

--- a/content/manuals/ai/sandboxes/troubleshooting.md
+++ b/content/manuals/ai/sandboxes/troubleshooting.md
@@ -280,10 +280,10 @@ is enabled and the SSH agent row shows the intended socket mode:
 $ sbx setup
 ```
 
-In dynamic mode, reconnect from a shell where `SSH_AUTH_SOCK` points to the
-intended agent. In fixed mode, confirm that the configured path points to your
-active host agent socket. After changing forwarding or the socket mode, run
-`sbx daemon restart`.
+If you use each client's current `SSH_AUTH_SOCK`, reconnect from a shell where
+it points to the intended agent. If you use a fixed socket, confirm that the
+configured path points to an active host agent. After changing forwarding or
+the socket selection, run `sbx daemon restart`.
 
 If `ssh-add -L` prints `The agent has no identities.`, the sandbox can reach
 the forwarded agent, but the host agent doesn't have a loaded key. Load the

--- a/content/manuals/ai/sandboxes/troubleshooting.md
+++ b/content/manuals/ai/sandboxes/troubleshooting.md
@@ -273,7 +273,7 @@ the command again:
 Docker Sandboxes can sign Git commits with SSH keys from your host agent.
 For setup steps, see [Commit signing](workflows/git.md#commit-signing).
 
-Confirm that forwarding is enabled:
+Forwarding is enabled by default. Confirm that it hasn't been disabled:
 
 ```console
 $ sbx settings get ssh.agentForwardingEnabled
@@ -281,7 +281,7 @@ $ sbx settings get ssh.agentForwardingEnabled
 
 If you configured `ssh.agentSocketPath`, confirm that it points to your active
 host agent socket. An empty value uses the `SSH_AUTH_SOCK` from the client that
-started or joined the sandbox. After changing either setting, run
+created, started, or joined the sandbox. After changing either setting, run
 `sbx daemon restart`.
 
 If `ssh-add -L` prints `The agent has no identities.`, the sandbox can reach

--- a/content/manuals/ai/sandboxes/troubleshooting.md
+++ b/content/manuals/ai/sandboxes/troubleshooting.md
@@ -273,6 +273,17 @@ the command again:
 Docker Sandboxes can sign Git commits with SSH keys from your host agent.
 For setup steps, see [Commit signing](workflows/git.md#commit-signing).
 
+Confirm that forwarding is enabled:
+
+```console
+$ sbx settings get ssh.agentForwardingEnabled
+```
+
+If you configured `ssh.agentSocketPath`, confirm that it points to your active
+host agent socket. An empty value uses the `SSH_AUTH_SOCK` from the client that
+started or joined the sandbox. After changing either setting, run
+`sbx daemon restart`.
+
 If `ssh-add -L` prints `The agent has no identities.`, the sandbox can reach
 the forwarded agent, but the host agent doesn't have a loaded key. Load the
 signing key into your host SSH agent:

--- a/content/manuals/ai/sandboxes/troubleshooting.md
+++ b/content/manuals/ai/sandboxes/troubleshooting.md
@@ -273,16 +273,17 @@ the command again:
 Docker Sandboxes can sign Git commits with SSH keys from your host agent.
 For setup steps, see [Commit signing](workflows/git.md#commit-signing).
 
-Forwarding is enabled by default. Run `sbx setup` and confirm that forwarding
-is enabled and the SSH agent row shows the intended socket mode:
+Forwarding is enabled by default. Confirm that it hasn't been disabled and
+check whether a fixed socket path is configured:
 
 ```console
-$ sbx setup
+$ sbx settings get ssh.agentForwardingEnabled
+$ sbx settings get ssh.agentSocketPath
 ```
 
 If you use each client's current `SSH_AUTH_SOCK`, reconnect from a shell where
-it points to the intended agent. If you use a fixed socket, confirm that the
-configured path points to an active host agent. After changing forwarding or
+it points to the intended agent. If `ssh.agentSocketPath` returns a path,
+confirm that it points to an active host agent. After changing forwarding or
 the socket selection, run `sbx daemon restart`.
 
 If `ssh-add -L` prints `The agent has no identities.`, the sandbox can reach

--- a/content/manuals/ai/sandboxes/workflows/git.md
+++ b/content/manuals/ai/sandboxes/workflows/git.md
@@ -183,27 +183,20 @@ yourself after reviewing the changes.
 
 ## Commit signing
 
-Sandboxes can forward your host SSH agent into the sandbox, so the agent can
-sign commits with your SSH key without the private key ever leaving your host.
+SSH agent forwarding is enabled by default. When `SSH_AUTH_SOCK` is set,
+sandboxes forward your host SSH agent into the sandbox, so the agent can sign
+commits with your SSH key without the private key ever leaving your host. If
+you turned off forwarding or use a fixed SSH agent socket, see
+[SSH agent configuration](../configuration/credentials.md#ssh-agent).
 
-1. On your host, turn on SSH agent forwarding:
-
-   ```console
-   $ sbx settings set ssh.agentForwardingEnabled true
-   $ sbx daemon restart
-   ```
-
-   Forwarding is off by default. If you use a custom SSH agent socket, first
-   [configure its path](../configuration/credentials.md#ssh-agent).
-
-2. Make sure the signing key is loaded in your host SSH agent:
+1. Make sure the signing key is loaded in your host SSH agent:
 
    ```console
    $ ssh-add ~/.ssh/id_ed25519
    $ ssh-add -L  # confirm the key appears
    ```
 
-3. Inside the sandbox, configure Git to sign with SSH. Use the forwarded key
+2. Inside the sandbox, configure Git to sign with SSH. Use the forwarded key
    directly rather than a file path, since host paths don't exist inside the
    sandbox:
 
@@ -212,7 +205,7 @@ sign commits with your SSH key without the private key ever leaving your host.
    $ git config --global user.signingkey "key::$(ssh-add -L | head -n 1)"
    ```
 
-4. Sign commits as usual:
+3. Sign commits as usual:
 
    ```console
    $ git commit -S -m "feat: my change"

--- a/content/manuals/ai/sandboxes/workflows/git.md
+++ b/content/manuals/ai/sandboxes/workflows/git.md
@@ -183,18 +183,27 @@ yourself after reviewing the changes.
 
 ## Commit signing
 
-Sandboxes forward your host SSH agent into the sandbox, so the agent can
-sign commits with your SSH key without the private key ever leaving your
-host.
+Sandboxes can forward your host SSH agent into the sandbox, so the agent can
+sign commits with your SSH key without the private key ever leaving your host.
 
-1. On your host, make sure the signing key is loaded in your SSH agent:
+1. On your host, turn on SSH agent forwarding:
+
+   ```console
+   $ sbx settings set ssh.agentForwardingEnabled true
+   $ sbx daemon restart
+   ```
+
+   Forwarding is off by default. If you use a custom SSH agent socket, first
+   [configure its path](../configuration/credentials.md#ssh-agent).
+
+2. Make sure the signing key is loaded in your host SSH agent:
 
    ```console
    $ ssh-add ~/.ssh/id_ed25519
    $ ssh-add -L  # confirm the key appears
    ```
 
-2. Inside the sandbox, configure Git to sign with SSH. Use the forwarded key
+3. Inside the sandbox, configure Git to sign with SSH. Use the forwarded key
    directly rather than a file path, since host paths don't exist inside the
    sandbox:
 
@@ -203,7 +212,7 @@ host.
    $ git config --global user.signingkey "key::$(ssh-add -L | head -n 1)"
    ```
 
-3. Sign commits as usual:
+4. Sign commits as usual:
 
    ```console
    $ git commit -S -m "feat: my change"


### PR DESCRIPTION
## Summary

Document the v0.42 SSH agent forwarding behavior and controls:

- Forwarding is enabled by default and can be explicitly disabled.
- An empty `ssh.agentSocketPath` uses the `SSH_AUTH_SOCK` supplied by each client, while a non-empty value selects a fixed socket.
- Existing forwarders require a daemon restart after either setting changes.
- Commit-signing, isolation, and troubleshooting guidance reflects these defaults.

@netlify /ai/sandboxes/configuration/credentials/

## Preview

- [Credentials](https://deploy-preview-25898--docsdocker.netlify.app/ai/sandboxes/configuration/credentials/)
- [Git workflows](https://deploy-preview-25898--docsdocker.netlify.app/ai/sandboxes/workflows/git/)
- [Isolation layers](https://deploy-preview-25898--docsdocker.netlify.app/ai/sandboxes/security/isolation/)
- [Troubleshooting](https://deploy-preview-25898--docsdocker.netlify.app/ai/sandboxes/troubleshooting/)

Generated by Codex
