### PR TITLE
docs: document sandbox clipboard writes

### DIFF
--- a/content/manuals/ai/sandboxes/faq.md
+++ b/content/manuals/ai/sandboxes/faq.md
@@ -158,6 +158,20 @@ Keep project-specific skills and other agent configuration in the project
 itself. This versions the configuration alongside the code. Don't use symlinks
 to host paths because a sandboxed agent can't follow them outside the sandbox.
 
+## Can a sandbox copy text to my host clipboard?
+
+Starting with `sbx` version 0.42.0, processes in a local sandbox can write text
+to your host clipboard. Use `wl-copy`, `xclip` in input mode, `xsel`, `pbcopy`,
+or `clip.exe`. For example, run this command inside a sandbox:
+
+```console
+$ printf 'Copied from a sandbox' | wl-copy
+```
+
+The `clipboard.imagePaste` setting isn't required for clipboard writes. That
+setting controls opt-in image reads from the host clipboard. Host clipboard
+text isn't available to processes inside the sandbox.
+
 ## Can I paste images into an agent?
 
 Yes, but it's off by default. Text paste already works, because the terminal

--- a/content/manuals/ai/sandboxes/faq.md
+++ b/content/manuals/ai/sandboxes/faq.md
@@ -158,20 +158,6 @@ Keep project-specific skills and other agent configuration in the project
 itself. This versions the configuration alongside the code. Don't use symlinks
 to host paths because a sandboxed agent can't follow them outside the sandbox.
 
-## Can a sandbox copy text to my host clipboard?
-
-Starting with `sbx` version 0.42.0, processes in a local sandbox can write text
-to your host clipboard. Use `wl-copy`, `xclip` in input mode, `xsel`, `pbcopy`,
-or `clip.exe`. For example, run this command inside a sandbox:
-
-```console
-$ printf 'Copied from a sandbox' | wl-copy
-```
-
-The `clipboard.imagePaste` setting isn't required for clipboard writes. That
-setting controls opt-in image reads from the host clipboard. Host clipboard
-text isn't available to processes inside the sandbox.
-
 ## Can I paste images into an agent?
 
 Yes, but it's off by default. Text paste already works, because the terminal

--- a/content/manuals/ai/sandboxes/security/isolation.md
+++ b/content/manuals/ai/sandboxes/security/isolation.md
@@ -31,6 +31,12 @@ processes, files, or resources outside its defined boundaries.
 The agent runs as a non-root user with sudo privileges inside the VM. The
 hypervisor boundary is the isolation control, not in-VM privilege separation.
 
+Processes in a local sandbox can write text to your host clipboard through the
+provided clipboard command shims. This integration doesn't give the sandbox
+access to existing clipboard text. Host clipboard image reads are separate and
+opt-in. After running untrusted code, check clipboard contents before pasting
+them on the host.
+
 ## Network isolation
 
 Each sandbox has its own isolated network. Sandboxes cannot communicate

--- a/content/manuals/ai/sandboxes/security/isolation.md
+++ b/content/manuals/ai/sandboxes/security/isolation.md
@@ -31,11 +31,10 @@ processes, files, or resources outside its defined boundaries.
 The agent runs as a non-root user with sudo privileges inside the VM. The
 hypervisor boundary is the isolation control, not in-VM privilege separation.
 
-Processes in a local sandbox can write text to your host clipboard through the
-provided clipboard command shims. This integration doesn't give the sandbox
-access to existing clipboard text. Host clipboard image reads are separate and
-opt-in. After running untrusted code, check clipboard contents before pasting
-them on the host.
+Processes in a local sandbox can write text to your host clipboard, but can't
+read existing clipboard text. Host clipboard image reads are a separate,
+opt-in feature. After running untrusted code, check clipboard contents before
+pasting them on the host.
 
 ## Network isolation
 


### PR DESCRIPTION
## Summary

Document local sandbox clipboard writes as a bounded host integration in the isolation documentation. Clarify that clipboard writes don't expose existing clipboard text and that host clipboard image reads remain a separate opt-in feature.

@netlify /ai/sandboxes/security/isolation/

[Preview the updated isolation documentation](https://deploy-preview-25947--docsdocker.netlify.app/ai/sandboxes/security/isolation/)

Generated by Codex