### PR TITLE
docs(swarm): use 'an HTML' in configs example

### DIFF
--- a/content/manuals/engine/swarm/configs.md
+++ b/content/manuals/engine/swarm/configs.md
@@ -244,7 +244,7 @@ This example assumes that you have PowerShell installed.
     <html lang="en">
       <head><title>Hello Docker</title></head>
       <body>
-        <p>Hello Docker! You have deployed a HTML page.</p>
+        <p>Hello Docker! You have deployed an HTML page.</p>
       </body>
     </html>
     ```


### PR DESCRIPTION
## Summary
- Fix article in swarm configs HTML example: "a HTML" → "an HTML".

Tiny unsolicited docs grammar fix.