### PR TITLE
docs: label Desktop installer downloads for Marlin

### DIFF
--- a/content/manuals/desktop/features/wsl/_index.md
+++ b/content/manuals/desktop/features/wsl/_index.md
@@ -35,8 +35,8 @@ Before you turn on the Docker Desktop WSL 2 feature, ensure you have:
 Before installing Docker Desktop, uninstall any version of Docker Engine or the Docker CLI
 that was installed directly inside a WSL Linux distribution. Running both can cause conflicts.
 
-1. Download and install the latest version of [Docker Desktop for Windows](https://desktop.docker.com/win/main/amd64/Docker%20Desktop%20Installer.exe?utm_source=docker&utm_medium=webreferral&utm_campaign=docs-driven-download-windows).
-2. Follow the usual installation instructions to install Docker Desktop. Depending on which version of Windows you are using, Docker Desktop may prompt you to turn on WSL 2 during installation. Read the information displayed on the screen and turn on the WSL 2 feature to continue.
+1. [Install Docker Desktop for Windows](/manuals/desktop/setup/install/windows-install.md).
+2. During installation, Docker Desktop may prompt you to turn on WSL 2. Read the information displayed on the screen and turn on the WSL 2 feature to continue.
 3. Start Docker Desktop from the **Windows Start** menu.
 4. Navigate to **Settings**.
 5. From the **General** tab, select **Use WSL 2 based engine**.

--- a/content/manuals/desktop/setup/install/mac-install.md
+++ b/content/manuals/desktop/setup/install/mac-install.md
@@ -23,8 +23,8 @@ aliases:
 
 This page provides download links, system requirements, and step-by-step installation instructions for Docker Desktop on Mac.
 
-{{< button text="Docker Desktop for Mac with Apple silicon" url="https://desktop.docker.com/mac/main/arm64/Docker.dmg?utm_source=docker&utm_medium=webreferral&utm_campaign=docs-driven-download-mac-arm64" >}}
-{{< button text="Docker Desktop for Mac with Intel chip" url="https://desktop.docker.com/mac/main/amd64/Docker.dmg?utm_source=docker&utm_medium=webreferral&utm_campaign=docs-driven-download-mac-amd64" >}}
+{{< button text="Docker Desktop for Mac with Apple silicon" url="https://desktop.docker.com/mac/main/arm64/Docker.dmg?utm_source=docker&utm_medium=webreferral&utm_campaign=docs-driven-download-mac-arm64" marlin_label="download_dmg_click" >}}
+{{< button text="Docker Desktop for Mac with Intel chip" url="https://desktop.docker.com/mac/main/amd64/Docker.dmg?utm_source=docker&utm_medium=webreferral&utm_campaign=docs-driven-download-mac-amd64" marlin_label="download_dmg_click" >}}
 
 *For checksums, see [Release notes](/manuals/desktop/release-notes.md).*
 

--- a/content/manuals/desktop/setup/install/windows-install.md
+++ b/content/manuals/desktop/setup/install/windows-install.md
@@ -24,9 +24,9 @@ aliases:
 
 This page provides download links, system requirements, and step-by-step installation instructions for Docker Desktop on Windows.
 
-{{< button text="Docker Desktop for Windows - x86_64" url="https://desktop.docker.com/win/main/amd64/Docker%20Desktop%20Installer.exe?utm_source=docker&utm_medium=webreferral&utm_campaign=docs-driven-download-win-amd64" >}}
+{{< button text="Docker Desktop for Windows - x86_64" url="https://desktop.docker.com/win/main/amd64/Docker%20Desktop%20Installer.exe?utm_source=docker&utm_medium=webreferral&utm_campaign=docs-driven-download-win-amd64" marlin_label="download_exe_click" >}}
 {{< button text="Docker Desktop for Windows - x86_64 on the Microsoft Store" url="https://apps.microsoft.com/detail/xp8cbj40xlbwkx?hl=en-GB&gl=GB" >}}
-{{< button text="Docker Desktop for Windows - Arm (Early Access)" url="https://desktop.docker.com/win/main/arm64/Docker%20Desktop%20Installer.exe?utm_source=docker&utm_medium=webreferral&utm_campaign=docs-driven-download-win-arm64" >}}
+{{< button text="Docker Desktop for Windows - Arm (Early Access)" url="https://desktop.docker.com/win/main/arm64/Docker%20Desktop%20Installer.exe?utm_source=docker&utm_medium=webreferral&utm_campaign=docs-driven-download-win-arm64" marlin_label="download_exe_click" >}}
 
 _For checksums, see [Release notes](/manuals/desktop/release-notes.md)_
 

--- a/layouts/_shortcodes/button.html
+++ b/layouts/_shortcodes/button.html
@@ -1,5 +1,6 @@
 {{ $text := .Get "text" }}
 {{ $url := .Get "url" }}
+{{ $marlinLabel := .Get "marlin_label" }}
 {{- if (strings.HasPrefix $url "http") -}}
   {{ $url = $url | safeURL }}
 {{- else if (strings.FindRE `([^_]|^)index.md` $url 1) -}}
@@ -7,4 +8,4 @@
 {{- else -}}
   {{ $url = ref .Page $url }}
 {{- end -}}
-<a class="button not-prose" href="{{ $url }}">{{ $text }}</a>
+<a class="button not-prose" href="{{ $url }}"{{ with $marlinLabel }} marlin-label="{{ . }}"{{ end }}>{{ $text }}</a>

--- a/layouts/_shortcodes/desktop-install-v2.html
+++ b/layouts/_shortcodes/desktop-install-v2.html
@@ -12,6 +12,7 @@
     {{- if or $all $win }}
       <li>
         <a rel="noopener"
+           marlin-label="download_exe_click"
            href="https://desktop.docker.com/win/main/amd64{{ $build_path }}Docker%20Desktop%20Installer.exe?utm_source=docker&utm_medium=webreferral&utm_campaign=docs-driven-download-windows">Windows</a>
         (<a rel="noopener"
             href="https://desktop.docker.com/win/main/amd64{{ $build_path }}checksums.txt">checksum</a>)
@@ -20,6 +21,7 @@
     {{- if or $win_arm_release }}
         <li>
           <a rel="noopener"
+             marlin-label="download_exe_click"
              href="https://desktop.docker.com/win/main/arm64{{ $build_path }}Docker%20Desktop%20Installer.exe?utm_source=docker&utm_medium=webreferral&utm_campaign=docs-driven-download-windows">Windows ARM {{ $win_arm_release }}</a>
           (<a rel="noopener"
               href="https://desktop.docker.com/win/main/arm64{{ $build_path }}checksums.txt">checksum</a>)
@@ -30,12 +32,12 @@
     {{- if or $all $mac }}
       <ul>
         <li>
-          <a rel="noopener" href="https://desktop.docker.com/mac/main/arm64{{ $build_path }}Docker.dmg?utm_source=docker&utm_medium=webreferral&utm_campaign=docs-driven-download-mac-arm64">Mac with Apple chip</a>
+          <a rel="noopener" marlin-label="download_dmg_click" href="https://desktop.docker.com/mac/main/arm64{{ $build_path }}Docker.dmg?utm_source=docker&utm_medium=webreferral&utm_campaign=docs-driven-download-mac-arm64">Mac with Apple chip</a>
           (<a rel="noopener"
               href="https://desktop.docker.com/mac/main/arm64{{ $build_path }}checksums.txt">checksum</a>)
         </li>
         <li>
-          <a rel="noopener" href="https://desktop.docker.com/mac/main/amd64{{ $build_path }}Docker.dmg?utm_source=docker&utm_medium=webreferral&utm_campaign=docs-driven-download-mac-amd64">Mac with Intel chip</a>
+          <a rel="noopener" marlin-label="download_dmg_click" href="https://desktop.docker.com/mac/main/amd64{{ $build_path }}Docker.dmg?utm_source=docker&utm_medium=webreferral&utm_campaign=docs-driven-download-mac-amd64">Mac with Intel chip</a>
           (<a rel="noopener"
               href="https://desktop.docker.com/mac/main/amd64{{ $build_path }}checksums.txt">checksum</a>)
         </li>

--- a/layouts/_shortcodes/desktop-install.html
+++ b/layouts/_shortcodes/desktop-install.html
@@ -10,22 +10,24 @@
 <p>
   {{- if or $all $win }}
   <a rel="noopener"
+     marlin-label="download_exe_click"
      href="https://desktop.docker.com/win/main/amd64{{ $build_path }}Docker%20Desktop%20Installer.exe">Windows</a>
   (<a rel="noopener"
       href="https://desktop.docker.com/win/main/amd64{{ $build_path }}checksums.txt">checksum</a>) |
   {{ end }}
   {{- if or $win_arm_release }}
   <a rel="noopener"
+     marlin-label="download_exe_click"
      href="https://desktop.docker.com/win/main/arm64{{ $build_path }}Docker%20Desktop%20Installer.exe">Windows ARM {{ $win_arm_release }}</a>
   (<a rel="noopener"
       href="https://desktop.docker.com/win/main/arm64{{ $build_path }}checksums.txt">checksum</a>) |
   {{ end }}
   {{- if or $all $mac }}
-  <a rel="noopener" href="https://desktop.docker.com/mac/main/arm64{{ $build_path }}Docker.dmg">Mac
+  <a rel="noopener" marlin-label="download_dmg_click" href="https://desktop.docker.com/mac/main/arm64{{ $build_path }}Docker.dmg">Mac
     with Apple chip</a>
   (<a rel="noopener"
       href="https://desktop.docker.com/mac/main/arm64{{ $build_path }}checksums.txt">checksum</a>) |
-  <a rel="noopener" href="https://desktop.docker.com/mac/main/amd64{{ $build_path }}Docker.dmg">Mac
+  <a rel="noopener" marlin-label="download_dmg_click" href="https://desktop.docker.com/mac/main/amd64{{ $build_path }}Docker.dmg">Mac
     with Intel chip</a>
   (<a rel="noopener"
       href="https://desktop.docker.com/mac/main/amd64{{ $build_path }}checksums.txt">checksum</a>)


### PR DESCRIPTION
## Summary

Add explicit Marlin labels matching the legacy Segment events to Docker Desktop installer links on the install pages and in release notes. Route WSL readers through the Windows installation guide instead of a hard-coded x86_64 download; the remaining get-started download cards are removed by #25986.

@netlify /desktop/setup/install/windows-install/

Preview: [Windows install](https://deploy-preview-26018--docsdocker.netlify.app/desktop/setup/install/windows-install/) · [Mac install](https://deploy-preview-26018--docsdocker.netlify.app/desktop/setup/install/mac-install/) · [WSL](https://deploy-preview-26018--docsdocker.netlify.app/desktop/features/wsl/)

Generated by Codex