### PR TITLE
[docs-scanner] Broken anchor link to SSO enforcement section

### DIFF
--- a/content/manuals/enterprise/security/enforce-sign-in/_index.md
+++ b/content/manuals/enterprise/security/enforce-sign-in/_index.md
@@ -55,7 +55,7 @@ On the next Docker Desktop restart:
 
 ## Enforcing sign-in versus enforcing single sign-on (SSO)
 
-Enforcing Docker Desktop sign-in and [enforcing SSO](/manuals/enterprise/security/single-sign-on/connect.md#optional-enforce-sso) are different features that serve different purposes:
+Enforcing Docker Desktop sign-in and [enforcing SSO](/manuals/enterprise/security/single-sign-on/connect.md#enforce-sso) are different features that serve different purposes:
 
 
 | Enforcement                       | Description                                                     | Benefits                                                                                                                                                                                                                                                   |


### PR DESCRIPTION
## Description

This PR fixes the documentation issue reported in #25970: corrects `[enforcing SSO](/manuals/enterprise/security/single-sign-on/connect.md#optional-enforce-sso)` to `[enforcing SSO](/manuals/enterprise/security/single-sign-on/connect.md#enforce-sso)` in `content/manuals/enterprise/security/enforce-sign-in/_index.md`.

Fixes #25970

## Related issues or tickets

## Reviews

- [ ] Technical review
- [ ] Editorial review
- [ ] Product review

Fixes #25970