### PR TITLE
docs(build): document local cache reset option

### DIFF
--- a/content/manuals/build/cache/backends/local.md
+++ b/content/manuals/build/cache/backends/local.md
@@ -36,6 +36,7 @@ The following table describes the available CSV parameters that you can pass to
 | `compression-level` | `cache-to`   | `0..22`                 |         | Compression level, see [cache compression][3].                                                                                  |
 | `force-compression` | `cache-to`   | `true`,`false`          | `false` | Forcibly apply compression, see [cache compression][3].                                                                         |
 | `ignore-error`      | `cache-to`   | Boolean                 | `false` | Ignore errors caused by failed cache exports.                                                                                   |
+| `reset`             | `cache-to`   | `true`,`false`          | `false` | Remove blobs from the cache directory that aren't referenced by the current manifests in `index.json`. Useful for preventing the local cache directory from growing indefinitely. |
 
 [1]: _index.md#cache-mode
 [2]: _index.md#oci-media-types


### PR DESCRIPTION
## Description

Document the `reset` attribute for the local cache exporter in the local cache backend reference.

The option was added upstream in [moby/buildkit#6612](https://github.com/moby/buildkit/pull/6612) and is now merged. When `reset=true`, BuildKit removes blobs in the local cache directory that are not referenced by the current manifests in `index.json`; the default is `false`.

Fixes #25959

## Validation

- `git diff --check`
- Confirmed the behavior and default against the merged BuildKit implementation and README documentation.
