### PR TITLE
docs(engine): clarify Raspberry Pi OS 32-bit table warning means deprecated

### DIFF
--- a/content/manuals/engine/install/_index.md
+++ b/content/manuals/engine/install/_index.md
@@ -67,6 +67,12 @@ Click on a platform's link to view the relevant installation procedure.
 | [Ubuntu](ubuntu.md)                            |       ✅       |       ✅        |      ✅      |   ✅    |  ✅   |
 | [Binaries](binaries.md)                        |       ✅       |       ✅        |      ✅      |         |       |
 
+> [!WARNING]
+>
+> The ⚠️ for Raspberry Pi OS (32-bit) means support is **deprecated**, not
+> partially supported. Docker Engine v28 is the last major version with `armhf`
+> packages. See [Install Docker Engine on Raspberry Pi OS (32-bit)](raspberry-pi-os.md).
+
 ### Other Linux distributions
 
 > [!NOTE]


### PR DESCRIPTION
## Summary
Fixes #25879.

The Linux install matrix marked Raspberry Pi OS (32-bit) with ⚠️, which usually reads as partial support. The platform page states armhf is deprecated after Docker Engine v28.

## Change
- Add a short warning under the matrix clarifying that ⚠️ here means deprecated, with a link to the Raspberry Pi OS install page.

## Test plan
- [x] Compared matrix row with raspberry-pi-os.md deprecation banner
- [x] Docs-only change