### PR TITLE
docs: clarify setup.files permissions

### DIFF
--- a/content/manuals/ai/sandboxes/customize/kit-reference.md
+++ b/content/manuals/ai/sandboxes/customize/kit-reference.md
@@ -472,6 +472,11 @@ Files written at sandbox start, with runtime substitution.
 | `mode`          | `"0644"` | File permissions in octal.                                |
 | `onlyIfMissing` | `false`  | Skip if the file already exists.                          |
 
+The runtime writes these files as the agent user with UID 1000. The target
+path must be writable by that user. To write to a root-owned path such as
+`/etc`, use an `install` command, which runs as root by default. Set ownership
+in the install command if the agent needs to modify the file later.
+
 ## Static files
 
 ```text


### PR DESCRIPTION
## Summary

Clarify that `setup.files` runs as the non-root agent user with UID 1000 and requires an agent-writable target. Direct kit authors to `setup.install` when writing root-owned paths.

@netlify /ai/sandboxes/customize/kit-reference/

Closes docker/sbx-releases#467

Companion specification update: docker/sbx-kits-contrib#227

[Preview the kit spec reference](https://deploy-preview-25899--docsdocker.netlify.app/ai/sandboxes/customize/kit-reference/)

Generated by Codex