### PR TITLE
docs: update what's new for 2026-08-23

### DIFF
--- a/data/whats-new.json
+++ b/data/whats-new.json
@@ -1,7 +1,61 @@
 {
-  "period_start": "2026-07-13",
-  "period_end": "2026-08-11",
+  "period_start": "2026-07-24",
+  "period_end": "2026-08-23",
   "items": [
+    {
+      "product": "Docker Verified Publisher",
+      "title": "Join Docker Verified Publisher through self-service plans",
+      "description": "Apply for DVP Starter or Growth, complete checkout after approval, and manage publisher analytics, tracked companies, and billing.",
+      "url": "/subscription/plans/docker-verified-publisher/",
+      "published": "2026-08-20",
+      "source_prs": [25891, 25903],
+      "featured": true
+    },
+    {
+      "product": "Docker Sandboxes",
+      "title": "Sign and enforce trusted sandbox kits",
+      "description": "Sign kits with cosign-compatible Sigstore signatures, verify keyless or key-based signatures, and reject kits outside a trusted-signer policy.",
+      "url": "/ai/sandboxes/customize/kits/#sign-and-verify-kits",
+      "published": "2026-08-20",
+      "source_prs": [25791, 25896],
+      "featured": false
+    },
+    {
+      "product": "Docker Sandboxes",
+      "title": "Define reproducible sandbox environments",
+      "description": "Capture an agent, workspaces, kits, credentials, ports, and resources in a shareable .sbxenv.yaml file and manage it with sbx env.",
+      "url": "/ai/sandboxes/configuration/environment-files/",
+      "published": "2026-08-19",
+      "source_prs": [25487, 25896],
+      "featured": true
+    },
+    {
+      "product": "Docker Sandboxes",
+      "title": "Resolve sandbox secrets from external sources",
+      "description": "Keep references to 1Password, AWS Secrets Manager, or host commands in the secret store and resolve credentials on the host when the proxy needs them.",
+      "url": "/ai/sandboxes/configuration/credentials/#use-a-dynamic-secret-source",
+      "published": "2026-08-19",
+      "source_prs": [25785, 25896],
+      "featured": false
+    },
+    {
+      "product": "Docker Sandboxes",
+      "title": "Run GPU workloads in sandboxes",
+      "description": "Pass an NVIDIA GPU through to a sandbox on supported Linux hosts for GPU-accelerated agent workloads.",
+      "url": "/ai/sandboxes/configuration/gpu-passthrough/",
+      "published": "2026-08-19",
+      "source_prs": [25869],
+      "featured": false
+    },
+    {
+      "product": "Docker Hardened Images",
+      "title": "Query DHI VEX data with the GraphQL API",
+      "description": "Build automation or dashboards that query image packages, CVEs, VEX statements, and suppressed vulnerabilities by digest.",
+      "url": "/dhi/tools/api/",
+      "published": "2026-08-17",
+      "source_prs": [25836],
+      "featured": false
+    },
     {
       "product": "Docker Desktop",
       "title": "Use Docker VMM on Mac and Windows",
@@ -41,11 +95,11 @@
     {
       "product": "Docker AI Governance",
       "title": "Search and forward audit events",
-      "description": "Search and export policy decisions from Docker Cloud, or forward events to Splunk, Dynatrace, and custom HTTPS endpoints.",
+      "description": "Search and export policy decisions from Docker Cloud, or forward events to Splunk Cloud, Dynatrace, and Datadog.",
       "url": "/ai/sandboxes/governance/audit/",
       "published": "2026-08-03",
-      "source_prs": [25679, 25687],
-      "featured": true
+      "source_prs": [25679, 25687, 25887],
+      "featured": false
     },
     {
       "product": "Docker Desktop",
@@ -60,7 +114,7 @@
       "product": "Docker Sandboxes",
       "title": "Share agent skills across sandboxes",
       "description": "Import skills from supported host agents into a persistent store that sandboxes can share.",
-      "url": "/ai/sandboxes/workflows/#share-agent-skills",
+      "url": "/ai/sandboxes/workflows/agent-skills/",
       "published": "2026-07-24",
       "source_prs": [25588],
       "featured": false
@@ -72,24 +126,6 @@
       "url": "/ai/sandboxes/integrations/",
       "published": "2026-07-24",
       "source_prs": [25557],
-      "featured": true
-    },
-    {
-      "product": "Docker Hardened Images",
-      "title": "Query the DHI catalog from AI assistants",
-      "description": "Search DHI repositories, inspect images, retrieve SBOMs, check CVEs, and manage mirrors through the DHI MCP server.",
-      "url": "/dhi/tools/mcp/",
-      "published": "2026-07-23",
-      "source_prs": [25589],
-      "featured": false
-    },
-    {
-      "product": "Docker Enterprise",
-      "title": "Authenticate GitHub Actions with OIDC connections",
-      "description": "Exchange GitHub OIDC tokens for short-lived access to Docker resources without storing long-lived workflow credentials.",
-      "url": "/enterprise/security/oidc-connections/",
-      "published": "2026-07-21",
-      "source_prs": [25336],
       "featured": true
     }
   ]


### PR DESCRIPTION
## Publication period

2026-07-24 through 2026-08-23, inclusive. This was an incremental review of
pull requests merged after the 2026-08-11 checkpoint.

## Selected highlights

- Docker Verified Publisher self-service Starter and Growth plans
  ([#25891](https://github.com/docker/docs/pull/25891),
  [#25903](https://github.com/docker/docs/pull/25903))
- Sigstore signing, verification, and trusted-signer enforcement for sandbox
  kits ([#25791](https://github.com/docker/docs/pull/25791),
  [#25896](https://github.com/docker/docs/pull/25896))
- Declarative, reproducible Docker Sandbox environments
  ([#25487](https://github.com/docker/docs/pull/25487),
  [#25896](https://github.com/docker/docs/pull/25896))
- Dynamic sandbox secrets backed by 1Password, AWS Secrets Manager, or host
  commands ([#25785](https://github.com/docker/docs/pull/25785),
  [#25896](https://github.com/docker/docs/pull/25896))
- Experimental NVIDIA GPU passthrough for Docker Sandboxes
  ([#25869](https://github.com/docker/docs/pull/25869))
- Programmatic DHI VEX and suppressed-vulnerability queries through the DHI
  GraphQL API ([#25836](https://github.com/docker/docs/pull/25836))

Eight existing highlights dated July 24 through August 10 remain in the window.
The AI Governance audit item was corrected to list the supported SIEM
destinations documented by
[#25887](https://github.com/docker/docs/pull/25887). Two items published before
July 24 expired from the sliding window.

## Plausible exclusions

- [#25825](https://github.com/docker/docs/pull/25825) adds a score to existing
  local Scout policy output, an incremental observability enhancement rather
  than a distinct workflow.
- [#25745](https://github.com/docker/docs/pull/25745) backfills Build Cloud
  release notes and records lower-level version and default-behavior changes.
- [#25778](https://github.com/docker/docs/pull/25778) documents Docker Desktop
  4.87 fixes and bundled dependency updates, with no independently newsworthy
  product launch.
- [#25699](https://github.com/docker/docs/pull/25699) documents a narrow DHI
  mirroring permission change.
- [#25834](https://github.com/docker/docs/pull/25834) simplifies the existing
  GitHub OIDC login workflow to one action step.
- [#25789](https://github.com/docker/docs/pull/25789),
  [#25790](https://github.com/docker/docs/pull/25790), and
  [#25892](https://github.com/docker/docs/pull/25892) add narrow controls or
  integrations within existing Docker Sandboxes workflows.
- [#25878](https://github.com/docker/docs/pull/25878) is a generated Docker
  Agent documentation sync.

Generated by Codex
