### PR TITLE
docs: restore /docker-for-windows/troubleshoot/ alias

### DIFF
--- a/content/manuals/desktop/troubleshoot-and-support/troubleshoot/_index.md
+++ b/content/manuals/desktop/troubleshoot-and-support/troubleshoot/_index.md
@@ -7,6 +7,7 @@ toc_max: 2
 title: Troubleshoot Docker Desktop
 linkTitle: Troubleshoot and diagnose
 aliases:
+  - /docker-for-windows/troubleshoot/
   - /desktop/troubleshoot/overview/
   - /desktop/troubleshoot/
 tags: [Troubleshooting]


### PR DESCRIPTION
## Description

`/docker-for-windows/troubleshoot/` currently returns a 404. This restores
the alias on the Docker Desktop troubleshoot page.

That alias was removed deliberately in #25115 ("redirect tidy"), along with
seven others on the same page, as old and unused based on traffic analysis.
I'm proposing to restore one of them because there's a live inbound link
that traffic data wouldn't have shown as a working path:

[VS Code's dev container tips and tricks page](https://code.visualstudio.com/docs/devcontainers/tips-and-tricks)
links to `https://docs.docker.com/docker-for-windows/troubleshoot/#volumes`.
Readers following that link land on a 404, which is how #26020 was reported.

**Scope:** only `/docker-for-windows/troubleshoot/`. The other seven aliases
removed in #25115 also 404 today, but I didn't find inbound links for them,
so I left them alone. Happy to restore more if you'd prefer.

**On the anchor:** `#volumes` no longer resolves — that content moved to the
troubleshoot topics page. The alias lands readers on the troubleshoot
overview, which links through to it. Still better than a 404.

## Related issues or tickets

Fixes #26020

## Reviews

- [ ] Technical review
- [ ] Editorial review
- [ ] Product review