### PR TITLE
Fix PID namespace example: Redis label vs nginx image

### DIFF
--- a/data/cli/engine/docker_container_run.yaml
+++ b/data/cli/engine/docker_container_run.yaml
@@ -1229,7 +1229,7 @@ examples: |-
     Joining another container's PID namespace can be useful for debugging that
     container.
 
-    1. Start a container running a Redis server:
+    1. Start a container running an Nginx server:
 
        ```console
        $ docker run --rm --name my-nginx -d nginx:alpine


### PR DESCRIPTION
## Description

The PID namespace example titled "Start a container running a Redis server" actually runs `nginx:alpine` as `my-nginx`. Update the step text to say Nginx so it matches the image and container name.

## Related issues or tickets

Fixes #25857

## Reviews

- [x] Technical review
- [x] Editorial review
- [ ] Product review
