### PR TITLE
Fix rootless host network docs

### DIFF
--- a/content/manuals/engine/security/rootless/troubleshoot.md
+++ b/content/manuals/engine/security/rootless/troubleshoot.md
@@ -296,6 +296,8 @@ network namespace. Use `docker run -p` instead.
 This was an expected behavior until Docker Engine v29.5, as the daemon was namespaced inside RootlessKit's
 network namespace. Use `docker run -p` instead, or upgrade to Docker Engine v29.5 or later.
 
+**As of Docker Engine v29.5, `--net=host` correctly listens on the host network namespace.**
+
 #### Network is slow
 
 Docker with rootless mode uses a TCP/IP stack running in user mode, such as:


### PR DESCRIPTION
## Description

Updates the rootless networking troubleshooting documentation to make the behavior of `--net=host` clear for Docker Engine v29.5 and later.

The current documentation describes the limitation as historical but still tells users to upgrade to v29.5 or later, which can be confusing now that v29.5 has been released.

This change:
- Clarifies that the `--net=host` limitation was resolved in Docker Engine v29.5.
- Updates the troubleshooting guidance to distinguish Docker Engine v29.4 and earlier from v29.5 and later.
- Removes ambiguity around whether `docker run -p` is still required as a workaround.

## Related issues or tickets

- #25968

## Reviews

- [ ] Technical review
- [ ] Editorial review
- [ ] Product review