### PR TITLE
docs(rootless): clarify --net=host limitation was fixed in v29.5

### DIFF
--- a/content/manuals/engine/security/rootless/troubleshoot.md
+++ b/content/manuals/engine/security/rootless/troubleshoot.md
@@ -94,6 +94,7 @@ weight: 30
 
 - Host network (`docker run --net=host`) was namespaced inside RootlessKit.
   This meant that ports listened by containers with `--net=host` were not reachable from the real host network namespace.
+- This limitation was resolved in Docker Engine v29.5. See [Engine v29.5 release notes](/engine/release-notes/29/#2950).
 
 ## Troubleshooting
 
@@ -294,8 +295,7 @@ network namespace. Use `docker run -p` instead.
 
 #### `--net=host` doesn't listen ports on the host network namespace
 
-This was an expected behavior until Docker Engine v29.5, as the daemon was namespaced inside RootlessKit's
-network namespace. Use `docker run -p` instead, or upgrade to Docker Engine v29.5 or later.
+This was an expected behavior in Docker Engine v29.4 and earlier, as the daemon was namespaced inside RootlessKit's network namespace. Docker Engine v29.5 and later support `--net=host` correctly in rootless mode. If you're on an earlier version, use `docker run -p` instead, or upgrade.
 
 #### Network is slow
 


### PR DESCRIPTION
<!--Delete sections as needed -->

## Description

The "Historical limitations" section noted that `--net=host` ports weren't reachable from the host network namespace under RootlessKit, but didn't say this was resolved. Meanwhile, a separate troubleshooting entry on the same page still told readers to "upgrade to Docker Engine v29.5 or later" which implied that the fix might still be pending, even though v29.5 shipped months ago and the current Engine version is v29.7.2.

I confirmed the fix in the v29.5.0 release notes, under Bug fixes and enhancements: "Rootless: Properly support --net=host and localhost registries" (moby/moby#47103).

This updates the Historical limitations bullet to note the fix landed in v29.5, and rewords the troubleshooting entry so it no longer suggests current users need to upgrade. A related section on this same page ("Network is slow") was already updated for this in #25066 and this closes the remaining gap that PR left.

## Related issues or tickets

Fixes #25968

## Reviews

<!-- Notes for reviewers here -->
<!-- List applicable reviews (optionally @tag reviewers) -->

- [ ] Technical review
- [ ] Editorial review
- [ ] Product review