### PR TITLE
scout: align policy names

### DIFF
--- a/content/manuals/build/building/best-practices.md
+++ b/content/manuals/build/building/best-practices.md
@@ -252,8 +252,8 @@ to look up and include the image digest for base image versions manually each
 time you want to update it. And you're opting out of automated security fixes,
 which is likely something you want to get.
 
-Docker Scout's default [**Up-to-Date Base Images**
-policy](../../scout/policy/_index.md#up-to-date-base-images) checks whether the
+Docker Scout's default [**No outdated base images**
+policy](../../scout/policy/_index.md#no-outdated-base-images) checks whether the
 base image version you're using is in fact the latest version. This policy also
 checks if pinned digests in your Dockerfile correspond to the correct version.
 If a publisher updates an image that you've pinned, the policy evaluation

--- a/content/manuals/scout/policy/_index.md
+++ b/content/manuals/scout/policy/_index.md
@@ -30,8 +30,8 @@ package, it's non-compliant with that policy.
 Docker Scout includes the following built-in policy types:
 
 - [Severity-Based Vulnerability](#severity-based-vulnerability)
-- [Compliant Licenses](#compliant-licenses)
-- [Up-to-Date Base Images](#up-to-date-base-images)
+- [No copyleft licenses](#no-copyleft-licenses)
+- [No outdated base images](#no-outdated-base-images)
 - [High-Profile Vulnerabilities](#high-profile-vulnerabilities)
 - [Supply Chain Attestations](#supply-chain-attestations)
 - [Default Non-Root User](#default-non-root-user)
@@ -51,15 +51,15 @@ severity vulnerabilities where a fix version is available.
 Configurable parameters include severity levels, a grace period for newly
 disclosed CVEs, fixable-only filtering, and package type filtering.
 
-### Compliant Licenses
+### No copyleft licenses
 
-The **Compliant Licenses** policy type checks whether your images contain
+The **No copyleft licenses** policy type checks whether your images contain
 packages distributed under an inappropriate license. You can configure the
 list of licenses to flag and add package-level exceptions.
 
-### Up-to-Date Base Images
+### No outdated base images
 
-The **Up-to-Date Base Images** policy type checks whether the base images you
+The **No outdated base images** policy type checks whether the base images you
 use are current. Images are non-compliant if the tag you built from points to
 a different digest than what you're using.
 
@@ -110,7 +110,7 @@ successfully. For more information, see [No base image data](#no-base-image-data
 
 ## No base image data
 
-The **Up-to-Date Base Images** and **Approved Base Images** policies require
+The **No outdated base images** and **Approved Base Images** policies require
 provenance attestations to determine the base image used in your build. Without
 them, these policies report **No data**.
 

--- a/content/manuals/scout/policy/local.md
+++ b/content/manuals/scout/policy/local.md
@@ -167,7 +167,7 @@ policy's Rego metadata, or override it per policy in the policy-config file:
 {
   "policies": [
     {
-      "name": "no-copyleft-licenses",
+      "name": "copyleft-license",
       "weight": 0
     }
   ]


### PR DESCRIPTION
<!--Delete sections as needed -->

## Description

Align policy names with output from new local policy feature.

- `content/manuals/scout/policy/local.md`: fix the copyleft policy's stable ID
  in the weight-override example (`no-copyleft-licenses` → `copyleft-license`).
- `content/manuals/scout/policy/_index.md`: replace the policy names
  (`Compliant Licenses`, `Up-to-Date Base Images`) with the names the CLI
  actually outputs (`No copyleft licenses`, `No outdated base images`), and
  update the matching anchor in `best-practices.md`.

## Related issues or tickets

Fixes #25934
Fixes #25935
Fixes #25936

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Technical review
- [ ] Editorial review
- [ ] Product review