### PR TITLE
hub: add kits catalog

### DIFF
--- a/content/manuals/docker-hub/image-library/_index.md
+++ b/content/manuals/docker-hub/image-library/_index.md
@@ -18,6 +18,7 @@ In this section, learn about:
   Docker Official Images, Verified Publisher content, and Docker-Sponsored Open
   Source Software images, all vetted for security and reliability to streamline
   your workflows.
-- [Catalogs](./catalogs.md): Explore specialized collections like the generative AI catalogs.
+- [Generative AI](./catalogs.md): Explore Docker Hub's generative AI catalogs
+  and sandbox kits.
 - [Mirroring](./mirror.md): Learn how to create a mirror of Docker Hub's
   container image library as a pull-through cache.

--- a/content/manuals/docker-hub/image-library/catalogs.md
+++ b/content/manuals/docker-hub/image-library/catalogs.md
@@ -58,3 +58,20 @@ With the AI Models Catalog and Docker Model Runner, you can:
 Whether you're building generative AI applications, integrating LLMs into your
 workflows, or experimenting with machine learning tools, the AI Models Catalog
 simplifies the model management experience.
+
+## Sandbox Kits
+
+The [Sandbox Kits](https://hub.docker.com/search?type=sbx_kit) catalog lists
+kits for [Docker Sandboxes](../../ai/sandboxes/_index.md), which run AI coding
+agents in isolated microVM sandboxes.
+
+Each kit packages what an agent needs to run in a sandbox, including:
+
+- The agent's image and entrypoint
+- Tools, credentials, and environment variables
+- Network rules that scope what the sandbox can reach
+- Startup commands and agent memory instructions
+
+Each kit's Hub page shows the command to run it, in the form
+`sbx run <agent> --kit docker.io/<namespace>/<kit-name>`. To learn more about
+building and running kits, see [Kits](../../ai/sandboxes/customize/kits.md).

--- a/content/manuals/docker-hub/image-library/catalogs.md
+++ b/content/manuals/docker-hub/image-library/catalogs.md
@@ -1,16 +1,17 @@
 ---
-description: Explore specialized Docker Hub collections like the generative AI catalogs.
-keywords: Docker Hub, Hub, catalog
-title: Docker Hub catalogs
-linkTitle: Catalogs
+description: Explore Docker Hub's generative AI catalogs and sandbox kits.
+keywords: Docker Hub, Hub, generative AI, catalog
+title: Docker Hub Generative AI
+linkTitle: Generative AI
 weight: 60
 ---
 
-Docker Hub catalogs are your go-to collections of trusted, ready-to-use
-container images and resources, tailored to meet specific development needs.
-They make it easier to find high-quality, pre-verified content so you can
-quickly build, deploy, and manage your applications with confidence. Catalogs in
-Docker Hub:
+Docker Hub groups its generative AI content, including curated catalogs and
+sandbox kits, under Generative AI. Catalogs are your go-to collections of
+trusted, ready-to-use container images and resources, tailored to meet
+specific development needs. They make it easier to find high-quality,
+pre-verified content so you can quickly build, deploy, and manage your
+applications with confidence. Catalogs in Docker Hub:
 
 - Simplify content discovery: Organized and curated content makes it easy to
   discover tools and resources tailored to your specific domain or technology.
@@ -19,7 +20,8 @@ Docker Hub:
 - Accelerate development: Quickly integrate advanced capabilities into your
   applications without the hassle of extensive research or setup.
 
-The following sections provide an overview of the key catalogs available in Docker Hub.
+The following sections provide an overview of the generative AI content
+available in Docker Hub.
 
 ## MCP Catalog
 
@@ -59,18 +61,11 @@ Whether you're building generative AI applications, integrating LLMs into your
 workflows, or experimenting with machine learning tools, the AI Models Catalog
 simplifies the model management experience.
 
-## Sandbox Kits
+## Sandbox kits
 
-The [Sandbox Kits](https://hub.docker.com/search?type=sbx_kit) catalog lists
-kits for [Docker Sandboxes](../../ai/sandboxes/_index.md), which run AI coding
-agents in isolated microVM sandboxes.
-
-Each kit packages what an agent needs to run in a sandbox, including:
-
-- The agent's image and entrypoint
-- Tools, credentials, and environment variables
-- Network rules that scope what the sandbox can reach
-- Startup commands and agent memory instructions
+[Sandbox kits](https://hub.docker.com/search?type=sbx_kit) package what an AI
+coding agent needs to run in a [Docker Sandbox](../../ai/sandboxes/_index.md):
+its image, tools, credentials, network rules, and startup commands.
 
 Each kit's Hub page shows the command to run it, in the form
 `sbx run <agent> --kit docker.io/<namespace>/<kit-name>`. To learn more about

--- a/content/manuals/docker-hub/image-library/catalogs.md
+++ b/content/manuals/docker-hub/image-library/catalogs.md
@@ -1,7 +1,7 @@
 ---
 description: Explore Docker Hub's generative AI catalogs and sandbox kits.
 keywords: Docker Hub, Hub, generative AI, catalog
-title: Docker Hub Generative AI
+title: Generative AI content
 linkTitle: Generative AI
 weight: 60
 ---

--- a/content/manuals/docker-hub/image-library/search.md
+++ b/content/manuals/docker-hub/image-library/search.md
@@ -25,7 +25,7 @@ specific needs of developers and organizations. These products include:
 
 - Images
 - Extensions
-- Sandbox Kits
+- Sandbox kits
 - Helm charts
 - Compose files
 - AI models
@@ -72,7 +72,7 @@ Desktop's interface.
 To learn more about extensions, see [Docker
 Extensions](/manuals/extensions/_index.md).
 
-#### Sandbox Kits
+#### Sandbox kits
 
 Docker Hub hosts kits for [Docker Sandboxes](/manuals/ai/sandboxes/_index.md),
 which run AI coding agents in isolated microVM sandboxes. A kit packages what
@@ -267,5 +267,5 @@ The **Sandbox Kit type** filter lets you narrow sandbox kit results by kind.
 > [!NOTE]
 >
 > The **Sandbox Kit type** filter is only available for sandbox kits. To make
-> the filter available, you must select only the **Sandbox Kits** filter in
+> the filter available, you must select only the **Sandbox kits** filter in
 > **Products**.

--- a/content/manuals/docker-hub/image-library/search.md
+++ b/content/manuals/docker-hub/image-library/search.md
@@ -25,6 +25,7 @@ specific needs of developers and organizations. These products include:
 
 - Images
 - Extensions
+- Sandbox Kits
 - Helm charts
 - Compose files
 - AI models
@@ -70,6 +71,20 @@ Desktop's interface.
 
 To learn more about extensions, see [Docker
 Extensions](/manuals/extensions/_index.md).
+
+#### Sandbox Kits
+
+Docker Hub hosts kits for [Docker Sandboxes](/manuals/ai/sandboxes/_index.md),
+which run AI coding agents in isolated microVM sandboxes. A kit packages what
+an agent needs to run in a sandbox, such as its image, tools, credentials,
+network rules, and startup commands. Sandbox kits come in two kinds:
+
+- Sandbox: Defines a full agent from scratch, including its image and
+  entrypoint.
+- Mixin: Layers tools, credentials, or configuration onto an existing agent.
+
+To learn more about building and running kits, see
+[Kits](/manuals/ai/sandboxes/customize/kits.md).
 
 #### Helm charts
 
@@ -241,3 +256,16 @@ extension has been reviewed by Docker for quality and reliability.
 >
 > The **Reviewed by Docker** filter is only available for extensions. To make
 > the filter available, you must select only the **Extensions** filter in **Products**.
+
+### Sandbox Kit type
+
+The **Sandbox Kit type** filter lets you narrow sandbox kit results by kind.
+
+- **Sandbox**: Kits that define a full agent from scratch.
+- **Mixin**: Kits that layer onto an existing agent's sandbox.
+
+> [!NOTE]
+>
+> The **Sandbox Kit type** filter is only available for sandbox kits. To make
+> the filter available, you must select only the **Sandbox Kits** filter in
+> **Products**.


### PR DESCRIPTION
<!--Delete sections as needed -->

## Description

Added sandbox kits catalog and search filters for Hub.
Renamed topic to align conceptually with Hub. `catalogs` -> `generative ai`.

## Related issues or tickets

ENGDOCS-3361

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Technical review
- [ ] Editorial review
- [ ] Product review