### PR TITLE
docs: replace self-referencing team management link

### DIFF
--- a/content/manuals/admin/organization/manage/manage-a-team.md
+++ b/content/manuals/admin/organization/manage/manage-a-team.md
@@ -59,8 +59,7 @@ For more information on roles, see
 ## Set team repository permissions
 
 You must create a team before you are able to configure repository permissions.
-For more details, see [Create and manage a
-team](/manuals/admin/organization/manage/manage-a-team.md).
+For more details, see [Create a team](#create-a-team).
 
 To set team repository permissions:
 


### PR DESCRIPTION
## Summary

Fixes #25923

The "Set team repository permissions" section linked back to the same page instead of the relevant section above. This PR replaces the self-referencing link with an anchor to the "Create a team" section.

## Test plan

- [x] Verified the anchor matches the section heading on the same page
