### PR TITLE
ci: bump actions/download-artifact to v8.0.1 for Node 24

### DIFF
--- a/.github/workflows/validate-upstream.yml
+++ b/.github/workflows/validate-upstream.yml
@@ -39,7 +39,7 @@ jobs:
           repository: docker/docs
       -
         name: Download data files
-        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         if: ${{ inputs.data-files-id != '' && inputs.data-files-folder != '' }}
         with:
           name: ${{ inputs.data-files-id }}


### PR DESCRIPTION
## Summary

GitHub is [removing Node 20 from Actions runners on September 23, 2026](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/). I checked the `runs.using` value of every action pinned in `.github/workflows/`: `actions/download-artifact` v5 in `validate-upstream.yml` was the only one still declaring `node20`. This bumps it to v8.0.1 (Node 24), using the same SHA already pinned in `notify-release-notes-pr.yml`.

Artifact compatibility is unchanged: v5 and v8 both use the Artifacts v2 API, so upstream repos calling this reusable workflow do not need to change their upload side.

Generated by Claude Code