### PR TITLE
build: explain GitHub Actions cache write restrictions

### DIFF
--- a/content/manuals/build/cache/backends/gha.md
+++ b/content/manuals/build/cache/backends/gha.md
@@ -80,6 +80,11 @@ GitHub's [cache access restrictions](https://docs.github.com/en/actions/advanced
 still apply. Only the cache for the current branch, the base branch and the
 default branch is accessible by a workflow.
 
+Cache writes also depend on the workflow's cache access. Some events receive
+read-only access in the default-branch context. See
+[Cache write restrictions](../../ci/github-actions/cache.md#cache-write-restrictions)
+for affected triggers and how to configure cache imports and exports.
+
 ## Version
 
 If you don’t set `version` explicitly, the default is v1. However, if the environment variable `$ACTIONS_CACHE_SERVICE_V2` is set to a value interpreted as `true` ( `1`, `true`, `yes`), then v2 is used automatically.

--- a/content/manuals/build/ci/github-actions/cache.md
+++ b/content/manuals/build/ci/github-actions/cache.md
@@ -1,5 +1,6 @@
 ---
 title: Cache management with GitHub Actions
+description: Configure build cache backends for GitHub Actions and handle cache write restrictions.
 linkTitle: Cache management
 keywords: ci, github actions, gha, buildkit, buildx, cache
 ---
@@ -178,6 +179,41 @@ jobs:
 >         }
 >       }
 > ```
+
+### Cache write restrictions
+
+Cache export requires write access to the GitHub Actions cache. GitHub gives
+events such as `issue_comment` and `pull_request_target` read-only cache access
+by default when they run in the default-branch context. These workflows can
+restore existing cache entries, but exporting with `cache-to: type=gha` can fail
+with `error writing layer blob: failed to reserve cache`, even after the image
+has been built and pushed.
+
+This also affects `pull_request` workflows with `types: [closed]` when a pull
+request is merged into the default branch: the run uses the target branch ref
+instead of the pull request merge ref. Regular `pull_request` runs using a
+merge ref retain read-write cache access by default. See GitHub's
+[cache access policy](https://github.blog/changelog/2026-06-26-read-only-actions-cache-for-untrusted-triggers/).
+
+For workflows with read-only cache access, keep `cache-from: type=gha` and omit
+`cache-to`. Populate the cache from a workflow with write access, such as a
+`push` workflow on the default branch. For builds after a merge, use `push` on
+the target branch instead of `pull_request` with `types: [closed]`.
+
+GitHub's workflow or job-level
+[`cache-mode` setting](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#cache-mode)
+can override the default cache access. Granting write access to untrusted
+workflows increases the risk of cache poisoning.
+
+If cache export is optional, you can make export failures non-fatal:
+
+```yaml
+cache-from: type=gha
+cache-to: type=gha,mode=max,ignore-error=true
+```
+
+`ignore-error=true` suppresses all cache export errors, not only access errors.
+It doesn't grant write access or save the cache when writes are denied.
 
 ### Cache mounts
 


### PR DESCRIPTION
## Description

Document GitHub Actions cache write restrictions that can cause cache export to fail after a successful image push, including workflows triggered when a pull request is merged into the default branch. Explain how to restore cache in read-only workflows and populate it from a workflow with write access.

Clarify how `cache-mode` overrides affect access and why `ignore-error=true` suppresses export failures without fixing denied writes.

## Related issues or tickets

closes https://github.com/docker/build-push-action/issues/1571