### PR TITLE
docs: send Docker Pro upgrades to the pricing page

### DIFF
--- a/content/manuals/build-cloud/builder-settings.md
+++ b/content/manuals/build-cloud/builder-settings.md
@@ -47,7 +47,7 @@ two builders:
 
 ### Get more build cache space
 
-To get more Build cache space, [upgrade your subscription](/manuals/subscription/manage.md#upgrade-plans).
+To get more Build cache space, [upgrade your subscription](/manuals/subscription/plans/docker.md).
 
 > [!TIP]
 >

--- a/content/manuals/docker-hub/troubleshoot.md
+++ b/content/manuals/docker-hub/troubleshoot.md
@@ -33,7 +33,7 @@ You have reached your pull rate limit. You may increase the limit by authenticat
 You can use one of the following solutions:
 
 - [Authenticate](./usage/pulls.md#authentication) or
-  [upgrade](../subscription/manage.md#upgrade-plans) your Docker
+  [upgrade](../subscription/plans/docker.md) your Docker
   account.
 - [View your pull rate limit](./usage/pulls.md#view-hourly-pull-rate-and-limit),
   wait until your pull rate limit decreases, and then try again.

--- a/content/manuals/subscription/_index.md
+++ b/content/manuals/subscription/_index.md
@@ -67,7 +67,7 @@ Plans come with usage entitlements that can be extended without upgrading to a d
 
 ## Manage your plans
 
-To subscribe to a new plan or upgrade an active plan, see [Manage plans](/manuals/subscription/manage.md) or [Docker plans](/manuals/subscription/plans/docker.md). You can also <a href="https://www.docker.com/pricing/contact-sales/" id="dkr_docs_index_sales" class="link" rel="noopener">contact sales</a>.
+To subscribe to a new plan or upgrade an active plan, see [Manage plans](/manuals/subscription/manage.md). See [Docker plans](/manuals/subscription/plans/docker.md) to learn about Docker Team, Business, and Pro. You can also <a href="https://www.docker.com/pricing/contact-sales/" id="dkr_docs_index_sales" class="link" rel="noopener">contact sales</a>.
 
 ## Next steps
 

--- a/content/manuals/subscription/_index.md
+++ b/content/manuals/subscription/_index.md
@@ -67,9 +67,7 @@ Plans come with usage entitlements that can be extended without upgrading to a d
 
 ## Manage your plans
 
-To subscribe to a new plan, you can self-serve through **Billing** in [Docker Home](https://app.docker.com), or by <a href="https://www.docker.com/pricing/contact-sales/" id="dkr_docs_index_sales" class="link" rel="noopener">contacting sales</a>.
-
-To learn more about adding a new plan or upgrading an active plan, see [Manage plans](/manuals/subscription/manage.md).
+To subscribe to a new plan or upgrade an active plan, see [Manage plans](/manuals/subscription/manage.md) or [Docker plans](/manuals/subscription/plans/docker.md). You can also <a href="https://www.docker.com/pricing/contact-sales/" id="dkr_docs_index_sales" class="link" rel="noopener">contact sales</a>.
 
 ## Next steps
 

--- a/content/manuals/subscription/faq.md
+++ b/content/manuals/subscription/faq.md
@@ -30,6 +30,12 @@ Docker offers two content contribution programs:
 
 You can also join the [Developer Preview Program](https://www.docker.com/community/get-involved/developer-preview/) or sign up for early access programs to participate in research and try new features.
 
+## How do I upgrade to Docker Pro?
+
+To upgrade to Docker Pro, go to the
+<a href="https://www.docker.com/pricing?ref=Docs&refAction=DocsSubscriptionFaqPro" id="dkr_docs_pricing_faq_pro" class="link" rel="noopener">Docker pricing page</a>
+and select **Buy now**.
+
 > [!TIP]
 > 
 > Need to upgrade? <a href="https://www.docker.com/pricing?ref=Docs&refAction=DocsSubscriptionFaq" id="pricing-link" class="link" rel="noopener">Compare Docker Team and Docker Business</a> to choose the plan that best fits your team's needs.

--- a/content/manuals/subscription/manage.md
+++ b/content/manuals/subscription/manage.md
@@ -22,9 +22,13 @@ aliases:
 You can add and manage your plans from the billing portal in Docker Home. Within the billing portal, you use the product catalog to view
 self-serve Docker products, while the Overview page shows your active plans with options to upgrade or cancel.
 
+To upgrade to Docker Pro, go to the
+<a href="https://www.docker.com/pricing/" id="dkr_docs_pricing_manage_pro" class="link" rel="noopener">Docker pricing page</a>
+and select **Buy now**.
+
 ## Set up a new plan
 
-You can purchase Docker plans through the product catalog:
+You can purchase Docker Team, Docker Business, and other products through the product catalog:
 
 1. Sign in to [Docker Home](https://app.docker.com/), then choose your personal
    account or your organization account.

--- a/content/manuals/subscription/manage.md
+++ b/content/manuals/subscription/manage.md
@@ -22,10 +22,6 @@ aliases:
 You can add and manage your plans from the billing portal in Docker Home. Within the billing portal, you use the product catalog to view
 self-serve Docker products, while the Overview page shows your active plans with options to upgrade or cancel.
 
-To upgrade to Docker Pro, go to the
-<a href="https://www.docker.com/pricing/" id="dkr_docs_pricing_manage_pro" class="link" rel="noopener">Docker pricing page</a>
-and select **Buy now**.
-
 ## Set up a new plan
 
 You can purchase Docker Team, Docker Business, and other products through the product catalog:
@@ -43,6 +39,10 @@ You can purchase Docker Team, Docker Business, and other products through the pr
      checkbox and enter your Tax ID.
    - Your VAT number must include your country prefix. For example, enter
      `DE123456789` for a German VAT number.
+
+To upgrade to Docker Pro, go to the
+<a href="https://www.docker.com/pricing/" id="dkr_docs_pricing_manage_pro" class="link" rel="noopener">Docker pricing page</a>
+and select **Buy now**.
 
 ## Upgrade plans
 

--- a/content/manuals/subscription/plans/_index.md
+++ b/content/manuals/subscription/plans/_index.md
@@ -42,7 +42,7 @@ grid:
 > Interested in pricing details? Check out the
 > <a href="https://www.docker.com/pricing/" id="dkr_docs_index_pricing" class="link" rel="noopener">pricing page</a> to compare plans.
 
-You can subscribe to plans on a self-serve basis when you go to the Docker product catalog from the billing portal. Plans can be tied to personal or organization account types, and include options to extend usage limits.
+To subscribe to a plan, see [Manage plans](../manage.md) or [Docker plans](docker.md). Plans can be tied to personal or organization account types, and include options to extend usage limits.
 
 This section covers usage entitlements, billing cycle, and plan management options for each available plan.
 

--- a/content/manuals/subscription/plans/docker.md
+++ b/content/manuals/subscription/plans/docker.md
@@ -26,7 +26,10 @@ licensing, and expanded feature sets.
 - Docker Personal is free for individual developers. Docker Pro adds unlimited private repositories, Docker Build Cloud, and commercial Docker Desktop use.
 - Docker Team and Docker Business are plans for organizations, with Team adding audit logs and role-based access control, and Business adding SSO, SCIM, hardened Docker Desktop, and image access management.
 
-To upgrade your free Docker plan in the billing portal, see [Manage plans](../manage.md).
+To upgrade to Docker Pro, go to the
+<a href="https://www.docker.com/pricing/" id="dkr_docs_pricing_docker_pro" class="link" rel="noopener">Docker pricing page</a>
+and select **Buy now**.
+To upgrade to Docker Team or Docker Business, see [Manage plans](../manage.md).
 
 ## Usage
 


### PR DESCRIPTION
## Summary

Support was sending customers to Docker Home Billing, then the product catalog, then **View plans** to upgrade to Docker Pro. The way to upgrade to Pro is the [Docker pricing page](https://www.docker.com/pricing/): select **Buy now**.

This change puts that path in three owned CTAs and retargets inbound upgrade links so they land on those CTAs instead of restating the same sentence.

**Why 3 copy locations:** Docker Pro purchase copy should live only where people (and Gordon) look: the Docker plans page, the subscription FAQ, and Manage plans (the upgrade landing page, including `/subscription/upgrade/`). Repeating a Pro → pricing aside on every overview and feature page would drift when Billing changes the flow. Three sentences are the maintainable set.

**Why silent links:** `/subscription/` and the plans index currently imply every plan is purchased from Docker Home Billing / the product catalog. Those pages should point at Manage plans / Docker plans instead of restating Pro copy. Hub pull-limit troubleshooting and Build Cloud cache "upgrade your subscription" sent Personal users to `manage.md#upgrade-plans` (catalog). Retarget those links at the Docker plans page so they pick up the owned CTA without a fourth/fifth copy.

@netlify /subscription/plans/docker/

Preview:

- https://deploy-preview-25992--docsdocker.netlify.app/subscription/plans/docker/
- https://deploy-preview-25992--docsdocker.netlify.app/subscription/faq/
- https://deploy-preview-25992--docsdocker.netlify.app/subscription/manage/