### PR TITLE
docs: fix incorrect description in local cache page

### DIFF
--- a/content/manuals/build/cache/backends/local.md
+++ b/content/manuals/build/cache/backends/local.md
@@ -1,6 +1,6 @@
 ---
 title: Local cache
-description: Manage build cache with Amazon S3 buckets
+description: Manage build cache with a local directory
 keywords: build, buildx, cache, backend, local
 aliases:
   - /build/building/cache/backends/local/


### PR DESCRIPTION
## Description

The `local` cache page's front matter description reads
"Manage build cache with Amazon S3 buckets", which belongs to the
S3 cache page and is unrelated to the local cache backend.

Updated it to match the wording used by the other storage-location
backends (`azblob`, `registry`, `s3`), which all follow the
"Manage build cache with ..." pattern.

This description appears in search results and page metadata.

## Reviews

- [x] Editorial review