### PR TITLE
Add links to how to migrate from Autobuilds

### DIFF
--- a/content/manuals/docker-hub/repos/manage/builds/_index.md
+++ b/content/manuals/docker-hub/repos/manage/builds/_index.md
@@ -17,6 +17,7 @@ aliases:
 > [!WARNING]
 > Docker Hub Automated Builds is a deprecated feature.
 > It will be fully retired on April 1, 2027.
+> See the [migration guide](migrate.md) to move to a supported CI/CD workflow.
 
 Docker Hub can automatically build images from source code in an external
 repository and automatically push the built image to your Docker repositories.

--- a/content/manuals/docker-hub/repos/manage/builds/advanced.md
+++ b/content/manuals/docker-hub/repos/manage/builds/advanced.md
@@ -12,6 +12,7 @@ aliases:
 > [!WARNING]
 > Docker Hub Automated Builds is a deprecated feature.
 > It will be fully retired on April 1, 2027.
+> See the [migration guide](migrate.md) to move to a supported CI/CD workflow.
 
 > [!NOTE]
 >

--- a/content/manuals/docker-hub/repos/manage/builds/automated-testing.md
+++ b/content/manuals/docker-hub/repos/manage/builds/automated-testing.md
@@ -10,6 +10,7 @@ aliases:
 > [!WARNING]
 > Docker Hub Automated Builds is a deprecated feature.
 > It will be fully retired on April 1, 2027.
+> See the [migration guide](migrate.md) to move to a supported CI/CD workflow.
 
 > [!NOTE]
 >

--- a/content/manuals/docker-hub/repos/manage/builds/link-source.md
+++ b/content/manuals/docker-hub/repos/manage/builds/link-source.md
@@ -14,6 +14,7 @@ aliases:
 > [!WARNING]
 > Docker Hub Automated Builds is a deprecated feature.
 > It will be fully retired on April 1, 2027.
+> See the [migration guide](migrate.md) to move to a supported CI/CD workflow.
 
 > [!NOTE]
 >

--- a/content/manuals/docker-hub/repos/manage/builds/manage-builds.md
+++ b/content/manuals/docker-hub/repos/manage/builds/manage-builds.md
@@ -9,6 +9,7 @@ aliases:
 > [!WARNING]
 > Docker Hub Automated Builds is a deprecated feature.
 > It will be fully retired on April 1, 2027.
+> See the [migration guide](migrate.md) to move to a supported CI/CD workflow.
 
 > [!NOTE]
 >

--- a/content/manuals/docker-hub/repos/manage/builds/migrate.md
+++ b/content/manuals/docker-hub/repos/manage/builds/migrate.md
@@ -3,7 +3,7 @@ description: Migrate from Autobuilds to CI/CD workflows
 keywords: automated builds, autobuilds, migration, github actions, bitbucket pipelines
 title: Migrate from Autobuilds
 linkTitle: Migrate
-weight: 80
+weight: 1
 ---
 
 > [!WARNING]

--- a/content/manuals/docker-hub/repos/manage/builds/setup.md
+++ b/content/manuals/docker-hub/repos/manage/builds/setup.md
@@ -13,6 +13,7 @@ aliases:
 > [!WARNING]
 > Docker Hub Automated Builds is a deprecated feature.
 > It will be fully retired on April 1, 2027.
+> See the [migration guide](migrate.md) to move to a supported CI/CD workflow.
 
 > [!NOTE]
 >

--- a/content/manuals/docker-hub/repos/manage/builds/troubleshoot.md
+++ b/content/manuals/docker-hub/repos/manage/builds/troubleshoot.md
@@ -11,6 +11,7 @@ aliases:
 > [!WARNING]
 > Docker Hub Automated Builds is a deprecated feature.
 > It will be fully retired on April 1, 2027.
+> See the [migration guide](migrate.md) to move to a supported CI/CD workflow.
 
 > [!NOTE]
 >


### PR DESCRIPTION
<!--Delete sections as needed -->

## Description

<!-- Tell us what you did and why -->

This PR adds a link to the migration guide in every deprecation notice in autobuilds pages.
Also, it moves the page up in the navigation, right under the main one to ease its finding as it is a the most important one from now on.

## Related issues or tickets

https://docker.atlassian.net/browse/DSB-245

<!-- Related issues, pull requests, or Jira tickets -->

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Technical review
- [ ] Editorial review
- [ ] Product review
