### PR TITLE
docs: merge Subscription and Billing into one Platform section

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -25,13 +25,11 @@
 
 /content/reference/cli/ @dvdksn
 
-/content/manuals/subscription/ @sarahsanders-docker
+/content/manuals/subscription-billing/ @sarahsanders-docker
 
 /content/manuals/security/ @aevesdocker @sarahsanders-docker
 
 /content/manuals/admin/ @sarahsanders-docker
-
-/content/manuals/billing/ @sarahsanders-docker
 
 /content/manuals/accounts/ @sarahsanders-docker
 

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -143,12 +143,12 @@ area/scout:
 area/billing:
   - changed-files:
       - any-glob-to-any-file:
-          - content/manuals/billing/**
+          - content/manuals/subscription-billing/**
 
 area/subscription:
   - changed-files:
       - any-glob-to-any-file:
-          - content/manuals/subscription/**
+          - content/manuals/subscription-billing/**
 
 area/admin:
   - changed-files:

--- a/content/manuals/_index.md
+++ b/content/manuals/_index.md
@@ -83,10 +83,10 @@ params:
     description: Centralized observability for companies and organizations.
     icon: shield-check
     link: /admin/
-  - title: Billing
-    description: Manage billing and payment methods.
+  - title: Subscription and billing
+    description: Manage Docker subscriptions, plans, billing, and payments.
     icon: credit-card
-    link: /billing/
+    link: /subscription-billing/
   - title: Accounts
     description: Manage your Docker account.
     icon: user-circle
@@ -95,10 +95,6 @@ params:
     description: Security guardrails for both administrators and developers.
     icon: lock-closed
     link: /security/
-  - title: Subscription
-    description: Commercial use licenses for Docker products.
-    icon: credit-card
-    link: /subscription/
   enterprise:
   - title: Deploy Docker Desktop
     description: Deploy Docker Desktop at scale within your company

--- a/content/manuals/accounts/deactivate-user-account.md
+++ b/content/manuals/accounts/deactivate-user-account.md
@@ -38,7 +38,7 @@ requirements:
   and then remove yourself, or deactivate the company.
 - If you have an active Docker subscription,
   [downgrade it to a Docker Personal
-  subscription](/manuals/subscription/plans/docker.md#cancel-a-docker-plan).
+  subscription](/manuals/subscription-billing/subscription/plans/docker.md#cancel-a-docker-plan).
 - Download any images and tags you want to keep. Use
   `docker pull -a <image>` to pull all tags, or `docker pull <image>:<tag>`
   to pull a specific tag.

--- a/content/manuals/admin/organization/deactivate-account.md
+++ b/content/manuals/admin/organization/deactivate-account.md
@@ -32,7 +32,7 @@ organization:
   to pull all tags, or `docker pull <image>:<tag>` to pull a specific tag.
 - If you have an active Docker subscription, [downgrade it to a basic
   organization
-  account](/manuals/subscription/plans/docker.md#cancel-a-docker-plan).
+  account](/manuals/subscription-billing/subscription/plans/docker.md#cancel-a-docker-plan).
 - Remove all other members within the organization.
 - Unlink your [GitHub and Bitbucket
   accounts](/manuals/docker-hub/repos/manage/builds/link-source.md#unlink-a-github-user-account).

--- a/content/manuals/admin/organization/manage/_index.md
+++ b/content/manuals/admin/organization/manage/_index.md
@@ -20,7 +20,7 @@ grid:
   - title: Billing
     description: Manage payment methods and view billing history.
     icon: credit-card
-    link: /billing/
+    link: /subscription-billing/billing/
 ---
 
 As an organization owner, you manage your organization's membership, access,

--- a/content/manuals/admin/organization/manage/manage-licenses.md
+++ b/content/manuals/admin/organization/manage/manage-licenses.md
@@ -13,7 +13,7 @@ products.
 
 > [!TIP]
 > To learn more about product licenses, Docker Core seats, and other Docker
-> add-ons, see [Docker plans](/manuals/subscription/plans/_index.md),
+> add-ons, see [Docker plans](/manuals/subscription-billing/subscription/plans/_index.md),
 > or
 > <a href="https://www.docker.com/pricing/contact-sales/" id="dkr_docs_cs_admin_licenses" class="link" rel="noopener">contact sales</a>
 > to purchase licenses.
@@ -114,11 +114,11 @@ To manage licenses for your organization:
 
 Explore Docker Core add-ons and products that need licenses:
 
-- [Docker plans](/manuals/subscription/plans/_index.md) to learn about different
+- [Docker plans](/manuals/subscription-billing/subscription/plans/_index.md) to learn about different
   add-ons
 - [Manage seats](/manuals/admin/organization/manage/manage-seats.md) to add more
   seats to your Docker Core subscription
-- [AI Governance plan](/manuals/subscription/plans/ai-governance.md) to learn
+- [AI Governance plan](/manuals/subscription-billing/subscription/plans/ai-governance.md) to learn
   about AI Governance license usage and billing
 - [Docker Offload](/manuals/offload/about.md) to let your developers offload
   building and running containers to the cloud

--- a/content/manuals/admin/organization/manage/manage-products.md
+++ b/content/manuals/admin/organization/manage/manage-products.md
@@ -140,7 +140,7 @@ following table to learn where you can monitor organization usage:
 | Docker Offload       | From [Docker Home](https://app.docker.com/), select **Offload**, then **Offload activity**. See [Docker Offload usage and billing](../../../offload/usage.md) for more details.                  |
 
 If your usage or seat count exceeds your subscription amount, you can
-[add seats](./manage-seats.md) or [view available Docker plans](../../../subscription/plans/_index.md) to meet your needs.
+[add seats](./manage-seats.md) or [view available Docker plans](../../../subscription-billing/subscription/plans/_index.md) to meet your needs.
 
 ## Next steps
 

--- a/content/manuals/admin/organization/setup/onboard.md
+++ b/content/manuals/admin/organization/setup/onboard.md
@@ -122,7 +122,7 @@ For more details, see [Invite members](/manuals/admin/organization/manage/member
 
 Configuring SSO and SCIM is optional and only available to Docker Business
 subscribers. To upgrade a Docker Team subscription to a Docker Business
-subscription, see [Upgrade a plan](/manuals/subscription/manage.md#upgrade-plans).
+subscription, see [Upgrade a plan](/manuals/subscription-billing/subscription/manage.md#upgrade-plans).
 
 Use your identity provider (IdP) to manage members and provision them to Docker
 automatically via SSO and SCIM. See the following for more details:

--- a/content/manuals/admin/organization/setup/orgs.md
+++ b/content/manuals/admin/organization/setup/orgs.md
@@ -71,7 +71,7 @@ the following steps:
 1. Based on the number of seats from the secondary organization, [purchase additional seats](../manage/manage-seats.md) for the primary organization account that you want to keep.
 1. Manually add users to the primary organization and remove existing users from the secondary organization.
 1. Manually move over your data, including all repositories.
-1. Once you're done moving all of your users and data, [downgrade](../../../subscription/plans/docker.md#cancel-a-docker-plan) the secondary account to a free subscription. Note that Docker does not offer refunds for downgrading organizations mid-billing cycle.
+1. Once you're done moving all of your users and data, [downgrade](../../../subscription-billing/subscription/plans/docker.md#cancel-a-docker-plan) the secondary account to a free subscription. Note that Docker does not offer refunds for downgrading organizations mid-billing cycle.
 
 If your organization has a Docker Business subscription with a purchase
 order, contact Support or your Account Manager at Docker.

--- a/content/manuals/agentic-platform/_index.md
+++ b/content/manuals/agentic-platform/_index.md
@@ -65,6 +65,6 @@ Account-level configuration can be reused across sandboxes:
 
 To begin, open [Docker Agentic Platform](https://agentic-platform.docker.com/)
 and sign in with your Docker account. Docker meters sandbox compute per second.
-For account and payment information, see [Docker Billing](/billing/).
+For account and payment information, see [Docker Billing](/subscription-billing/billing/).
 
 {{< grid >}}

--- a/content/manuals/agentic-platform/faq.md
+++ b/content/manuals/agentic-platform/faq.md
@@ -49,7 +49,7 @@ also shows the equivalent hourly rate.
 
 Model inference is billed separately. The sandbox uses your credential for an
 external model provider, which meters and bills inference under that provider
-account. See [Docker Billing](/billing/) for account, usage, and payment
+account. See [Docker Billing](/subscription-billing/billing/) for account, usage, and payment
 information.
 
 ## How long are logs, telemetry, and snapshots retained?

--- a/content/manuals/agentic-platform/sandboxes.md
+++ b/content/manuals/agentic-platform/sandboxes.md
@@ -62,7 +62,7 @@ when the sandbox is created and cannot be changed while it runs.
 
 Docker bills sandbox compute per second while the sandbox runs. Model inference
 uses your external provider credential and is metered by that provider. For
-account, usage, and payment information, see [Docker Billing](/billing/).
+account, usage, and payment information, see [Docker Billing](/subscription-billing/billing/).
 
 ## Check sandbox configuration
 

--- a/content/manuals/ai/sandboxes/governance/audit/_index.md
+++ b/content/manuals/ai/sandboxes/governance/audit/_index.md
@@ -29,7 +29,7 @@ don't send audit data to audit logs.
 
 To use AI Governance Audit Logs, your organization needs:
 
-- A Docker [AI Governance plan](/manuals/subscription/plans/ai-governance.md)
+- A Docker [AI Governance plan](/manuals/subscription-billing/subscription/plans/ai-governance.md)
 - An enforced organization governance policy
 - A Docker organization account
 - An organization owner, or a user with a [custom role](/manuals/enterprise/security/roles-and-permissions/custom-roles/_index.md) that includes AI Governance audit permissions, to configure delivery and view hosted events

--- a/content/manuals/ai/sandboxes/governance/audit/configure.md
+++ b/content/manuals/ai/sandboxes/governance/audit/configure.md
@@ -19,7 +19,7 @@ together:
 
 Your organization needs:
 
-- A Docker [AI Governance plan](/manuals/subscription/plans/ai-governance.md)
+- A Docker [AI Governance plan](/manuals/subscription-billing/subscription/plans/ai-governance.md)
 - An enforced organization governance policy
 - Organization owner access, or a [custom role](/manuals/enterprise/security/roles-and-permissions/custom-roles/_index.md) with AI Governance audit permissions
 

--- a/content/manuals/build-cloud/builder-settings.md
+++ b/content/manuals/build-cloud/builder-settings.md
@@ -47,7 +47,7 @@ two builders:
 
 ### Get more build cache space
 
-To get more Build cache space, [upgrade your subscription](/manuals/subscription/manage.md#upgrade-plans).
+To get more Build cache space, [upgrade your subscription](/manuals/subscription-billing/subscription/manage.md#upgrade-plans).
 
 > [!TIP]
 >

--- a/content/manuals/desktop/release-notes.md
+++ b/content/manuals/desktop/release-notes.md
@@ -5262,7 +5262,7 @@ The updated [Docker Subscription Service Agreement](https://www.docker.com/legal
 - **No changes** to Docker Engine or any other upstream **open source** Docker or Moby project.
 
 To understand how these changes affect you, read the [FAQs](https://www.docker.com/pricing/faq).
-For more information, see [Docker subscription overview](../subscription/_index.md).
+For more information, see [Docker subscription overview](../subscription-billing/subscription/_index.md).
 
 ### Upgrades
 

--- a/content/manuals/dhi/how-to/select-enterprise.md
+++ b/content/manuals/dhi/how-to/select-enterprise.md
@@ -20,7 +20,7 @@ To use this workflow, you need:
 - One of the following:
   - A DHI Select or Enterprise subscription. [Contact Docker
     sales](https://www.docker.com/products/hardened-images/#compare) to purchase DHI Enterprise
-    or [learn more about DHI plans](../../subscription/plans/dhi.md).
+    or [learn more about DHI plans](../../subscription-billing/subscription/plans/dhi.md).
   - An active DHI trial. [Start a free DHI
     trial](https://hub.docker.com/hardened-images/start-free-trial).
 - [Docker Desktop](../../desktop/release-notes.md) 4.65 or later to use the

--- a/content/manuals/docker-hub/release-notes.md
+++ b/content/manuals/docker-hub/release-notes.md
@@ -182,7 +182,7 @@ known issues for each Docker Hub release.
 
 ### New
 
-- You can now purchase or upgrade to a Docker Business subscription using a credit card. To learn more, see [Upgrade your subscription](../subscription/plans/docker.md).
+- You can now purchase or upgrade to a Docker Business subscription using a credit card. To learn more, see [Upgrade your subscription](../subscription-billing/subscription/plans/docker.md).
 
 ## 2021-08-31
 
@@ -199,7 +199,7 @@ The updated [Docker Subscription Service Agreement](https://www.docker.com/legal
 - The existing Docker Free subscription has been renamed **Docker Personal**.
 - **No changes** to Docker Engine or any other upstream **open source** Docker or Moby project.
 
-  To understand how these changes affect you, read the [FAQs](https://www.docker.com/pricing/faq). For more information, see [Docker subscription overview](../subscription/_index.md).
+  To understand how these changes affect you, read the [FAQs](https://www.docker.com/pricing/faq). For more information, see [Docker subscription overview](../subscription-billing/subscription/_index.md).
 
 ## 2021-05-05
 
@@ -223,7 +223,7 @@ You can now specify any email address to receive billing-related emails for your
 
 To change the email address receiving billing-related emails, log into Docker Hub and navigate to the **Billing** tab of your organization. Select **Payment Methods** > **Billing Information**. Enter the new email address that you'd like to use in the **Email** field. Click **Update** for the changes to take effect.
 
-For details on how to update your billing information, see [Update billing information](../billing/_index.md).
+For details on how to update your billing information, see [Update billing information](../subscription-billing/billing/_index.md).
 
 ## 2021-03-22
 
@@ -257,7 +257,7 @@ Docker introduces Hub Vulnerability Scanning which enables you to automatically 
 
 ### New features
 
-- Docker has announced a new, per-seat pricing model to accelerate developer workflows for cloud-native development. The previous private repository/concurrent autobuild-based plans have been replaced with new **Pro** and **Team** plans that include unlimited private repositories. For more information, see [Docker subscription](../subscription/_index.md).
+- Docker has announced a new, per-seat pricing model to accelerate developer workflows for cloud-native development. The previous private repository/concurrent autobuild-based plans have been replaced with new **Pro** and **Team** plans that include unlimited private repositories. For more information, see [Docker subscription](../subscription-billing/subscription/_index.md).
 
 - Docker has enabled download rate limits for downloads and pull requests on Docker Hub. This caps the number of objects that users can download within a specified timeframe. For more information, see [Usage and limits](/manuals/docker-hub/usage/_index.md).
 
@@ -328,7 +328,7 @@ Docker introduces Hub Vulnerability Scanning which enables you to automatically 
 
 ### Enhancements
 
-- The [billing page](../subscription/plans/docker.md) for personal accounts has been updated. You can access the page at its new URL: [https://hub.docker.com/billing/plan](https://hub.docker.com/billing/plan).
+- The [billing page](../subscription-billing/subscription/plans/docker.md) for personal accounts has been updated. You can access the page at its new URL: [https://hub.docker.com/billing/plan](https://hub.docker.com/billing/plan).
 
 ### Known Issues
 

--- a/content/manuals/docker-hub/troubleshoot.md
+++ b/content/manuals/docker-hub/troubleshoot.md
@@ -33,7 +33,7 @@ You have reached your pull rate limit. You may increase the limit by authenticat
 You can use one of the following solutions:
 
 - [Authenticate](./usage/pulls.md#authentication) or
-  [upgrade](../subscription/manage.md#upgrade-plans) your Docker
+  [upgrade](../subscription-billing/subscription/manage.md#upgrade-plans) your Docker
   account.
 - [View your pull rate limit](./usage/pulls.md#view-hourly-pull-rate-and-limit),
   wait until your pull rate limit decreases, and then try again.

--- a/content/manuals/scout/_index.md
+++ b/content/manuals/scout/_index.md
@@ -38,7 +38,7 @@ grid:
       Ensure that your artifacts align with supply chain best practices.
     icon: shield-check
   - title: Upgrade
-    link: /subscription/change/
+    link: /subscription-billing/subscription/manage/
     description: |
       A Personal subscription includes up to 1 repository. Upgrade for more.
     icon: arrow-up-circle

--- a/content/manuals/subscription-billing/_index.md
+++ b/content/manuals/subscription-billing/_index.md
@@ -1,0 +1,16 @@
+---
+title: Subscription and billing
+linkTitle: Subscription and billing
+description: Manage Docker subscriptions, plans, billing, and payments.
+keywords: subscription, billing, docker plans, payments, invoices, pricing
+weight: 20
+params:
+  sidebar:
+    group: Platform
+aliases:
+  - /subscription/
+  - /billing/
+  - /docker-hub/billing/
+  - /docker-hub/billing/faq/
+  - /billing/docker-hub-pricing/
+---

--- a/content/manuals/subscription-billing/billing/3d-secure.md
+++ b/content/manuals/subscription-billing/billing/3d-secure.md
@@ -4,6 +4,8 @@ linkTitle: 3D Secure
 description: Learn how 3D Secure authentication works for Docker subscription payments and how to troubleshoot verification issues.
 keywords: billing, payments, subscriptions, 3D Secure, 3DS, credit card verification, payment authentication
 weight: 30
+aliases:
+  - /billing/3d-secure/
 ---
 
 Docker supports 3D Secure (3DS), an extra layer of authentication required
@@ -27,10 +29,10 @@ requirements.
 You may be asked to verify your identity when performing any of the following
 actions:
 
-- Starting a [paid subscription](../subscription/manage.md)
-- Changing your [billing cycle](/manuals/billing/details.md#billing-cycle) from monthly to annual
-- [Upgrading your subscription](../subscription/manage.md#upgrade-plans)
-- [Adding seats](../admin/organization/manage/manage-seats.md) to an existing
+- Starting a [paid subscription](/manuals/subscription-billing/subscription/manage.md)
+- Changing your [billing cycle](/manuals/subscription-billing/billing/details.md#billing-cycle) from monthly to annual
+- [Upgrading your subscription](/manuals/subscription-billing/subscription/manage.md#upgrade-plans)
+- [Adding seats](/manuals/admin/organization/manage/manage-seats.md) to an existing
   subscription
 
 If 3DS is required and your payment method supports it, the verification prompt

--- a/content/manuals/subscription-billing/billing/_index.md
+++ b/content/manuals/subscription-billing/billing/_index.md
@@ -8,33 +8,28 @@ keywords:
   billing, invoice, payment, subscription, Docker billing, update payment
   method, billing history, invoices, payment verification, tax exemption,
   usage, costs, credits, metered billing
-weight: 30
-params:
-  sidebar:
-    group: Platform
+weight: 20
 grid_core:
   - title: Add or update a payment method
     description: Learn how to add or update a payment method for your personal account or organization.
-    link: /billing/payment-method/
+    link: /subscription-billing/billing/payment-method/
     icon: credit-card
   - title: Update billing information
     description: Learn how to update billing information for your personal account or organization.
-    link: /billing/details/
+    link: /subscription-billing/billing/details/
     icon: pencil-square
   - title: View billing history
     description: Learn how to view billing history and download past invoices.
-    link: /billing/history/
+    link: /subscription-billing/billing/history/
     icon: credit-card
   - title: 3D Secure authentication
     description: Learn how 3DS works and how to troubleshoot verification issues.
-    link: /billing/3d-secure/
+    link: /subscription-billing/billing/3d-secure/
     icon: wallet
   - title: Taxes
     description: Learn how to submit a US tax exemption certificate or add a VAT number.
-    link: /billing/tax-certificate/
+    link: /subscription-billing/billing/tax-certificate/
     icon: document-text
-aliases:
-  - /billing/docker-hub-pricing/
 ---
 
 You can use the billing portal to manage your Docker subscriptions, such
@@ -72,8 +67,8 @@ from this page.
 
 Your invoice history is a reference to the Docker plans you subscribe
 to. For information about your billing cycle and renewal dates, see
-[Billing cycle](/manuals/billing/details.md#billing-cycle). To upgrade or add
-a new plan, see [Subscription](/manuals/subscription/_index.md).
+[Billing cycle](/manuals/subscription-billing/billing/details.md#billing-cycle). To upgrade or add
+a new plan, see [Subscription](/manuals/subscription-billing/subscription/_index.md).
 
 ## Next steps
 

--- a/content/manuals/subscription-billing/billing/details.md
+++ b/content/manuals/subscription-billing/billing/details.md
@@ -5,6 +5,7 @@ weight: 40
 description: Learn how to update billing details, like contact information, addresses, and notification email for Docker subscriptions.
 keywords: payments, billing, subscription, invoices, update billing email, change billing address, Docker billing account
 aliases:
+  - /billing/details/
   - /billing/cycle/
 ---
 
@@ -22,7 +23,7 @@ To update your billing information from **Settings** in Docker Home:
 1. Select **Edit** to make your changes.
 1. Verify your information, then select **Save as default**.
 
-For more information on changing your default payment method, see [Change default payment method](/manuals/billing/payment-method.md#change-default-payment-method).
+For more information on changing your default payment method, see [Change default payment method](/manuals/subscription-billing/billing/payment-method.md#change-default-payment-method).
 
 ## Billing notifications
 
@@ -37,4 +38,4 @@ to the billing account's email address. These communications include:
 
 Billing cycles are defined on a per-plan basis. Depending on the product you
 subscribe to, your cycle can be monthly, annual, or another cadence. For
-plan-specific billing cycle details, see [Plans](/manuals/subscription/plans/_index.md).
+plan-specific billing cycle details, see [Plans](/manuals/subscription-billing/subscription/plans/_index.md).

--- a/content/manuals/subscription-billing/billing/history.md
+++ b/content/manuals/subscription-billing/billing/history.md
@@ -5,6 +5,7 @@ weight: 60
 description: Learn how to view your Docker billing history, understand what's on an invoice, and pay by invoice.
 keywords: payments, billing, subscription, invoices, renewals, billing history, pay by invoice
 aliases:
+  - /billing/history/
   - /billing/core-billing/history/
 ---
 
@@ -58,7 +59,7 @@ Docker finalizes your invoice. For more information, see [Update billing informa
 
 ## View renewal date
 
-Renewal dates are set on a per-plan basis, so check each plan individually if you subscribe to more than one. Depending on the product, your billing cycle can be monthly, annual, or another cadence. For plan-specific renewal and billing cycle details, see [Plans](/manuals/subscription/plans/_index.md).
+Renewal dates are set on a per-plan basis, so check each plan individually if you subscribe to more than one. Depending on the product, your billing cycle can be monthly, annual, or another cadence. For plan-specific renewal and billing cycle details, see [Plans](/manuals/subscription-billing/subscription/plans/_index.md).
 
 ## Pay by invoice
 

--- a/content/manuals/subscription-billing/billing/payment-method.md
+++ b/content/manuals/subscription-billing/billing/payment-method.md
@@ -5,6 +5,7 @@ weight: 20
 description: Learn how to manage cards, US bank accounts, Stripe Link, and pay by invoice for Docker subscriptions.
 keywords: payments, billing, subscription, payment methods, credit card, ACH, US bank account, Stripe Link, pay by invoice, failed payments
 aliases:
+  - /billing/payment-method/
   - /billing/core-billing/payment-method/
 ---
 
@@ -72,7 +73,7 @@ You can only remove secondary payment methods. To remove a secondary payment met
 1. Select the **Actions** menu next to the payment method you want to remove, then select **Remove**.
 1. Verify your billing details, then select **Save as default**.
 
-To remove your default payment method, first set a different payment method as default, or [downgrade to a free subscription](/manuals/subscription/plans/docker.md#cancel-a-docker-plan).
+To remove your default payment method, first set a different payment method as default, or [downgrade to a free subscription](/manuals/subscription-billing/subscription/plans/docker.md#cancel-a-docker-plan).
 
 ## Enable and disable pay by invoice
 

--- a/content/manuals/subscription-billing/billing/tax-certificate.md
+++ b/content/manuals/subscription-billing/billing/tax-certificate.md
@@ -8,6 +8,8 @@ keywords:
   billing, sales tax, VAT, tax exemption certificate, tax ID, VAT number,
   United States tax exemption, Docker Support, billing portal
 weight: 70
+aliases:
+  - /billing/tax-certificate/
 ---
 
 Depending on your location, Docker may collect sales tax or VAT on your
@@ -88,4 +90,4 @@ Your VAT number must include your country prefix. For example, enter
 > existing payment method or billing details in billing settings.
 
 Add a VAT number or tax ID when you
-[set up a new plan](/manuals/subscription/manage.md#set-up-a-new-plan).
+[set up a new plan](/manuals/subscription-billing/subscription/manage.md#set-up-a-new-plan).

--- a/content/manuals/subscription-billing/desktop-license.md
+++ b/content/manuals/subscription-billing/desktop-license.md
@@ -2,8 +2,9 @@
 title: Docker Desktop license agreement
 description: Information about Docker Desktop's license agreement and commercial use requirements
 keywords: docker desktop license, subscription service agreement, commercial use, licensing terms
-weight: 40
+weight: 30
 aliases:
+  - /subscription/desktop-license/
   - /subscription/products/desktop-license/
   - /subscription/plans/desktop-license/
 ---

--- a/content/manuals/subscription-billing/faqs/_index.md
+++ b/content/manuals/subscription-billing/faqs/_index.md
@@ -1,0 +1,9 @@
+---
+build:
+  render: never
+title: FAQs
+linkTitle: FAQs
+description: Frequently asked questions about Docker subscriptions and billing
+keywords: subscription faq, billing faq, docker plans
+weight: 40
+---

--- a/content/manuals/subscription-billing/faqs/billing.md
+++ b/content/manuals/subscription-billing/faqs/billing.md
@@ -1,10 +1,12 @@
 ---
 title: Billing FAQs
-linkTitle: FAQs
+linkTitle: Billing FAQ
 description: Find answers to common questions about Docker billing, failed payments, taxes, and pay by invoice.
 keywords: billing, renewal, failed payments, sales tax, VAT, academic pricing, pay by invoice
 tags: [FAQ]
-weight: 80
+weight: 20
+aliases:
+  - /billing/faqs/
 ---
 
 ## What happens if my subscription payment fails?
@@ -32,7 +34,7 @@ Stripe.
 
 Before retrying, verify that your default payment method is up to date. For
 instructions, see
-[Manage a payment method](/manuals/billing/payment-method.md#manage-payment-method).
+[Manage a payment method](/manuals/subscription-billing/billing/payment-method.md#manage-payment-method).
 
 ## Does Docker collect sales tax and VAT?
 
@@ -44,9 +46,9 @@ Docker collects sales tax or VAT from the following customers:
 - For United Kingdom customers, Docker began collecting VAT on May 1, 2025.
 
 To help ensure correct tax assessments, keep your
-[billing information](/manuals/billing/details.md) up to date. For details on
+[billing information](/manuals/subscription-billing/billing/details.md) up to date. For details on
 adding a VAT number or submitting a US tax exemption certificate, see
-[Taxes](/manuals/billing/tax-certificate.md).
+[Taxes](/manuals/subscription-billing/billing/tax-certificate.md).
 
 ## Does Docker offer academic pricing?
 
@@ -60,4 +62,4 @@ purchasing upgrades or additional seats. You must use card payment or US bank
 accounts for these changes.
 
 For a list of supported payment methods, see
-[Add or update a payment method](/manuals/billing/payment-method.md).
+[Add or update a payment method](/manuals/subscription-billing/billing/payment-method.md).

--- a/content/manuals/subscription-billing/faqs/subscription.md
+++ b/content/manuals/subscription-billing/faqs/subscription.md
@@ -1,13 +1,15 @@
 ---
 title: Plan FAQs
-linkTitle: FAQs
+linkTitle: Subscription FAQ
 description: Frequently asked questions about Docker subscriptions and billing
 keywords: subscription faqs, docker billing, subscription transfer, academic pricing, docker programs
 tags: [FAQ]
-weight: 30
+weight: 10
+aliases:
+  - /subscription/faq/
 ---
 
-For more information on Docker subscriptions, see [Docker subscription overview](_index.md).  
+For more information on Docker subscriptions, see [Docker subscription overview](/manuals/subscription-billing/subscription/_index.md).  
 
 ## Can I transfer my subscription from one user or organization account to another?
 
@@ -25,8 +27,8 @@ Contact the [Docker Sales Team](https://www.docker.com/company/contact) for info
 
 Docker offers two content contribution programs:
 
-- [Docker-Sponsored Open Source Program (DSOS)](../docker-hub/repos/manage/trusted-content/dsos-program.md) for open source projects
-- [Docker Verified Publisher (DVP)](../docker-hub/repos/manage/trusted-content/dvp-program.md) for commercial publishers
+- [Docker-Sponsored Open Source Program (DSOS)](/manuals/docker-hub/repos/manage/trusted-content/dsos-program.md) for open source projects
+- [Docker Verified Publisher (DVP)](/manuals/docker-hub/repos/manage/trusted-content/dvp-program.md) for commercial publishers
 
 You can also join the [Developer Preview Program](https://www.docker.com/community/get-involved/developer-preview/) or sign up for early access programs to participate in research and try new features.
 

--- a/content/manuals/subscription-billing/subscription/_index.md
+++ b/content/manuals/subscription-billing/subscription/_index.md
@@ -6,10 +6,7 @@ keywords:
   docker subscription, pricing, billing, subscription types, subscription
   plans, docker hardened images, gordon, cloud sandboxes, subscription
   management
-weight: 20
-params:
-  sidebar:
-    group: Platform
+weight: 10
 grid_subscriptions:
   - title: Compare Docker plans
     description: Visit the pricing page to see what's included in different Docker plans.
@@ -17,23 +14,20 @@ grid_subscriptions:
     icon: magnifying-glass
   - title: Manage plans
     description: Add a new plan, upgrade an active plan, or cancel auto-renewal.
-    link: /subscription/manage/
+    link: /subscription-billing/subscription/manage/
     icon: shopping-cart
   - title: Explore plans
     description: Browse available Docker plans and add-ons for individuals, teams, and organizations.
-    link: /subscription/plans/
+    link: /subscription-billing/subscription/plans/
     icon: chart-bar
   - title: Docker Desktop license agreement
     description: Review the terms of the Docker Subscription Service Agreement.
-    link: /subscription/desktop-license/
+    link: /subscription-billing/desktop-license/
     icon: document-text
   - title: Plan FAQs
     description: Find the answers you need and explore common questions.
-    link: /subscription/faq/
+    link: /subscription-billing/faqs/subscription/
     icon: question-mark-circle
-aliases:
-  - /docker-hub/billing/
-  - /docker-hub/billing/faq/
 ---
 
 You can subscribe to several Docker plans that range from free to paid plans. When you upgrade a plan, you expand your usage entitlements and feature sets for Docker products. You can also top up some plans, extending usage to more users without changing your plan type.
@@ -44,14 +38,14 @@ You can subscribe to plans for individual or organization accounts, or plans for
 
 | Plans                                                                  | Billing model                                             | Types                                                     |
 | ---------------------------------------------------------------------- | --------------------------------------------------------- | --------------------------------------------------------- |
-| [Docker](/manuals/subscription/plans/docker.md)                        | Flat-rate plans for personal and organization accounts    | Docker Personal, Docker Pro, Docker Team, Docker Business |
-| [Docker Agentic Platform](/manuals/subscription/plans/docker-agentic-platform.md) | Pay-as-you-go (PayGo) for cloud sandbox usage             | Docker Agentic Platform                          |
-| [Docker Hardened Images (DHI)](/manuals/subscription/plans/dhi.md)     | Graduated security features for hardened container images | DHI Community, DHI Select, DHI Enterprise                 |
-| [Gordon](/manuals/subscription/plans/gordon.md)                        | Prepaid usage for the Gordon AI agent                     | Gordon Plus, Gordon Max, Gordon Ultra                     |
-| [AI Governance](/manuals/subscription/plans/ai-governance.md)          | Purchase set amount of licenses                           | AI Governance                                             |
-| [Docker Verified Publisher (DVP)](/manuals/subscription/plans/docker-verified-publisher.md)  | Annual plans based on consuming domains                   | DVP Starter, DVP Growth                                   |
+| [Docker](/manuals/subscription-billing/subscription/plans/docker.md)                        | Flat-rate plans for personal and organization accounts    | Docker Personal, Docker Pro, Docker Team, Docker Business |
+| [Docker Agentic Platform](/manuals/subscription-billing/subscription/plans/docker-agentic-platform.md) | Pay-as-you-go (PayGo) for cloud sandbox usage             | Docker Agentic Platform                          |
+| [Docker Hardened Images (DHI)](/manuals/subscription-billing/subscription/plans/dhi.md)     | Graduated security features for hardened container images | DHI Community, DHI Select, DHI Enterprise                 |
+| [Gordon](/manuals/subscription-billing/subscription/plans/gordon.md)                        | Prepaid usage for the Gordon AI agent                     | Gordon Plus, Gordon Max, Gordon Ultra                     |
+| [AI Governance](/manuals/subscription-billing/subscription/plans/ai-governance.md)          | Purchase set amount of licenses                           | AI Governance                                             |
+| [Docker Verified Publisher (DVP)](/manuals/subscription-billing/subscription/plans/docker-verified-publisher.md)  | Annual plans based on consuming domains                   | DVP Starter, DVP Growth                                   |
 
-Docker plans that upgrade your account (Docker Pro or Docker Team and Business) can provide a foundation for most use cases. Some product plans may require an upgraded Docker account while other product plans let you subscribe without an upgraded account. To learn more, see [Docker plans](/manuals/subscription/plans/_index.md).
+Docker plans that upgrade your account (Docker Pro or Docker Team and Business) can provide a foundation for most use cases. Some product plans may require an upgraded Docker account while other product plans let you subscribe without an upgraded account. To learn more, see [Docker plans](/manuals/subscription-billing/subscription/plans/_index.md).
 
 ## Top up your plan
 
@@ -69,7 +63,7 @@ Plans come with usage entitlements that can be extended without upgrading to a d
 
 To subscribe to a new plan, you can self-serve through **Billing** in [Docker Home](https://app.docker.com), or by <a href="https://www.docker.com/pricing/contact-sales/" id="dkr_docs_index_sales" class="link" rel="noopener">contacting sales</a>.
 
-To learn more about adding a new plan or upgrading an active plan, see [Manage plans](/manuals/subscription/manage.md).
+To learn more about adding a new plan or upgrading an active plan, see [Manage plans](/manuals/subscription-billing/subscription/manage.md).
 
 ## Next steps
 

--- a/content/manuals/subscription-billing/subscription/manage.md
+++ b/content/manuals/subscription-billing/subscription/manage.md
@@ -9,6 +9,7 @@ keywords:
   products, upgrade subscription, downgrade subscription, docker billing, cancel auto-renewal, cancel, top up, manage
 weight: 20
 aliases:
+  - /subscription/manage/
   - /subscription/change/
   - /subscription/setup/
   - /docker-hub/upgrade/
@@ -57,17 +58,17 @@ You can upgrade active plans from the billing Overview page.
 > [!TIP]
 > Billing cycle details vary from plan to plan. Learn more about usage, downgrading, or canceling plans
 > from the relevant
-> [product page](/manuals/subscription/plans/_index.md).
+> [product page](/manuals/subscription-billing/subscription/plans/_index.md).
 
 ## View your credits
 
 Docker displays available account credits in the billing portal. Credits
 offset eligible usage automatically before Docker charges your payment
 method. To review credit balance and applied credits, see
-[Credits](/manuals/billing/_index.md#credits).
+[Credits](/manuals/subscription-billing/billing/_index.md#credits).
 
 Credits apply to
-[Docker Agentic Platform](/manuals/subscription/plans/docker-agentic-platform.md).
+[Docker Agentic Platform](/manuals/subscription-billing/subscription/plans/docker-agentic-platform.md).
 When you sign up for Docker Agentic Platform, Docker adds a one-time
 promotional credit to your account. This credit is non-recurring,
 doesn't expire, and applies to cloud compute usage only. It doesn't
@@ -80,9 +81,9 @@ Some products are sales-led. You must
 
 ## Next steps
 
-- [Learn about available plans](/manuals/subscription/plans/_index.md)
-- [Set up payment information](/manuals/billing/payment-method.md)
-- [View invoices](/manuals/billing/history.md)
-- To learn more about managing your billing details, see [Billing](/manuals/billing/_index.md).
+- [Learn about available plans](/manuals/subscription-billing/subscription/plans/_index.md)
+- [Set up payment information](/manuals/subscription-billing/billing/payment-method.md)
+- [View invoices](/manuals/subscription-billing/billing/history.md)
+- To learn more about managing your billing details, see [Billing](/manuals/subscription-billing/billing/_index.md).
 - To learn about sales tax and VAT, see
-  [Taxes](/manuals/billing/tax-certificate.md).
+  [Taxes](/manuals/subscription-billing/billing/tax-certificate.md).

--- a/content/manuals/subscription-billing/subscription/plans/_index.md
+++ b/content/manuals/subscription-billing/subscription/plans/_index.md
@@ -9,6 +9,7 @@ keywords:
   docker build cloud, gordon plans, docker agentic platform, product catalog
 weight: 10
 aliases:
+  - /subscription/plans/
   - /subscription/products/
   - /subscription/scale/
   - /subscription/details/
@@ -18,23 +19,23 @@ aliases:
 grid:
   - title: Docker
     description: Personal and organization plans, including build and runtime minutes.
-    link: /subscription/plans/docker/
+    link: /subscription-billing/subscription/plans/docker/
     icon: credit-card
   - title: Gordon plans
     description: Usage plans that increase your Gordon allowance.
-    link: /subscription/plans/gordon/
+    link: /subscription-billing/subscription/plans/gordon/
     icon: /icons/gordon.svg
   - title: Docker Hardened Images (DHI)
     description: Hardened image repositories for organization accounts.
-    link: /subscription/plans/dhi/
+    link: /subscription-billing/subscription/plans/dhi/
     icon: /icons/dhi.svg
   - title: AI Governance
     description: Licenses for organization-wide AI policy enforcement.
-    link: /subscription/plans/ai-governance/
+    link: /subscription-billing/subscription/plans/ai-governance/
     icon: shield-check
   - title: Docker Verified Publisher (DVP)
     description: Publisher analytics and reporting plans for organization accounts.
-    link: /subscription/plans/docker-verified-publisher/
+    link: /subscription-billing/subscription/plans/docker-verified-publisher/
     icon: check-badge
 ---
 
@@ -46,7 +47,7 @@ You can subscribe to plans on a self-serve basis when you go to the Docker produ
 
 This section covers usage entitlements, billing cycle, and plan management options for each available plan.
 
-To manage your plans by adding a new plan or upgrading an active plan, see [Manage plans](/manuals/subscription/manage.md).
+To manage your plans by adding a new plan or upgrading an active plan, see [Manage plans](/manuals/subscription-billing/subscription/manage.md).
 
 ## Product catalog
 

--- a/content/manuals/subscription-billing/subscription/plans/ai-governance.md
+++ b/content/manuals/subscription-billing/subscription/plans/ai-governance.md
@@ -9,6 +9,7 @@ keywords:
   subscription management
 weight: 50
 aliases:
+  - /subscription/plans/ai-governance/
   - /subscription/products/ai-governance/
   - /subscription/ai-governance/
 ---

--- a/content/manuals/subscription-billing/subscription/plans/dhi.md
+++ b/content/manuals/subscription-billing/subscription/plans/dhi.md
@@ -9,6 +9,7 @@ keywords: dhi select, dhi enterprise, docker hardened images, hardened images,
   repositories, organization subscription, secure images
 weight: 40
 aliases:
+  - /subscription/plans/dhi/
   - /subscription/products/dhi-select/
   - /subscription/dhi-select/
   - /subscription/plans/dhi-select/

--- a/content/manuals/subscription-billing/subscription/plans/docker-agentic-platform.md
+++ b/content/manuals/subscription-billing/subscription/plans/docker-agentic-platform.md
@@ -11,12 +11,14 @@ keywords:
   compute, usage and billing
 weight: 20
 sitemap: false
+aliases:
+  - /subscription/plans/docker-agentic-platform/
 ---
 
 > [!TIP]
 > Docker Agentic Platform signups receive a one-time promotional
 > credit toward cloud compute usage. To review your balance, see
-> [Credits](/manuals/billing/_index.md#credits).
+> [Credits](/manuals/subscription-billing/billing/_index.md#credits).
 
 [Docker Agentic Platform](https://agentic-platform.docker.com/) is a
 pay-as-you-go plan for running agent and tool workloads in isolated
@@ -77,6 +79,6 @@ the plan period.
 ## Next steps
 
 - To add or cancel a plan, see
-  [Manage plans](/manuals/subscription/manage.md)
+  [Manage plans](/manuals/subscription-billing/subscription/manage.md)
 - To track usage across plans, see
-  [Usage](/manuals/billing/_index.md#usage)
+  [Usage](/manuals/subscription-billing/billing/_index.md#usage)

--- a/content/manuals/subscription-billing/subscription/plans/docker-verified-publisher.md
+++ b/content/manuals/subscription-billing/subscription/plans/docker-verified-publisher.md
@@ -9,6 +9,8 @@ keywords:
   domains, publisher analytics, organization subscription, apply
   for dvp, auto-renewal, billing portal, docker hub
 weight: 60
+aliases:
+  - /subscription/plans/docker-verified-publisher/
 ---
 
 [Docker Verified Publisher (DVP)](/manuals/docker-hub/repos/manage/trusted-content/dvp-program.md)

--- a/content/manuals/subscription-billing/subscription/plans/docker.md
+++ b/content/manuals/subscription-billing/subscription/plans/docker.md
@@ -10,6 +10,7 @@ keywords:
   pricing, subscription changes, build cloud minutes, testcontainers minutes
 weight: 10
 aliases:
+  - /subscription/plans/docker/
   - /subscription/plans/core/
   - /subscription/products/core/
   - /subscription/core/

--- a/content/manuals/subscription-billing/subscription/plans/gordon.md
+++ b/content/manuals/subscription-billing/subscription/plans/gordon.md
@@ -9,6 +9,7 @@ keywords:
   personal subscription, ai assistant, usage allowance
 weight: 30
 aliases:
+  - /subscription/plans/gordon/
   - /subscription/products/gordon/
   - /subscription/gordon/
 ---
@@ -20,7 +21,7 @@ aliases:
 - Gordon Max is for power users who rely on Gordon throughout their workflow. It offers a significantly higher usage allowance than Plus.
 - Gordon Ultra is for developers with the highest usage needs. It provides the maximum monthly allowance available on a self-serve plan.
 
-To upgrade to a Gordon paid plan, see [Manage plans](/manuals/subscription/manage.md).
+To upgrade to a Gordon paid plan, see [Manage plans](/manuals/subscription-billing/subscription/manage.md).
 
 ## Usage
 

--- a/data/redirects.yml
+++ b/data/redirects.yml
@@ -321,7 +321,7 @@
   - /go/settings-management/
 
 # Billing - cancellation
-"/subscription/desktop-license/":
+"/subscription-billing/desktop-license/":
   - /go/desktop-license/
 "/docker-hub/usage/pulls/":
   - /go/hub-pull-limits/

--- a/data/whats-new.json
+++ b/data/whats-new.json
@@ -6,7 +6,7 @@
       "product": "Docker Verified Publisher",
       "title": "Join Docker Verified Publisher through self-service plans",
       "description": "Apply for DVP Starter or Growth, complete checkout after approval, and manage publisher analytics, tracked companies, and billing.",
-      "url": "/subscription/plans/docker-verified-publisher/",
+      "url": "/subscription-billing/subscription/plans/docker-verified-publisher/",
       "published": "2026-08-20",
       "source_prs": [25891, 25903],
       "featured": true


### PR DESCRIPTION
## Summary

Combine the top-level Platform sections Subscription and Billing into one **Subscription and billing** section at `/subscription-billing/`. Old `/subscription/` and `/billing/` URLs alias to the new parent; nested pages keep the existing overview content. Inbound links were retargeted, and `/go/desktop-license/` now points at the new desktop-license URL.

The parent landing body is empty on purpose (content in a later change).

@netlify /subscription-billing/

Preview:
- https://deploy-preview-25981--docsdocker.netlify.app/subscription-billing/
- https://deploy-preview-25981--docsdocker.netlify.app/subscription-billing/subscription/
- https://deploy-preview-25981--docsdocker.netlify.app/subscription-billing/billing/

Generated by Cursor Grok 4.6