### PR TITLE
docs: replace self-referencing team management link

### DIFF
--- a/content/manuals/accounts/organization/manage/manage-a-team.md
+++ b/content/manuals/accounts/organization/manage/manage-a-team.md
@@ -60,8 +60,7 @@ For more information on roles, see
 ## Set team repository permissions
 
 You must create a team before you are able to configure repository permissions.
-For more details, see [Create and manage a
-team](/manuals/accounts/organization/manage/manage-a-team.md).
+For more details, see [Create a team](#create-a-team).
 
 To set team repository permissions:
 


### PR DESCRIPTION
Fixes #25923

Replaces the circular self-referencing link pointing back to same file in **Set team repository permissions** with a standard, local anchor link pointing to **Create a team** section on the same page.