### PR TITLE
docs: explain unresolved governance status

### DIFF
--- a/content/manuals/ai/sandboxes/governance/monitor-and-enforce/monitoring.md
+++ b/content/manuals/ai/sandboxes/governance/monitor-and-enforce/monitoring.md
@@ -69,6 +69,14 @@ stale timestamp, the daemon may not have the most recent org policy. Run
 `sbx policy reset` to force a fresh pull. `Hidden` reports how many inactive
 rules are suppressed and how to reveal them.
 
+If Docker can't determine which organization governs your account, policy
+output shows `Governance: Unresolved`, and the dashboard shows the same
+unresolved state. For example, this happens when your account belongs to
+multiple organizations with governance enabled. Policy enforcement fails closed
+until the conflict is resolved, so local allow rules can't grant access. Contact
+an administrator for the affected organizations to resolve the conflicting
+governance configuration.
+
 ### Showing inactive rules
 
 When organization governance is active, local and kit-defined allow rules are


### PR DESCRIPTION
## Summary

Explain the unresolved governance state shown when Docker cannot determine which organization governs an account. Document the multiple-organization trigger, fail-closed behavior, and administrator escalation.

@netlify /ai/sandboxes/governance/monitor-and-enforce/monitoring/

[Preview the monitoring policies page](https://deploy-preview-26028--docsdocker.netlify.app/ai/sandboxes/governance/monitor-and-enforce/monitoring/)

Generated by Codex