### PR TITLE
docs(extensions): use 'an HTTP' in OAuth Basic Auth note

### DIFF
--- a/content/manuals/extensions/extensions-sdk/guides/oauth2-flow.md
+++ b/content/manuals/extensions/extensions-sdk/guides/oauth2-flow.md
@@ -79,7 +79,7 @@ POST https://authorization-server.com/token
 
 > [!NOTE]
 >
-> The client's credentials are included in the `POST` query params in this example. OAuth authorization servers may require that the credentials are sent as a HTTP Basic Authentication header or might support different formats. See your OAuth provider docs for details.
+> The client's credentials are included in the `POST` query params in this example. OAuth authorization servers may require that the credentials are sent as an HTTP Basic Authentication header or might support different formats. See your OAuth provider docs for details.
 
 ### Store the access token
 


### PR DESCRIPTION
## Summary
- Fix article before HTTP: "a HTTP Basic Authentication" → "an HTTP Basic Authentication".

Tiny unsolicited docs grammar fix.