### PR TITLE
engine/security: Document AF_VSOCK SELinux limitation

### DIFF
--- a/content/manuals/engine/security/seccomp.md
+++ b/content/manuals/engine/security/seccomp.md
@@ -103,7 +103,7 @@ the reason each syscall is blocked rather than white-listed.
 | `setns`             | Deny associating a thread with a namespace. Also gated by `CAP_SYS_ADMIN`.                                                                                                                                                                     |
 | `settimeofday`      | Time/date is not namespaced. Also gated by `CAP_SYS_TIME`.                                                                                                                                                                                     |
 | `stime`             | Time/date is not namespaced. Also gated by `CAP_SYS_TIME`.                                                                                                                                                                                     |
-| `socket`            | Blocked for `AF_ALG` to prevent in-container privilege escalation via the kernel cryptographic API ([CVE-2026-31431](https://nvd.nist.gov/vuln/detail/CVE-2026-31431)). Also blocked for `AF_VSOCK`. These do not cover `socketcall(2)`, which can be easily bypassed. `AF_ALG` is denied on both paths by the default AppArmor profile (`deny network alg,`) or the SELinux policy module; `AF_VSOCK` has no equivalent LSM rule. See [moby/moby#52494](https://github.com/moby/moby/pull/52494). |
+| `socket`            | Blocked for `AF_ALG` to prevent in-container privilege escalation via the kernel cryptographic API ([CVE-2026-31431](https://nvd.nist.gov/vuln/detail/CVE-2026-31431)). Also blocked for `AF_VSOCK`. Seccomp argument filtering doesn't cover `socketcall(2)`. The default AppArmor profile and SELinux policy module deny both address families through `socket(2)` and `socketcall(2)`. See [moby/moby#52494](https://github.com/moby/moby/pull/52494) and [moby/moby#53551](https://github.com/moby/moby/pull/53551). |
 | `swapon`            | Deny start/stop swapping to file/device. Also gated by `CAP_SYS_ADMIN`.                                                                                                                                                                        |
 | `swapoff`           | Deny start/stop swapping to file/device. Also gated by `CAP_SYS_ADMIN`.                                                                                                                                                                        |
 | `sysfs`             | Obsolete syscall.                                                                                                                                                                                                                              |
@@ -116,6 +116,15 @@ the reason each syscall is blocked rather than white-listed.
 | `ustat`             | Obsolete syscall.                                                                                                                                                                                                                              |
 | `vm86`              | In kernel x86 real mode virtual machine. Also gated by `CAP_SYS_ADMIN`.                                                                                                                                                                        |
 | `vm86old`           | In kernel x86 real mode virtual machine. Also gated by `CAP_SYS_ADMIN`.                                                                                                                                                                        |
+
+> [!IMPORTANT]
+>
+> The SELinux rule that blocks `AF_VSOCK` requires SELinux userspace 3.6 or
+> later, the `container-selinux` policy, and SELinux enabled for the Docker
+> daemon. RHEL 8 ships an older SELinux userspace, so its standard packages
+> can't apply this rule. On affected hosts, use AppArmor or a custom seccomp
+> profile that denies `socketcall`. Denying `socketcall` can break networking
+> for 32-bit programs that use it.
 
 ## Run without the default seccomp profile
 


### PR DESCRIPTION
The AF_VSOCK LSM rule requires SELinux userspace 3.6 or later, so standard RHEL 8 installations cannot apply it. Document the AppArmor and custom seccomp alternatives, including the 32-bit compatibility cost of denying socketcall.

<!--Delete sections as needed -->

## Description

<!-- Tell us what you did and why -->

## Related issues or tickets

<!-- Related issues, pull requests, or Jira tickets -->

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Technical review
- [ ] Editorial review
- [ ] Product review