### PR TITLE
docs(swarm): use 'an HTML' in secrets example

### DIFF
--- a/content/manuals/engine/swarm/secrets.md
+++ b/content/manuals/engine/swarm/secrets.md
@@ -301,7 +301,7 @@ This example assumes that you have PowerShell installed.
     <html lang="en">
       <head><title>Hello Docker</title></head>
       <body>
-        <p>Hello Docker! You have deployed a HTML page.</p>
+        <p>Hello Docker! You have deployed an HTML page.</p>
       </body>
     </html>
     ```


### PR DESCRIPTION
## Summary
- Fix article in swarm secrets HTML example: "a HTML" → "an HTML".

Tiny unsolicited docs grammar fix.