### PR TITLE
docs: correct DOCKER_MIGRATE_SNAPSHOTTER_THRESHOLD description

### DIFF
--- a/content/manuals/engine/storage/containerd.md
+++ b/content/manuals/engine/storage/containerd.md
@@ -138,7 +138,8 @@ To enable automatic migration, add the `containerd-migration` feature to your
 
 You can also set the `DOCKER_MIGRATE_SNAPSHOTTER_THRESHOLD` environment
 variable to make the daemon switch automatically if you have no containers and
-your image count is at or below the threshold. For systemd:
+the total size of all image layers is at or below the threshold. The value is a
+human-readable size (for example, `200M` or `1G`). For systemd:
 
 ```console
 $ sudo systemctl edit docker.service
@@ -148,11 +149,12 @@ Add:
 
 ```ini
 [Service]
-Environment="DOCKER_MIGRATE_SNAPSHOTTER_THRESHOLD=5"
+Environment="DOCKER_MIGRATE_SNAPSHOTTER_THRESHOLD=200M"
 ```
 
-If you have no running or stopped containers and 5 or fewer images, the daemon
-switches to the containerd image store on restart. Your overlay2 data remains
+If you have no running or stopped containers and the total size of all image
+layers is 200M or less, the daemon switches to the containerd image store on
+restart. Your overlay2 data remains
 on disk but becomes hidden.
 
 ## Additional resources


### PR DESCRIPTION
## Summary

Fixes #25914

The `DOCKER_MIGRATE_SNAPSHOTTER_THRESHOLD` environment variable is parsed as a human-readable size and compared against the total layer sizes of all images, not the image count.

This PR updates the automatic migration docs to describe the threshold correctly and changes the example from `5` to `200M`.

## Test plan

- [x] Verified wording against moby/moby daemon migration logic
- [x] Confirmed example matches integration test usage in upstream engine code
