### PR TITLE
docs(engine): use 'an HTTP' in proxy troubleshooting link

### DIFF
--- a/content/manuals/engine/daemon/troubleshoot.md
+++ b/content/manuals/engine/daemon/troubleshoot.md
@@ -120,7 +120,7 @@ ExecStart=/usr/bin/dockerd
 ```
 
 There are other times when you might need to configure `systemd` with Docker,
-such as [configuring a HTTP or HTTPS proxy](./proxy.md).
+such as [configuring an HTTP or HTTPS proxy](./proxy.md).
 
 > [!NOTE]
 >


### PR DESCRIPTION
## Summary
- Fix article before HTTP: "configuring a HTTP" → "configuring an HTTP".

Tiny unsolicited docs grammar fix.