### PR TITLE
docs: fix accidental ordered-list rendering in develop-with-containers

### DIFF
--- a/content/get-started/introduction/develop-with-containers.md
+++ b/content/get-started/introduction/develop-with-containers.md
@@ -153,11 +153,7 @@ Before you move on, take a moment and reflect on what happened here. Within a fe
 
 - Start a complete development project with zero installation effort. The containerized environment provided the development environment, ensuring you have everything you need. You didn't have to install Node, MySQL, or any of the other dependencies directly on your machine. All you needed was Docker Desktop and a code editor.
 
-- Make changes and see them immediately. This was made possible because
-  1. the processes running in each container are watching and responding to
-     file changes and 2) the files in your local project directory are shared
-     with the containerized environment, so edits you make locally are
-     automatically synced to the containers.
+- Make changes and see them immediately. This was made possible because 1) the processes running in each container are watching and responding to file changes and 2) the files in your local project directory are shared with the containerized environment, so edits you make locally are automatically synced to the containers.
 
 Docker Desktop enables all of this and so much more. Once you start thinking with containers, you can create almost any environment and easily share it with your team.
 


### PR DESCRIPTION
While reading this page, I noticed "1)" renders as a bullet point while "2)" stays inline mid-sentence:

> This was made possible because
> 1. the processes running in each container are watching and responding to
>    file changes and 2) the files in your local project directory are shared
>    ...

Checked the file history with `git log -L` — the original text used `1)` and `2)` symmetrically as an inline parenthetical enumeration, all on one line. A later commit addressing #24394 (clarifying where the files are located) expanded the paragraph and reflowed it across multiple lines, which put `1)` at the start of a line. Per the [CommonMark spec](https://spec.commonmark.org/0.31.2/#ordered-list-marker), both `.` and `)` after a digit at the start of a line are valid ordered-list markers — so `1)` now renders as an actual list item, while `2)`, still mid-line, stays as plain text. Inconsistent and presumably unintended.

This PR restores the sentence to a single paragraph (matching the pre-#24394 formatting), keeping the additional clarifying text that #24394 added. Verified in a local Markdown preview that it now renders as plain prose with no stray list item.