### PR TITLE
docs: fix some broken links from malformed markdown

### DIFF
--- a/content/guides/language-translation.md
+++ b/content/guides/language-translation.md
@@ -314,7 +314,7 @@ To run the application using Docker:
    >
    > For Windows users, you may get an error when running the container. Verify
    > that the line endings in the `entrypoint.sh` are `LF` (`\n`) and not `CRLF` (`\r\n`),
-   > then rebuild the image. For more details, see [Avoid unexpected syntax errors, use Unix style line endings for files in containers](/desktop/troubleshoot-and-support/troubleshoot/topics/#Unexpected-syntax-errors-use-Unix-style-line endings-for-files-in-containers).
+   > then rebuild the image. For more details, see [Avoid unexpected syntax errors, use Unix style line endings for files in containers](/desktop/troubleshoot-and-support/troubleshoot/topics/#unexpected-syntax-errors-use-unix-style-line-endings-for-files-in-containers).
 
    You will see the following in your console after the container starts.
 

--- a/content/guides/named-entity-recognition.md
+++ b/content/guides/named-entity-recognition.md
@@ -317,7 +317,7 @@ To run the application using Docker:
    >
    > For Windows users, you may get an error when running the container. Verify
    > that the line endings in the `entrypoint.sh` are `LF` (`\n`) and not `CRLF` (`\r\n`),
-   > then rebuild the image. For more details, see [Avoid unexpected syntax errors, use Unix style line endings for files in containers](/desktop/troubleshoot-and-support/troubleshoot/topics/#Unexpected-syntax-errors-use-Unix-style-line endings-for-files-in-containers).
+   > then rebuild the image. For more details, see [Avoid unexpected syntax errors, use Unix style line endings for files in containers](/desktop/troubleshoot-and-support/troubleshoot/topics/#unexpected-syntax-errors-use-unix-style-line-endings-for-files-in-containers).
 
    You will see the following in your console after the container starts.
 

--- a/content/guides/sentiment-analysis.md
+++ b/content/guides/sentiment-analysis.md
@@ -330,7 +330,7 @@ To run the application using Docker:
    >
    > For Windows users, you may get an error when running the container. Verify
    > that the line endings in the `entrypoint.sh` are `LF` (`\n`) and not `CRLF` (`\r\n`),
-   > then rebuild the image. For more details, see [Avoid unexpected syntax errors, use Unix style line endings for files in containers](/desktop/troubleshoot-and-support/troubleshoot/topics/#Unexpected-syntax-errors-use-Unix-style-line endings-for-files-in-containers).
+   > then rebuild the image. For more details, see [Avoid unexpected syntax errors, use Unix style line endings for files in containers](/desktop/troubleshoot-and-support/troubleshoot/topics/#unexpected-syntax-errors-use-unix-style-line-endings-for-files-in-containers).
 
    You will see the following in your console after the container starts.
 

--- a/content/guides/text-classification.md
+++ b/content/guides/text-classification.md
@@ -389,7 +389,7 @@ To run the application using Docker:
    >
    > For Windows users, you may get an error when running the container. Verify
    > that the line endings in the `entrypoint.sh` are `LF` (`\n`) and not `CRLF` (`\r\n`),
-   > then rebuild the image. For more details, see [Avoid unexpected syntax errors, use Unix style line endings for files in containers](/desktop/troubleshoot-and-support/troubleshoot/topics/#Unexpected-syntax-errors-use-Unix-style-line endings-for-files-in-containers).
+   > then rebuild the image. For more details, see [Avoid unexpected syntax errors, use Unix style line endings for files in containers](/desktop/troubleshoot-and-support/troubleshoot/topics/#unexpected-syntax-errors-use-unix-style-line-endings-for-files-in-containers).
 
    You will see the following in your console after the container starts.
 

--- a/content/guides/text-summarization.md
+++ b/content/guides/text-summarization.md
@@ -323,7 +323,7 @@ To run the application using Docker:
    >
    > For Windows users, you may get an error when running the container. Verify
    > that the line endings in the `entrypoint.sh` are `LF` (`\n`) and not `CRLF` (`\r\n`),
-   > then rebuild the image. For more details, see [Avoid unexpected syntax errors, use Unix style line endings for files in containers](/desktop/troubleshoot-and-support/troubleshoot/topics/#Unexpected-syntax-errors-use-Unix-style-line endings-for-files-in-containers).
+   > then rebuild the image. For more details, see [Avoid unexpected syntax errors, use Unix style line endings for files in containers](/desktop/troubleshoot-and-support/troubleshoot/topics/#unexpected-syntax-errors-use-unix-style-line-endings-for-files-in-containers).
 
    You will see the following in your console after the container starts.
 

--- a/content/manuals/desktop/troubleshoot-and-support/troubleshoot/topics.md
+++ b/content/manuals/desktop/troubleshoot-and-support/troubleshoot/topics.md
@@ -166,7 +166,7 @@ On macOS, users without administrator privileges cannot perform in-app upgrades 
 To upgrade Docker Desktop:
 
 - Ask an administrator to install the newer version over the existing one.
-- Use the []`--user` install flag](/manuals/desktop/setup/install/mac-install.md#security-and-access) if appropriate for your setup.
+- Use the [`--user` install flag](/manuals/desktop/setup/install/mac-install.md#security-and-access) if appropriate for your setup.
 
 ### Persistent notification telling me an application has changed my Desktop configurations
 

--- a/content/manuals/dhi/how-to/use.md
+++ b/content/manuals/dhi/how-to/use.md
@@ -23,7 +23,7 @@ package manager, and may run as a non-root user by default.
 > pull DHI Community images. You can authenticate using either of the following:
 >
 > - **Docker ID and password:** Use your Docker Hub username and password. If
->   you don't have a Docker account, [create one](../../accounts/individual/create-account.md
+>   you don't have a Docker account, [create one](../../accounts/individual/create-account.md)
 >   for free.
 > - **Access token:** Use a [personal access token
 >   (PAT)](../../security/access-tokens/personal-access-tokens.md) for personal accounts, or an


### PR DESCRIPTION
## Description
This PR is here to fix 7 broken markdown links with a missing parenthesis, a stray bracket, and literal spaces that Hugo's link resolver doesn't flag.

Feel free to provide any feedbacks 🚀