### PR TITLE
docs(cli): align PID namespace example text with nginx image

### DIFF
--- a/data/cli/engine/docker_container_run.yaml
+++ b/data/cli/engine/docker_container_run.yaml
@@ -1229,7 +1229,7 @@ examples: |-
     Joining another container's PID namespace can be useful for debugging that
     container.
 
-    1. Start a container running a Redis server:
+    1. Start a container running an Nginx server:
 
        ```console
        $ docker run --rm --name my-nginx -d nginx:alpine


### PR DESCRIPTION
## Summary
Fixes #25857.

In the "join another container's PID namespace" example, step 1 said "Redis server" while the command uses `nginx:alpine` and container name `my-nginx`.

## Change
- Update the step text to say Nginx so it matches the example.

## Test plan
- [x] Confirmed the example heading/commands already use `my-nginx` / `nginx:alpine`
- [x] Single wording change only