### PR TITLE
docs: replace GHA local cache workaround with reset

### DIFF
--- a/content/manuals/build/ci/github-actions/cache.md
+++ b/content/manuals/build/ci/github-actions/cache.md
@@ -273,11 +273,12 @@ For more information about this workaround, refer to the
 
 ### Local cache
 
-> [!WARNING]
+> [!NOTE]
 >
-> At the moment, old cache entries aren't deleted, so the cache size [keeps growing](https://github.com/docker/build-push-action/issues/252).
-> The following example uses the `Move cache` step as a workaround (see [`moby/buildkit#1896`](https://github.com/moby/buildkit/issues/1896)
-> for more info).
+> Exporting to a directory that already holds a cache leaves the blobs of the
+> previous export behind, so the directory grows with every run. The following
+> example passes `reset=true` to delete them. This parameter requires Buildx
+> version 0.35.0 or later.
 
 You can also leverage [GitHub cache](https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows)
 using the [actions/cache](https://github.com/actions/cache) and [local cache exporter](../../cache/backends/local.md)
@@ -316,13 +317,5 @@ jobs:
           push: true
           tags: user/app:latest
           cache-from: type=local,src=${{ runner.temp }}/.buildx-cache
-          cache-to: type=local,dest=${{ runner.temp }}/.buildx-cache-new,mode=max
-
-      - # Temp fix
-        # https://github.com/docker/build-push-action/issues/252
-        # https://github.com/moby/buildkit/issues/1896
-        name: Move cache
-        run: |
-          rm -rf ${{ runner.temp }}/.buildx-cache
-          mv ${{ runner.temp }}/.buildx-cache-new ${{ runner.temp }}/.buildx-cache
+          cache-to: type=local,dest=${{ runner.temp }}/.buildx-cache,mode=max,reset=true
 ```


### PR DESCRIPTION
> [!NOTE]
> Depends on #25976, which documents the `reset` parameter this example now
> uses. Please merge that one first.

The local cache example carried a `Move cache` step to work around the cache
directory growing on every run, pointing at `moby/buildkit#1896`. That issue is
closed — moby/buildkit#6612 added a `reset` attribute to the local cache
exporter, and Buildx v0.35.0 is the first release to carry it.

This exports to the cache directory directly with `reset=true` and drops the
extra step.

### Verification

Five runs exporting to the same directory, each with a changed layer:

| Run | without `reset` | with `reset=true` |
| --- | --- | --- |
| 1 | 5 blobs, 1896 KB | 5 blobs, 1896 KB |
| 2 | 9 blobs, 1912 KB | 5 blobs, 1896 KB |
| 3 | 13 blobs, 1928 KB | 5 blobs, 1896 KB |
| 4 | 17 blobs, 1944 KB | 5 blobs, 1896 KB |
| 5 | 21 blobs, 1960 KB | 5 blobs, 1896 KB |

The cache still works after five reset cycles. Importing from that directory on
a fresh `docker-container` builder, with no local build cache to fall back on,
hit both layers and produced no import warnings.

`cache-from` and `cache-to` pointing at the same directory is fine here: the
import runs during the solve and the reset runs after it.

### Version requirement

`setup-buildx-action` installs the latest Buildx when `version` is unset, so the
default setup meets this. The note states the requirement for anyone pinning an
older version.

### Callout

Changed from a warning to a note. The growth is still worth mentioning, but it
has a supported fix now rather than being an open problem.
