### PR TITLE
docs: align provider credential references

### DIFF
--- a/content/manuals/agentic-platform/get-started.md
+++ b/content/manuals/agentic-platform/get-started.md
@@ -21,7 +21,7 @@ creating the sandbox or provide it in the launcher when prompted.
 
 The available sandbox types are Claude Code, Codex, OpenCode, Copilot, and
 Gemini CLI. The supported model provider credentials are Anthropic, OpenAI,
-GitHub Copilot, and Google.
+GitHub Copilot, Google, Groq, and xAI.
 
 ## Start a sandbox
 

--- a/content/manuals/agentic-platform/release-notes.md
+++ b/content/manuals/agentic-platform/release-notes.md
@@ -6,6 +6,10 @@ keywords: docker agentic platform, release notes, updates, fixes
 weight: 90
 ---
 
+## August 27, 2026
+
+- Added Groq and xAI credentials under **Secrets** for OpenCode sandboxes.
+
 ## August 26, 2026
 
 Docker Agentic Platform is available for running agent and tool workloads in

--- a/content/manuals/agentic-platform/secrets.md
+++ b/content/manuals/agentic-platform/secrets.md
@@ -19,6 +19,8 @@ Docker Agentic Platform supports the following credentials:
 | Anthropic     | `ANTHROPIC_API_KEY` | Claude Code and OpenCode with Anthropic models    |
 | OpenAI        | `OPENAI_API_KEY`    | Codex and OpenCode with OpenAI models             |
 | Google Gemini | `GEMINI_API_KEY`    | Gemini CLI and OpenCode with Google models        |
+| Groq          | `GROQ_API_KEY`      | OpenCode with Groq models                         |
+| xAI           | `XAI_API_KEY`       | OpenCode with xAI models                          |
 | GitHub        | `GITHUB_TOKEN`      | Copilot and any sandbox type that accesses GitHub |
 
 Provider-specific credentials are applied only to matching requests from


### PR DESCRIPTION
## Summary

Aligns provider credential references with supported secret types and adds a brief release note.

Generated by Codex