### PR TITLE
docs: assign accounts and admin CODEOWNERS to @akristen

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -25,15 +25,19 @@
 
 /content/reference/cli/ @dvdksn
 
-/content/manuals/subscription/ @sarahsanders-docker
+/content/manuals/subscription/ @akristen
 
-/content/manuals/security/ @aevesdocker @sarahsanders-docker
+/content/manuals/security/ @aevesdocker @akristen
 
-/content/manuals/admin/ @sarahsanders-docker
+/content/manuals/admin/ @akristen
 
-/content/manuals/billing/ @sarahsanders-docker
+/content/manuals/billing/ @akristen
 
-/content/manuals/accounts/ @sarahsanders-docker
+/content/manuals/accounts/ @akristen
+
+/content/manuals/support/ @akristen
+
+/content/manuals/platform-release-notes.md @akristen
 
 /content/manuals/ai/ @dvdksn
 


### PR DESCRIPTION
## Summary

Replace `@sarahsanders-docker` with `@akristen` on accounts, admin, billing, and subscription docs. Keep `@aevesdocker` as co-owner on security, and add ownership for support and the platform release notes.