### PR TITLE
docs: document Shell sandboxes

### DIFF
--- a/content/manuals/agentic-platform/faq.md
+++ b/content/manuals/agentic-platform/faq.md
@@ -11,8 +11,8 @@ aliases:
 ## What can I run in Docker Agentic Platform?
 
 Docker Agentic Platform provides predefined sandbox types for Claude Code,
-Codex, OpenCode, Copilot, and Gemini CLI. Each runs in an isolated, Docker-hosted
-sandbox with a live terminal.
+Codex, OpenCode, Copilot, Gemini CLI, and Shell. Each type runs in an isolated,
+Docker-hosted sandbox with a live terminal.
 
 ## How does Docker Agentic Platform differ from Docker Sandboxes?
 

--- a/content/manuals/agentic-platform/get-started.md
+++ b/content/manuals/agentic-platform/get-started.md
@@ -1,7 +1,7 @@
 ---
 title: Get started with Docker Agentic Platform
 linkTitle: Get started
-description: Choose an agent environment and start a Docker Agentic Platform sandbox.
+description: Choose an environment and start a Docker Agentic Platform sandbox.
 keywords: docker agentic platform, get started, agents, sandbox, live terminal
 weight: 10
 aliases:
@@ -11,25 +11,26 @@ aliases:
 ---
 
 The Docker Agentic Platform launcher collects the configuration needed to start
-an agent in an isolated sandbox.
+an isolated sandbox.
 
 ## Before you begin
 
-You need a Docker account, access to Docker Agentic Platform, and an API key for
-the model provider you want to use. You can add the key under **Secrets** before
-creating the sandbox or provide it in the launcher when prompted.
+You need a Docker account and access to Docker Agentic Platform. The launcher
+prompts for a model provider API key when needed. You can add the key under
+**Secrets** before creating the sandbox or provide it in the launcher when
+prompted.
 
-The available sandbox types are Claude Code, Codex, OpenCode, Copilot, and
-Gemini CLI. The supported model provider credentials are Anthropic, OpenAI,
+The available sandbox types are Claude Code, Codex, OpenCode, Copilot, Gemini
+CLI, and Shell. The supported model provider credentials are Anthropic, OpenAI,
 GitHub Copilot, Google, Groq, and xAI.
 
 ## Start a sandbox
 
 1. Open [Docker Agentic Platform](https://agentic-platform.docker.com/) and
    select **New**.
-2. Choose a sandbox type and select or add its required model credential.
-   Copilot uses `GITHUB_TOKEN`; add the same GitHub secret to any other sandbox
-   type that needs private repository access.
+2. Choose a sandbox type and add any requested model credential. Copilot uses
+   `GITHUB_TOKEN`; add the same GitHub secret to any other sandbox type that
+   needs private repository access.
 3. Configure the sandbox. The initial settings are **open access**, **no tools
    added**, and **medium compute**.
 4. Choose whether Docker stops or deletes the sandbox when its timer expires,
@@ -40,7 +41,7 @@ You cannot change the sandbox's authentication, tools, access policy, or compute
 size after it starts. Docker creates the sandbox, marks it as running, and opens
 its terminal.
 
-Use the terminal to interact with the selected agent or tool.
+Use the terminal to interact with the sandbox.
 
 Return to **Sandboxes** to find the running sandbox and reopen its terminal.
 

--- a/content/manuals/agentic-platform/sandboxes.md
+++ b/content/manuals/agentic-platform/sandboxes.md
@@ -1,6 +1,6 @@
 ---
 title: Sandboxes
-description: Create and manage hosted agent environments in Docker Agentic Platform.
+description: Create and manage hosted environments in Docker Agentic Platform.
 keywords: docker agentic platform, sandboxes, agents, cloud runtime, terminal, compute
 weight: 20
 aliases:
@@ -8,15 +8,22 @@ aliases:
   - /agentic-platform/guides/manage-sandboxes/
 ---
 
-A sandbox is an isolated runtime for an agent or tool. Docker hosts and meters
-the sandbox on managed cloud infrastructure and provides a live terminal for
+A sandbox is an isolated runtime on Docker-managed cloud infrastructure.
+Docker hosts and meters the sandbox and provides a live terminal for
 interacting with it.
 
 Docker Agentic Platform provides predefined sandbox types for Claude Code,
-Codex, OpenCode, Copilot, and Gemini CLI. Each sandbox has its own compute,
-filesystem, network access, and terminal. A sandbox continues running
-independently of your connection to the Console until it is paused, stopped by
-its lifecycle timer, or deleted.
+Codex, OpenCode, Copilot, Gemini CLI, and Shell. All sandbox types run Ubuntu on
+x86-64 compute with Docker pre-installed. Each sandbox has its own compute,
+filesystem, network access, and terminal. The compute size that you select
+determines its CPU and memory resources.
+
+The Shell type opens a Bash shell without a pre-installed agent. It uses the
+same agent-less environment as [`sbx run shell`](/manuals/ai/sandboxes/agents/shell.md)
+and is useful for working manually or installing your own agent.
+
+A sandbox continues running independently of your connection to the Console
+until it is paused, stopped by its lifecycle timer, or deleted.
 
 ## Source code and files
 
@@ -41,7 +48,7 @@ but writing to them still requires authentication.
 ## Open a sandbox
 
 After you select **Run**, Docker creates the sandbox and opens its detail page.
-Use the terminal to interact with the selected agent or tool.
+Use the terminal to interact with the sandbox.
 
 Open **Sandboxes** to review each sandbox's name, type, status, hourly rate,
 expiration, and age. Select a sandbox to reopen its detail page and terminal.
@@ -67,11 +74,11 @@ account, usage, and payment information, see [Docker Billing](/subscription-bill
 
 ## Check sandbox configuration
 
-If the agent cannot reach a service or use a tool, check the configuration that
-applies to the request:
+If the sandbox cannot reach a service or use a tool, check the configuration
+that applies to the request:
 
 - Confirm that the network policies permit the destination.
-- If the agent needs an MCP tool, confirm that its server is connected and
+- If the sandbox needs an MCP tool, confirm that its server is connected and
   authorized.
 - If the destination requires authentication, confirm that the sandbox was
   created with the service credential.


### PR DESCRIPTION
## Summary

Adds Shell to the available sandbox types and clarifies its base environment, compute sizing, and credential behavior.

@netlify /agentic-platform/sandboxes/

Preview: [Sandboxes](https://deploy-preview-25999--docsdocker.netlify.app/agentic-platform/sandboxes/), [Get started](https://deploy-preview-25999--docsdocker.netlify.app/agentic-platform/get-started/), [FAQ](https://deploy-preview-25999--docsdocker.netlify.app/agentic-platform/faq/)

Generated by Codex