### PR TITLE
docs(compose): fix indentation in Step 6 infra.yaml example

### DIFF
--- a/content/manuals/compose/gettingstarted.md
+++ b/content/manuals/compose/gettingstarted.md
@@ -389,7 +389,7 @@ you want to reuse infrastructure definitions across projects.
 1. Create a new file in your project directory called `infra.yaml` and move the Redis service and volume into it:
 
    ```yaml
-    services:
+   services:
      redis:
        image: redis:alpine
        volumes:


### PR DESCRIPTION
The `infra.yaml` code block under Step 6 (Structure your project with multiple Compose files) was nested inside an ordered list, which left stray leading whitespace on `services:` and `volumes:`. When users copy-paste the example verbatim, `docker compose` fails with:

    go-yaml load error in parser at L13.C1: did not find expected <document start>

This change aligns the YAML with the standard 0/2/4-space indent used elsewhere in the tutorial, and also normalizes the leading whitespace of the surrounding code fence.

<!--Delete sections as needed -->

## Description

<!-- Tell us what you did and why -->

## Related issues or tickets

<!-- Related issues, pull requests, or Jira tickets -->

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Technical review
- [ ] Editorial review
- [ ] Product review