### PR TITLE
docs: fix arithmetic in build cache GC policy example

### DIFF
--- a/content/manuals/build/cache/garbage-collection.md
+++ b/content/manuals/build/cache/garbage-collection.md
@@ -47,8 +47,9 @@ you have 11GB worth of build cache, where:
 - 7GB of which is "stale" cache
 - 4GB is other, more valuable cache
 
-A GC sweep would delete 5GB of stale cache as part of the 1st policy, with a
-remainder of 6GB, meaning the 2nd policy does not need to clear any more cache.
+A GC sweep would delete 2GB of stale cache as part of the 1st policy, leaving
+9GB of cache in total, meaning the 2nd policy does not need to clear any more
+cache.
 
 The default GC policies are (approximately):
 


### PR DESCRIPTION
## Description

The GC policy example in `content/manuals/build/cache/garbage-collection.md`
defines the first policy as:

> Find "stale" cache records that haven't been used in the past 48 hours, and
> delete records until there's maximum 5GB of "stale" cache left.

It then walks through a sweep over 11GB of cache (7GB stale, 4GB other) and
concludes:

> A GC sweep would delete 5GB of stale cache as part of the 1st policy, with a
> remainder of 6GB, meaning the 2nd policy does not need to clear any more cache.

Both numbers contradict the policy as defined. Keeping a *maximum of 5GB* of
stale cache means deleting 2GB of the 7GB, which leaves 5GB stale plus 4GB
other, for 9GB in total.

The 6GB figure is internally consistent only with the opposite reading —
"delete 5GB of stale cache", leaving 2GB stale plus 4GB other. That reading is
what the sentence asserts, and it is not what the policy says, so the two
numbers are wrong together rather than independently.

The example's point survives the correction: 9GB is still under the second
policy's 10GB limit, so the second policy does not need to clear any more
cache.

```diff
-A GC sweep would delete 5GB of stale cache as part of the 1st policy, with a
-remainder of 6GB, meaning the 2nd policy does not need to clear any more cache.
+A GC sweep would delete 2GB of stale cache as part of the 1st policy, leaving
+9GB of cache in total, meaning the 2nd policy does not need to clear any more
+cache.
```

Note for the reporter of #25927: the "delete 2GB" half of the report is right,
but the report also says the "remainder of 6GB" is correct. It isn't —
11GB minus 2GB is 9GB. 6GB only follows from the misreading being corrected
here.

## Related issues or tickets

Fixes #25927

## Reviews

- [ ] Technical review
- [ ] Editorial review
- [ ] Product review

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TGSfAZyRTEw9qGGzVECGYk
