### PR TITLE
engine/network: Update legacy-link deprecation

### DIFF
--- a/content/manuals/engine/network/links.md
+++ b/content/manuals/engine/network/links.md
@@ -11,13 +11,11 @@ aliases:
 
 > [!WARNING]
 >
-> The `--link` flag is a legacy feature of Docker. It may eventually
-be removed. Unless you absolutely need to continue using it, we recommend that you use
-user-defined networks to facilitate communication between two containers instead of using
-`--link`. One feature that user-defined networks do not support that you can do
-with `--link` is sharing environment variables between containers. However,
-you can use other mechanisms such as volumes to share environment variables
-between containers in a more controlled way.
+> Links on the default `bridge` network are deprecated and scheduled for removal
+> in Docker Engine 30.0. Starting with Docker Engine 29.6, Docker emits a
+> deprecation warning when you create a container with these links. Links on
+> non-default networks remain supported. Use user-defined networks instead of
+> the legacy `--link` flag whenever possible.
 >
 > See [Differences between user-defined bridges and the default bridge](drivers/bridge.md#differences-between-user-defined-bridges-and-the-default-bridge)
 > for some alternatives to using `--link`.
@@ -255,6 +253,14 @@ recipient container in two ways:
 * Updating the `/etc/hosts` file.
 
 ### Environment variables
+
+> [!WARNING]
+>
+> Legacy-link environment variables were deprecated in Docker Engine 28.4, are
+> disabled by default in Docker Engine 29.0, and are scheduled for removal in
+> Docker Engine 30.0. In Docker Engine 29.x, set
+> `DOCKER_KEEP_DEPRECATED_LEGACY_LINKS_ENV_VARS=1` in the `dockerd` process
+> environment and restart the daemon to temporarily re-enable them.
 
 Docker creates several environment variables when you link containers. Docker
 automatically creates environment variables in the target container based on


### PR DESCRIPTION
Keep the legacy-link reference while warning that default-bridge links and legacy-link environment variables are scheduled for removal in Docker Engine 30.0.
Document the environment variable escape hatch.

<!--Delete sections as needed -->

## Description

<!-- Tell us what you did and why -->

## Related issues or tickets

<!-- Related issues, pull requests, or Jira tickets -->

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Technical review
- [ ] Editorial review
- [ ] Product review