### PR TITLE
chore: update docker-agent-action to v2.0.5

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   review:
-    uses: docker/docker-agent-action/.github/workflows/review-pr.yml@baf90543d81f5de59751dfd10e6cf45e21a5a982 # v2.0.3
+    uses: docker/docker-agent-action/.github/workflows/review-pr.yml@06e1767af06263c93d712449cbf859778d9392ee # v2.0.5
     # Scoped to the job so other jobs in this workflow aren't over-permissioned
     permissions:
       contents: read # Read repository files and PR diffs
@@ -19,7 +19,7 @@ jobs:
       issues: write # Create security incident issues if secrets detected
       checks: write # (Optional) Show review progress as a check run
       id-token: write # Required for OIDC authentication to AWS Secrets Manager
-      actions: read # Download artifacts from trigger workflow
+      actions: write # Download artifacts from trigger workflow
     with:
       trigger-run-id: ${{ github.event_name == 'workflow_run' && format('{0}', github.event.workflow_run.id) || '' }}
       add-prompt-files: STYLE.md,COMPONENTS.md


### PR DESCRIPTION
## Summary
Updates `docker-agent-action` reference in `.github/workflows/pr-review.yml` to [v2.0.5](https://github.com/docker/docker-agent-action/releases/tag/v2.0.5).
- **Commit**: `06e1767af06263c93d712449cbf859778d9392ee`
- **Version**: `v2.0.5`
Also raises the caller `permissions:` grants that v2.0.5 requires (a caller granting less fails GitHub's workflow validation at startup):
- `actions`: `read` → `write` (job:review)
> Auto-generated by the [release](https://github.com/docker/docker-agent-action/actions/runs/32832244227) workflow.