### PR TITLE
docs: document machine-wide Windows MSI

### DIFF
--- a/content/manuals/ai/sandboxes/install.md
+++ b/content/manuals/ai/sandboxes/install.md
@@ -68,11 +68,34 @@ $ brew install docker/tap/sbx
 
 ## Install on Windows
 
+### Install for the current user
+
 Install `sbx` using Windows Package Manager:
 
 ```powershell
 winget install -h Docker.sbx
 ```
+
+WinGet installs the per-user `DockerSandboxes.msi` package in
+`%LOCALAPPDATA%\DockerSandboxes` and adds its `bin` directory to your user
+`PATH`. You can install it without administrator privileges.
+
+### Install for all users
+
+For administrator-managed deployments, download
+`DockerSandboxesMachine.msi` from the
+[Docker Sandboxes releases](https://github.com/docker/sbx-releases/releases).
+From an elevated PowerShell prompt, install the package silently:
+
+```powershell
+msiexec.exe /i DockerSandboxesMachine.msi /quiet
+```
+
+The machine-wide package installs in `%ProgramFiles%\DockerSandboxes` and adds
+its `bin` directory to the system `PATH`.
+
+A machine-wide upgrade might require restarting Windows if an `sbx` daemon in
+another user's session is using the installed files.
 
 ## Install on Ubuntu
 


### PR DESCRIPTION
## Summary

Document the per-user and machine-wide Windows MSI install scopes, including their install locations and PATH changes. Add the silent administrator install command and the verified machine-upgrade reboot caveat for Docker Sandboxes v0.42.

@netlify /ai/sandboxes/install/

## Preview

[Install Docker Sandboxes](https://deploy-preview-25948--docsdocker.netlify.app/ai/sandboxes/install/)

Generated by Codex