### PR TITLE
docs: mention immutable tags during deletion

### DIFF
--- a/content/manuals/docker-hub/repos/manage/hub-images/manage.md
+++ b/content/manuals/docker-hub/repos/manage/hub-images/manage.md
@@ -30,6 +30,10 @@ Use the following steps to delete one or more items via the graphical user
 interface. To delete in bulk, see the [deletion API
 endpoint](/reference/api/registry/latest/#tag/delete).
 
+> [!NOTE]
+> Images associated with [immutable tags](./immutable-tags.md) can't be
+> deleted. Only items associated with mutable tags can be deleted.
+
 1. Sign in to [Docker Hub](https://hub.docker.com).
 2. Select **My Hub** > **Repositories**.
 3. In the list, select a repository.

--- a/content/manuals/docker-hub/repos/manage/hub-images/tags.md
+++ b/content/manuals/docker-hub/repos/manage/hub-images/tags.md
@@ -50,6 +50,10 @@ You can select a tag's digest to see more details.
 Only the repository owner or other team members with granted permissions can
 delete tags.
 
+> [!NOTE]
+> If your repository has [immutable tags](./immutable-tags.md) enabled, those
+> tags can't be deleted. Only mutable tags can be deleted.
+
 1. Sign in to [Docker Hub](https://hub.docker.com).
 2. Select **My Hub** > **Repositories**.
 


### PR DESCRIPTION
Fixes #25997

Add notes to the Docker Hub tag and image-management deletion instructions explaining that immutable tags cannot be deleted and linking to the immutable-tags guide.

Validation:
- `git diff --check` passed
- Local Prettier could not run because `prettier-plugin-go-template` is unavailable
- Docker lint/Vale could not run because the Docker CLI is unavailable
- GitHub Actions should provide repository validation and preview checks