### PR TITLE
docs: document tag parameter and restructure local cache versioning

### DIFF
--- a/content/manuals/build/cache/backends/local.md
+++ b/content/manuals/build/cache/backends/local.md
@@ -28,6 +28,7 @@ The following table describes the available CSV parameters that you can pass to
 |---------------------|--------------|-------------------------|---------|---------------------------------------------------------------------------------------------------------------------------------|
 | `src`               | `cache-from` | String                  |         | Path of the local directory where cache gets imported from.                                                                     |
 | `digest`            | `cache-from` | String                  |         | Digest of manifest to import, see [cache versioning][4].                                                                        |
+| `tag`               | `cache-to`,`cache-from` | String                  | `latest` | Tag of the cache manifest, see [cache versioning][4].                                                                          |
 | `dest`              | `cache-to`   | String                  |         | Path of the local directory where cache gets exported to.                                                                       |
 | `mode`              | `cache-to`   | `min`,`max`             | `min`   | Cache layers to export, see [cache mode][1].                                                                                    |
 | `oci-mediatypes`    | `cache-to`   | `true`,`false`          | `true`  | Use OCI media types in exported manifests, see [OCI media types][2].                                                            |
@@ -47,10 +48,28 @@ build continues.
 
 ## Cache versioning
 
-<!-- FIXME: update once https://github.com/moby/buildkit/pull/3111 is released -->
-
 This section describes how versioning works for caches on a local filesystem,
-and how you can use the `digest` parameter to use older versions of cache.
+and how you can use the `digest` and `tag` parameters to select which version of
+the cache to use.
+
+Cache exports are annotated with a tag, which defaults to `latest`. Use the
+`tag` parameter to scope exports, which lets you keep multiple cache versions in
+the same directory:
+
+```console
+$ docker buildx build --cache-to type=local,dest=path/to/local/dir,tag=v1 .
+$ docker buildx build --cache-to type=local,dest=path/to/local/dir,tag=v2 .
+```
+
+To import a specific version, pass the same tag to `--cache-from`:
+
+```console
+$ docker buildx build --cache-from type=local,src=path/to/local/dir,tag=v1 .
+```
+
+If you specify `digest`, the `tag` parameter is ignored. Use `digest` to pin the
+cache to an exact manifest, and `tag` when you want a stable name that you can
+update over time.
 
 If you inspect the cache directory manually, you can see the resulting OCI image
 layout:

--- a/content/manuals/build/cache/backends/local.md
+++ b/content/manuals/build/cache/backends/local.md
@@ -48,66 +48,41 @@ build continues.
 
 ## Cache versioning
 
-This section describes how versioning works for caches on a local filesystem,
-and how you can use the `digest` and `tag` parameters to select which version of
-the cache to use.
+A local cache directory uses an OCI image layout. Its `index.json` file
+associates tags with cache manifests, while the `blobs` directory stores the
+manifest and cache data.
 
-Cache exports are annotated with a tag, which defaults to `latest`. Use the
-`tag` parameter to scope exports, which lets you keep multiple cache versions in
-the same directory:
+By default, BuildKit exports and imports the cache tagged `latest`. Use
+different tags to keep multiple caches in the same directory:
 
 ```console
 $ docker buildx build --cache-to type=local,dest=path/to/local/dir,tag=v1 .
 $ docker buildx build --cache-to type=local,dest=path/to/local/dir,tag=v2 .
 ```
 
-To import a specific version, pass the same tag to `--cache-from`:
+Exporting another cache with the same tag updates that tag to reference the new
+manifest. Manifests referenced by other tags remain unchanged.
+
+Import a cache by specifying its tag:
 
 ```console
 $ docker buildx build --cache-from type=local,src=path/to/local/dir,tag=v1 .
 ```
 
-If you specify `digest`, the `tag` parameter is ignored. Use `digest` to pin the
-cache to an exact manifest, and `tag` when you want a stable name that you can
-update over time.
-
-If you inspect the cache directory manually, you can see the resulting OCI image
-layout:
+A digest identifies an exact cache manifest. BuildKit reports the digest of
+each exported manifest in the build output. Use `digest` instead of `tag` when
+you need a specific manifest:
 
 ```console
-$ ls cache
-blobs  index.json  ingest
-$ cat cache/index.json | jq
-{
-  "schemaVersion": 2,
-  "manifests": [
-    {
-      "mediaType": "application/vnd.oci.image.index.v1+json",
-      "digest": "sha256:6982c70595cb91769f61cd1e064cf5f41d5357387bab6b18c0164c5f98c1f707",
-      "size": 1560,
-      "annotations": {
-        "org.opencontainers.image.ref.name": "latest"
-      }
-    }
-  ]
-}
+$ docker buildx build \
+  --cache-from type=local,src=path/to/local/dir,digest=sha256:<DIGEST> .
 ```
 
-Like other cache types, local cache gets replaced on export, by replacing the
-contents of the `index.json` file. However, previous caches will still be
-available in the `blobs` directory. These old caches are addressable by digest,
-and kept indefinitely. Therefore, the size of the local cache will continue to
-grow (see [`moby/buildkit#1896`](https://github.com/moby/buildkit/issues/1896)
-for more information).
+If you specify both `digest` and `tag`, BuildKit uses `digest`.
 
-When importing cache using `--cache-from`, you can specify the `digest` parameter
-to force loading an older version of the cache, for example:
-
-```console
-$ docker buildx build --push -t <registry>/<image> \
-  --cache-to type=local,dest=path/to/local/dir \
-  --cache-from type=local,ref=path/to/local/dir,digest=sha256:6982c70595cb91769f61cd1e064cf5f41d5357387bab6b18c0164c5f98c1f707 .
-```
+By default, updating a tag doesn't delete the blobs used by its previous
+manifest. The previous manifest remains available by digest, so the local cache
+directory grows over time.
 
 ## Further reading
 


### PR DESCRIPTION
## Description

The `tag` parameter for the `local` cache backend was added in
[moby/buildkit#3111](https://github.com/moby/buildkit/pull/3111) but was
never documented. The page also carried a `FIXME` comment waiting on that
PR, which has long since been released.

Changes:
- Add `tag` to the parameter table
- Document tag-based scoping in the "Cache versioning" section
- Remove the stale `FIXME` comment

Verified against `client/solve.go` and by running builds locally:
- Exports are annotated with `org.opencontainers.image.ref.name`,
  defaulting to `latest`
- Different tags coexist in the same directory as separate manifests
- `--cache-from` with a matching tag restores the cache on a fresh builder
- When `digest` is set, `tag` is ignored

## Reviews

- [x] Technical review
- [x] Editorial review