### PR TITLE
mcp: add Mistral Vibe to verify connections section

### DIFF
--- a/content/manuals/ai/mcp-catalog-and-toolkit/get-started.md
+++ b/content/manuals/ai/mcp-catalog-and-toolkit/get-started.md
@@ -386,6 +386,9 @@ MCP servers:
 Mistral Vibe uses a TOML configuration file at `~/.vibe/config.toml`. Add the
 MCP Toolkit as a stdio MCP server in the `[[mcp_servers]]` section:
 
+{{< tabs >}}
+{{< tab name="macOS / Linux" >}}
+
 ```toml
 [[mcp_servers]]
 name = "MCP_DOCKER"
@@ -396,37 +399,39 @@ startup_timeout_sec = 60
 disabled = false
 ```
 
+{{< /tab >}}
+{{< tab name="Windows" >}}
+
+On Windows, the Docker installation path (`C:\Program Files\Docker\...`)
+contains a space. Use a list for `command` with the full path to `docker.exe`,
+and add `PROGRAMFILES` and `PROGRAMDATA` environment variables that the MCP
+Python SDK doesn't inherit by default:
+
+```toml
+[[mcp_servers]]
+name = "MCP_DOCKER"
+transport = "stdio"
+command = ["C:/Program Files/Docker/Docker/resources/bin/docker.exe"]
+args = ["mcp", "gateway", "run", "--profile", "my_profile"]
+env = { PROGRAMFILES = "C:\\Program Files", PROGRAMDATA = "C:\\ProgramData" }
+startup_timeout_sec = 60
+disabled = false
+```
+
+{{< /tab >}}
+{{< /tabs >}}
+
 The `startup_timeout_sec = 60` is recommended because the Docker MCP Gateway
 takes approximately 15-25 seconds to start. The default timeout is 10 seconds,
 which isn't enough for the gateway to initialize.
 
-> [!NOTE]
-> On Windows, the Docker installation path (`C:\Program Files\Docker\...`)
-> contains a space. Use a list for `command` with the full path to
-> `docker.exe`, and add `PROGRAMFILES` and `PROGRAMDATA` environment
-> variables that the MCP Python SDK doesn't inherit by default:
->
-> ```toml
-> [[mcp_servers]]
-> name = "MCP_DOCKER"
-> transport = "stdio"
-> command = ["C:/Program Files/Docker/Docker/resources/bin/docker.exe"]
-> args = ["mcp", "gateway", "run", "--profile", "my_profile"]
-> env = { PROGRAMFILES = "C:\\Program Files", PROGRAMDATA = "C:\\ProgramData" }
-> startup_timeout_sec = 60
-> disabled = false
-> ```
-
-Restart Vibe. If the connection is successful, Vibe exposes MCP tools prefixed
-with `MCP_DOCKER_` (such as `MCP_DOCKER_fetch`, `MCP_DOCKER_search`, and so on).
-To verify, check that no `MCP stdio discovery failed` warnings appear in the
-log:
+Restart Vibe and run the `/mcp` command in a Vibe CLI session. The
+`MCP_DOCKER` server should appear with its tools listed:
 
 ```console
-$ grep "MCP stdio discovery failed" ~/.vibe/logs/vibe.log
+$ vibe
+> /mcp
 ```
-
-If the command returns no output, the connection is successful.
 
 Test the connection by submitting a prompt that invokes one of your installed
 MCP servers:

--- a/content/manuals/ai/mcp-catalog-and-toolkit/get-started.md
+++ b/content/manuals/ai/mcp-catalog-and-toolkit/get-started.md
@@ -438,8 +438,8 @@ The `startup_timeout_sec = 60` is recommended because the Docker MCP Gateway
 takes approximately 15-25 seconds to start. The default timeout is 10 seconds,
 which isn't enough for the gateway to initialize.
 
-Restart Vibe and run the `/mcp` command in a Vibe CLI session. The
-`MCP_DOCKER` server should appear with its tools listed:
+Restart Vibe. In a Vibe CLI session, run `/mcp` to view active MCP servers.
+The `MCP_DOCKER` server should appear in the list:
 
 ```console
 $ vibe

--- a/content/manuals/ai/mcp-catalog-and-toolkit/get-started.md
+++ b/content/manuals/ai/mcp-catalog-and-toolkit/get-started.md
@@ -130,6 +130,7 @@ is working:
 - [Sema4.ai](#sema4)
 - [Visual Studio Code](#vscode)
 - [Zed](#zed)
+- [Mistral Vibe](#mistral-vibe)
 
 ### Claude Code
 
@@ -378,6 +379,58 @@ MCP servers:
 
 ```plaintext
 {{% param test_prompt %}}
+```
+
+### Mistral Vibe
+
+Mistral Vibe uses a TOML configuration file at `~/.vibe/config.toml`. Add the
+MCP Toolkit as a stdio MCP server in the `[[mcp_servers]]` section:
+
+```toml
+[[mcp_servers]]
+name = "MCP_DOCKER"
+transport = "stdio"
+command = ["docker"]
+args = ["mcp", "gateway", "run", "--profile", "my_profile"]
+startup_timeout_sec = 60
+disabled = false
+```
+
+> [!NOTE]
+> On Windows, the Docker installation path (`C:\Program Files\Docker\...`)
+> contains a space. Use a list for `command` with the full path to
+> `docker.exe`, and add `PROGRAMFILES` and `PROGRAMDATA` environment
+> variables that the MCP Python SDK doesn't inherit by default:
+>
+> ```toml
+> [[mcp_servers]]
+> name = "MCP_DOCKER"
+> transport = "stdio"
+> command = ["C:/Program Files/Docker/Docker/resources/bin/docker.exe"]
+> args = ["mcp", "gateway", "run", "--profile", "my_profile"]
+> env = { PROGRAMFILES = "C:\\Program Files", PROGRAMDATA = "C:\\ProgramData" }
+> startup_timeout_sec = 60
+> disabled = false
+> ```
+
+Restart Vibe and check the MCP server status. Vibe logs MCP connection
+results at startup. Check the log for a successful connection:
+
+```console
+$ grep "MCP" ~/.vibe/logs/vibe.log | tail -5
+```
+
+If the connection fails, the log shows the error:
+
+```console
+$ grep "MCP stdio discovery failed" ~/.vibe/logs/vibe.log
+```
+
+Test the connection by submitting a prompt that invokes one of your installed
+MCP servers:
+
+```console
+$ vibe "{{% param test_prompt %}}"
 ```
 
 ## Further reading

--- a/content/manuals/ai/mcp-catalog-and-toolkit/get-started.md
+++ b/content/manuals/ai/mcp-catalog-and-toolkit/get-started.md
@@ -387,7 +387,20 @@ Mistral Vibe uses a TOML configuration file at `~/.vibe/config.toml`. Add the
 MCP Toolkit as a stdio MCP server in the `[[mcp_servers]]` section:
 
 {{< tabs >}}
-{{< tab name="macOS / Linux" >}}
+{{< tab name="Linux" >}}
+
+```toml
+[[mcp_servers]]
+name = "MCP_DOCKER"
+transport = "stdio"
+command = ["docker"]
+args = ["mcp", "gateway", "run", "--profile", "my_profile"]
+startup_timeout_sec = 60
+disabled = false
+```
+
+{{< /tab >}}
+{{< tab name="macOS" >}}
 
 ```toml
 [[mcp_servers]]

--- a/content/manuals/ai/mcp-catalog-and-toolkit/get-started.md
+++ b/content/manuals/ai/mcp-catalog-and-toolkit/get-started.md
@@ -396,6 +396,10 @@ startup_timeout_sec = 60
 disabled = false
 ```
 
+The `startup_timeout_sec = 60` is recommended because the Docker MCP Gateway
+takes approximately 15-25 seconds to start. The default timeout is 10 seconds,
+which isn't enough for the gateway to initialize.
+
 > [!NOTE]
 > On Windows, the Docker installation path (`C:\Program Files\Docker\...`)
 > contains a space. Use a list for `command` with the full path to
@@ -413,18 +417,16 @@ disabled = false
 > disabled = false
 > ```
 
-Restart Vibe and check the MCP server status. Vibe logs MCP connection
-results at startup. Check the log for a successful connection:
-
-```console
-$ grep "MCP" ~/.vibe/logs/vibe.log | tail -5
-```
-
-If the connection fails, the log shows the error:
+Restart Vibe. If the connection is successful, Vibe exposes MCP tools prefixed
+with `MCP_DOCKER_` (such as `MCP_DOCKER_fetch`, `MCP_DOCKER_search`, and so on).
+To verify, check that no `MCP stdio discovery failed` warnings appear in the
+log:
 
 ```console
 $ grep "MCP stdio discovery failed" ~/.vibe/logs/vibe.log
 ```
+
+If the command returns no output, the connection is successful.
 
 Test the connection by submitting a prompt that invokes one of your installed
 MCP servers:


### PR DESCRIPTION
## Description

Adds Mistral Vibe (Mistral Vibe CLI) to the "Verify connections" section
of the MCP Toolkit get-started guide, with instructions for verifying
the MCP Toolkit connection.

The section includes:
- TOML configuration for `config.toml` with platform-specific tabs
  (Linux, macOS, Windows)
- `startup_timeout_sec = 60` recommendation (Docker MCP Gateway takes
  ~15-25 seconds to start; default timeout is 10 seconds)
- Windows-specific configuration for paths with spaces and missing
  `PROGRAMFILES`/`PROGRAMDATA` environment variables
- Verification using the `/mcp` command in a Vibe CLI session

## AI usage disclosure

This contribution was drafted with the assistance of the Mistral Vibe CLI
(an AI coding agent). The content was reviewed and validated by a human
contributor who tested the configuration on both macOS and Windows
environments.

## Related issues

N/A