### PR TITLE
docs: list AI Governance policy-change events in activity logs

### DIFF
--- a/content/manuals/admin/activity-logs.md
+++ b/content/manuals/admin/activity-logs.md
@@ -111,6 +111,22 @@ Refer to the following section for a list of events and their descriptions:
 | Change SSO Connection Type | Details of a connection type change on an existing org/company SSO connection |
 | Toggle JIT provisioning | Details of a JIT toggle on an existing org/company SSO connection |
 
+### AI Governance events
+
+These events record who created or edited an
+[AI Governance](/manuals/ai/sandboxes/governance/) policy in Docker Home.
+They are not the same as
+[AI Governance Audit Logs](/manuals/ai/sandboxes/governance/audit/),
+which record sandbox policy decisions at runtime.
+
+| Event | Description |
+|:------|:------------|
+| Created governance policy | An organization owner created an AI Governance policy |
+| Created governance policy rule | A rule was added to an AI Governance policy |
+| Updated governance policy rule | A rule on an AI Governance policy was changed |
+| Deleted governance policy rule | A rule was removed from an AI Governance policy |
+| Set governance setting | An AI Governance setting was changed from one value to another |
+
 ### Repository events
 
 > [!NOTE]

--- a/content/manuals/admin/activity-logs.md
+++ b/content/manuals/admin/activity-logs.md
@@ -114,9 +114,9 @@ Refer to the following section for a list of events and their descriptions:
 ### AI Governance events
 
 These events record who created or edited an
-[AI Governance](/manuals/ai/sandboxes/governance/) policy in Docker Home.
+[AI Governance](/manuals/ai/sandboxes/governance/_index.md) policy in Docker Home.
 They are not the same as
-[AI Governance Audit Logs](/manuals/ai/sandboxes/governance/audit/),
+[AI Governance Audit Logs](/manuals/ai/sandboxes/governance/audit/_index.md),
 which record sandbox policy decisions at runtime.
 
 | Event | Description |

--- a/content/manuals/ai/sandboxes/governance/audit/_index.md
+++ b/content/manuals/ai/sandboxes/governance/audit/_index.md
@@ -48,7 +48,7 @@ as they become available.
 
 Changes to the policies themselves (who created or edited a policy) are
 recorded in the organization
-[Activity logs](/manuals/admin/activity-logs/#ai-governance-events), not here.
+[Activity logs](/manuals/admin/activity-logs.md#ai-governance-events), not here.
 
 ## Delivery modes
 
@@ -85,5 +85,5 @@ Policy](https://www.docker.com/legal/privacy/).
 - [View and export audit events](view-export.md)
 - [SIEM forwarding](siem.md)
 - [Audit record reference](record-reference.md)
-- [Activity logs](/manuals/admin/activity-logs/#ai-governance-events) for
+- [Activity logs](/manuals/admin/activity-logs.md#ai-governance-events) for
   policy-change events

--- a/content/manuals/ai/sandboxes/governance/audit/_index.md
+++ b/content/manuals/ai/sandboxes/governance/audit/_index.md
@@ -46,6 +46,10 @@ AI Governance Audit Logs cover Docker Sandboxes policy decisions and sandbox
 session events. Other Docker AI sources can emit records through the same schema
 as they become available.
 
+Changes to the policies themselves (who created or edited a policy) are
+recorded in the organization
+[Activity logs](/manuals/admin/activity-logs/#ai-governance-events), not here.
+
 ## Delivery modes
 
 Docker supports two delivery modes for audit records:
@@ -81,3 +85,5 @@ Policy](https://www.docker.com/legal/privacy/).
 - [View and export audit events](view-export.md)
 - [SIEM forwarding](siem.md)
 - [Audit record reference](record-reference.md)
+- [Activity logs](/manuals/admin/activity-logs/#ai-governance-events) for
+  policy-change events


### PR DESCRIPTION
Activity logs listed Settings Management policies but not the AI Governance ones (create/update/delete policy and rules). Those show up on the org Activity tab; the sandbox audit pages are the runtime decisions. Linked the two so they don't get mixed up.

@netlify /admin/activity-logs/

Fixes #25262