### PR TITLE
docs: scope the SCIM note in the team removal section

### DIFF
--- a/content/manuals/accounts/organization/manage/members.md
+++ b/content/manuals/accounts/organization/manage/members.md
@@ -196,11 +196,12 @@ being added to the team.
 
 ### Remove members from teams
 
-If your organization uses single sign-on (SSO) with
-[SCIM](/manuals/security/provisioning/scim/_index.md) enabled, you
-should remove members from your identity provider (IdP). This automatically
-removes members from Docker. If SCIM is disabled, follow procedures in this
-doc to remove members manually in Docker.
+To remove members from your organization when single sign-on (SSO) with
+[SCIM](/manuals/security/provisioning/scim/_index.md) is enabled, remove them
+from the Docker application in your identity provider (IdP). SCIM removes
+them from your Docker organization. If SCIM is disabled, see
+[Remove users](/manuals/security/authentication/single-sign-on/manage.md#remove-users)
+for the manual organization removal procedure.
 
 Organization owners can remove a member from a team. Removing the member from
 the team revokes their access to the permitted resources. To remove a member


### PR DESCRIPTION
## Description

The "Remove members from teams" section opened with SCIM guidance written at
organization scope, then gave a procedure that only removes someone from a
team. It also told readers to "follow procedures in this doc" for manual
removal, which this page does not contain - the manual organization removal
procedure lives in
[Remove users](https://docs.docker.com/security/authentication/single-sign-on/manage/#remove-users).

This scopes the SCIM note to organization membership, links to that procedure,
and leaves the section's own procedure clearly about team membership.

Two wording changes beyond the link:

- The note said to remove members "from your identity provider (IdP)". The SCIM
  documentation describes the action more narrowly - removing the user from the
  Docker application in the IdP - so this matches that wording.
- "removes members from Docker" is now "removes them from your Docker
  organization", since organization scope was the ambiguity being reported.

**Related, not changed here:** the SCIM page and the platform FAQ both point to
this page as the reference for organization removal
(`security/provisioning/scim/_index.md`, `faqs/platform.md`). With this change
readers who land here from either one can follow the link through. Happy to
adjust those references instead, or in addition, if you'd prefer they point
straight at the SSO page.

**Verified:** the linked procedure and its anchor exist in the current docs.

## Related issues or tickets

Fixes #26042

## Reviews

- [ ] Technical review
- [ ] Editorial review
- [ ] Product review
