### PR TITLE
docs: document reset parameter for local cache backend

### DIFF
--- a/content/manuals/build/cache/backends/local.md
+++ b/content/manuals/build/cache/backends/local.md
@@ -37,6 +37,7 @@ The following table describes the available CSV parameters that you can pass to
 | `compression-level` | `cache-to`   | `0..22`                 |         | Compression level, see [cache compression][3].                                                                                  |
 | `force-compression` | `cache-to`   | `true`,`false`          | `false` | Forcibly apply compression, see [cache compression][3].                                                                         |
 | `ignore-error`      | `cache-to`   | Boolean                 | `false` | Ignore errors caused by failed cache exports.                                                                                   |
+| `reset`             | `cache-to`   | `true`,`false`          | `false` | Delete blobs that no tag references, see [cache versioning][4].                                                                 |
 
 [1]: _index.md#cache-mode
 [2]: _index.md#oci-media-types
@@ -83,6 +84,16 @@ If you specify both `digest` and `tag`, BuildKit uses `digest`.
 By default, updating a tag doesn't delete the blobs used by its previous
 manifest. The previous manifest remains available by digest, so the local cache
 directory grows over time.
+
+Buildx version 0.35.0 and later supports `reset=true` on export, which deletes
+blobs that no tag references:
+
+```console
+$ docker buildx build --cache-to type=local,dest=path/to/local/dir,reset=true .
+```
+
+Blobs that other tags reference are kept. Manifests that no tag references are
+deleted, so you can no longer import them by digest.
 
 ## Further reading
 


### PR DESCRIPTION
Fixes #25959.

That issue asked for two things. The stale `moby/buildkit#1896` reference was
already removed in #25943; this adds the missing `reset` documentation.

### Verification

Tested against `buildx v0.35.0-desktop.2`:

- `reset=true` removed the blobs belonging to a manifest no tag pointed at
  (10 blobs to 7), and left the blobs of the other tag in place.
- Importing the removed manifest by digest afterwards reports
  `local cache import ... skipped: digest ... unavailable: content ...: not found`
  and the build continues.
- Without `reset`, re-exporting the same tag twice grows the directory, matching
  the paragraph above the new text.

### Version gate

The gate is the Buildx version, not the BuildKit daemon version.
moby/buildkit#6612 changes `client/solve.go` only, and `resetCacheStore` runs
client-side after the solve. Confirmed both ways:

| Combination | Result |
| --- | --- |
| buildx v0.35.0 + BuildKit daemon v0.30.0 | works |
| buildx v0.34.1 + BuildKit daemon v0.32.2 | silently ignored, no warning |

Buildx v0.35.0 is the first release to vendor `moby/buildkit v0.31.0`.
This matters because `docker buildx inspect` reports the *daemon* BuildKit
version, so naming BuildKit here would send readers to the wrong number.

### Not included

**Concurrent exports.** If two builds export to the same directory with
`reset=true`, one can delete a blob the other just registered, leaving
`index.json` pointing at a missing blob. I filed this upstream as
moby/buildkit#7102. I left it out of the docs because the same concurrent
export loses a tag entry even without `reset`, so it isn't specific to this
parameter, and it reads more like a bug to fix than behavior to document.
Happy to add a note if you'd rather warn readers in the meantime.

**GitHub Actions page.** `content/manuals/build/ci/github-actions/cache.md`
still says old cache entries aren't deleted and points at `moby/buildkit#1896`
for the `Move cache` workaround. That contradicts this page now. It's a separate
page and a separate fix, so I left it for a follow-up — let me know if you'd
prefer it here.
