### PR TITLE
feat: hidden subtrees should still render its local sidenav

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -126,6 +126,54 @@ Additional common fields:
 - `linkTitle:` — sidebar label (keep under 30 chars)
 - `weight:` — ordering within a section
 
+## Sidebar navigation
+
+The section sidebar is rendered by
+`layouts/_partials/sidebar/sections.html`. It starts at `.FirstSection` and
+recursively walks each section's `.Pages`. Page weight controls the default
+order. Section front matter can group entries with `sidebar.groups`, reverse
+their order with `sidebar.reverse`, override a link with `sidebar.goto`, and
+add a badge with `sidebar.badge`.
+
+The sidebar expands the current page's ancestor sections and marks the current
+page with `aria-current`. When changing the recursive templates, pass all
+navigation state through both `renderChildren` and `renderList`. Keep the page
+filter and the `$hasChildren` calculation aligned so an expand control never
+points to an empty list or disappears for a rendered list.
+
+## Hidden pages
+
+Set `sitemap: false` to hide a page from site-wide discovery. This setting:
+
+- Excludes the page from `sitemap.xml`, `metadata.json`, and `llms-full.txt`
+- Excludes the page body from the site search index
+- Adds a `noindex` robots meta tag
+
+The page is still built and remains available through direct links. This is
+not an access control mechanism.
+
+Hugo does not automatically apply `sitemap: false` from a section page to its
+descendants. To hide an entire subtree, cascade the value from the section's
+`_index.md`:
+
+```yaml
+sitemap: false
+cascade:
+  sitemap: false
+```
+
+## Hidden sections in the sidebar
+
+The sidebar uses `sitemap` as a navigation visibility filter. A hidden page is
+absent from the sidebar outside its active navigation path. The current page
+and its ancestors remain visible so direct links to hidden pages do not produce
+an empty navigation path.
+
+When the active path enters a hidden section, `revealHidden` propagates down
+that branch and renders the whole hidden subtree. This keeps the section's
+navigation available while you are in it. The state must remain scoped to that
+branch so unrelated hidden pages stay hidden.
+
 ## Hugo shortcodes
 
 Shortcodes are defined in `layouts/shortcodes/`. Syntax reference is in

--- a/content/manuals/agentic-platform/_index.md
+++ b/content/manuals/agentic-platform/_index.md
@@ -4,6 +4,8 @@ description: Run agents and tools in isolated, hosted sandboxes with Docker Agen
 keywords: docker agentic platform, agents, sandboxes, mcp, secrets, network policies
 weight: 5
 sitemap: false
+cascade:
+  sitemap: false
 params:
   sidebar:
     group: AI and agents

--- a/layouts/_partials/sidebar/sections.html
+++ b/layouts/_partials/sidebar/sections.html
@@ -8,33 +8,35 @@
   */
 -}}
 <!-- section tree -->
-<nav class="navbar-font flex flex-col mt-1 mx-1">
+<nav class="navbar-font mx-1 mt-1 flex flex-col">
   <ul>
-    {{ template "renderChildren" .FirstSection }}
+    {{ template "renderChildren" (dict "section" .FirstSection "revealHidden" false) }}
   </ul>
 </nav>
 
 {{ define "renderChildren" }}
-  {{- $sourcePages := .Pages }}
-  {{- if .Params.sidebar.reverse }}
+  {{- $section := .section }}
+  {{- $revealHidden := .revealHidden }}
+  {{- $sourcePages := $section.Pages }}
+  {{- if $section.Params.sidebar.reverse }}
     {{ $sourcePages = $sourcePages.Reverse }}
   {{- end }}
   {{- $pages := slice }}
   {{- range $sourcePages }}
     {{- $isActive := or (eq page .) (page.IsDescendant .) }}
-    {{- if or (ne .Params.sitemap false) $isActive }}
+    {{- if or (ne .Params.sitemap false) $isActive $revealHidden }}
       {{- $pages = $pages | append . }}
     {{- end }}
   {{- end }}
   {{- $ungrouped := where $pages "Params.sidebar.group" "==" nil }}
   {{- range $ungrouped }}
     {{- if .IsSection }}
-      {{- template "renderList" . }}
+      {{- template "renderList" (dict "section" . "revealHidden" $revealHidden) }}
     {{- else }}
       {{- template "renderSingle" . }}
     {{- end }}
   {{- end }}
-  {{- range .Params.sidebar.groups }}
+  {{- range $section.Params.sidebar.groups }}
     <!--  Main titles -->
     <div class="navbar-group">
       <li class="navbar-group-font-title">
@@ -42,7 +44,7 @@
       </li>
       {{- range where $pages "Params.sidebar.group" . }}
         {{- if .IsSection }}
-          {{- template "renderList" . }}
+          {{- template "renderList" (dict "section" . "revealHidden" $revealHidden) }}
         {{- else }}
           {{- template "renderSingle" . }}
         {{- end }}
@@ -54,8 +56,10 @@
 
 {{/* Recursive template for sidebar items */}}
 {{ define "renderList" }}
-  {{ $isCurrent := eq page . }}
-  {{ $expanded := or $isCurrent (page.IsDescendant .) }}
+  {{- $section := .section }}
+  {{- $isCurrent := eq page $section }}
+  {{- $expanded := or $isCurrent (page.IsDescendant $section) }}
+  {{- $revealHidden := or .revealHidden (and (eq $section.Params.sitemap false) $expanded) }}
   <li class="" x-data="{ expanded: {{ $expanded }} }">
     <div
       class="{{ if $isCurrent }}
@@ -63,7 +67,7 @@
       {{ end }} flex w-full items-center justify-between rounded-sm"
     >
       <div class="navbar-entry-margin w-full truncate">
-        {{- if .Permalink }}
+        {{- if $section.Permalink }}
           {{/* If the link is not empty, use it */}}
           <!-- Sections that have children and linking to a page -->
           <a
@@ -71,9 +75,9 @@
               aria-current="page" id="sidebar-current-page"
             {{ end }}
             class="hover:text-blue block select-none hover:dark:text-blue-400"
-            href="{{ .Permalink }}"
+            href="{{ $section.Permalink }}"
           >
-            {{ template "renderTitle" . }}
+            {{ template "renderTitle" $section }}
           </a>
         {{- else }}
           {{/* Otherwise, just expand the section */}}
@@ -82,38 +86,45 @@
             @click="expanded = !expanded"
             class="hover:text-blue w-full text-left select-none hover:dark:text-blue-400"
           >
-            {{ template "renderTitle" . }}
+            {{ template "renderTitle" $section }}
           </button>
         {{- end }}
       </div>
       {{/* Only show expand group button if section has children */}}
-      {{- $hasChildren := gt (len (where .Pages "Params.sitemap" "ne" "false")) 0 }}
+      {{- $children := slice }}
+      {{- range $section.Pages }}
+        {{- $isActive := or (eq page .) (page.IsDescendant .) }}
+        {{- if or (ne .Params.sitemap false) $isActive $revealHidden }}
+          {{- $children = $children | append . }}
+        {{- end }}
+      {{- end }}
+      {{- $hasChildren := gt (len $children) 0 }}
       {{- if $hasChildren }}
-      <!-- Expand group button -->
-      <button
-        @click="expanded = !expanded"
-        class="rounded-sm px-1 hover:bg-gray-200 hover:dark:bg-gray-800"
-      >
-        <span
-          :class="{ 'hidden' : expanded }"
-          class="icon-svg icon-sm {{ if $expanded }}hidden{{ end }}"
+        <!-- Expand group button -->
+        <button
+          @click="expanded = !expanded"
+          class="rounded-sm px-1 hover:bg-gray-200 hover:dark:bg-gray-800"
         >
-          {{ partialCached "icon" "chevron-down" "chevron-down" }}
-        </span>
-        <span
-          :class="{ 'hidden' : !expanded }"
-          class="icon-svg icon-sm {{ if not $expanded }}hidden{{ end }}"
-        >
-          {{ partialCached "icon" "chevron-up" "chevron-up" }}
-        </span>
-      </button>
+          <span
+            :class="{ 'hidden' : expanded }"
+            class="icon-svg icon-sm {{ if $expanded }}hidden{{ end }}"
+          >
+            {{ partialCached "icon" "chevron-down" "chevron-down" }}
+          </span>
+          <span
+            :class="{ 'hidden' : !expanded }"
+            class="icon-svg icon-sm {{ if not $expanded }}hidden{{ end }}"
+          >
+            {{ partialCached "icon" "chevron-up" "chevron-up" }}
+          </span>
+        </button>
       {{- end }}
     </div>
     <ul
       :class="{ 'hidden' : !expanded }"
       class="{{ if not $expanded }}hidden{{ end }} ml-3"
     >
-      {{ template "renderChildren" . }}
+      {{ template "renderChildren" (dict "section" $section "revealHidden" $revealHidden) }}
     </ul>
   </li>
 {{ end }}


### PR DESCRIPTION
## Summary

Cascaded `sitemap: false` through a subtree means pages stay out of generated discovery indexes, but the complete section navigation while viewing hidden pages is preserved. Also added docs for the sidebar and hidden-page behavior in `AGENTS.md`.


Generated by Codex