### PR TITLE
Make a python3 example and not a python2 example.

### DIFF
--- a/content/manuals/engine/logging/drivers/journald.md
+++ b/content/manuals/engine/logging/drivers/journald.md
@@ -139,5 +139,5 @@ reader = systemd.journal.Reader()
 reader.add_match('CONTAINER_NAME=web')
 
 for msg in reader:
-    print '{CONTAINER_ID_FULL}: {MESSAGE}'.format(**msg)
+    print('{CONTAINER_ID_FULL}: {MESSAGE}'.format(**msg))
 ```


### PR DESCRIPTION
## Description

Make a python3 example and not a python2 example.

Python 2 is not maintened anymore. I think it is better to just use a Python 3 example.