### PR TITLE
docs: add bot-detection honeypot

### DIFF
--- a/content/bot-detection.md
+++ b/content/bot-detection.md
@@ -1,0 +1,9 @@
+---
+title: Automated traffic detection
+description: This page supports automated traffic detection for Docker documentation.
+keywords: bot detection, automated traffic, Docker documentation
+sitemap: false
+layout: wide
+---
+
+This page is used to identify automated traffic.

--- a/layouts/_partials/footer.html
+++ b/layouts/_partials/footer.html
@@ -93,3 +93,4 @@
     >Copyright © 2013-{{ time.Now.Year }} Docker Inc. All rights reserved.</span
   >
 </div>
+<a href="{{ "bot-detection/" | relURL }}" hidden>Automated traffic detection</a>


### PR DESCRIPTION
## Summary

Adds a hidden site-wide link to an identifiable `/bot-detection/` route and excludes the target page from search, navigation, and machine-readable discovery surfaces. The existing Marlin integration automatically records a page view for the route, so this needs no custom analytics event.

@netlify /bot-detection/

Preview: https://deploy-preview-25955--docsdocker.netlify.app/bot-detection/

Generated by Codex