### PR TITLE
docs: assign AI governance code owner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -37,6 +37,8 @@
 
 /content/manuals/ai/ @dvdksn
 
+/content/manuals/ai/sandboxes/governance/ @craig-osterhout
+
 /_vendor @dvdksn
 
 /content/manuals/offload/ @craig-osterhout


### PR DESCRIPTION
## Summary

Assign the Docker Sandboxes governance and audit log documentation to `@craig-osterhout` while preserving the existing owner for the rest of the AI documentation.

Generated by Codex