### PR TITLE
docs(engine): use 'an SSH' when reusing connections

### DIFF
--- a/content/manuals/engine/security/protect-access.md
+++ b/content/manuals/engine/security/protect-access.md
@@ -67,7 +67,7 @@ $ docker info
 ### SSH Tips
 
 For the best user experience with SSH, configure `~/.ssh/config` as follows to allow
-reusing a SSH connection for multiple invocations of the `docker` CLI:
+reusing an SSH connection for multiple invocations of the `docker` CLI:
 
 ```text
 ControlMaster     auto


### PR DESCRIPTION
## Description
Fix article: "a SSH connection" → "an SSH connection" in the remote daemon access guide.

## Related issues
n/a