### PR TITLE
ai-gov: approval-required network access

### DIFF
--- a/content/manuals/ai/sandboxes/governance/access-controls/local.md
+++ b/content/manuals/ai/sandboxes/governance/access-controls/local.md
@@ -210,3 +210,11 @@ a `Governance:` status line showing `Managed by <org>`, it is. Add
 `--include-inactive` to confirm your rule shows an `inactive` status. If so,
 the block can only be lifted by updating the org policy in Docker Home or via
 the [API](/reference/api/ai-governance/).
+
+### A request is blocked with "Approval required"
+
+The destination is allowed by an organization policy that requires approval.
+Run `sbx policy approval ls` to see the pending request and respond to it with
+`sbx policy approval respond`. Approving applies to later requests, not the one
+that was blocked, so run the operation again afterward. See
+[Respond to an approval request](network.md#respond-to-an-approval-request).

--- a/content/manuals/ai/sandboxes/governance/access-controls/network.md
+++ b/content/manuals/ai/sandboxes/governance/access-controls/network.md
@@ -66,6 +66,103 @@ organization or to selected teams. For setup steps and team scoping, see
 Use [Monitoring policies](../monitor-and-enforce/monitoring.md) to inspect
 which network rules are active on a developer machine.
 
+## Approval-required access
+
+An organization network policy can require approval instead of granting access
+outright. Destinations the policy allows aren't reachable until the developer
+confirms them, which keeps an allowlist broad enough to be usable while still
+putting a person in front of each destination an agent reaches for.
+
+Approval is a property of the policy rather than of individual rules, so
+turning it on applies it to every allow rule in that policy. A destination stays
+directly reachable only when every policy that allows it is one that doesn't
+require approval. If a policy that requires approval also matches, the request
+needs approval regardless of what the other policies allow.
+
+Only a destination the developer has already approved satisfies the
+requirement. Preset rules, [kit-defined rules](../../customize/kits.md#control-network-access),
+and rules the developer added with `sbx policy allow network` don't answer it.
+An approval also can't reach a destination the organization doesn't allow at
+all, and it can't override a deny rule. To withdraw a destination, add a deny
+rule, which takes precedence over any approval already recorded.
+
+Requiring approval on a policy is available only with organization
+governance. To turn it on, see
+[Organization policies](organization.md#require-approval-for-a-network-policy).
+
+### Respond to an approval request
+
+When an organization policy requires approval, a sandbox can't reach a
+destination until you confirm it. The request is blocked and the sandbox
+receives a message naming the destination:
+
+```plaintext
+Approval required for api.example.com.
+
+Review and respond with:
+  sbx policy approval ls
+```
+
+If your organization
+[configures a support message](organization.md#configure-a-support-message), it
+appears after the approval instructions.
+
+The request that triggers the prompt doesn't wait for an answer. It's denied,
+and approving the destination affects later requests. Agents that retry a
+failed request pick up the new access on their next attempt. For others, run
+the operation again.
+
+List the destinations waiting for a response:
+
+```console
+$ sbx policy approval ls
+APPROVAL network:c2FuZGJveA  (sandbox: my-sandbox)
+  api.example.com:443
+  Protocol: TCP
+  Resource type: domain
+  approval required by policy "default network"
+
+  OPTION    LABEL
+  allow     Allow
+  dismiss   Dismiss
+```
+
+Each entry names the destination, the sandbox that asked for it, and the policy
+that requires the approval. To inspect a single entry, pass its ID to
+`sbx policy approval inspect`.
+
+Respond by selecting one of the options the entry offers:
+
+```console
+$ sbx policy approval respond network:c2FuZGJveA --option allow
+Recorded: Allow
+```
+
+Choosing `allow` grants access to that destination. Choosing `dismiss` leaves
+it blocked, and the destination is requested again the next time the sandbox
+tries to reach it. Repeated attempts collapse into a single entry, so a sandbox
+retrying in a loop doesn't produce a queue of duplicates.
+
+#### What approving grants
+
+Approving records a rule that allows the destination the sandbox actually
+asked for, scoped to the sandbox that asked. Three things follow from that:
+
+- The rule covers one destination, not the pattern the policy rule used. A
+  policy that allows `*.example.com` with approval asks about
+  `api.example.com` and `cdn.example.com` separately.
+- A destination includes its port, so `api.example.com:443` and
+  `api.example.com:8443` are approved separately.
+- Another sandbox reaching the same destination asks again.
+
+Approved destinations stay allowed until the rule is removed. List them with
+`sbx policy ls --wide --created-via approval`, and remove one the same way as
+any other local rule, with [`sbx policy rm network`](local.md#managing-rules).
+
+Approvals live in the local policy store, so [`sbx policy reset`](local.md#resetting)
+removes all of them along with your other local rules. Each destination is
+requested again the next time a sandbox reaches it.
+
 > [!NOTE]
 > To manage Model Context Protocol (MCP) server registration and requests
 > through Docker's MCP gateway, use [MCP access policies](mcp.md). These

--- a/content/manuals/ai/sandboxes/governance/access-controls/organization.md
+++ b/content/manuals/ai/sandboxes/governance/access-controls/organization.md
@@ -59,9 +59,33 @@ To create a policy:
    **Add rule** for each rule. For MCP policies, enter Cedar statements in the
    policy editor. For syntax and examples, use the relevant access-control page
    in [Choose a policy type](#choose-a-policy-type).
+1. For a network policy, set **Require approval before access** if developers
+   should confirm each destination before a sandbox can reach it. See
+   [Require approval for a network policy](#require-approval-for-a-network-policy).
 
 Existing policies are listed with their name, scope, rule count, and last
 update. Use the action menu (⋮) to edit or delete a policy.
+
+### Require approval for a network policy
+
+Turning on **Require approval before access** means the destinations a network
+policy allows aren't reachable until the developer confirms each one. For how
+approval behaves and what satisfies it, see
+[Approval-required access](network.md#approval-required-access).
+
+To set it on an existing policy:
+
+1. Sign in to [Docker Home](https://app.docker.com) and select your
+   organization.
+1. In the left-hand navigation, expand **AI Platform** and select
+   **Network access**.
+1. Select the policy, then choose **Edit**.
+1. Turn on **Require approval before access**.
+1. Select **Save changes**.
+
+The policy's detail page reports approval as **Required** or **Not required**.
+Editing a policy replaces it in full, so turning the setting off removes the
+requirement from every rule in that policy.
 
 ## Configure a support message
 
@@ -147,8 +171,11 @@ propagate to developer machines. To apply changes immediately, users can run
 organization policies on the next `sbx` command.
 
 > [!WARNING]
-> `sbx policy reset` deletes all locally configured policy rules. The command
-> prompts for confirmation before proceeding.
+> `sbx policy reset` deletes all locally configured policy rules, including any
+> destinations the developer has approved under an
+> [approval-required policy](network.md#approval-required-access). Those
+> destinations are requested again the next time a sandbox reaches them. The
+> command prompts for confirmation before proceeding.
 
 #### Enforcement timing by policy type
 
@@ -158,6 +185,11 @@ developer machine:
 - Network policy is evaluated on every outbound request. Once a policy
   change has synced to the developer's machine (up to 5 minutes), it applies
   immediately to subsequent requests.
+
+- An approval requirement applies from the point the policy change syncs.
+  Destinations a developer already approved stay reachable, because the
+  approval is recorded on the developer's machine. To withdraw one, add a deny
+  rule. A deny takes precedence over a recorded approval.
 
 - Filesystem policy is only checked when a workspace is mounted — that
   is, when a sandbox is created. Once a sandbox is running, changing the

--- a/content/manuals/ai/sandboxes/governance/concepts.md
+++ b/content/manuals/ai/sandboxes/governance/concepts.md
@@ -41,6 +41,12 @@ share the same domain, either `network` or `filesystem`. MCP policies use Cedar
 statements written in the `MCP` namespace instead of the network and filesystem
 rule format.
 
+An organization network policy can also require approval, which turns every
+allow in that policy into a request the developer must confirm before access is
+granted. Approval is set on the policy rather than on individual rules, so it
+applies to all of the policy's allow rules at once. See
+[Approval-required access](access-controls/network.md#approval-required-access).
+
 ### Limits
 
 Organization policies have the following limits, which help ensure fair usage
@@ -193,6 +199,13 @@ team-scoped policy, which makes org-wide deny rules useful as guardrails.
 Local and kit-defined allow rules take no part in this evaluation. Deny rules
 from those sources do still apply. See [Precedence](#precedence).
 
+A request that an approval-required policy allows produces a third outcome.
+Rather than being allowed outright, it's held back until the developer confirms
+the destination, and the confirmation governs later requests to it. This holds
+even when another policy allows the same request without requiring approval. A
+matching deny still wins, so a denied destination is blocked without asking.
+See [Approval-required access](access-controls/network.md#approval-required-access).
+
 ## Precedence
 
 What applies depends on whether your organization has governance enabled:
@@ -222,6 +235,13 @@ top of organization policy is always a network deny. `sbx policy ls` hides
 inactive rules by default. See
 [Monitoring](monitor-and-enforce/monitoring.md#showing-inactive-rules) for how
 to list them.
+
+A local deny takes precedence over an organization approval requirement as
+well, so the request is blocked and no approval is requested. Rules that a
+developer gains by approving a request are the one exception to local allow
+rules being inactive, because they record an answer to the organization's own
+approval requirement rather than granting new access. See
+[Approval-required access](access-controls/network.md#approval-required-access).
 
 When organization governance is active, a user's organization policies are
 evaluated together, as described in [Rule evaluation](#rule-evaluation).

--- a/content/manuals/ai/sandboxes/governance/monitor-and-enforce/monitoring.md
+++ b/content/manuals/ai/sandboxes/governance/monitor-and-enforce/monitoring.md
@@ -47,6 +47,17 @@ $ sbx policy inspect Balanced
 Use `--source` to filter by origin (`local`, `org`, or `kit`) and `--decision`
 to filter by outcome (`allow` or `deny`).
 
+Use `--created-via` to filter by how a rule was created. Pass `default` for
+preset rules, `added` for rules you added yourself, `provisioned` for rules a
+kit or application added, or `approval` for rules recorded when you approved a
+destination. A wide listing shows the same information per rule:
+
+```console
+$ sbx policy ls --wide --created-via approval
+```
+
+See [Approval-required access](../access-controls/network.md#approval-required-access).
+
 A `STATUS` column also appears when you pass `--include-inactive`; see
 [Showing inactive rules](#showing-inactive-rules).
 


### PR DESCRIPTION
## Description

Document approval-required network access. An organization network policy can
require a developer to confirm each destination before a sandbox reaches it.

Split from #26051. The HTTP method and path rules are in #26060, which is
branched off this PR and merges after it.

| Page | What changed |
| --- | --- |
| [`network.md`](https://deploy-preview-26059--docsdocker.netlify.app/ai/sandboxes/governance/access-controls/network/) | What approval is, what satisfies it, how overlapping policies behave, and the `sbx policy approval` workflow |
| [`organization.md`](https://deploy-preview-26059--docsdocker.netlify.app/ai/sandboxes/governance/access-controls/organization/) | The **Require approval before access** setting, and that resetting local policy clears recorded approvals |
| [`concepts.md`](https://deploy-preview-26059--docsdocker.netlify.app/ai/sandboxes/governance/concepts/) | Approval as a policy-level setting and a third evaluation outcome |
| [`local.md`](https://deploy-preview-26059--docsdocker.netlify.app/ai/sandboxes/governance/access-controls/local/) | Troubleshooting entry for a request blocked pending approval |
| [`monitoring.md`](https://deploy-preview-26059--docsdocker.netlify.app/ai/sandboxes/governance/monitor-and-enforce/monitoring/) | Filter for rules recorded from an approval |

## Related issues or tickets

ENGDOCS-3373

## Reviews

- [ ] Technical review
- [ ] Editorial review
- [ ] Product review