### PR TITLE
Confirmed the updated text distinguishes between Sales setup and the UI toggle

### DIFF
--- a/content/manuals/subscription-billing/manage/payment-method.md
+++ b/content/manuals/subscription-billing/manage/payment-method.md
@@ -80,20 +80,19 @@ To remove your default payment method, first set a different payment method as d
 > [!TIP]
 > Do you need to pay by invoice? [Upgrade to a Docker Business or Docker Team plan](https://www.docker.com/pricing?ref=Docs&refAction=DocsBillingPaymentMethod) and choose the annual subscription.
 
-Pay by invoice requires you to pay upfront for your first subscription period using a payment card or ACH bank transfer. At renewal time, instead of automatic payment, you'll receive an invoice via
-email that you must pay manually.
+Pay by invoice is available for annual Docker Team and Docker Business subscriptions. Docker Sales may need to enable pay by invoice on your account before it appears in Docker Home. For the first subscription period, you pay using a payment card or ACH bank transfer. At renewal time, instead of automatic payment, you'll receive an invoice by email that you must pay manually.
 
 Follow these steps to enable or disable pay by invoice:
 
-1. Sign in to [Docker Home](https://app.docker.com/) and select your
-   organization.
+1. Sign in to [Docker Home](https://app.docker.com/) and select your organization.
 2. Select **Billing**, then **Payment methods**.
-3. Select **Pay by invoice**, then select the pay by invoice toggle to enable or disable.
+3. Select **Pay by invoice**, then use the pay by invoice toggle to enable or disable.
 4. Confirm your billing contact details. If you need to change them, select
    **Change** and enter your new details.
 
-Pay by invoice is not available for
-subscription upgrades or changes.
+If the pay by invoice option isn't available in Docker Home, contact your Docker sales representative.
+
+Pay by invoice isn't available for subscription upgrades or changes.
 
 ## Verify a bank account
 
@@ -129,19 +128,3 @@ after each failed payment attempt.
 If the invoice remains unpaid after the grace period, the
 subscription downgrades to a free subscription and all paid features are
 disabled.
-
-## Pay by invoice
-
-> [!TIP]
->
-> To pay by invoice,
-> [upgrade to a Docker Team or Docker Business plan](https://www.docker.com/pricing?ref=Docs&refAction=DocsBillingPaymentMethod)
-> and choose an annual subscription.
-
-Pay by invoice requires upfront payment for your first subscription period
-using a payment card or ACH bank transfer. At renewal, Docker emails you an
-invoice to pay manually instead of charging your default payment method.
-
-- To add pay by invoice as a payment method, contact your Docker sales representative.
-- You can only pay by invoice by choosing it as a payment method when subscribing to Docker Team or Docker Business plans. 
-- Pay by invoice isn't available for subscription upgrades or changes.

--- a/content/manuals/subscription-billing/manage/payment-method.md
+++ b/content/manuals/subscription-billing/manage/payment-method.md
@@ -1,12 +1,15 @@
 ---
+
 title: Add or update a payment method
 linkTitle: Payment methods
 weight: 20
 description: Learn how to manage cards, US bank accounts, Stripe Link, and pay by invoice for Docker subscriptions.
 keywords: payments, billing, subscription, payment methods, credit card, ACH, US bank account, Stripe Link, pay by invoice, failed payments
 aliases:
-  - /billing/payment-method/
-  - /billing/core-billing/payment-method/
+
+* /billing/payment-method/
+* /billing/core-billing/payment-method/
+
 ---
 
 Docker supports several payment methods for paid personal accounts and
@@ -27,9 +30,9 @@ States dollars (USD). Docker supports the following payment methods:
 
 Some payment methods require additional setup before changing it to your default payment method. For example:
 
-- Verify a
+* Verify a
   [bank account](#verify-a-bank-account) before choosing it as a payment method.
-- Use an existing Stripe Link account, or enter your card information to set up
+* Use an existing Stripe Link account, or enter your card information to set up
   Stripe Link.
 
 ## Manage payment method
@@ -42,36 +45,38 @@ update, or remove payment methods.
 You can add multiple payment methods in the billing portal. When you add a new payment method, you set it as a new default payment method.
 
 1. Sign in to [Docker Home](https://app.docker.com/).
-1. Select your username for a personal account, or select your organization
+2. Select your username for a personal account, or select your organization
    name for an organization.
-1. Select **Billing** to go to the billing portal, then **Change** in the **Payment method** tile.
-1. From the **Change payment method** modal, choose to add a card, a US bank account, or a Stripe Link payment.
-   - To pay with a card, enter your card information.
-   - To pay with a US bank account, verify your **Email** and **Full name**.
-     - If your bank is listed, select your bank's name.
-     - If your bank is not listed, select **Search for your bank**.
-   - To pay through Stripe Link, select an existing payment method, then select
+3. Select **Billing** to go to the billing portal, then **Change** in the **Payment method** tile.
+4. From the **Change payment method** modal, choose to add a card, a US bank account, or a Stripe Link payment.
+
+   * To pay with a card, enter your card information.
+   * To pay with a US bank account, verify your **Email** and **Full name**.
+
+     * If your bank is listed, select your bank's name.
+     * If your bank is not listed, select **Search for your bank**.
+   * To pay through Stripe Link, select an existing payment method, then select
      **Use this card**.
-1. For first-time setup, enter your billing information.
-1. Finish adding the payment method by selecting **Save as default**.
+5. For first-time setup, enter your billing information.
+6. Finish adding the payment method by selecting **Save as default**.
 
 ### Change default payment method
 
 After adding one or more payment methods, you can set one as a default method.
 
 1. From **Billing**, go to the **Payment method** tile.
-1. Select **Change** to open the **Change payment method** modal, then select **Change** next to your current default method.
-1. Choose the payment method you want to set as default.
-1. Verify your information, then select **Save as default**.
+2. Select **Change** to open the **Change payment method** modal, then select **Change** next to your current default method.
+3. Choose the payment method you want to set as default.
+4. Verify your information, then select **Save as default**.
 
 ### Remove payment method
 
 You can only remove secondary payment methods. To remove a secondary payment method:
 
 1. From **Billing**, go to the **Payment method** tile.
-1. Select **Change** to open the **Change payment method** modal.
-1. Select the **Actions** menu next to the payment method you want to remove, then select **Remove**.
-1. Verify your billing details, then select **Save as default**.
+2. Select **Change** to open the **Change payment method** modal.
+3. Select the **Actions** menu next to the payment method you want to remove, then select **Remove**.
+4. Verify your billing details, then select **Save as default**.
 
 To remove your default payment method, first set a different payment method as default, or [downgrade to a free subscription](/manuals/subscription-billing/plans/docker.md#cancel-a-docker-plan).
 
@@ -99,13 +104,13 @@ Pay by invoice isn't available for subscription upgrades or changes.
 You can verify your bank account with instant verification for supported banks. You must sign in to your US bank account when adding your bank as a payment method:
 
 1. From **Billing**, go to the **Payment method** tile and select **Change**.
-1. Choose **US bank account** as your payment method.
-1. Verify your **Email** and **Full name**.
-1. Search for your bank, then select it to initiate the sign-in flow.
-1. Review the terms and conditions. This agreement
+2. Choose **US bank account** as your payment method.
+3. Verify your **Email** and **Full name**.
+4. Search for your bank, then select it to initiate the sign-in flow.
+5. Review the terms and conditions. This agreement
    allows Docker to debit payments from your connected bank account.
-1. Select **Agree and continue**.
-1. Select an account to link and verify, then select **Connect account**.
+6. Select **Agree and continue**.
+7. Select an account to link and verify, then select **Connect account**.
 
 When the account is verified, a success message appears.
 
@@ -117,9 +122,9 @@ You have a grace period of 15 days, including the due date, when your payment
 fails. Docker attempts to collect the payment three times using the following
 schedule:
 
-- 3 days after the due date
-- 5 days after the previous attempt
-- 7 days after the previous attempt
+* 3 days after the due date
+* 5 days after the previous attempt
+* 7 days after the previous attempt
 
 Docker also sends an email notification
 `Action Required - Credit Card Payment Failed` with an attached unpaid invoice
@@ -128,4 +133,3 @@ after each failed payment attempt.
 If the invoice remains unpaid after the grace period, the
 subscription downgrades to a free subscription and all paid features are
 disabled.
-

--- a/content/manuals/subscription-billing/manage/payment-method.md
+++ b/content/manuals/subscription-billing/manage/payment-method.md
@@ -128,3 +128,4 @@ after each failed payment attempt.
 If the invoice remains unpaid after the grace period, the
 subscription downgrades to a free subscription and all paid features are
 disabled.
+


### PR DESCRIPTION
## Description
This PR clarifies the pay-by-invoice guidance in the payment methods documentation.

## What changed
- Reworded the pay-by-invoice guidance to remove confusing wording
- Clarified that Docker Sales may need to enable pay by invoice before it appears in Docker Home
- Removed the duplicate pay-by-invoice section at the bottom of the page

## Why
The page contained contradictory guidance: one section implied users could toggle pay by invoice themselves, while another said they must contact Sales to add it.

## Validation
- Reviewed the wording for consistency with related billing docs
- Confirmed the updated text distinguishes between Sales setup and the UI toggle

Fixes #26024

## Reviews
- [ ] Technical review
- [ ] Editorial review
- [ ] Product review