### PR TITLE
docs: fix mismatched image name in PID namespace example

### DIFF
--- a/data/cli/engine/docker_container_run.yaml
+++ b/data/cli/engine/docker_container_run.yaml
@@ -1216,7 +1216,7 @@ examples: |-
     Joining another container's PID namespace can be useful for debugging that
     container.
 
-    1. Start a container running a Redis server:
+    1. Start a container running an nginx server:
 
        ```console
        $ docker run --rm --name my-nginx -d nginx:alpine


### PR DESCRIPTION
## Summary

Fixes #25857

The PID namespace example uses `nginx:alpine` and names the container `my-nginx`, but step 1 incorrectly described the container as a Redis server.

## Test plan

- [x] Verified the example text now matches the commands in the same section
