### PR TITLE
docs: fix self-referencing team link

### DIFF
--- a/content/manuals/admin/organization/manage/manage-a-team.md
+++ b/content/manuals/admin/organization/manage/manage-a-team.md
@@ -59,8 +59,7 @@ For more information on roles, see
 ## Set team repository permissions
 
 You must create a team before you are able to configure repository permissions.
-For more details, see [Create and manage a
-team](/manuals/admin/organization/manage/manage-a-team.md).
+For more details, see the [Create a team](#create-a-team) section.
 
 To set team repository permissions:
 


### PR DESCRIPTION
## Summary

Fixes #25923 by linking the team repository permissions guidance to the existing `Create a team` section on the same page.

## Validation

- `git diff --check` passed
- Local `rumdl` and Vale checks were unavailable in the shallow clone; GitHub Actions will provide repository validation

This is a docs-only change.